### PR TITLE
Add new prover rule

### DIFF
--- a/certora/harnesses/StrategyManagerHarness.sol
+++ b/certora/harnesses/StrategyManagerHarness.sol
@@ -8,6 +8,58 @@ contract StrategyManagerHarness is StrategyManager {
         StrategyManager(_delegation, _eigenPodManager, _slasher)
         {}
 
+    function slashSharesSinglet(
+        address slashedAddress,
+        address recipient,
+        IStrategy strategy,
+        IERC20 token,
+        uint256 strategyIndex,
+        uint256 shareAmount
+    )
+        external
+        onlyOwner
+        onlyFrozen(slashedAddress)
+        nonReentrant
+    {
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = strategy;
+        IERC20[] memory tokens = new IERC20[](1);
+        tokens[0] = token;
+        uint256[] memory strategyIndexes = new uint256[](1);
+        strategyIndexes[0] = strategyIndex;
+        uint256[] memory shareAmounts = new uint256[](1);
+        shareAmounts[0] = shareAmount;
+        require(tokens.length == strategies.length, "StrategyManager.slashShares: input length mismatch");
+        uint256 strategyIndexIndex;
+        uint256 strategiesLength = strategies.length;
+        for (uint256 i = 0; i < strategiesLength;) {
+            // the internal function will return 'true' in the event the strategy was
+            // removed from the slashedAddress's array of strategies -- i.e. stakerStrategyList[slashedAddress]
+            if (_removeShares(slashedAddress, strategyIndexes[strategyIndexIndex], strategies[i], shareAmounts[i])) {
+                unchecked {
+                    ++strategyIndexIndex;
+                }
+            }
+
+            if (strategies[i] == beaconChainETHStrategy) {
+                 //withdraw the beaconChainETH to the recipient
+                _withdrawBeaconChainETH(slashedAddress, recipient, shareAmounts[i]);
+            }
+            else {
+                // withdraw the shares and send funds to the recipient
+                strategies[i].withdraw(recipient, tokens[i], shareAmounts[i]);
+            }
+
+            // increment the loop
+            unchecked {
+                ++i;
+            }
+        }
+
+        // modify delegated shares accordingly, if applicable
+        delegation.decreaseDelegatedShares(slashedAddress, strategies, shareAmounts);
+    }
+
     function strategy_is_in_stakers_array(address staker, IStrategy strategy) public view returns (bool) {
         uint256 length = stakerStrategyList[staker].length;
         for (uint256 i = 0; i < length; ++i) {

--- a/certora/specs/core/Slasher.spec
+++ b/certora/specs/core/Slasher.spec
@@ -143,12 +143,11 @@ invariant listHeadHasSmallestValueOfLatestUpdateBlock(address operator, uint256 
 */
 
 /*
-TODO: rule doesn't pass.
+TODO: rule doesn't pass. We've got separate rules for checking the LinkedList lib properties.
 key properties seem to be that
 1) `StructuredLinkedList._createLink` creates only two-way links
 2) `StructuredLinkedList.remove` removes both links from a node, and stiches together its existing links (which it breaks)
 3) `StructuredLinkedList._insert` similarly inserts a new node 'between' nodes, ensuring that the new node is well-linked
-*/
 invariant consistentListStructure(address operator, uint256 node1)
 	(
 	// either node1 doesn't exist
@@ -157,6 +156,7 @@ invariant consistentListStructure(address operator, uint256 node1)
 	||
 	nodeIsWellLinked(operator, node1)
 	)
+*/
 
 /* TODO: assess if this rule is salvageable. seems to have poor storage assumptions due to the way 'node existence' is defined
 rule cannotAddSameContractTwice(address operator, address contractAddress) {

--- a/certora/specs/core/StrategyManager.spec
+++ b/certora/specs/core/StrategyManager.spec
@@ -1,3 +1,5 @@
+// to allow calling ERC20 token within this spec
+using ERC20 as token
 
 methods {
     //// External Calls
@@ -27,6 +29,8 @@ methods {
 
 	// external calls to EigenPodManager
 	withdrawRestakedBeaconChainETH(address,address,uint256) => DISPATCHER(true)
+    // call made to EigenPodManager by DelayedWithdrawalRouter
+    getPod(address) => DISPATCHER(true)
 
     // external calls to EigenPod (from EigenPodManager)
     withdrawRestakedBeaconChainETH(address, uint256) => DISPATCHER(true)
@@ -46,6 +50,9 @@ methods {
     balanceOf(address) returns (uint256) => DISPATCHER(true)
     transfer(address, uint256) returns (bool) => DISPATCHER(true)
     transferFrom(address, address, uint256) returns (bool) => DISPATCHER(true)
+
+    // calls to ERC20 in this spec
+    token.balanceOf(address) returns(uint256) envfree
 
     // external calls to ERC1271 (can import OpenZeppelin mock implementation)
     // isValidSignature(bytes32 hash, bytes memory signature) returns (bytes4 magicValue) => DISPATCHER(true)
@@ -138,3 +145,21 @@ invariant totalSharesGeqSumOfShares(address strategy)
         // require strategy != beaconChainETHStrategy();
         require strategy != 1088545275507480024404324736574744392984337050304;
     } }
+
+/**
+ * Verifies that ERC20 tokens are transferred out of the account only of the msg.sender.
+ * Called 'safeApprovalUse' since approval-related vulnerabilites in general allow a caller to transfer tokens out of a different account.
+ * This behavior is not always unsafe, but since we don't ever use it (at present) we can do a blanket-check against it.
+ */
+rule safeApprovalUse(address user) {
+    uint256 tokenBalanceBefore = token.balanceOf(user);
+    method f;
+    env e;
+    calldataarg args;
+    f(e,args);
+    uint256 tokenBalanceAfter = token.balanceOf(user);
+    if (tokenBalanceAfter < tokenBalanceBefore) {
+        assert(e.msg.sender == user, "unsafeApprovalUse?");
+    }
+    assert true;
+}

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -8,10 +8,9 @@ import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
 import "@openzeppelin-upgrades/contracts/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "../interfaces/IEigenPodManager.sol";
 import "../permissions/Pausable.sol";
 import "./StrategyManagerStorage.sol";
-import "../interfaces/IServiceManager.sol";
-import "../interfaces/IEigenPodManager.sol";
 
 /**
  * @title The primary entry- and exit-point for funds into and out of EigenLayer.


### PR DESCRIPTION
Inspired by SushiSwap router hack. Add a Prover rule that shows that we never transfer tokens out of an account other than the caller. (or conversely, if a user's token balance decreases as the result of a call to our contract(s), then that user must be the caller).
PR also comments out an old (failing) draft rule.