### PR TITLE
Reuse Existing Unit Tests for strategyWithTVLLimits

### DIFF
--- a/src/test/unit/StrategyBaseTVLLimitsUnit.sol
+++ b/src/test/unit/StrategyBaseTVLLimitsUnit.sol
@@ -1,66 +1,48 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
-import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "./StrategyBaseUnit.t.sol";
 
-import "../../contracts/strategies/StrategyBase.sol";
 import "../../contracts/strategies/StrategyBaseTVLLimits.sol";
-import "../../contracts/permissions/PauserRegistry.sol";
 
-import "../mocks/StrategyManagerMock.sol";
-import "../mocks/ERC20_SetTransferReverting_Mock.sol";
-
-import "forge-std/Test.sol";
-
-contract StrategyBaseTVLLimitsUnitTests is Test {
-
-    Vm cheats = Vm(HEVM_ADDRESS);
-
-    ProxyAdmin public proxyAdmin;
-    PauserRegistry public pauserRegistry;
-    IStrategyManager public strategyManager;
-    IERC20 public underlyingToken;
+contract StrategyBaseTVLLimitsUnitTests is StrategyBaseUnitTests {
     StrategyBaseTVLLimits public strategyBaseTVLLimitsImplementation;
-    StrategyBaseTVLLimits public strategy;
+    StrategyBaseTVLLimits public strategyWithTVLLimits;
 
-    address public pauser = address(555);
-    address public unpauser = address(999);
+    // defaults for tests, used in setup
+    uint256 maxTotalDeposits = 32e18;
+    uint256 maxPerDeposit = 3200e18;
 
-    uint256 initialSupply = 1e65;
-    address initialOwner = address(this);
+    function setUp() virtual public override {
+        // copy setup for StrategyBaseUnitTests
+        StrategyBaseUnitTests.setUp();
 
-    uint256 maxDeposits = 100;
-    uint256 maxPerDeposit = 5;
-
-    function setUp() virtual public {
-        proxyAdmin = new ProxyAdmin();
-
-        pauserRegistry = new PauserRegistry(pauser, unpauser);
-
-        strategyManager = new StrategyManagerMock();
-
-        underlyingToken = new ERC20PresetFixedSupply("Test Token", "TEST", initialSupply, initialOwner);
-
+        // depoloy the TVL-limited strategy
         strategyBaseTVLLimitsImplementation = new StrategyBaseTVLLimits(strategyManager);
-
-        strategy = StrategyBaseTVLLimits(
+        strategyWithTVLLimits = StrategyBaseTVLLimits(
             address(
                 new TransparentUpgradeableProxy(
                     address(strategyBaseTVLLimitsImplementation),
                     address(proxyAdmin),
-                    abi.encodeWithSelector(StrategyBase.initialize.selector, underlyingToken, pauserRegistry)
+                    abi.encodeWithSelector(StrategyBaseTVLLimits.initialize.selector, maxPerDeposit, maxTotalDeposits, underlyingToken, pauserRegistry)
                 )
             )
         );
+
+        // verify that limits were set up correctly
+        require(strategyWithTVLLimits.maxTotalDeposits() == maxTotalDeposits, "bad test setup");
+        require(strategyWithTVLLimits.maxPerDeposit() == maxPerDeposit, "bad test setup");
+
+        // replace the strategy from the non-TVL-limited tests with the TVL-limited strategy
+        // this should result in all the StrategyBaseUnitTests also running against the `StrategyBaseTVLLimits` contract
+        strategy = strategyWithTVLLimits;
     }
 
     function testSetTVLLimits(uint256 maxDepositsFuzzedInput, uint256 maxPerDepositFuzzedInput) public {
         cheats.startPrank(pauser);
-        strategy.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
+        strategyWithTVLLimits.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
         cheats.stopPrank();
-        (uint256 _maxPerDeposit, uint256 _maxDeposits) = strategy.getTVLLimits();
+        (uint256 _maxPerDeposit, uint256 _maxDeposits) = strategyWithTVLLimits.getTVLLimits();
 
         assertEq(_maxPerDeposit, maxPerDepositFuzzedInput);
         assertEq(_maxDeposits, maxDepositsFuzzedInput);
@@ -71,67 +53,67 @@ contract StrategyBaseTVLLimitsUnitTests is Test {
         cheats.assume(notPauser != pauser);
         cheats.startPrank(notPauser);
         cheats.expectRevert(bytes("msg.sender is not permissioned as pauser"));
-        strategy.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
+        strategyWithTVLLimits.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
         cheats.stopPrank();
     }
 
     function testDepositMoreThanMaxPerDeposit(uint256 maxDepositsFuzzedInput, uint256 maxPerDepositFuzzedInput, uint256 amount) public {
         cheats.assume(amount > maxPerDepositFuzzedInput);
         cheats.startPrank(pauser);
-        strategy.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
+        strategyWithTVLLimits.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
         cheats.stopPrank();
 
         cheats.startPrank(address(strategyManager));
         cheats.expectRevert(bytes("StrategyBaseTVLLimits: max per deposit exceeded"));
-        strategy.deposit(underlyingToken, amount);
+        strategyWithTVLLimits.deposit(underlyingToken, amount);
         cheats.stopPrank();
     }
 
     function testDepositMorethanMaxDeposits() public {
-        maxDeposits = 1e12;
+        maxTotalDeposits = 1e12;
         maxPerDeposit = 3e11;
-        uint256 numDeposits = maxDeposits / maxPerDeposit;
+        uint256 numDeposits = maxTotalDeposits / maxPerDeposit;
 
-        underlyingToken.transfer(address(strategyManager), maxDeposits);
+        underlyingToken.transfer(address(strategyManager), maxTotalDeposits);
         cheats.startPrank(pauser);
-        strategy.setTVLLimits(maxPerDeposit, maxDeposits);
+        strategyWithTVLLimits.setTVLLimits(maxPerDeposit, maxTotalDeposits);
         cheats.stopPrank();
 
         cheats.startPrank(address(strategyManager));
         for (uint256 i = 0; i < numDeposits; i++) {
-            underlyingToken.transfer(address(strategy), maxPerDeposit);
-            strategy.deposit(underlyingToken, maxPerDeposit);
+            underlyingToken.transfer(address(strategyWithTVLLimits), maxPerDeposit);
+            strategyWithTVLLimits.deposit(underlyingToken, maxPerDeposit);
         }
         cheats.stopPrank();
 
-        underlyingToken.transfer(address(strategy), maxPerDeposit);
-        require(underlyingToken.balanceOf(address(strategy)) > maxDeposits, "bad test setup");
+        underlyingToken.transfer(address(strategyWithTVLLimits), maxPerDeposit);
+        require(underlyingToken.balanceOf(address(strategyWithTVLLimits)) > maxTotalDeposits, "bad test setup");
 
         cheats.startPrank(address(strategyManager));
         cheats.expectRevert(bytes("StrategyBaseTVLLimits: max deposits exceeded"));
-        strategy.deposit(underlyingToken, maxPerDeposit);
+        strategyWithTVLLimits.deposit(underlyingToken, maxPerDeposit);
         cheats.stopPrank();
     }
 
     function testDepositValidAmount(uint256 depositAmount) public {
-        maxDeposits = 1e12;
+        maxTotalDeposits = 1e12;
         maxPerDeposit = 3e11;
         cheats.assume(depositAmount > 0);
         cheats.assume(depositAmount < maxPerDeposit);
 
         cheats.startPrank(pauser);
-        strategy.setTVLLimits(maxPerDeposit, maxDeposits);
+        strategyWithTVLLimits.setTVLLimits(maxPerDeposit, maxTotalDeposits);
         cheats.stopPrank();
 
         // we need to actually transfer the tokens to the strategy to avoid underflow in the `deposit` calculation
-        underlyingToken.transfer(address(strategy), depositAmount);
+        underlyingToken.transfer(address(strategyWithTVLLimits), depositAmount);
 
-        uint256 sharesBefore = strategy.totalShares();
+        uint256 sharesBefore = strategyWithTVLLimits.totalShares();
         cheats.startPrank(address(strategyManager));
-        strategy.deposit(underlyingToken, depositAmount);
+        strategyWithTVLLimits.deposit(underlyingToken, depositAmount);
         cheats.stopPrank();
 
-        require(strategy.totalShares() == depositAmount + sharesBefore, "total shares not updated correctly");
+        require(strategyWithTVLLimits.totalShares() == depositAmount + sharesBefore, "total shares not updated correctly");
     }
 
     /// @notice General-purpose test, re-useable, handles whether the deposit should revert or not and returns 'true' if it did revert.
@@ -142,51 +124,51 @@ contract StrategyBaseTVLLimitsUnitTests is Test {
         cheats.assume(depositAmount <= initialSupply);
         // set TVL limits
         cheats.startPrank(pauser);
-        strategy.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
+        strategyWithTVLLimits.setTVLLimits(maxPerDepositFuzzedInput, maxDepositsFuzzedInput);
         cheats.stopPrank();
 
         // we need to calculate this before transferring tokens to the strategy
-        uint256 expectedSharesOut = strategy.underlyingToShares(depositAmount);
+        uint256 expectedSharesOut = strategyWithTVLLimits.underlyingToShares(depositAmount);
 
         // we need to actually transfer the tokens to the strategy to avoid underflow in the `deposit` calculation
-        underlyingToken.transfer(address(strategy), depositAmount);
+        underlyingToken.transfer(address(strategyWithTVLLimits), depositAmount);
 
         if (depositAmount > maxPerDepositFuzzedInput) {
             cheats.startPrank(address(strategyManager));
             cheats.expectRevert("StrategyBaseTVLLimits: max per deposit exceeded");
-            strategy.deposit(underlyingToken, depositAmount);
+            strategyWithTVLLimits.deposit(underlyingToken, depositAmount);
             cheats.stopPrank();
 
             // transfer the tokens back from the strategy to not mess up the state
-            cheats.startPrank(address(strategy));
+            cheats.startPrank(address(strategyWithTVLLimits));
             underlyingToken.transfer(address(this), depositAmount);
             cheats.stopPrank();
 
             // return 'true' since the call to `deposit` reverted
             return true;
-        } else if (underlyingToken.balanceOf(address(strategy)) > maxDepositsFuzzedInput) {
+        } else if (underlyingToken.balanceOf(address(strategyWithTVLLimits)) > maxDepositsFuzzedInput) {
             cheats.startPrank(address(strategyManager));
             cheats.expectRevert("StrategyBaseTVLLimits: max deposits exceeded");
-            strategy.deposit(underlyingToken, depositAmount);
+            strategyWithTVLLimits.deposit(underlyingToken, depositAmount);
             cheats.stopPrank();
 
             // transfer the tokens back from the strategy to not mess up the state
-            cheats.startPrank(address(strategy));
+            cheats.startPrank(address(strategyWithTVLLimits));
             underlyingToken.transfer(address(this), depositAmount);
             cheats.stopPrank();
 
             // return 'true' since the call to `deposit` reverted
             return true;
         } else {
-            uint256 totalSharesBefore = strategy.totalShares();
+            uint256 totalSharesBefore = strategyWithTVLLimits.totalShares();
             if (expectedSharesOut == 0) {
                 cheats.startPrank(address(strategyManager));
                 cheats.expectRevert("StrategyBase.deposit: newShares cannot be zero");
-                strategy.deposit(underlyingToken, depositAmount);
+                strategyWithTVLLimits.deposit(underlyingToken, depositAmount);
                 cheats.stopPrank();
 
                 // transfer the tokens back from the strategy to not mess up the state
-                cheats.startPrank(address(strategy));
+                cheats.startPrank(address(strategyWithTVLLimits));
                 underlyingToken.transfer(address(this), depositAmount);
                 cheats.stopPrank();
 
@@ -194,10 +176,10 @@ contract StrategyBaseTVLLimitsUnitTests is Test {
                 return true;
             } else {
                 cheats.startPrank(address(strategyManager));
-                strategy.deposit(underlyingToken, depositAmount);
+                strategyWithTVLLimits.deposit(underlyingToken, depositAmount);
                 cheats.stopPrank();
 
-                require(strategy.totalShares() == expectedSharesOut + totalSharesBefore, "total shares not updated correctly");
+                require(strategyWithTVLLimits.totalShares() == expectedSharesOut + totalSharesBefore, "total shares not updated correctly");
 
                 // return 'false' since the call to `deposit` succeeded
                 return false;
@@ -205,4 +187,51 @@ contract StrategyBaseTVLLimitsUnitTests is Test {
         }
     }
 
+    /// OVERRIDING EXISTING TESTS TO FILTER INPUTS THAT WOULD FAIL DUE TO DEPOSIT-LIMITING
+    modifier filterToValidDepositAmounts(uint256 amountToDeposit) {
+        (uint256 _maxPerDeposit, uint256 _maxTotalDeposits) = strategyWithTVLLimits.getTVLLimits();
+        cheats.assume(amountToDeposit <= _maxPerDeposit && amountToDeposit <= _maxTotalDeposits);
+        _;
+    }
+
+    function testCanWithdrawDownToSmallShares(uint256 amountToDeposit, uint32 sharesToLeave) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testCanWithdrawDownToSmallShares(amountToDeposit, sharesToLeave);
+    }
+
+    function testDepositWithNonzeroPriorBalanceAndNonzeroPriorShares(uint256 priorTotalShares, uint256 amountToDeposit
+    ) public virtual override filterToValidDepositAmounts(priorTotalShares) filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testDepositWithNonzeroPriorBalanceAndNonzeroPriorShares(priorTotalShares, amountToDeposit);
+    }
+
+    function testDepositWithZeroPriorBalanceAndZeroPriorShares(uint256 amountToDeposit) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
+    }
+
+    function testIntegrityOfSharesToUnderlyingWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountSharesToQuery
+    ) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testIntegrityOfSharesToUnderlyingWithNonzeroTotalShares(amountToDeposit, amountToTransfer, amountSharesToQuery);
+    }
+
+    function testIntegrityOfUnderlyingToSharesWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountUnderlyingToQuery
+    ) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testIntegrityOfUnderlyingToSharesWithNonzeroTotalShares(amountToDeposit, amountToTransfer, amountUnderlyingToQuery);
+    }
+
+    function testWithdrawFailsWhenSharesGreaterThanTotalShares(uint256 amountToDeposit, uint256 sharesToWithdraw
+    ) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testWithdrawFailsWhenSharesGreaterThanTotalShares(amountToDeposit, sharesToWithdraw);
+    }
+
+    function testWithdrawFailsWhenWithdrawalsPaused(uint256 amountToDeposit) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testWithdrawFailsWhenWithdrawalsPaused(amountToDeposit);
+    }
+
+    function testWithdrawWithPriorTotalSharesAndAmountSharesEqual(uint256 amountToDeposit) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testWithdrawWithPriorTotalSharesAndAmountSharesEqual(amountToDeposit);
+    }
+
+    function testWithdrawWithPriorTotalSharesAndAmountSharesNotEqual(uint96 amountToDeposit, uint96 sharesToWithdraw
+    ) public virtual override filterToValidDepositAmounts(amountToDeposit) {
+        StrategyBaseUnitTests.testWithdrawWithPriorTotalSharesAndAmountSharesNotEqual(amountToDeposit, sharesToWithdraw);
+    }
 }

--- a/src/test/unit/StrategyBaseTVLLimitsUnit.sol
+++ b/src/test/unit/StrategyBaseTVLLimitsUnit.sol
@@ -10,8 +10,8 @@ contract StrategyBaseTVLLimitsUnitTests is StrategyBaseUnitTests {
     StrategyBaseTVLLimits public strategyWithTVLLimits;
 
     // defaults for tests, used in setup
-    uint256 maxTotalDeposits = 32e18;
-    uint256 maxPerDeposit = 3200e18;
+    uint256 maxTotalDeposits = 3200e18;
+    uint256 maxPerDeposit = 32e18;
 
     function setUp() virtual public override {
         // copy setup for StrategyBaseUnitTests

--- a/src/test/unit/StrategyBaseUnit.t.sol
+++ b/src/test/unit/StrategyBaseUnit.t.sol
@@ -27,7 +27,7 @@ contract StrategyBaseUnitTests is Test {
     address public pauser = address(555);
     address public unpauser = address(999);
 
-    uint256 initialSupply = 1e24;
+    uint256 initialSupply = 1e36;
     address initialOwner = address(this);
 
     /**
@@ -79,7 +79,7 @@ contract StrategyBaseUnitTests is Test {
         cheats.stopPrank();
     }
 
-    function testDepositWithZeroPriorBalanceAndZeroPriorShares(uint256 amountToDeposit) public {
+    function testDepositWithZeroPriorBalanceAndZeroPriorShares(uint256 amountToDeposit) public virtual {
         // sanity check / filter
         cheats.assume(amountToDeposit <= underlyingToken.balanceOf(address(this)));
         cheats.assume(amountToDeposit >= 1);
@@ -97,7 +97,7 @@ contract StrategyBaseUnitTests is Test {
         require(totalSharesAfter - totalSharesBefore == newShares, "totalSharesAfter - totalSharesBefore != newShares");
     }
 
-    function testDepositWithNonzeroPriorBalanceAndNonzeroPriorShares(uint256 priorTotalShares, uint256 amountToDeposit) public {
+    function testDepositWithNonzeroPriorBalanceAndNonzeroPriorShares(uint256 priorTotalShares, uint256 amountToDeposit) public virtual {
         cheats.assume(priorTotalShares >= 1 && amountToDeposit > 0);
 
         testDepositWithZeroPriorBalanceAndZeroPriorShares(priorTotalShares);
@@ -156,7 +156,7 @@ contract StrategyBaseUnitTests is Test {
         cheats.stopPrank();
     }
 
-    function testWithdrawWithPriorTotalSharesAndAmountSharesEqual(uint256 amountToDeposit) public {
+    function testWithdrawWithPriorTotalSharesAndAmountSharesEqual(uint256 amountToDeposit) public virtual {
         cheats.assume(amountToDeposit >= 1);
         testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
 
@@ -175,7 +175,7 @@ contract StrategyBaseUnitTests is Test {
         require(tokenBalanceAfter - tokenBalanceBefore == strategyBalanceBefore, "tokenBalanceAfter - tokenBalanceBefore != strategyBalanceBefore");
     }
 
-    function testWithdrawWithPriorTotalSharesAndAmountSharesNotEqual(uint96 amountToDeposit, uint96 sharesToWithdraw) public {
+    function testWithdrawWithPriorTotalSharesAndAmountSharesNotEqual(uint96 amountToDeposit, uint96 sharesToWithdraw) public virtual {
         cheats.assume(amountToDeposit >= 1);
         testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
 
@@ -197,7 +197,7 @@ contract StrategyBaseUnitTests is Test {
             "token balance did not increase appropriately");
     }
 
-    function testWithdrawFailsWhenWithdrawalsPaused(uint256 amountToDeposit) public {
+    function testWithdrawFailsWhenWithdrawalsPaused(uint256 amountToDeposit) public virtual {
         cheats.assume(amountToDeposit >= 1);
         testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
 
@@ -239,7 +239,7 @@ contract StrategyBaseUnitTests is Test {
         cheats.stopPrank();
     }
 
-    function testWithdrawFailsWhenSharesGreaterThanTotalShares(uint256 amountToDeposit, uint256 sharesToWithdraw) public {
+    function testWithdrawFailsWhenSharesGreaterThanTotalShares(uint256 amountToDeposit, uint256 sharesToWithdraw) public virtual {
         cheats.assume(amountToDeposit >= 1);
         testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
 
@@ -289,7 +289,8 @@ contract StrategyBaseUnitTests is Test {
     }
 
     // amountSharesToQuery input is uint96 to prevent overflow
-    function testIntegrityOfSharesToUnderlyingWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountSharesToQuery) public {
+    function testIntegrityOfSharesToUnderlyingWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountSharesToQuery
+    ) public virtual {
         // sanity check / filter
         cheats.assume(amountToDeposit <= underlyingToken.balanceOf(address(this)));
         cheats.assume(amountToDeposit >= 1);
@@ -311,7 +312,8 @@ contract StrategyBaseUnitTests is Test {
     }
 
     // amountUnderlyingToQuery input is uint96 to prevent overflow
-    function testIntegrityOfUnderlyingToSharesWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountUnderlyingToQuery) public {
+    function testIntegrityOfUnderlyingToSharesWithNonzeroTotalShares(uint256 amountToDeposit, uint256 amountToTransfer, uint96 amountUnderlyingToQuery
+    ) public virtual {
         // sanity check / filter
         cheats.assume(amountToDeposit <= underlyingToken.balanceOf(address(this)));
         cheats.assume(amountToDeposit >= 1);
@@ -332,7 +334,7 @@ contract StrategyBaseUnitTests is Test {
     }
 
     // verify that small remaining share amounts (nonzero in particular) are allowed
-    function testCanWithdrawDownToSmallShares(uint256 amountToDeposit, uint32 sharesToLeave) public {
+    function testCanWithdrawDownToSmallShares(uint256 amountToDeposit, uint32 sharesToLeave) public virtual {
         cheats.assume(amountToDeposit >= 1);
         testDepositWithZeroPriorBalanceAndZeroPriorShares(amountToDeposit);
 


### PR DESCRIPTION
make StrategyBaseTVLLimitsUnitTests also run the existing StrategyBaseUnitTests against the strategyWithTVLLimits

- have StrategyBaseTVLLimitsUnitTests inherit from StrategyBaseUnitTests
- modify setup so existing tests run against version with TVL limits
- add filtering for fuzzed inputs to existing tests
- fix initialization and add a check for this