### PR TITLE
Add middleware

### DIFF
--- a/src/contracts/interfaces/IServiceManager.sol
+++ b/src/contracts/interfaces/IServiceManager.sol
@@ -24,9 +24,6 @@ interface IServiceManager {
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a final stake update (on operator deregistration)
     function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external;
 
-    /// @notice Token used for placing a gurantee on challenges & payment commits
-    function paymentChallengeToken() external view returns (IERC20);
-
     /// @notice Returns the `latestTime` until which operators must serve.
     function latestTime() external view returns (uint32);
 

--- a/src/contracts/middleware/BLSRegistry.sol
+++ b/src/contracts/middleware/BLSRegistry.sol
@@ -90,7 +90,8 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
         address _whitelister,
         bool _whitelistEnabled,
         uint256[] memory _quorumBips,
-        StrategyAndWeightingMultiplier[][] memory _quorumStrategiesConsideredAndMultipliers
+        StrategyAndWeightingMultiplier[] memory _firstQuorumStrategiesConsideredAndMultipliers,
+        StrategyAndWeightingMultiplier[] memory _secondQuorumStrategiesConsideredAndMultipliers
     ) public virtual initializer {
         _setWhitelister(_whitelister);
         whitelistEnabled = _whitelistEnabled;
@@ -98,7 +99,8 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
         _processApkUpdate(BN254.G1Point(0, 0));
         RegistryBase._initialize(
             _quorumBips,
-            _quorumStrategiesConsideredAndMultipliers
+            _firstQuorumStrategiesConsideredAndMultipliers,
+            _secondQuorumStrategiesConsideredAndMultipliers
         );
     }
 

--- a/src/contracts/middleware/RegistryBase.sol
+++ b/src/contracts/middleware/RegistryBase.sol
@@ -71,7 +71,9 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
         uint8 _NUMBER_OF_QUORUMS
     ) VoteWeigherBase(_strategyManager, _serviceManager, _NUMBER_OF_QUORUMS)
     // solhint-disable-next-line no-empty-blocks
-    {}
+    {
+        require(_NUMBER_OF_QUORUMS <= 2, "RegistryBase.constructor: NUMBER_OF_QUORUMS must be less than or equal to 2");
+    }
 
     /**
      * @notice Adds empty first entries to the dynamic arrays `totalStakeHistory` and `totalOperatorsHistory`,
@@ -81,8 +83,7 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
      */
     function _initialize(
         uint256[] memory _quorumBips,
-        StrategyAndWeightingMultiplier[] memory _firstQuorumStrategiesConsideredAndMultipliers,
-        StrategyAndWeightingMultiplier[] memory _secondQuorumStrategiesConsideredAndMultipliers
+        StrategyAndWeightingMultiplier[][] memory _quorumStrategiesConsideredAndMultipliers
     ) internal virtual onlyInitializing {
         VoteWeigherBase._initialize(_quorumBips);
 
@@ -94,8 +95,13 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
         OperatorIndex memory _totalOperators;
         totalOperatorsHistory.push(_totalOperators);
 
-        _addStrategiesConsideredAndMultipliers(0, _firstQuorumStrategiesConsideredAndMultipliers);
-        _addStrategiesConsideredAndMultipliers(1, _secondQuorumStrategiesConsideredAndMultipliers);
+        // add the strategies and multipliers to each quorum
+        for (uint i = 0; i < _quorumStrategiesConsideredAndMultipliers.length;) {
+            _addStrategiesConsideredAndMultipliers(i, _quorumStrategiesConsideredAndMultipliers[i]);
+            unchecked {
+                i++;
+            }
+        }
     }
 
     /**

--- a/src/contracts/middleware/RegistryBase.sol
+++ b/src/contracts/middleware/RegistryBase.sol
@@ -72,7 +72,7 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
     ) VoteWeigherBase(_strategyManager, _serviceManager, _NUMBER_OF_QUORUMS)
     // solhint-disable-next-line no-empty-blocks
     {
-        require(_NUMBER_OF_QUORUMS <= 2, "RegistryBase.constructor: NUMBER_OF_QUORUMS must be less than or equal to 2");
+        require(_NUMBER_OF_QUORUMS <= 2, "RegistryBase: NUMBER_OF_QUORUMS must be less than or equal to 2");
     }
 
     /**
@@ -83,7 +83,8 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
      */
     function _initialize(
         uint256[] memory _quorumBips,
-        StrategyAndWeightingMultiplier[][] memory _quorumStrategiesConsideredAndMultipliers
+        StrategyAndWeightingMultiplier[] memory _firstQuorumStrategiesConsideredAndMultipliers,
+        StrategyAndWeightingMultiplier[] memory _secondQuorumStrategiesConsideredAndMultipliers
     ) internal virtual onlyInitializing {
         VoteWeigherBase._initialize(_quorumBips);
 
@@ -95,13 +96,8 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
         OperatorIndex memory _totalOperators;
         totalOperatorsHistory.push(_totalOperators);
 
-        // add the strategies and multipliers to each quorum
-        for (uint i = 0; i < _quorumStrategiesConsideredAndMultipliers.length;) {
-            _addStrategiesConsideredAndMultipliers(i, _quorumStrategiesConsideredAndMultipliers[i]);
-            unchecked {
-                i++;
-            }
-        }
+        _addStrategiesConsideredAndMultipliers(0, _firstQuorumStrategiesConsideredAndMultipliers);
+        _addStrategiesConsideredAndMultipliers(1, _secondQuorumStrategiesConsideredAndMultipliers);
     }
 
     /**

--- a/src/contracts/middleware/RegistryBase.sol
+++ b/src/contracts/middleware/RegistryBase.sol
@@ -72,7 +72,7 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
     ) VoteWeigherBase(_strategyManager, _serviceManager, _NUMBER_OF_QUORUMS)
     // solhint-disable-next-line no-empty-blocks
     {
-        require(_NUMBER_OF_QUORUMS <= 2, "RegistryBase: NUMBER_OF_QUORUMS must be less than or equal to 2");
+        require(_NUMBER_OF_QUORUMS <= 2 && _NUMBER_OF_QUORUMS > 0, "RegistryBase: NUMBER_OF_QUORUMS must be less than or equal to 2 and greater than 0");
     }
 
     /**

--- a/src/contracts/middleware/example/ECDSARegistry.sol
+++ b/src/contracts/middleware/example/ECDSARegistry.sol
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import "./RegistryBase.sol";
-import "../interfaces/IBLSPublicKeyCompendium.sol";
-import "../interfaces/IBLSRegistry.sol";
-import "../libraries/BN254.sol";
+import "../RegistryBase.sol";
 
 /**
  * @title A Registry-type contract using aggregate BLS signatures.
@@ -14,26 +11,8 @@ import "../libraries/BN254.sol";
  * - committing to and finalizing de-registration as an operator
  * - updating the stakes of the operator
  */
-contract BLSRegistry is RegistryBase, IBLSRegistry {
+contract ECDSARegistry is RegistryBase {
     using BytesLib for bytes;
-
-    // Hash of the zero public key
-    bytes32 internal constant ZERO_PK_HASH = hex"012893657d8eb2efad4de0a91bcd0e39ad9837745dec3ea923737ea803fc8e3d";
-
-    /// @notice contract used for looking up operators' BLS public keys
-    IBLSPublicKeyCompendium public immutable pubkeyCompendium;
-
-    /**
-     * @notice list of keccak256(apk_x, apk_y) of operators, and the block numbers at which the aggregate
-     * pubkeys were updated. This occurs whenever a new operator registers or deregisters.
-     */
-    ApkUpdate[] internal _apkUpdates;
-
-    /**
-     * @dev Initialized value of APK is the point at infinity: (0, 0)
-     * @notice used for storing current aggregate public key
-     */
-    BN254.G1Point public apk;
 
     /// @notice the address that can whitelist people
     address public whitelister;
@@ -46,17 +25,10 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
     /**
      * @notice Emitted upon the registration of a new operator for the middleware
      * @param operator Address of the new operator
-     * @param pkHash The keccak256 hash of the operator's public key
-     * @param pk The operator's public key itself
-     * @param apkHashIndex The index of the latest (i.e. the new) APK update
-     * @param apkHash The keccak256 hash of the new Aggregate Public Key
+     * @param socket The ip:port of the operator
      */
     event Registration(
         address indexed operator,
-        bytes32 pkHash,
-        BN254.G1Point pk,
-        uint32 apkHashIndex,
-        bytes32 apkHash,
         string socket
     );
 
@@ -71,21 +43,16 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
 
     constructor(
         IStrategyManager _strategyManager,
-        IServiceManager _serviceManager,
-        uint8 _NUMBER_OF_QUORUMS,
-        IBLSPublicKeyCompendium _pubkeyCompendium
+        IServiceManager _serviceManager
     )
         RegistryBase(
             _strategyManager,
             _serviceManager,
-            _NUMBER_OF_QUORUMS
+            1
         )
-    {
-        //set compendium
-        pubkeyCompendium = _pubkeyCompendium;
-    }
+    {}
 
-    /// @notice Initialize the APK, the payment split between quorums, and the quorum strategies + multipliers.
+    /// @notice Initialize whitelister and the quorum strategies + multipliers.
     function initialize(
         address _whitelister,
         bool _whitelistEnabled,
@@ -94,8 +61,7 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
     ) public virtual initializer {
         _setWhitelister(_whitelister);
         whitelistEnabled = _whitelistEnabled;
-        // process an apk update to get index and totalStake arrays to the same length
-        _processApkUpdate(BN254.G1Point(0, 0));
+
         RegistryBase._initialize(
             _quorumBips,
             _quorumStrategiesConsideredAndMultipliers
@@ -139,21 +105,17 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
 
     /**
      * @notice called for registering as an operator
-     * @param operatorType specifies whether the operator want to register as staker for one or both quorums
-     * @param pk is the operator's G1 public key
      * @param socket is the socket address of the operator
      */
-    function registerOperator(uint8 operatorType, BN254.G1Point memory pk, string calldata socket) external virtual {
-        _registerOperator(msg.sender, operatorType, pk, socket);
+    function registerOperator(string calldata socket) external virtual {
+        _registerOperator(msg.sender, socket);
     }
 
     /**
      * @param operator is the node who is registering to be a operator
-     * @param operatorType specifies whether the operator want to register as staker for one or both quorums
-     * @param pk is the operator's G1 public key
      * @param socket is the socket address of the operator
      */
-    function _registerOperator(address operator, uint8 operatorType, BN254.G1Point memory pk, string calldata socket)
+    function _registerOperator(address operator, string calldata socket)
         internal
     {
         if(whitelistEnabled) {
@@ -161,67 +123,34 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
         }
 
         // validate the registration of `operator` and find their `OperatorStake`
-        OperatorStake memory _operatorStake = _registrationStakeEvaluation(operator, operatorType);
-
-        // getting pubkey hash
-        bytes32 pubkeyHash = BN254.hashG1Point(pk);
-
-        require(pubkeyHash != ZERO_PK_HASH, "BLSRegistry._registerOperator: Cannot register with 0x0 public key");
-
-
-        require(
-            pubkeyCompendium.pubkeyHashToOperator(pubkeyHash) == operator,
-            "BLSRegistry._registerOperator: operator does not own pubkey"
-        );
-
-        // the new aggregate public key is the current one added to registering operator's public key
-        BN254.G1Point memory newApk = BN254.plus(apk, pk);
-
-        // record the APK update and get the hash of the new APK
-        bytes32 newApkHash = _processApkUpdate(newApk);
+        OperatorStake memory _operatorStake = _registrationStakeEvaluation(operator, 1);
 
         // add the operator to the list of registrants and do accounting
-        _addRegistrant(operator, pubkeyHash, _operatorStake);
+        _addRegistrant(operator, bytes32(uint256(uint160(operator))), _operatorStake);
 
-        emit Registration(operator, pubkeyHash, pk, uint32(_apkUpdates.length - 1), newApkHash, socket);
+        emit Registration(operator, socket);
     }
 
     /**
      * @notice Used by an operator to de-register itself from providing service to the middleware.
-     * @param pkToRemove is the sender's pubkey in affine coordinates
      * @param index is the sender's location in the dynamic array `operatorList`
      */
-    function deregisterOperator(BN254.G1Point memory pkToRemove, uint32 index) external virtual returns (bool) {
-        _deregisterOperator(msg.sender, pkToRemove, index);
+    function deregisterOperator(uint32 index) external virtual returns (bool) {
+        _deregisterOperator(msg.sender, index);
         return true;
     }
 
     /**
      * @notice Used to process de-registering an operator from providing service to the middleware.
      * @param operator The operator to be deregistered
-     * @param pkToRemove is the sender's pubkey
      * @param index is the sender's location in the dynamic array `operatorList`
      */
-    function _deregisterOperator(address operator, BN254.G1Point memory pkToRemove, uint32 index) internal {
+    function _deregisterOperator(address operator, uint32 index) internal {
         // verify that the `operator` is an active operator and that they've provided the correct `index`
         _deregistrationCheck(operator, index);
 
-
-        /// @dev Fetch operator's stored pubkeyHash
-        bytes32 pubkeyHash = registry[operator].pubkeyHash;
-        /// @dev Verify that the stored pubkeyHash matches the 'pubkeyToRemoveAff' input
-        require(
-            pubkeyHash == BN254.hashG1Point(pkToRemove),
-            "BLSRegistry._deregisterOperator: pubkey input does not match stored pubkeyHash"
-        );
-
         // Perform necessary updates for removing operator, including updating operator list and index histories
-        _removeOperator(operator, pubkeyHash, index);
-
-        // the new apk is the current one minus the sender's pubkey (apk = apk + (-pk))
-        BN254.G1Point memory newApk = BN254.plus(apk, BN254.negate(pkToRemove));
-        // update the aggregate public key of all registered operators and record this update in history
-        _processApkUpdate(newApk);
+        _removeOperator(operator, bytes32(uint256(uint160(operator))), index);
     }
 
     /**
@@ -242,19 +171,19 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
         // iterating over all the tuples that are to be updated
         for (uint256 i = 0; i < operatorsLength;) {
             // get operator's pubkeyHash
-            pubkeyHash = registry[operators[i]].pubkeyHash;
+            pubkeyHash = bytes32(uint256(uint160(operators[i])));
             // fetch operator's existing stakes
             currentStakes = pubkeyHashToStakeHistory[pubkeyHash][pubkeyHashToStakeHistory[pubkeyHash].length - 1];
+
+            // Note: we only edit the first quorum stake because this is a single quorum registry example
             // decrease _totalStake by operator's existing stakes
             _totalStake.firstQuorumStake -= currentStakes.firstQuorumStake;
-            _totalStake.secondQuorumStake -= currentStakes.secondQuorumStake;
 
             // update the stake for the i-th operator
             currentStakes = _updateOperatorStake(operators[i], pubkeyHash, currentStakes, prevElements[i]);
 
             // increase _totalStake by operator's updated stakes
             _totalStake.firstQuorumStake += currentStakes.firstQuorumStake;
-            _totalStake.secondQuorumStake += currentStakes.secondQuorumStake;
 
             unchecked {
                 ++i;
@@ -322,67 +251,9 @@ contract BLSRegistry is RegistryBase, IBLSRegistry {
     //     _recordTotalStakeUpdate(_totalStake);
     // }
 
-    /**
-     * @notice Updates the stored APK to `newApk`, calculates its hash, and pushes new entries to the `_apkUpdates` array
-     * @param newApk The updated APK. This will be the `apk` after this function runs!
-     */
-    function _processApkUpdate(BN254.G1Point memory newApk) internal returns (bytes32) {
-        // update stored aggregate public key
-        // slither-disable-next-line costly-loop
-        apk = newApk;
-
-        // find the hash of aggregate pubkey
-        bytes32 newApkHash = BN254.hashG1Point(newApk);
-
-        // store the apk hash and the current block number in which the aggregated pubkey is being updated
-        _apkUpdates.push(ApkUpdate({
-            apkHash: newApkHash,
-            blockNumber: uint32(block.number)
-        }));
-
-        return newApkHash;
-    }
-
     function _setWhitelister(address _whitelister) internal {
         require(_whitelister != address(0), "BLSRegistry.initialize: cannot set whitelister to zero address");
         emit WhitelisterTransferred(whitelister, _whitelister);
         whitelister = _whitelister;
-    }
-
-    /**
-     * @notice get hash of a historical aggregated public key corresponding to a given index;
-     * called by checkSignatures in BLSSignatureChecker.sol.
-     */
-    function getCorrectApkHash(uint256 index, uint32 blockNumber) external view returns (bytes32) {
-        // check that the `index`-th APK update occurred at or before `blockNumber`
-        require(blockNumber >= _apkUpdates[index].blockNumber, "BLSRegistry.getCorrectApkHash: index too recent");
-
-        // if not last update
-        if (index != _apkUpdates.length - 1) {
-            // check that there was not *another APK update* that occurred at or before `blockNumber`
-            require(blockNumber < _apkUpdates[index + 1].blockNumber, "BLSRegistry.getCorrectApkHash: Not latest valid apk update");
-        }
-
-        return _apkUpdates[index].apkHash;
-    }
-
-    /// @notice returns the total number of APK updates that have ever occurred (including one for initializing the pubkey as the generator)
-    function getApkUpdatesLength() external view returns (uint256) {
-        return _apkUpdates.length;
-    }
-
-    /// @notice returns the `ApkUpdate` struct at `index` in the list of APK updates
-    function apkUpdates(uint256 index) external view returns (ApkUpdate memory) {
-        return _apkUpdates[index];
-    }
-
-    /// @notice returns the APK hash that resulted from the `index`th APK update
-    function apkHashes(uint256 index) external view returns (bytes32) {
-        return _apkUpdates[index].apkHash;
-    }
-
-    /// @notice returns the block number at which the `index`th APK update occurred
-    function apkUpdateBlockNumbers(uint256 index) external view returns (uint32) {
-        return _apkUpdates[index].blockNumber;
     }
 }

--- a/src/contracts/middleware/example/ECDSARegistry.sol
+++ b/src/contracts/middleware/example/ECDSARegistry.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.12;
 import "../RegistryBase.sol";
 
 /**
- * @title A Registry-type contract using aggregate BLS signatures.
+ * @title A Registry-type contract identifying operators by their Ethereum address, with only 1 quorum.
  * @author Layr Labs, Inc.
  * @notice This contract is used for
  * - registering new operators
@@ -48,7 +48,7 @@ contract ECDSARegistry is RegistryBase {
         RegistryBase(
             _strategyManager,
             _serviceManager,
-            1
+            1 // set the number of quorums to 1
         )
     {}
 
@@ -103,7 +103,6 @@ contract ECDSARegistry is RegistryBase {
             whitelisted[operators[i]] = false;
         }
     }
-
     /**
      * @notice called for registering as an operator
      * @param socket is the socket address of the operator
@@ -194,63 +193,6 @@ contract ECDSARegistry is RegistryBase {
         // update storage of total stake
         _recordTotalStakeUpdate(_totalStake);
     }
-
-    //TODO: The subgraph doesnt like uint256[4][] argument here. Figure this out laters
-    // // TODO: de-dupe code copied from `updateStakes`, if reasonably possible
-    // /**
-    //  * @notice Used for removing operators that no longer meet the minimum requirements
-    //  * @param operators are the nodes who will potentially be booted
-    //  */
-    // function bootOperators(
-    //     address[] calldata operators,
-    //     uint256[4][] memory pubkeysToRemoveAff,
-    //     uint32[] memory indices
-    // )
-    //     external
-    // {
-    //     // copy total stake to memory
-    //     OperatorStake memory _totalStake = totalStakeHistory[totalStakeHistory.length - 1];
-
-    //     // placeholders reused inside of loop
-    //     OperatorStake memory currentStakes;
-    //     bytes32 pubkeyHash;
-    //     uint256 operatorsLength = operators.length;
-    //     // iterating over all the tuples that are to be updated
-    //     for (uint256 i = 0; i < operatorsLength;) {
-    //         // get operator's pubkeyHash
-    //         pubkeyHash = registry[operators[i]].pubkeyHash;
-    //         // fetch operator's existing stakes
-    //         currentStakes = pubkeyHashToStakeHistory[pubkeyHash][pubkeyHashToStakeHistory[pubkeyHash].length - 1];
-    //         // decrease _totalStake by operator's existing stakes
-    //         _totalStake.firstQuorumStake -= currentStakes.firstQuorumStake;
-    //         _totalStake.secondQuorumStake -= currentStakes.secondQuorumStake;
-
-    //         // update the stake for the i-th operator
-    //         currentStakes = _updateOperatorStake(operators[i], pubkeyHash, currentStakes);
-
-    //         // remove the operator from the list of operators if they do *not* meet the minimum requirements
-    //         if (
-    //             (currentStakes.firstQuorumStake < minimumStakeFirstQuorum)
-    //                 && (currentStakes.secondQuorumStake < minimumStakeSecondQuorum)
-    //         ) {
-    //             // TODO: optimize better if possible? right now this pushes an APK update for each operator removed.
-    //             _deregisterOperator(operators[i], pubkeysToRemoveAff[i], indices[i]);
-    //         }
-    //         // in the case that the operator *does indeed* meet the minimum requirements
-    //         else {
-    //             // increase _totalStake by operator's updated stakes
-    //             _totalStake.firstQuorumStake += currentStakes.firstQuorumStake;
-    //             _totalStake.secondQuorumStake += currentStakes.secondQuorumStake;
-    //         }
-
-    //         unchecked {
-    //             ++i;
-    //         }
-    //     }
-
-    //     // update storage of total stake
-    //     _recordTotalStakeUpdate(_totalStake);
-    // }
 
     function _setWhitelister(address _whitelister) internal {
         require(_whitelister != address(0), "BLSRegistry.initialize: cannot set whitelister to zero address");

--- a/src/contracts/middleware/example/ECDSARegistry.sol
+++ b/src/contracts/middleware/example/ECDSARegistry.sol
@@ -57,14 +57,15 @@ contract ECDSARegistry is RegistryBase {
         address _whitelister,
         bool _whitelistEnabled,
         uint256[] memory _quorumBips,
-        StrategyAndWeightingMultiplier[][] memory _quorumStrategiesConsideredAndMultipliers
+        StrategyAndWeightingMultiplier[] memory _quorumStrategiesConsideredAndMultipliers
     ) public virtual initializer {
         _setWhitelister(_whitelister);
         whitelistEnabled = _whitelistEnabled;
 
         RegistryBase._initialize(
             _quorumBips,
-            _quorumStrategiesConsideredAndMultipliers
+            _quorumStrategiesConsideredAndMultipliers,
+            new StrategyAndWeightingMultiplier[](0)
         );
     }
 

--- a/src/contracts/middleware/example/HashThreshold.sol
+++ b/src/contracts/middleware/example/HashThreshold.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import "../../interfaces/IServiceManager.sol";
+import "./ECDSARegistry.sol";
+
+/**
+ * @title An EigenLayer middleware example service manager that slashes validators that sign a message that, when hashed 1000 types starts with less than 5 0s.
+ * @author Layr Labs, Inc.
+ */
+contract HashThreshold is Ownable, IServiceManager {
+    uint32 constant disputePeriodBlocks = 1 days / 12 seconds;
+    uint8 constant numZeroes = 5;
+    ISlasher public immutable slasher;
+    ECDSARegistry public immutable registry;
+
+
+    struct CertifiedMessageMetadata {
+        bytes32 signaturesHash;
+        uint32 validAfterBlock;
+    }
+
+    uint32 public taskNumber = 0;
+    uint32 public latestTime = 0;
+    mapping(bytes32 => CertifiedMessageMetadata) public certifiedMessageMetadatas;
+
+    event MessageCertified(bytes32);
+
+    modifier onlyRegistry {
+        require(msg.sender == address(registry), "Only registry can call this function");
+    }
+
+    constructor(
+        ISlasher _slasher,
+        ECDSARegistry _registry
+    ) {
+        slasher = _slasher;
+        registry = _registry;
+    }
+
+    function owner() public view override(Ownable, IServiceManager) returns (address) {
+        return Ownable.owner();
+    }
+
+    function kiloHash(bytes32 message) public pure returns (bytes32) {
+        bytes32 hash = message;
+        for (uint256 i = 0; i < 1000; i++) {
+            hash = keccak256(abi.encodePacked(hash));
+        }
+        return hash;
+    }
+
+    function submitSignatures(bytes32 message, bytes calldata signatures) external {
+        // this makes it so that the signatures are viewable in calldata
+        require(msg.sender == tx.origin, "EOA must call this function");
+        uint128 stakeSigned = 0;
+        for(uint256 i = 0; i < signatures.length; i += 65) {
+            // we fetch all the signers and check their signatures and their stake
+            address signer = ECDSA.recover(message, signatures[i:i+65]);
+            require(registry.isActiveOperator(signer), "Signer is not an active operator");
+            stakeSigned += registry.firstQuorumStakedByOperator(signer);
+        }
+        (uint96 totalStake,) = registry.totalStake();
+        require(stakeSigned >= 666667 * uint256(totalStake) / 1000000, "Need more than 2/3 of stake to sign");
+
+        uint32 newLatestTime = uint32(block.number + disputePeriodBlocks);
+
+        certifiedMessageMetadatas[message] = CertifiedMessageMetadata({
+            validAfterBlock: newLatestTime,
+            signaturesHash: keccak256(signatures)
+        });
+
+        // increment global service manager values
+        taskNumber++;
+        latestTime = newLatestTime;
+        
+        emit MessageCertified(message);
+    }
+
+    function slashSigners(bytes32 message, bytes calldata signatures) external {
+        CertifiedMessageMetadata memory certifiedMessageMetadata = certifiedMessageMetadatas[message];
+        require(certifiedMessageMetadata.validAfterBlock > block.number, "Dispute period has passed");
+        require(certifiedMessageMetadata.signaturesHash == keccak256(signatures), "Signatures do not match");
+        require(kiloHash(message) >> (256 - numZeroes) == 0, "Message does not hash to enough zeroes");
+        for (uint i = 0; i < signatures.length; i += 65) {
+            slasher.freezeOperator(ECDSA.recover(message, signatures[i:i+65]));
+        }
+        certifiedMessageMetadatas[message].validAfterBlock = type(uint32).max;
+    }
+
+    function freezeOperator(address operator) external onlyRegistry {
+        slasher.freezeOperator(operator);
+    }
+
+    function recordFirstStakeUpdate(address operator, uint32 serveUntil) external onlyRegistry {
+        slasher.recordFirstStakeUpdate(operator, serveUntil);
+    }
+
+    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external onlyRegistry {
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntil);
+    }
+
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntil, uint256 prevElement) external onlyRegistry {
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, prevElement);
+    }
+}

--- a/src/contracts/middleware/example/HashThreshold.sol
+++ b/src/contracts/middleware/example/HashThreshold.sol
@@ -31,6 +31,7 @@ contract HashThreshold is Ownable, IServiceManager {
 
     modifier onlyRegistry {
         require(msg.sender == address(registry), "Only registry can call this function");
+        _;
     }
 
     constructor(


### PR DESCRIPTION
Added a simple little middleware that allows validators to sign off on on a msg to confirm it. A dispute can be launched that hashes the message 1000 times and if the message doesnt start with a threshold amount of zeros, then all validators that signed are slashed.

I also added a ECDSA registry.

Planning to comment a bit soon, but mostly should be self explanatory for reviewers.

This will help middlewares get a better idea of how to integrate as we realized we didn't have a service manager implementation in the repo and the BLS registry contains a bit of logic that is unneccesary for peeps not using BLS.

TODO:
- Add tests for ECDSA registry
- ~~Add Natspec and more inline comments~~