### PR TITLE
Restrict state mutability to pure to silence warnings.

### DIFF
--- a/src/test/utils/Operators.sol
+++ b/src/test/utils/Operators.sol
@@ -13,7 +13,7 @@ contract Operators is Test {
         operatorConfigJson = vm.readFile("./src/test/test-data/operators.json");
     }
 
-    function operatorPrefix(uint256 index) public returns(string memory) {
+    function operatorPrefix(uint256 index) public pure returns(string memory) {
         return string.concat(".operators[", string.concat(vm.toString(index), "]."));
     }
 

--- a/src/test/utils/Owners.sol
+++ b/src/test/utils/Owners.sol
@@ -13,7 +13,7 @@ contract Owners is Test {
         ownersConfigJson = vm.readFile("./src/test/test-data/owners.json");
     }
 
-    function ownerPrefix(uint256 index) public returns(string memory) {
+    function ownerPrefix(uint256 index) public pure returns(string memory) {
         return string.concat(".owners[", string.concat(vm.toString(index), "]."));
     }
 


### PR DESCRIPTION
Title. Silences the below warnings.

```console
warning[2018]: Warning: Function state mutability can be restricted to pure
  --> src/test/utils/Operators.sol:16:5:
   |
16 |     function operatorPrefix(uint256 index) public returns(string memory) {
   |     ^ (Relevant source part starts here and spans across multiple lines).



warning[2018]: Warning: Function state mutability can be restricted to pure
  --> src/test/utils/Owners.sol:16:5:
   |
16 |     function ownerPrefix(uint256 index) public returns(string memory) {
   |     ^ (Relevant source part starts here and spans across multiple lines).
```