### PR TITLE
switch from latestTime to latestServeUntilBlock

### DIFF
--- a/src/contracts/core/Slasher.sol
+++ b/src/contracts/core/Slasher.sol
@@ -284,7 +284,7 @@ contract Slasher is Initializable, OwnableUpgradeable, ISlasher, Pausable {
         return(
             withdrawalStartBlock < update.stalestUpdateBlock 
             &&
-            uint32(block.timestamp) > update.latestServeUntilBlock
+            uint32(block.number) > update.latestServeUntilBlock
         );
     }
 

--- a/src/contracts/interfaces/IServiceManager.sol
+++ b/src/contracts/interfaces/IServiceManager.sol
@@ -16,16 +16,16 @@ interface IServiceManager {
     function freezeOperator(address operator) external;
 
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording an initial stake update (on operator registration)
-    function recordFirstStakeUpdate(address operator, uint32 serveUntil) external;
+    function recordFirstStakeUpdate(address operator, uint32 serveUntilBlock) external;
 
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a stake update
-    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntil, uint256 prevElement) external;
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 prevElement) external;
 
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a final stake update (on operator deregistration)
-    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external;
+    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntilBlock) external;
 
-    /// @notice Returns the `latestTime` until which operators must serve.
-    function latestTime() external view returns (uint32);
+    /// @notice Returns the latest block until which operators must serve.
+    function latestServeUntilBlock() external view returns (uint32);
 
     function owner() external view returns (address);
 }

--- a/src/contracts/interfaces/ISlasher.sol
+++ b/src/contracts/interfaces/ISlasher.sol
@@ -17,8 +17,8 @@ interface ISlasher {
 
     // struct used to store details relevant to a single middleware that an operator has opted-in to serving
     struct MiddlewareDetails {
-        // the UTC timestamp before which the contract is allowed to slash the user
-        uint32 contractCanSlashOperatorUntil;
+        // the block before which the contract is allowed to slash the user
+        uint32 contractCanSlashOperatorUntilBlock;
         // the block at which the middleware's view of the operator's stake was most recently updated
         uint32 latestUpdateBlock;
     }
@@ -47,10 +47,10 @@ interface ISlasher {
      * @notice this function is a called by middlewares during an operator's registration to make sure the operator's stake at registration 
      *         is slashable until serveUntil
      * @param operator the operator whose stake update is being recorded
-     * @param serveUntil the timestamp until which the operator's stake at the current block is slashable
+     * @param serveUntilBlock the block until which the operator's stake at the current block is slashable
      * @dev adds the middleware's slashing contract to the operator's linked list
      */
-    function recordFirstStakeUpdate(address operator, uint32 serveUntil) external;
+    function recordFirstStakeUpdate(address operator, uint32 serveUntilBlock) external;
 
     /**
      * @notice this function is a called by middlewares during a stake update for an operator (perhaps to free pending withdrawals)
@@ -68,11 +68,11 @@ interface ISlasher {
      * @notice this function is a called by middlewares during an operator's deregistration to make sure the operator's stake at deregistration 
      *         is slashable until serveUntil
      * @param operator the operator whose stake update is being recorded
-     * @param serveUntil the timestamp until which the operator's stake at the current block is slashable
+     * @param serveUntilBlock the block until which the operator's stake at the current block is slashable
      * @dev removes the middleware's slashing contract to the operator's linked list and revokes the middleware's (i.e. caller's) ability to
      * slash `operator` once `serveUntil` is reached
      */
-    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external;
+    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntilBlock) external;
 
     /**
      * @notice Used to determine whether `staker` is actively 'frozen'. If a staker is frozen, then they are potentially subject to
@@ -86,8 +86,8 @@ interface ISlasher {
     /// @notice Returns true if `slashingContract` is currently allowed to slash `toBeSlashed`.
     function canSlash(address toBeSlashed, address slashingContract) external view returns (bool);
 
-    /// @notice Returns the UTC timestamp until which `serviceContract` is allowed to slash the `operator`.
-    function contractCanSlashOperatorUntil(address operator, address serviceContract) external view returns (uint32);
+    /// @notice Returns the block until which `serviceContract` is allowed to slash the `operator`.
+    function contractCanSlashOperatorUntilBlock(address operator, address serviceContract) external view returns (uint32);
 
     /// @notice Returns the block at which the `serviceContract` last updated its view of the `operator`'s stake
     function latestUpdateBlock(address operator, address serviceContract) external view returns (uint32);
@@ -127,7 +127,7 @@ interface ISlasher {
     function getMiddlewareTimesIndexBlock(address operator, uint32 index) external view returns(uint32);
 
     /// @notice Getter function for fetching `operatorToMiddlewareTimes[operator][index].latestServeUntil`.
-    function getMiddlewareTimesIndexServeUntil(address operator, uint32 index) external view returns(uint32);
+    function getMiddlewareTimesIndexServeUntilBlock(address operator, uint32 index) external view returns(uint32);
 
     /// @notice Getter function for fetching `_operatorToWhitelistedContractsByUpdate[operator].size`.
     function operatorWhitelistedContractsLinkedListSize(address operator) external view returns (uint256);

--- a/src/contracts/interfaces/ISlasher.sol
+++ b/src/contracts/interfaces/ISlasher.sol
@@ -11,8 +11,8 @@ interface ISlasher {
     struct MiddlewareTimes {
         // The update block for the middleware whose most recent update was earliest, i.e. the 'stalest' update out of all middlewares the operator is serving
         uint32 stalestUpdateBlock;
-        // The latest 'serveUntil' time from all of the middleware that the operator is serving
-        uint32 latestServeUntil;
+        // The latest 'serveUntilBlock' from all of the middleware that the operator is serving
+        uint32 latestServeUntilBlock;
     }
 
     // struct used to store details relevant to a single middleware that an operator has opted-in to serving
@@ -57,12 +57,12 @@ interface ISlasher {
      *         to make sure the operator's stake at updateBlock is slashable until serveUntil
      * @param operator the operator whose stake update is being recorded
      * @param updateBlock the block for which the stake update is being recorded
-     * @param serveUntil the timestamp until which the operator's stake at updateBlock is slashable
+     * @param serveUntilBlock the block until which the operator's stake at updateBlock is slashable
      * @param insertAfter the element of the operators linked list that the currently updating middleware should be inserted after
      * @dev insertAfter should be calculated offchain before making the transaction that calls this. this is subject to race conditions, 
      *      but it is anticipated to be rare and not detrimental.
      */
-    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntil, uint256 insertAfter) external;
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 insertAfter) external;
 
     /**
      * @notice this function is a called by middlewares during an operator's deregistration to make sure the operator's stake at deregistration 

--- a/src/contracts/middleware/RegistryBase.sol
+++ b/src/contracts/middleware/RegistryBase.sol
@@ -399,13 +399,13 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
         // remove the operator at `index` from the `operatorList`
         address swappedOperator = _popRegistrant(index);
 
-        // @notice Registrant must continue to serve until the latest time at which an active task expires. this info is used in challenges
-        uint32 latestTime = serviceManager.latestTime();
+        // @notice Registrant must continue to serve until the latest block at which an active task expires. this info is used in challenges
+        uint32 latestServeUntilBlock = serviceManager.latestServeUntilBlock();
         // committing to not signing off on any more middleware tasks
         registry[operator].status = IQuorumRegistry.Status.INACTIVE;
 
-        // record a stake update unbonding the operator after `latestTime`
-        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestTime);
+        // record a stake update unbonding the operator after `latestServeUntilBlock`
+        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestServeUntilBlock);
 
         // Emit `Deregistration` event
         emit Deregistration(operator, swappedOperator);
@@ -640,7 +640,7 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
         // push new stake to storage
         pubkeyHashToStakeHistory[pubkeyHash].push(updatedOperatorStake);
         // record stake update in the slasher
-        serviceManager.recordStakeUpdate(operator, uint32(block.number), serviceManager.latestTime(), insertAfter);
+        serviceManager.recordStakeUpdate(operator, uint32(block.number), serviceManager.latestServeUntilBlock(), insertAfter);
 
         emit StakeUpdate(
             operator,

--- a/src/contracts/middleware/RegistryBase.sol
+++ b/src/contracts/middleware/RegistryBase.sol
@@ -514,7 +514,7 @@ abstract contract RegistryBase is VoteWeigherBase, IQuorumRegistry {
     {
 
         require(
-            slasher.contractCanSlashOperatorUntil(operator, address(serviceManager)) == type(uint32).max,
+            slasher.contractCanSlashOperatorUntilBlock(operator, address(serviceManager)) == type(uint32).max,
             "RegistryBase._addRegistrant: operator must be opted into slashing by the serviceManager"
         );
         // store the Operator's info in mapping

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -57,12 +57,12 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         cheats.roll(2);
 
         cheats.startPrank(middleware);
-        // stake update with updateBlock = 2, serveUntil = 5
-        uint32 serveUntil = 5;
-        slasher.recordFirstStakeUpdate(staker, serveUntil);
+        // stake update with updateBlock = 2, serveUntilBlock = 5
+        uint32 serveUntilBlock = 5;
+        slasher.recordFirstStakeUpdate(staker, serveUntilBlock);
         cheats.stopPrank();
 
-        cheats.warp(6);
+        cheats.roll(6);
 
         // freeze the staker
         cheats.startPrank(middleware);
@@ -132,26 +132,26 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             cheats.stopPrank();
 
             cheats.startPrank(middleware);
-            // first stake update with updateBlock = 1, serveUntil = 5
+            // first stake update with updateBlock = 1, serveUntilBlock = 5
       
-            uint32 serveUntil = 5;
-            slasher.recordFirstStakeUpdate(staker, serveUntil);
+            uint32 serveUntilBlock = 5;
+            slasher.recordFirstStakeUpdate(staker, serveUntilBlock);
             cheats.stopPrank();
             //check middlewareTimes entry is correct
             require(slasher.getMiddlewareTimesIndexBlock(staker, 0) == 1, "middleware updateBlock update incorrect");
-            require(slasher.getMiddlewareTimesIndexServeUntil(staker, 0) == 5, "middleware serveUntil update incorrect");
+            require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 0) == 5, "middleware serveUntil update incorrect");
             
 
             cheats.startPrank(middleware_2);
-            // first stake update with updateBlock = 1, serveUntil = 6
-            slasher.recordFirstStakeUpdate(staker, serveUntil+1);
+            // first stake update with updateBlock = 1, serveUntilBlock = 6
+            slasher.recordFirstStakeUpdate(staker, serveUntilBlock+1);
             cheats.stopPrank();
             //check middlewareTimes entry is correct
             require(slasher.getMiddlewareTimesIndexBlock(staker, 1) == 1, "middleware updateBlock update incorrect");
-            require(slasher.getMiddlewareTimesIndexServeUntil(staker, 1) == 6, "middleware serveUntil update incorrect");
+            require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 1) == 6, "middleware serveUntil update incorrect");
             //check old entry has not changed
             require(slasher.getMiddlewareTimesIndexBlock(staker, 0) == 1, "middleware updateBlock update incorrect");
-            require(slasher.getMiddlewareTimesIndexServeUntil(staker, 0) == 5, "middleware serveUntil update incorrect");
+            require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 0) == 5, "middleware serveUntil update incorrect");
 
             //move ahead a block before queuing the withdrawal
             cheats.roll(2);
@@ -173,7 +173,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         cheats.roll(3);
 
         cheats.startPrank(middleware);
-        // stake update with updateBlock = 3, serveUntil = 7
+        // stake update with updateBlock = 3, serveUntilBlock = 7
         uint32 serveUntilBlock = 7;
         uint32 updateBlock = 3;
         uint256 insertAfter = 1;
@@ -181,18 +181,18 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 2) == 1, "middleware updateBlock update incorrect");
-        require(slasher.getMiddlewareTimesIndexServeUntil(staker, 2) == 7, "middleware serveUntil update incorrect");
+        require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 2) == 7, "middleware serveUntil update incorrect");
 
         cheats.startPrank(middleware_2);
-        // stake update with updateBlock = 3, serveUntil = 10
+        // stake update with updateBlock = 3, serveUntilBlock = 10
         slasher.recordStakeUpdate(staker, updateBlock, serveUntilBlock+3, insertAfter);
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 3) == 3, "middleware updateBlock update incorrect");
-        require(slasher.getMiddlewareTimesIndexServeUntil(staker, 3) == 10, "middleware serveUntil update incorrect");
+        require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 3) == 10, "middleware serveUntil update incorrect");
 
         cheats.startPrank(middleware);
-        // stake update with updateBlock = 3, serveUntil = 7
+        // stake update with updateBlock = 3, serveUntilBlock = 7
         serveUntilBlock = 7;
         updateBlock = 3;
         insertAfter = 2;
@@ -200,9 +200,9 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 4) == 3, "middleware updateBlock update incorrect");
-        require(slasher.getMiddlewareTimesIndexServeUntil(staker, 4) == 10, "middleware serveUntil update incorrect");
+        require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 4) == 10, "middleware serveUntil update incorrect");
 
-        //move timestamp to 6, one middleware is past serveUntil but the second middleware is still using the restaked funds.
+        //move timestamp to 6, one middleware is past serveUntilBlock but the second middleware is still using the restaked funds.
         cheats.warp(8);
         //Also move the current block ahead one
         cheats.roll(4);

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -174,10 +174,10 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
 
         cheats.startPrank(middleware);
         // stake update with updateBlock = 3, serveUntil = 7
-        uint32 serveUntil = 7;
+        uint32 serveUntilBlock = 7;
         uint32 updateBlock = 3;
         uint256 insertAfter = 1;
-        slasher.recordStakeUpdate(staker, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(staker, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 2) == 1, "middleware updateBlock update incorrect");
@@ -185,7 +185,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
 
         cheats.startPrank(middleware_2);
         // stake update with updateBlock = 3, serveUntil = 10
-        slasher.recordStakeUpdate(staker, updateBlock, serveUntil+3, insertAfter);
+        slasher.recordStakeUpdate(staker, updateBlock, serveUntilBlock+3, insertAfter);
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 3) == 3, "middleware updateBlock update incorrect");
@@ -193,10 +193,10 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
 
         cheats.startPrank(middleware);
         // stake update with updateBlock = 3, serveUntil = 7
-        serveUntil = 7;
+        serveUntilBlock = 7;
         updateBlock = 3;
         insertAfter = 2;
-        slasher.recordStakeUpdate(staker, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(staker, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexBlock(staker, 4) == 3, "middleware updateBlock update incorrect");

--- a/src/test/Slasher.t.sol
+++ b/src/test/Slasher.t.sol
@@ -99,19 +99,19 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
         
-        uint32 serveUntil = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
         //these calls come from middlewares, we need more than 1 middleware to trigger the if clause on line 179
         // we need more than 2 middlewares to trigger the incorrect insertAfter being supplied by getCorrectValueForInsertAfter()
         cheats.startPrank(middleware);
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
 
         cheats.startPrank(middleware_2);
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
         
         cheats.startPrank(middleware_3);
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
     
         cheats.startPrank(middleware);
@@ -122,7 +122,7 @@ contract SlasherTests is EigenLayerTestHelper {
         uint256 insertAfter = uint256(uint160(middleware));
         
         //Force fallbackRoutine to occur by specifying the wrong insertAfter. This then loops until we revert
-        slasher.recordStakeUpdate(operator,5, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,5, serveUntilBlock, insertAfter);
         
 
     }
@@ -168,7 +168,7 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
 
-        uint32 serveUntil = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
         //convert the middleware node address to a node number
         uint256 insertAfter = uint256(uint160(middleware));
 
@@ -176,26 +176,26 @@ contract SlasherTests is EigenLayerTestHelper {
 
         //calling before first stake update should fail
         cheats.expectRevert("Slasher.recordStakeUpdate: Removing middleware unsuccessful");
-        slasher.recordStakeUpdate(operator,1, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,1, serveUntilBlock, insertAfter);
 
         //set up first stake update
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
 
         cheats.expectRevert("Slasher.recordStakeUpdate: cannot provide update for future block");
-        slasher.recordStakeUpdate(operator,5, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,5, serveUntilBlock, insertAfter);
         cheats.stopPrank();
 
         cheats.startPrank(middleware_2);
         //calling from unapproved middleware should fail
         cheats.expectRevert("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller");
-        slasher.recordStakeUpdate(operator,1, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,1, serveUntilBlock, insertAfter);
         cheats.stopPrank();
 
 
         cheats.startPrank(middleware);
         //should succeed when given the correct settings
         cheats.roll(5);
-        slasher.recordStakeUpdate(operator,3, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,3, serveUntilBlock, insertAfter);
         cheats.stopPrank();
     }
 
@@ -207,7 +207,7 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
 
-        uint32 serveUntil = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
         //convert the middleware node address to a node number
         uint256 insertAfter = uint256(uint160(middleware));
 
@@ -215,7 +215,7 @@ contract SlasherTests is EigenLayerTestHelper {
         //set up first stake update so sizeOf check on line179 is equal to 1
         //uint256 sizeOf = slasher.sizeOfOperatorList(operator);
         uint256 sizeOf = slasher.operatorWhitelistedContractsLinkedListSize(operator);
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         require(sizeOf + 1 == slasher.operatorWhitelistedContractsLinkedListSize(operator));
         cheats.stopPrank();
 
@@ -223,27 +223,27 @@ contract SlasherTests is EigenLayerTestHelper {
         cheats.startPrank(middleware_3);
         sizeOf = slasher.operatorWhitelistedContractsLinkedListSize(operator);
         cheats.expectRevert("Slasher.recordStakeUpdate: Caller is not the list entrant");
-        slasher.recordStakeUpdate(operator,1, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator,1, serveUntilBlock, insertAfter);
         cheats.stopPrank();
         
     }
 
-    function testOnlyRegisteredForService(address _slasher, uint32 _serveUntil) public fuzzedAddress(_slasher){
+    function testOnlyRegisteredForService(address _slasher, uint32 _serveUntilBlock) public fuzzedAddress(_slasher){
         cheats.prank(operator);
         delegation.registerAsOperator(delegationTerms);
 
         //slasher cannot call stake update unless operator has oped in
         cheats.prank(_slasher);
         cheats.expectRevert("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller");
-        slasher.recordFirstStakeUpdate(operator, _serveUntil);
+        slasher.recordFirstStakeUpdate(operator, _serveUntilBlock);
 
         cheats.prank(_slasher);
         cheats.expectRevert("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller");
-        slasher.recordStakeUpdate(operator, 1,_serveUntil,1);
+        slasher.recordStakeUpdate(operator, 1,_serveUntilBlock,1);
 
         cheats.prank(_slasher);
         cheats.expectRevert("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller");
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, _serveUntil);
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, _serveUntilBlock);
     }
 
     function testOptIn(address _operator, address _slasher) public fuzzedAddress(_slasher) fuzzedAddress(_operator){

--- a/src/test/Slasher.t.sol
+++ b/src/test/Slasher.t.sol
@@ -99,7 +99,7 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
         
-        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.number) + 1000;
         //these calls come from middlewares, we need more than 1 middleware to trigger the if clause on line 179
         // we need more than 2 middlewares to trigger the incorrect insertAfter being supplied by getCorrectValueForInsertAfter()
         cheats.startPrank(middleware);
@@ -136,26 +136,26 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
 
-        uint32 serveUntil = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.number) + 1000;
 
         cheats.startPrank(middleware_2);
         //unapproved slasher calls should fail
         cheats.expectRevert("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller");
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
 
         cheats.startPrank(middleware);
         //valid conditions should succeed
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
 
         //repeated calls to FirstStakeUpdate from the same middleware should fail.
         cheats.expectRevert("Slasher.recordFirstStakeUpdate: Appending middleware unsuccessful");
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
 
         cheats.startPrank(middleware_3);
         //sequential calls from different approved slashing middlewares should succeed
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
         
     }
@@ -168,7 +168,7 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
 
-        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.number) + 1000;
         //convert the middleware node address to a node number
         uint256 insertAfter = uint256(uint160(middleware));
 
@@ -207,7 +207,7 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware_3);
         cheats.stopPrank();
 
-        uint32 serveUntilBlock = uint32(block.timestamp) + 1000;
+        uint32 serveUntilBlock = uint32(block.number) + 1000;
         //convert the middleware node address to a node number
         uint256 insertAfter = uint256(uint160(middleware));
 
@@ -315,23 +315,23 @@ contract SlasherTests is EigenLayerTestHelper {
         slasher.optIntoSlashing(middleware);
         cheats.stopPrank();
 
-        uint32 serveUntil = 10;
+        uint32 serveUntilBlock = 10;
 
         //stake update
         cheats.prank(middleware);
-        slasher.recordFirstStakeUpdate(operator,serveUntil);
+        slasher.recordFirstStakeUpdate(operator,serveUntilBlock);
 
-        console.log("serveUntil",slasher.getMiddlewareTimesIndexServeUntil(operator,0));
-        console.log("contractCanSlashOperatorUntil",slasher.contractCanSlashOperatorUntil(operator,middleware));
+        console.log("serveUntilBlock",slasher.getMiddlewareTimesIndexServeUntilBlock(operator,0));
+        console.log("contractCanSlashOperatorUntil",slasher.contractCanSlashOperatorUntilBlock(operator,middleware));
 
         //middle can slash
         require(slasher.canSlash(operator,middleware),"middlewre should be able to slash");
 
         //revoke slashing
         cheats.prank(middleware);
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator,serveUntil);
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator,serveUntilBlock);
 
-        cheats.warp(serveUntil);
+        cheats.roll(serveUntilBlock);
         //middleware can no longer slash
         require(!slasher.canSlash(operator,middleware),"middlewre should no longer be able to slash");
     }

--- a/src/test/mocks/MiddlewareRegistryMock.sol
+++ b/src/test/mocks/MiddlewareRegistryMock.sol
@@ -33,13 +33,13 @@ contract MiddlewareRegistryMock is IRegistry, DSTest{
     }
 
     function deregisterOperator(address operator) public {
-        uint32 latestTime = serviceManager.latestTime();
-        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestTime);
+        uint32 latestServeUntilBlock = serviceManager.latestServeUntilBlock();
+        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestServeUntilBlock);
     }
 
     function propagateStakeUpdate(address operator, uint32 blockNumber, uint256 prevElement) external {
-        uint32 serveUntil = serviceManager.latestTime();
-        serviceManager.recordStakeUpdate(operator, blockNumber, serveUntil, prevElement);
+        uint32 latestServeUntilBlock = serviceManager.latestServeUntilBlock();
+        serviceManager.recordStakeUpdate(operator, blockNumber, latestServeUntilBlock, prevElement);
     }
 
     function isActiveOperator(address operator) external pure returns (bool) {

--- a/src/test/mocks/MiddlewareVoteWeigherMock.sol
+++ b/src/test/mocks/MiddlewareVoteWeigherMock.sol
@@ -42,12 +42,12 @@ contract MiddlewareVoteWeigherMock is RegistryBase {
     }
 
     function deregisterOperator(address operator) public {
-        uint32 latestTime = serviceManager.latestTime();
-        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestTime);
+        uint32 latestServeUntilBlock = serviceManager.latestServeUntilBlock();
+        serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestServeUntilBlock);
     }
 
     function propagateStakeUpdate(address operator, uint32 blockNumber, uint256 prevElement) external {
-        uint32 serveUntil = serviceManager.latestTime();
-        serviceManager.recordStakeUpdate(operator, blockNumber, serveUntil, prevElement);
+        uint32 serveUntilBlock = serviceManager.latestServeUntilBlock();
+        serviceManager.recordStakeUpdate(operator, blockNumber, serveUntilBlock, prevElement);
     }
 }

--- a/src/test/mocks/ServiceManagerMock.sol
+++ b/src/test/mocks/ServiceManagerMock.sol
@@ -28,7 +28,7 @@ contract ServiceManagerMock is IServiceManager, DSTest {
     function recordFirstStakeUpdate(address operator, uint32 serveUntil) external pure {}
 
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a stake update
-    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntil, uint256 prevElement) external pure {}
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 prevElement) external pure {}
 
     /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a final stake update (on operator deregistration)
     function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external pure {}
@@ -43,8 +43,8 @@ contract ServiceManagerMock is IServiceManager, DSTest {
         return IDelegationManager(address(0));
     }
 
-    /// @notice Returns the `latestTime` until which operators must serve.
-    function latestTime() external pure returns (uint32) {
+    /// @notice Returns the `latestServeUntilBlock` until which operators must serve.
+    function latestServeUntilBlock() external pure returns (uint32) {
         return type(uint32).max;
     }
 

--- a/src/test/mocks/SlasherMock.sol
+++ b/src/test/mocks/SlasherMock.sol
@@ -28,7 +28,7 @@ contract SlasherMock is ISlasher, Test {
 
     function recordFirstStakeUpdate(address operator, uint32 serveUntil) external{}
 
-    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntil, uint256 insertAfter) external{}
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 insertAfter) external{}
 
     function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external{}
 

--- a/src/test/mocks/SlasherMock.sol
+++ b/src/test/mocks/SlasherMock.sol
@@ -26,17 +26,17 @@ contract SlasherMock is ISlasher, Test {
 
     function resetFrozenStatus(address[] calldata frozenAddresses) external{}
 
-    function recordFirstStakeUpdate(address operator, uint32 serveUntil) external{}
+    function recordFirstStakeUpdate(address operator, uint32 serveUntilBlock) external{}
 
     function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 insertAfter) external{}
 
-    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntil) external{}
+    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntilBlock) external{}
 
     /// @notice Returns true if `slashingContract` is currently allowed to slash `toBeSlashed`.
     function canSlash(address toBeSlashed, address slashingContract) external view returns (bool){}
 
     /// @notice Returns the UTC timestamp until which `serviceContract` is allowed to slash the `operator`.
-    function contractCanSlashOperatorUntil(address operator, address serviceContract) external view returns (uint32){}
+    function contractCanSlashOperatorUntilBlock(address operator, address serviceContract) external view returns (uint32){}
 
     /// @notice Returns the block at which the `serviceContract` last updated its view of the `operator`'s stake
     function latestUpdateBlock(address operator, address serviceContract) external view returns (uint32){}
@@ -65,8 +65,8 @@ contract SlasherMock is ISlasher, Test {
     /// @notice Getter function for fetching `operatorToMiddlewareTimes[operator][index].stalestUpdateBlock`.
     function getMiddlewareTimesIndexBlock(address operator, uint32 index) external view returns(uint32){}
 
-    /// @notice Getter function for fetching `operatorToMiddlewareTimes[operator][index].latestServeUntil`.
-    function getMiddlewareTimesIndexServeUntil(address operator, uint32 index) external view returns(uint32){}
+    /// @notice Getter function for fetching `operatorToMiddlewareTimes[operator][index].latestServeUntilBlock`.
+    function getMiddlewareTimesIndexServeUntilBlock(address operator, uint32 index) external view returns(uint32){}
 
     /// @notice Getter function for fetching `_operatorToWhitelistedContractsByUpdate[operator].size`.
     function operatorWhitelistedContractsLinkedListSize(address operator) external view returns (uint256) {}

--- a/src/test/unit/SlasherUnit.t.sol
+++ b/src/test/unit/SlasherUnit.t.sol
@@ -126,7 +126,7 @@ contract SlasherUnitTests is Test {
         slasher.optIntoSlashing(contractAddress);
         cheats.stopPrank();
 
-        assertEq(slasher.contractCanSlashOperatorUntil(operator, contractAddress), MAX_CAN_SLASH_UNTIL);
+        assertEq(slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress), MAX_CAN_SLASH_UNTIL);
         require(slasher.canSlash(operator, contractAddress), "contract was not properly granted slashing permission");
     }
 
@@ -258,7 +258,7 @@ contract SlasherUnitTests is Test {
 
         linkedListLengthBefore = slasher.operatorWhitelistedContractsLinkedListSize(operator);
         middlewareDetailsBefore = slasher.whitelistedContractDetails(operator, contractAddress);
-        contractCanSlashOperatorUntilBefore = slasher.contractCanSlashOperatorUntil(operator, contractAddress);
+        contractCanSlashOperatorUntilBefore = slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress);
 
         ISlasher.MiddlewareTimes memory mostRecentMiddlewareTimesStructBefore;
         // fetch the most recent struct, if at least one exists (otherwise leave the struct uninitialized)
@@ -311,10 +311,10 @@ contract SlasherUnitTests is Test {
         middlewareDetailsAfter = slasher.whitelistedContractDetails(operator, contractAddress);
         require(middlewareDetailsAfter.latestUpdateBlock == block.number,
             "latestUpdateBlock not updated correctly");
-        require(middlewareDetailsAfter.contractCanSlashOperatorUntil == middlewareDetailsBefore.contractCanSlashOperatorUntil,
-            "contractCanSlashOperatorUntil changed unexpectedly");
-        // check that `contractCanSlashOperatorUntil` did not change
-        require(slasher.contractCanSlashOperatorUntil(operator, contractAddress) == contractCanSlashOperatorUntilBefore, "contractCanSlashOperatorUntil changed unexpectedly");
+        require(middlewareDetailsAfter.contractCanSlashOperatorUntilBlock == middlewareDetailsBefore.contractCanSlashOperatorUntilBlock,
+            "contractCanSlashOperatorUntilBlock changed unexpectedly");
+        // check that `contractCanSlashOperatorUntilBlock` did not change
+        require(slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress) == contractCanSlashOperatorUntilBefore, "contractCanSlashOperatorUntilBlock changed unexpectedly");
     }
 
     function testRecordFirstStakeUpdate_RevertsWhenPaused() external {
@@ -393,7 +393,7 @@ contract SlasherUnitTests is Test {
 
         linkedListLengthBefore = slasher.operatorWhitelistedContractsLinkedListSize(operator);
         middlewareDetailsBefore = slasher.whitelistedContractDetails(operator, contractAddress);
-        contractCanSlashOperatorUntilBefore = slasher.contractCanSlashOperatorUntil(operator, contractAddress);
+        contractCanSlashOperatorUntilBefore = slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress);
 
         // filter out invalid fuzzed inputs. "can't push a previous update"
         cheats.assume(updateBlock >= middlewareDetailsBefore.latestUpdateBlock);
@@ -446,10 +446,10 @@ contract SlasherUnitTests is Test {
         middlewareDetailsAfter = slasher.whitelistedContractDetails(operator, contractAddress);
         require(middlewareDetailsAfter.latestUpdateBlock == updateBlock,
             "latestUpdateBlock not updated correctly");
-        require(middlewareDetailsAfter.contractCanSlashOperatorUntil == middlewareDetailsBefore.contractCanSlashOperatorUntil,
+        require(middlewareDetailsAfter.contractCanSlashOperatorUntilBlock == middlewareDetailsBefore.contractCanSlashOperatorUntilBlock,
             "contractCanSlashOperatorUntil changed unexpectedly");
-        // check that `contractCanSlashOperatorUntil` did not change
-        require(slasher.contractCanSlashOperatorUntil(operator, contractAddress) == contractCanSlashOperatorUntilBefore, "contractCanSlashOperatorUntil changed unexpectedly");
+        // check that `contractCanSlashOperatorUntilBlock` did not change
+        require(slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress) == contractCanSlashOperatorUntilBefore, "contractCanSlashOperatorUntilBlock changed unexpectedly");
     }
 
     function testRecordStakeUpdate_MultipleLinkedListEntries(
@@ -632,7 +632,7 @@ contract SlasherUnitTests is Test {
         require(middlewareDetailsAfter.latestUpdateBlock == block.number,
             "latestUpdateBlock not updated correctly");
         // check that slashing ability was revoked after `serveUntilBlock`
-        require(slasher.contractCanSlashOperatorUntil(operator, contractAddress) == serveUntilBlock, "contractCanSlashOperatorUntil not set correctly");
+        require(slasher.contractCanSlashOperatorUntilBlock(operator, contractAddress) == serveUntilBlock, "contractCanSlashOperatorUntil not set correctly");
     }
 
     function testRecordLastStakeUpdateAndRevokeSlashingAbility_RevertsWhenCallerCannotSlash(

--- a/src/test/unit/SlasherUnit.t.sol
+++ b/src/test/unit/SlasherUnit.t.sol
@@ -240,17 +240,17 @@ contract SlasherUnitTests is Test {
         cheats.stopPrank();
     }
 
-    function testRecordFirstStakeUpdate(address operator, address contractAddress, uint32 serveUntil)
+    function testRecordFirstStakeUpdate(address operator, address contractAddress, uint32 serveUntilBlock)
         public
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
         testOptIntoSlashing(operator, contractAddress);
-        _testRecordFirstStakeUpdate(operator, contractAddress, serveUntil);
+        _testRecordFirstStakeUpdate(operator, contractAddress, serveUntilBlock);
     }
 
     // internal function corresponding to the bulk of the logic in `testRecordFirstStakeUpdate`, so we can reuse it elsewhere without calling `testOptIntoSlashing`
-    function _testRecordFirstStakeUpdate(address operator, address contractAddress, uint32 serveUntil)
+    function _testRecordFirstStakeUpdate(address operator, address contractAddress, uint32 serveUntilBlock)
         internal
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
@@ -268,7 +268,7 @@ contract SlasherUnitTests is Test {
         }
 
         cheats.startPrank(contractAddress);
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
 
         ISlasher.MiddlewareTimes memory mostRecentMiddlewareTimesStructAfter = slasher.operatorToMiddlewareTimes(operator, slasher.middlewareTimesLength(operator) - 1);
@@ -280,12 +280,12 @@ contract SlasherUnitTests is Test {
         // verify that the node exists
         require(nodeExists, "node does not exist");
 
-        // if the `serveUntil` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntil` must be equal to the `serveUntil` input
-        if (serveUntil > mostRecentMiddlewareTimesStructBefore.latestServeUntil) {
+        // if the `serveUntilBlock` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntilBlock` must be equal to the `serveUntilBlock` input
+        if (serveUntilBlock > mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock) {
             require(slasher.middlewareTimesLength(operator) == middlewareTimesLengthBefore + 1, "MiddlewareTimes struct not pushed to array");
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil == serveUntil, "latestServeUntil not updated correctly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock == serveUntilBlock, "latestServeUntilBlock not updated correctly");
         } else {
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil  == mostRecentMiddlewareTimesStructBefore.latestServeUntil, "latestServeUntil updated incorrectly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock  == mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock, "latestServeUntilBlock updated incorrectly");
         }
         // if this is the first MiddlewareTimes struct in the array, then an update must have been pushed and the `stalestUpdateBlock` *must* be equal to the current block
         if (middlewareTimesLengthBefore == 0) {
@@ -320,7 +320,7 @@ contract SlasherUnitTests is Test {
     function testRecordFirstStakeUpdate_RevertsWhenPaused() external {
         address operator = address(this);
         address contractAddress = address(this);
-        uint32 serveUntil = 0;
+        uint32 serveUntilBlock = 0;
         testOptIntoSlashing(operator, contractAddress);
 
         // pause first stake updates
@@ -330,50 +330,50 @@ contract SlasherUnitTests is Test {
 
         cheats.startPrank(contractAddress);
         cheats.expectRevert(bytes("Pausable: index is paused"));
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 
     function testRecordFirstStakeUpdate_RevertsWhenCallerDoesntHaveSlashingPermission() external {
         address operator = address(this);
         address contractAddress = address(this);
-        uint32 serveUntil = 0;
+        uint32 serveUntilBlock = 0;
 
         require(!slasher.canSlash(operator, contractAddress), "improper slashing permission has been given");
 
         cheats.startPrank(contractAddress);
         cheats.expectRevert(bytes("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller"));
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 
     function testRecordFirstStakeUpdate_RevertsWhenCallerAlreadyInList() external {
         address operator = address(this);
         address contractAddress = address(this);
-        uint32 serveUntil = 0;
+        uint32 serveUntilBlock = 0;
 
-        testRecordFirstStakeUpdate(operator, contractAddress, serveUntil);
+        testRecordFirstStakeUpdate(operator, contractAddress, serveUntilBlock);
 
         cheats.startPrank(contractAddress);
         cheats.expectRevert(bytes("Slasher.recordFirstStakeUpdate: Appending middleware unsuccessful"));
-        slasher.recordFirstStakeUpdate(operator, serveUntil);
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 
     function testRecordStakeUpdate(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
+        uint32 prevServeUntilBlock,
         uint32 updateBlock,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
-        testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntil);
-        _testRecordStakeUpdate(operator, contractAddress, updateBlock, serveUntil, insertAfter);
+        testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntilBlock);
+        _testRecordStakeUpdate(operator, contractAddress, updateBlock, serveUntilBlock, insertAfter);
     }
 
     // internal function corresponding to the bulk of the logic in `testRecordStakeUpdate`, so we can reuse it elsewhere without calling `testOptIntoSlashing`
@@ -381,7 +381,7 @@ contract SlasherUnitTests is Test {
         address operator,
         address contractAddress,
         uint32 updateBlock,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         internal
@@ -403,7 +403,7 @@ contract SlasherUnitTests is Test {
         ISlasher.MiddlewareTimes memory mostRecentMiddlewareTimesStructBefore = slasher.operatorToMiddlewareTimes(operator, middlewareTimesLengthBefore - 1);
 
         cheats.startPrank(contractAddress);
-        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
 
         ISlasher.MiddlewareTimes memory mostRecentMiddlewareTimesStructAfter = slasher.operatorToMiddlewareTimes(operator, slasher.middlewareTimesLength(operator) - 1);
@@ -415,12 +415,12 @@ contract SlasherUnitTests is Test {
         // verify that the node exists
         require(nodeExists, "node does not exist");
 
-        // if the `serveUntil` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntil` must be equal to the `serveUntil` input
-        if (serveUntil > mostRecentMiddlewareTimesStructBefore.latestServeUntil) {
+        // if the `serveUntilBlock` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntilBlock` must be equal to the `serveUntilBlock` input
+        if (serveUntilBlock > mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock) {
             require(slasher.middlewareTimesLength(operator) == middlewareTimesLengthBefore + 1, "MiddlewareTimes struct not pushed to array");
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil == serveUntil, "latestServeUntil not updated correctly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock == serveUntilBlock, "latestServeUntilBlock not updated correctly");
         } else {
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil  == mostRecentMiddlewareTimesStructBefore.latestServeUntil, "latestServeUntil updated incorrectly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock  == mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock, "latestServeUntilBlock updated incorrectly");
         }
         // if this is the first MiddlewareTimes struct in the array, then an update must have been pushed and the `stalestUpdateBlock` *must* be equal to the current block
         if (middlewareTimesLengthBefore == 0) {
@@ -455,9 +455,9 @@ contract SlasherUnitTests is Test {
     function testRecordStakeUpdate_MultipleLinkedListEntries(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
+        uint32 prevServeUntilBlock,
         uint32 updateBlock,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
@@ -466,14 +466,14 @@ contract SlasherUnitTests is Test {
     {
         address _contractAddress = address(this);
         cheats.assume(contractAddress != _contractAddress);
-        testRecordFirstStakeUpdate(operator, _contractAddress, prevServeUntil);
-        testRecordStakeUpdate(operator, contractAddress, prevServeUntil, updateBlock, serveUntil, insertAfter);
+        testRecordFirstStakeUpdate(operator, _contractAddress, prevServeUntilBlock);
+        testRecordStakeUpdate(operator, contractAddress, prevServeUntilBlock, updateBlock, serveUntilBlock, insertAfter);
     }
 
     function testRecordStakeUpdate_RevertsWhenCallerNotAlreadyInList(
         address operator,
         address contractAddress,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
@@ -486,15 +486,15 @@ contract SlasherUnitTests is Test {
 
         cheats.expectRevert(bytes("Slasher.recordStakeUpdate: Removing middleware unsuccessful"));
         cheats.startPrank(contractAddress);
-        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
     }
 
     function testRecordStakeUpdate_RevertsWhenCallerNotAlreadyInList_MultipleLinkedListEntries(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
-        uint32 serveUntil,
+        uint32 prevServeUntilBlock,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
@@ -506,19 +506,19 @@ contract SlasherUnitTests is Test {
 
         cheats.assume(contractAddress != _contractAddress);
 
-        testRecordFirstStakeUpdate(operator, _contractAddress, prevServeUntil);
+        testRecordFirstStakeUpdate(operator, _contractAddress, prevServeUntilBlock);
         testOptIntoSlashing(operator, contractAddress);
 
         cheats.expectRevert(bytes("Slasher.recordStakeUpdate: Caller is not the list entrant"));
         cheats.startPrank(contractAddress);
-        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
     }
 
     function testRecordStakeUpdate_RevertsWhenCallerCannotSlash(
         address operator,
         address contractAddress,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
@@ -528,7 +528,7 @@ contract SlasherUnitTests is Test {
         uint32 updateBlock = 0;
         cheats.expectRevert(bytes("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller"));
         cheats.startPrank(contractAddress);
-        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
     }
 
@@ -536,9 +536,9 @@ contract SlasherUnitTests is Test {
     function testRecordStakeUpdate_RevertsWhenUpdateBlockInFuture(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
+        uint32 prevServeUntilBlock,
         uint32 updateBlock,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
@@ -548,30 +548,30 @@ contract SlasherUnitTests is Test {
         // filter to appropriate fuzzed inputs (appropriate for causing reverts!)
         cheats.assume(updateBlock > block.number);
 
-        testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntil);
+        testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntilBlock);
 
         cheats.expectRevert(bytes("Slasher.recordStakeUpdate: cannot provide update for future block"));
         cheats.startPrank(contractAddress);
-        slasher.recordStakeUpdate(operator, updateBlock, serveUntil, insertAfter);
+        slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, insertAfter);
         cheats.stopPrank();
     }
 
     function testRecordLastStakeUpdateAndRevokeSlashingAbility(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
+        uint32 prevServeUntilBlock,
         uint32 updateBlock,
-        uint32 serveUntil,
+        uint32 serveUntilBlock,
         uint256 insertAfter
     )
         public
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
-        // filter out setting the `serveUntil` time to the MAX, since the contract will revert in this instance.
-        cheats.assume(serveUntil != MAX_CAN_SLASH_UNTIL);
+        // filter out setting the `serveUntilBlock` time to the MAX, since the contract will revert in this instance.
+        cheats.assume(serveUntilBlock != MAX_CAN_SLASH_UNTIL);
 
-        testRecordStakeUpdate_MultipleLinkedListEntries(operator, contractAddress, prevServeUntil, updateBlock, serveUntil, insertAfter);
+        testRecordStakeUpdate_MultipleLinkedListEntries(operator, contractAddress, prevServeUntilBlock, updateBlock, serveUntilBlock, insertAfter);
 
         linkedListLengthBefore = slasher.operatorWhitelistedContractsLinkedListSize(operator);
         middlewareDetailsBefore = slasher.whitelistedContractDetails(operator, contractAddress);
@@ -589,7 +589,7 @@ contract SlasherUnitTests is Test {
 
         // perform the last stake update and revoke slashing ability, from the `contractAddress`
         cheats.startPrank(contractAddress);
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntil);
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntilBlock);
         cheats.stopPrank();
 
         ISlasher.MiddlewareTimes memory mostRecentMiddlewareTimesStructAfter = slasher.operatorToMiddlewareTimes(operator, slasher.middlewareTimesLength(operator) - 1);
@@ -600,12 +600,12 @@ contract SlasherUnitTests is Test {
         (nodeExists, /*prevNode*/, /*nextNode*/) = slasher.operatorWhitelistedContractsLinkedListEntry(operator, contractAddress);
         require(!nodeExists, "node exists when it should have been deleted");
 
-        // if the `serveUntil` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntil` must be equal to the `serveUntil` input
-        if (serveUntil > mostRecentMiddlewareTimesStructBefore.latestServeUntil) {
+        // if the `serveUntilBlock` time is greater than the previous maximum, then an update must have been pushed and the `latestServeUntilBlock` must be equal to the `serveUntilBlock` input
+        if (serveUntilBlock > mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock) {
             require(slasher.middlewareTimesLength(operator) == middlewareTimesLengthBefore + 1, "MiddlewareTimes struct not pushed to array");
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil == serveUntil, "latestServeUntil not updated correctly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock == serveUntilBlock, "latestServeUntilBlock not updated correctly");
         } else {
-            require(mostRecentMiddlewareTimesStructAfter.latestServeUntil  == mostRecentMiddlewareTimesStructBefore.latestServeUntil, "latestServeUntil updated incorrectly");
+            require(mostRecentMiddlewareTimesStructAfter.latestServeUntilBlock  == mostRecentMiddlewareTimesStructBefore.latestServeUntilBlock, "latestServeUntilBlock updated incorrectly");
         }
         // if this is the first MiddlewareTimes struct in the array, then an update must have been pushed and the `stalestUpdateBlock` *must* be equal to the current block
         if (middlewareTimesLengthBefore == 0) {
@@ -631,52 +631,52 @@ contract SlasherUnitTests is Test {
         middlewareDetailsAfter = slasher.whitelistedContractDetails(operator, contractAddress);
         require(middlewareDetailsAfter.latestUpdateBlock == block.number,
             "latestUpdateBlock not updated correctly");
-        // check that slashing ability was revoked after `serveUntil`
-        require(slasher.contractCanSlashOperatorUntil(operator, contractAddress) == serveUntil, "contractCanSlashOperatorUntil not set correctly");
+        // check that slashing ability was revoked after `serveUntilBlock`
+        require(slasher.contractCanSlashOperatorUntil(operator, contractAddress) == serveUntilBlock, "contractCanSlashOperatorUntil not set correctly");
     }
 
     function testRecordLastStakeUpdateAndRevokeSlashingAbility_RevertsWhenCallerCannotSlash(
         address operator,
         address contractAddress,
-        uint32 serveUntil
+        uint32 serveUntilBlock
     )
         public
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
-        // filter out setting the `serveUntil` time to the MAX, since the contract will revert in this instance.
-        cheats.assume(serveUntil != MAX_CAN_SLASH_UNTIL);
+        // filter out setting the `serveUntilBlock` time to the MAX, since the contract will revert in this instance.
+        cheats.assume(serveUntilBlock != MAX_CAN_SLASH_UNTIL);
 
         cheats.expectRevert(bytes("Slasher.onlyRegisteredForService: Operator has not opted into slashing by caller"));
         cheats.startPrank(contractAddress);
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntil);
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 
     function testRecordLastStakeUpdateAndRevokeSlashingAbility_RevertsWhenCallerNotAlreadyInList(
         address operator,
         address contractAddress,
-        uint32 serveUntil
+        uint32 serveUntilBlock
     )
         public
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
-        // filter out setting the `serveUntil` time to the MAX, since the contract will revert in this instance.
-        cheats.assume(serveUntil != MAX_CAN_SLASH_UNTIL);
+        // filter out setting the `serveUntilBlock` time to the MAX, since the contract will revert in this instance.
+        cheats.assume(serveUntilBlock != MAX_CAN_SLASH_UNTIL);
 
         testOptIntoSlashing(operator, contractAddress);
 
         cheats.expectRevert(bytes("Slasher.recordLastStakeUpdateAndRevokeSlashingAbility: Removing middleware unsuccessful"));
         cheats.startPrank(contractAddress);
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntil);
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 
-    function testRecordLastStakeUpdateAndRevokeSlashingAbility_RevertsWhenServeUntilInputIsMax(
+    function testRecordLastStakeUpdateAndRevokeSlashingAbility_RevertsWhenServeUntilBlockInputIsMax(
         address operator,
         address contractAddress,
-        uint32 prevServeUntil,
+        uint32 prevServeUntilBlock,
         uint32 updateBlock,
         uint256 insertAfter
     )
@@ -684,17 +684,17 @@ contract SlasherUnitTests is Test {
         filterFuzzedAddressInputs(operator)
         filterFuzzedAddressInputs(contractAddress)
     {
-        uint32 serveUntil = MAX_CAN_SLASH_UNTIL;
+        uint32 serveUntilBlock = MAX_CAN_SLASH_UNTIL;
 
         testOptIntoSlashing(operator, contractAddress);
 
-        _testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntil);
-        _testRecordStakeUpdate(operator, contractAddress, updateBlock, prevServeUntil, insertAfter);
+        _testRecordFirstStakeUpdate(operator, contractAddress, prevServeUntilBlock);
+        _testRecordStakeUpdate(operator, contractAddress, updateBlock, prevServeUntilBlock, insertAfter);
 
         // perform the last stake update and revoke slashing ability, from the `contractAddress`
         cheats.startPrank(contractAddress);
-        cheats.expectRevert(bytes("Slasher._revokeSlashingAbility: serveUntil time must be limited"));
-        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntil);
+        cheats.expectRevert(bytes("Slasher._revokeSlashingAbility: serveUntilBlock time must be limited"));
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntilBlock);
         cheats.stopPrank();
     }
 


### PR DESCRIPTION
We want to keep the updateBlock/latestServeUntil(block) logic consistent, so this switches the slasher to denominate entirely in blocks.