### PR TITLE
correct licensing

### DIFF
--- a/src/contracts/libraries/BN254.sol
+++ b/src/contracts/libraries/BN254.sol
@@ -17,7 +17,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-// The remainder of the code is written by LayrLabs Inc. and UNLICENSED
+// The remainder of the code is written by LayrLabs Inc. and is under the BUSL-1.1 license
 
 pragma solidity =0.8.12;
 

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENCED
+// SPDX-License-Identifier: BUSL-1.1
 
 pragma solidity =0.8.12;
 

--- a/src/contracts/libraries/Merkle.sol
+++ b/src/contracts/libraries/Merkle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENCED
+// SPDX-License-Identifier: BUSL-1.1
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (utils/cryptography/MerkleProof.sol)
 
 pragma solidity =0.8.12;


### PR DESCRIPTION
as noted in https://github.com/Layr-Labs/eigenlayer-contracts/issues/8, looks like we missed a few license notes/identifiers, probably mostly due to typos of 'UNLICENCED' instead of 'UNLICENSED'