### PR TITLE
Small gas optimization

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -150,23 +150,20 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         external
         onlyStrategyManager
     {
-        //if the staker is delegated to an operator
-        if (isDelegated(staker)) {
-            address operator = delegatedTo[staker];
+        address operator = delegatedTo[staker];
 
-            // add strategy shares to delegate's shares
-            operatorShares[operator][strategy] += shares;
+        // add strategy shares to delegate's shares
+        operatorShares[operator][strategy] += shares;
 
-            //Calls into operator's delegationTerms contract to update weights of individual staker
-            IStrategy[] memory stakerStrategyList = new IStrategy[](1);
-            uint256[] memory stakerShares = new uint[](1);
-            stakerStrategyList[0] = strategy;
-            stakerShares[0] = shares;
+        //Calls into operator's delegationTerms contract to update weights of individual staker
+        IStrategy[] memory stakerStrategyList = new IStrategy[](1);
+        uint256[] memory stakerShares = new uint[](1);
+        stakerStrategyList[0] = strategy;
+        stakerShares[0] = shares;
 
-            // call into hook in delegationTerms contract
-            IDelegationTerms dt = delegationTerms[operator];
-            _delegationReceivedHook(dt, staker, stakerStrategyList, stakerShares);
-        }
+        // call into hook in delegationTerms contract
+        IDelegationTerms dt = delegationTerms[operator];
+        _delegationReceivedHook(dt, staker, stakerStrategyList, stakerShares);
     }
 
     /**

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -643,8 +643,10 @@ contract StrategyManager is
         // add the returned shares to their existing shares for this strategy
         stakerStrategyShares[depositor][strategy] += shares;
 
-        // if applicable, increase delegated shares accordingly
-        delegation.increaseDelegatedShares(depositor, strategy, shares);
+        if (delegation.isDelegated(depositor)) {
+            // if applicable, increase delegated shares accordingly
+            delegation.increaseDelegatedShares(depositor, strategy, shares);
+        }
     }
 
     /**

--- a/src/contracts/strategies/StrategyBase.sol
+++ b/src/contracts/strategies/StrategyBase.sol
@@ -157,7 +157,7 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
         // Decrease the `totalShares` value to reflect the withdrawal
         totalShares = priorTotalShares - amountShares;
 
-        underlyingToken.safeTransfer(depositor, amountToSend);
+        token.safeTransfer(depositor, amountToSend);
     }
 
     /**


### PR DESCRIPTION
- Use `token` passed as arg instead of reading from storage (One less SLOAD)
- Check if staker is delegator before calling to increase delegate shares