### PR TITLE
Allowing for flexible fork testing w/ foundry

### DIFF
--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -34,23 +34,22 @@ contract DelegationTests is EigenLayerTestHelper {
     function setUp() public virtual override {
         EigenLayerDeployer.setUp();
 
+        // if(vm.envUint("DEPLOYMENT_ID") == 1){
+        //     cheats.startPrank(communityMultisig);
+        // }
         initializeMiddlewares();
     }
 
     function initializeMiddlewares() public {
         serviceManager = new ServiceManagerMock(slasher);
 
-        emit log("heheehhe");
 
         voteWeigher = MiddlewareVoteWeigherMock(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
-        emit log("heheehhe");
 
 
         voteWeigherImplementation = new MiddlewareVoteWeigherMock(delegation, strategyManager, serviceManager);
-         emit log("heheehhe");
-
 
         {
             uint96 multiplier = 1e18;
@@ -68,11 +67,13 @@ contract DelegationTests is EigenLayerTestHelper {
             eigenStratsAndMultipliers[0].strategy = eigenStrat;
             eigenStratsAndMultipliers[0].multiplier = multiplier;
 
+            cheats.startPrank(communityMultisig);
             eigenLayerProxyAdmin.upgradeAndCall(
                 TransparentUpgradeableProxy(payable(address(voteWeigher))),
                 address(voteWeigherImplementation),
                 abi.encodeWithSelector(MiddlewareVoteWeigherMock.initialize.selector, _quorumBips, ethStratsAndMultipliers, eigenStratsAndMultipliers)
             );
+            cheats.stopPrank();
         }
     }
 

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -40,11 +40,17 @@ contract DelegationTests is EigenLayerTestHelper {
     function initializeMiddlewares() public {
         serviceManager = new ServiceManagerMock(slasher);
 
+        emit log("heheehhe");
+
         voteWeigher = MiddlewareVoteWeigherMock(
             address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
         );
+        emit log("heheehhe");
+
 
         voteWeigherImplementation = new MiddlewareVoteWeigherMock(delegation, strategyManager, serviceManager);
+         emit log("heheehhe");
+
 
         {
             uint96 multiplier = 1e18;

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -101,6 +101,7 @@ contract EigenLayerDeployer is Operators {
     address eigenPodBeaconAddress;
     address beaconChainOracleAddress;
     address emptyContractAddress;
+    address communityMultisig;
 
     uint256 goerliFork;
 
@@ -151,7 +152,7 @@ contract EigenLayerDeployer is Operators {
 
         emptyContract = new EmptyContract();
         
-        emit log_named_uint("emptyContract ADDRESS", address(emptyContract).code.length);
+        emit log_named_address("emptyContract ADDRESS", eigenLayerProxyAdmin.owner());
 
         //deploy pauser registry
         eigenLayerPauserReg = PauserRegistry(eigenLayerPauserRegAddress);
@@ -365,6 +366,8 @@ contract EigenLayerDeployer is Operators {
         eigenPodManagerAddress = stdJson.readAddress(goerliDeploymentConfig, ".addresses.eigenPodManager"); 
         delayedWithdrawalRouterAddress = stdJson.readAddress(goerliDeploymentConfig, ".addresses.delayedWithdrawalRouter");
         emptyContractAddress = stdJson.readAddress(goerliDeploymentConfig, ".addresses.emptyContract");
+        communityMultisig = stdJson.readAddress(goerliDeploymentConfig, ".parameters.communityMultisig");
+        
     }
     
 }


### PR DESCRIPTION
Adding provisions for flexible fork testing w/ foundry for already deployed contracts on testnet/mainnet