### PR TITLE
added indexregistry

### DIFF
--- a/src/contracts/interfaces/IIndexRegistry.sol
+++ b/src/contracts/interfaces/IIndexRegistry.sol
@@ -8,6 +8,12 @@ import "./IRegistry.sol";
  * @author Layr Labs, Inc.
  */
 interface IIndexRegistry is IRegistry {
+    // EVENTS
+    // emitted when an operator's index in at quorum operator list is updated
+    event QuorumIndexUpdate(bytes32 indexed operatorId, uint8 quorumNumber, uint32 newIndex);
+    // emitted when an operator's index in the global operator list is updated
+    event GlobalIndexUpdate(bytes32 indexed operatorId, uint32 newIndex);
+
     // DATA STRUCTURES
 
     // struct used to give definitive ordering to operators at each blockNumber

--- a/src/contracts/interfaces/IIndexRegistry.sol
+++ b/src/contracts/interfaces/IIndexRegistry.sol
@@ -31,10 +31,11 @@ interface IIndexRegistry is IRegistry {
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
-     * @param indexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
+     * @param quorumToOperatorListIndexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
+     * @param globalOperatorListIndex is the index of the operator that is to be removed from the list;
      * @dev access restricted to the RegistryCoordinator
      */
-    function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory indexes) external;
+    function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external;
 
     /**
      * @notice Looks up the `operator`'s index for `quorumNumber` at the specified `blockNumber` using the `index`.

--- a/src/contracts/interfaces/IIndexRegistry.sol
+++ b/src/contracts/interfaces/IIndexRegistry.sol
@@ -31,11 +31,11 @@ interface IIndexRegistry is IRegistry {
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
-     * @param quorumToOperatorListIndexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
+     * @param operatorIdsToSwap is the list of operatorIds that are to be swapped with the last operator in the list for each quorum
      * @param globalOperatorListIndex is the index of the operator that is to be removed from the list
      * @dev access restricted to the RegistryCoordinator
      */
-    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external;
+    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers, bytes32[] memory operatorIdsToSwap, uint32 globalOperatorListIndex) external;
 
     /**
      * @notice Looks up the `operator`'s index for `quorumNumber` at the specified `blockNumber` using the `index`.

--- a/src/contracts/interfaces/IIndexRegistry.sol
+++ b/src/contracts/interfaces/IIndexRegistry.sol
@@ -32,7 +32,7 @@ interface IIndexRegistry is IRegistry {
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
      * @param quorumToOperatorListIndexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
-     * @param globalOperatorListIndex is the index of the operator that is to be removed from the list;
+     * @param globalOperatorListIndex is the index of the operator that is to be removed from the list
      * @dev access restricted to the RegistryCoordinator
      */
     function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external;

--- a/src/contracts/interfaces/IIndexRegistry.sol
+++ b/src/contracts/interfaces/IIndexRegistry.sol
@@ -25,7 +25,7 @@ interface IIndexRegistry is IRegistry {
      * @param quorumNumbers is the quorum numbers the operator is registered for
      * @dev access restricted to the RegistryCoordinator
      */
-    function registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) external;
+    function registerOperator(bytes32 operatorId, bytes calldata quorumNumbers) external;
 
     /**
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
@@ -35,7 +35,7 @@ interface IIndexRegistry is IRegistry {
      * @param globalOperatorListIndex is the index of the operator that is to be removed from the list
      * @dev access restricted to the RegistryCoordinator
      */
-    function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external;
+    function deregisterOperator(bytes32 operatorId, bytes calldata quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external;
 
     /**
      * @notice Looks up the `operator`'s index for `quorumNumber` at the specified `blockNumber` using the `index`.

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+
+import "../interfaces/IIndexRegistry.sol";
+import "../interfaces/IRegistryCoordinator.sol";
+import "../libraries/BN254.sol";
+
+
+contract IndexRegistry is IIndexRegistry {
+
+    IRegistryCoordinator registryCoordinator;
+    
+    bytes32[] public globalOperatorList;
+    mapping(uint8 => bytes32[]) public quorumToOperatorList;
+
+    mapping(bytes32 => mapping(uint8 => OperatorIndex[])) operatorIdToIndexHistory;
+    mapping(uint8 => OperatorIndex[]) totalOperatorsHistory;
+
+    modifier onlyRegistryCoordinator() {
+        require(msg.sender == address(registryCoordinator), "IndexRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
+        _;
+    }
+
+    constructor(
+        IRegistryCoordinator _registryCoordinator
+    ){
+        registryCoordinator = _registryCoordinator;
+
+    }
+    function registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) external onlyRegistryCoordinator {
+        //add operator to operatorList
+        for (uint i = 0; i < quorumNumbers.length; i++) {
+            uint8 quorumNumber = quorumNumbers[i];
+            quorumToOperatorList[quorumNumber].push(operatorId);
+            globalOperatorList.push(operatorId);
+
+            _updateOperatorIdToIndexHistory(operatorId, quorumNumber);
+            _updateTotalOperatorHistory(quorumNumber);
+        }
+    }
+
+    function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external onlyRegistryCoordinator {
+        require(quorumNumbers.length == indexes.length, "IndexRegistry.deregisterOperator: quorumNumbers and indexes must be the same length");
+
+        for (uint i = 0; i < quorumNumbers.length; i++) {
+            uint8 quorumNumber = quorumNumbers[i];
+
+            _removeOperatorFromQuorumToOperatorList(quorumNumber, quorumToOperatorListIndexes[i]);
+            _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
+            _updateTotalOperatorHistory(quorumNumber);
+        }
+    }
+
+    /**
+     * @notice Looks up the `operator`'s index for `quorumNumber` at the specified `blockNumber` using the `index`.
+     * @param operatorId is the id of the operator for which the index is desired
+     * @param quorumNumber is the quorum number for which the operator index is desired
+     * @param blockNumber is the block number at which the index of the operator is desired
+     * @param index Used to specify the entry within the dynamic array `operatorIdToIndexHistory[operatorId]` to 
+     * read data from
+     * @dev Function will revert in the event that the specified `index` input does not identify the appropriate entry in the
+     * array `operatorIdToIndexHistory[operatorId][quorumNumber]` to pull the info from.
+     */
+    function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
+        OperatorIndex memory operatorIndexToCheck = operatorIdToIndexHistory[operatorId][quorumNumber][index];
+        
+        require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+
+        if(index < operatorIdToIndexHistory[operatorId][quorumNumber].length - 1){
+            OperatorIndex memory nextOperatorIndex = operatorIdToIndexHistory[operatorId][quorumNumber][index + 1];
+            require(blockNumber < nextOperatorIndex.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number")
+        }
+        return operatorIndexToCheck.index;
+    }
+
+    /**
+     * @notice Looks up the number of total operators for `quorumNumber` at the specified `blockNumber`.
+     * @param quorumNumber is the quorum number for which the total number of operators is desired
+     * @param blockNumber is the block number at which the total number of operators is desired
+     * @param index is the index of the entry in the dynamic array `totalOperatorsHistory[quorumNumber]` to read data from
+     */
+    function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
+        OperatorIndex memory operatorIndexToCheck = totalOperatorsHistory[quorumNumber][index];
+
+        require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+        if(index < totalOperatorsHistory[quorumNumber].length - 1){
+            OperatorIndex memory nextOperatorIndex = totalOperatorsHistory[quorumNumber][index + 1];
+            require(blockNumber < nextOperatorIndex.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number")
+        }
+        return operatorIndexToCheck.index;
+    }
+
+    function totalOperatorsForQuorum(uint8 quorumNumber) external view returns (uint32){
+        return uint32(quorumToOperatorList[quorumNumber].length);
+    }
+
+
+    /// @notice Returns the current number of operators of this service.
+    function totalOperators() external view returns (uint32){
+        return numOperators;
+    }
+
+
+    function _updateTotalOperatorHistory(uint8 quorumNumber, uint256 numOperators) internal {
+        uint256 numOperators = quorumToOperatorList[quorumNumber].length;
+
+        OperatorIndex memory totalOperatorUpdate = OperatorIndex({
+            blockNumber: block.number,
+            index: uint32(numOperators)
+        });
+        totalOperatorsHistory[quorumNumber].push(totalOperatorUpdate);
+    }
+
+    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber) internal {
+        if (operatorIdToIndexHistoryLength > 0) {
+            uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length;
+            operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = block.number;
+        }
+        OperatorIndex memory latestOperatorIndex;
+        latestOperatorIndex.index = quorumToOperatorList[quorumNumber].length - 1;
+        operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
+    }
+
+
+    function _removeOperatorFromQuorumToOperatorList(uint8 quorumNumber, uint32 indexToRemove) internal {   
+
+        quorumToOperatorListLastIndex  = quorumToOperatorList[quorumNumber].length - 1;
+
+        if(indexToRemove != quorumToOperatorListLastIndex){
+            bytes32 operatorIdToSwap = quorumToOperatorList[quorumNumber][quorumToOperatorListLastIndex];
+            //update the swapped operator's
+            _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber);
+
+            quorumToOperatorList[quorumNumber][indexToRemove] = operatorIdToSwap;
+        }
+        quorumToOperatorList[quorumNumber].pop();
+    }
+
+    function _removeOperatorFromGlobalOperatorList(uint32 indexToRemove) internal {
+        uint32 globalOperatorListLastIndex = globalOperatorList.length - 1;
+
+        if(indexToRemove != globalOperatorListLastIndex){
+            bytes32 operatorIdToSwap = globalOperatorList[globalOperatorListLastIndex];
+            globalOperatorList[indexToRemove] = operatorIdToSwap;
+        }
+        globalOperatorList.pop();
+    }
+
+
+}

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -29,11 +29,11 @@ contract IndexRegistry is IIndexRegistry {
     }
     function registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) external onlyRegistryCoordinator {
         //add operator to operatorList
+        globalOperatorList.push(operatorId);
+
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = quorumNumbers[i];
             quorumToOperatorList[quorumNumber].push(operatorId);
-            globalOperatorList.push(operatorId);
-
             _updateOperatorIdToIndexHistory(operatorId, quorumNumber);
             _updateTotalOperatorHistory(quorumNumber);
         }
@@ -45,7 +45,6 @@ contract IndexRegistry is IIndexRegistry {
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = quorumNumbers[i];
-
             _removeOperatorFromQuorumToOperatorList(quorumNumber, quorumToOperatorListIndexes[i]);
             _updateTotalOperatorHistory(quorumNumber);
         }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -130,7 +130,8 @@ contract IndexRegistry is IIndexRegistry {
         }
 
         OperatorIndex memory totalOperatorUpdate;
-        totalOperatorUpdate.index = quorumToOperatorList[quorumNumber].length - 1;
+        // In the case of totalOperatorsHistory, the index parameter is the number of operators in the quorum
+        totalOperatorUpdate.index = quorumToOperatorList[quorumNumber].length;
         totalOperatorsHistory[quorumNumber].push(totalOperatorUpdate);
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -73,9 +73,6 @@ contract IndexRegistry is IIndexRegistry, Test {
         require(quorumNumbers.length == operatorIdsToSwap.length, "IndexRegistry.deregisterOperator: quorumNumbers and operatorIdsToSwap must be the same length");
 
         _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
-
-        
-
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             uint32 indexToRemove = operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].index;
@@ -175,10 +172,7 @@ contract IndexRegistry is IIndexRegistry, Test {
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
     function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 operatorIdToSwap) internal {   
-        uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
-        emit log("hehe");
-        uint32 operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].index;
-        emit log("hehe");
+        uint32 operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index;
         require(quorumToTotalOperatorCount[quorumNumber] - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum");
 
         // if the operator is not the last in the list, we must swap the last operator into their positon
@@ -187,7 +181,7 @@ contract IndexRegistry is IIndexRegistry, Test {
             _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber, indexToRemove);
         } else {
             //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
-            operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = uint32(block.number);
+            operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = uint32(block.number);
         }
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -52,7 +52,7 @@ contract IndexRegistry is IIndexRegistry, Test {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             _updateOperatorIdToIndexHistory(operatorId, quorumNumber, quorumToTotalOperatorCount[quorumNumber]);
             _updateTotalOperatorHistory(quorumNumber);
-            quorumToTotalOperatorCount[quorumNumber]++;
+            quorumToTotalOperatorCount[quorumNumber] += 1;
         }
     }
 
@@ -173,8 +173,8 @@ contract IndexRegistry is IIndexRegistry, Test {
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
     function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 memory operatorIdToSwap) internal {   
-        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index
-        require(totalOperatorsForQuorum(quorumNumber) - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum")
+        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index;
+        require(totalOperatorsForQuorum(quorumNumber) - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum");
 
         // if the operator is not the last in the list, we must swap the last operator into their positon
         if(operatorId != operatorIdToSwap){

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -61,6 +61,10 @@ contract IndexRegistry is IIndexRegistry {
     function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = operatorIdToIndexHistory[operatorId][quorumNumber][index];
         require(blockNumber <= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+        if(index != 0){
+            OperatorIndex memory previousOperatorIndex = operatorIdToIndexHistory[operatorId][quorumNumber][index - 1];
+            require(blockNumber > previousOperatorIndex.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number");
+        }
         return operatorIndexToCheck.index;
     }
 
@@ -72,8 +76,11 @@ contract IndexRegistry is IIndexRegistry {
      */
     function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = totalOperatorsHistory[quorumNumber][index];
-
         require(blockNumber <= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+        if expression(index != 0){
+            OperatorIndex memory previousOperatorIndex = totalOperatorsHistory[quorumNumber][index - 1];
+            require(blockNumber > previousOperatorIndex.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number");
+        }
         return operatorIndexToCheck.index;
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -74,6 +74,8 @@ contract IndexRegistry is IIndexRegistry, Test {
 
         _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
 
+        
+
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
             uint32 indexToRemove = operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].index;
@@ -172,10 +174,12 @@ contract IndexRegistry is IIndexRegistry, Test {
     ///         as well as any operatorIds we have to swap
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
-    function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 memory operatorIdToSwap) internal {   
+    function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 operatorIdToSwap) internal {   
         uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
-        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].index;
-        require(totalOperatorsForQuorum(quorumNumber) - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum");
+        emit log("hehe");
+        uint32 operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].index;
+        emit log("hehe");
+        require(quorumToTotalOperatorCount[quorumNumber] - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum");
 
         // if the operator is not the last in the list, we must swap the last operator into their positon
         if(operatorId != operatorIdToSwap){

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -61,11 +61,6 @@ contract IndexRegistry is IIndexRegistry {
     function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = operatorIdToIndexHistory[operatorId][quorumNumber][index];
         require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
-
-        if(index < operatorIdToIndexHistory[operatorId][quorumNumber].length - 1){
-            OperatorIndex memory nextOperatorIndex = operatorIdToIndexHistory[operatorId][quorumNumber][index + 1];
-            require(blockNumber < nextOperatorIndex.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number")
-        }
         return operatorIndexToCheck.index;
     }
 
@@ -79,10 +74,6 @@ contract IndexRegistry is IIndexRegistry {
         OperatorIndex memory operatorIndexToCheck = totalOperatorsHistory[quorumNumber][index];
 
         require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
-        if(index < totalOperatorsHistory[quorumNumber].length - 1){
-            OperatorIndex memory nextOperatorIndex = totalOperatorsHistory[quorumNumber][index + 1];
-            require(blockNumber < nextOperatorIndex.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number")
-        }
         return operatorIndexToCheck.index;
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -116,7 +116,7 @@ contract IndexRegistry is IIndexRegistry {
 
     function _removeOperatorFromQuorumToOperatorList(uint8 quorumNumber, uint32 indexToRemove) internal {   
 
-        quorumToOperatorListLastIndex  = quorumToOperatorList[quorumNumber].length - 1;
+        uint32 quorumToOperatorListLastIndex  = uint32(quorumToOperatorList[quorumNumber].length - 1);
 
         if(indexToRemove != quorumToOperatorListLastIndex){
             bytes32 operatorIdToSwap = quorumToOperatorList[quorumNumber][quorumToOperatorListLastIndex];
@@ -125,6 +125,8 @@ contract IndexRegistry is IIndexRegistry {
 
             quorumToOperatorList[quorumNumber][indexToRemove] = operatorIdToSwap;
         }
+        //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
+        operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = block.number;
         quorumToOperatorList[quorumNumber].pop();
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -50,7 +50,8 @@ contract IndexRegistry is IIndexRegistry, Test {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
 
             //this is the would-be index of the operator being registered, the total number of operators for that quorum (which is last index + 1)
-            uint32 numOperators = totalOperatorsHistory[quorumNumber].length > 0 ? totalOperatorsHistory[quorumNumber][totalOperatorsHistory[quorumNumber].length - 1].index : 0;
+            uint256 quorumHistoryLength = totalOperatorsHistory[quorumNumber].length;
+            uint32 numOperators = quorumHistoryLength > 0 ? totalOperatorsHistory[quorumNumber][quorumHistoryLength - 1].index : 0;
             _updateOperatorIdToIndexHistory(operatorId, quorumNumber, numOperators);
             _updateTotalOperatorHistory(quorumNumber, numOperators + 1);
         }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -60,7 +60,6 @@ contract IndexRegistry is IIndexRegistry, Test {
      * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
      * @param operatorId is the id of the operator that is being deregistered
      * @param quorumNumbers is the quorum numbers the operator is deregistered for
-     * @param quorumToOperatorListIndexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
      * @param globalOperatorListIndex is the index of the operator that is to be removed from the list
      * @dev access restricted to the RegistryCoordinator
      * @dev Preconditions:
@@ -150,14 +149,14 @@ contract IndexRegistry is IIndexRegistry, Test {
 
         OperatorIndex memory totalOperatorUpdate;
         // In the case of totalOperatorsHistory, the index parameter is the number of operators in the quorum
-        totalOperatorUpdate.index = uint32(quorumToOperatorList[quorumNumber].length);
+        totalOperatorUpdate.index = quorumToTotalOperatorCount[quorumNumber];
         totalOperatorsHistory[quorumNumber].push(totalOperatorUpdate);
     }
 
     /// 
     /// @param operatorId operatorId of the operator to update
     /// @param quorumNumber quorumNumber of the operator to update
-    /// @param index the latest index of that operator in quorumToOperatorList
+    /// @param index the latest index of that operator in the list of operators registered for this quorum
     function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
         uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
         //if there is a prior entry for the operator, set the previous entry's toBlocknumber
@@ -169,8 +168,8 @@ contract IndexRegistry is IIndexRegistry, Test {
         operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
     }
 
-    /// @notice when we remove an operator from quorumToOperatorList, we swap the last operator in 
-    ///         quorumToOperatorList[quorumNumber] to the position of the operator we are removing
+    /// @notice when we remove an operator from a quorum, we simply update the operator's index history
+    ///         as well as any operatorIds we have to swap
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
     function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 memory operatorIdToSwap) internal {   

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -179,10 +179,10 @@ contract IndexRegistry is IIndexRegistry, Test {
         if(operatorId != operatorIdToSwap){
             //update the swapped operator's operatorIdToIndexHistory list with a new entry, as their index has now changed
             _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber, indexToRemove);
-        } else {
-            //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
-            operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = uint32(block.number);
-        }
+        } 
+        //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
+        operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = uint32(block.number);
+        
     }
 
     /// @notice remove an operator from the globalOperatorList  

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -9,12 +9,12 @@ import "../libraries/BN254.sol";
 
 contract IndexRegistry is IIndexRegistry {
 
-    IRegistryCoordinator registryCoordinator;
+    IRegistryCoordinator public registryCoordinator;
     bytes32[] public globalOperatorList;
 
     mapping(uint8 => bytes32[]) public quorumToOperatorList;
-    mapping(bytes32 => mapping(uint8 => OperatorIndex[])) operatorIdToIndexHistory;
-    mapping(uint8 => OperatorIndex[]) totalOperatorsHistory;
+    mapping(bytes32 => mapping(uint8 => OperatorIndex[])) public operatorIdToIndexHistory;
+    mapping(uint8 => OperatorIndex[]) public totalOperatorsHistory;
 
     modifier onlyRegistryCoordinator() {
         require(msg.sender == address(registryCoordinator), "IndexRegistry.onlyRegistryCoordinator: caller is not the registry coordinator");
@@ -25,7 +25,6 @@ contract IndexRegistry is IIndexRegistry {
         IRegistryCoordinator _registryCoordinator
     ){
         registryCoordinator = _registryCoordinator;
-
     }
     function registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) external onlyRegistryCoordinator {
         //add operator to operatorList
@@ -77,7 +76,7 @@ contract IndexRegistry is IIndexRegistry {
     function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = totalOperatorsHistory[quorumNumber][index];
         require(blockNumber <= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
-        if expression(index != 0){
+        if (index != 0){
             OperatorIndex memory previousOperatorIndex = totalOperatorsHistory[quorumNumber][index - 1];
             require(blockNumber > previousOperatorIndex.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the past for provided block number");
         }
@@ -95,20 +94,19 @@ contract IndexRegistry is IIndexRegistry {
     }
 
 
-    function _updateTotalOperatorHistory(uint8 quorumNumber, uint256 numOperators) internal {
-        uint256 numOperators = quorumToOperatorList[quorumNumber].length;
+    function _updateTotalOperatorHistory(uint8 quorumNumber) internal {
+        if (totalOperatorsHistory[quorumNumber].length > 0) {
+            totalOperatorsHistory[quorumNumber][totalOperatorsHistory[quorumNumber].length - 1].toBlockNumber = block.number;
+        }
 
-        OperatorIndex memory totalOperatorUpdate = OperatorIndex({
-            blockNumber: block.number,
-            index: uint32(numOperators)
-        });
+        OperatorIndex memory totalOperatorUpdate;
+        totalOperatorUpdate.index = quorumToOperatorList[quorumNumber].length - 1;
         totalOperatorsHistory[quorumNumber].push(totalOperatorUpdate);
     }
 
     function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber) internal {
         if (operatorIdToIndexHistoryLength > 0) {
-            uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length;
-            operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = block.number;
+            operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length; - 1].toBlockNumber = block.number;
         }
         OperatorIndex memory latestOperatorIndex;
         latestOperatorIndex.index = quorumToOperatorList[quorumNumber].length - 1;

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -44,7 +44,7 @@ contract IndexRegistry is IIndexRegistry {
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             quorumToOperatorList[quorumNumber].push(operatorId);
-            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i]);
+            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i], quorumToOperatorList[quorumNumber].length - 1);
             _updateTotalOperatorHistory(quorumNumbers[i]);
         }
     }
@@ -139,7 +139,7 @@ contract IndexRegistry is IIndexRegistry {
     /// @param operatorId operatorId of the operator to update
     /// @param quorumNumber quorumNumber of the operator to update
     /// @param index the latest index of that operator in quorumToOperatorList
-    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber) internal {
+    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
         uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
 
         //if there is a prior entry for the operator, set the previous entry's toBlocknumber
@@ -147,7 +147,7 @@ contract IndexRegistry is IIndexRegistry {
             operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = block.number;
         }
         OperatorIndex memory latestOperatorIndex;
-        latestOperatorIndex.index = quorumToOperatorList[quorumNumber].length - 1;
+        latestOperatorIndex.index = index;
         operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -32,7 +32,7 @@ contract IndexRegistry is IIndexRegistry {
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             quorumToOperatorList[quorumNumber].push(operatorId);
-            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i]);
+            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i], quorumToOperatorList[quorumNumber].length - 1);
             _updateTotalOperatorHistory(quorumNumbers[i]);
         }
     }
@@ -104,12 +104,12 @@ contract IndexRegistry is IIndexRegistry {
         totalOperatorsHistory[quorumNumber].push(totalOperatorUpdate);
     }
 
-    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber) internal {
+    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
         if (operatorIdToIndexHistoryLength > 0) {
             operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length; - 1].toBlockNumber = block.number;
         }
         OperatorIndex memory latestOperatorIndex;
-        latestOperatorIndex.index = quorumToOperatorList[quorumNumber].length - 1;
+        latestOperatorIndex.index = index; 
         operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
     }
 
@@ -121,7 +121,7 @@ contract IndexRegistry is IIndexRegistry {
         if(indexToRemove != quorumToOperatorListLastIndex){
             bytes32 operatorIdToSwap = quorumToOperatorList[quorumNumber][quorumToOperatorListLastIndex];
             //update the swapped operator's
-            _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber);
+            _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber, indexToRemove);
 
             quorumToOperatorList[quorumNumber][indexToRemove] = operatorIdToSwap;
         }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -10,10 +10,15 @@ import "../libraries/BN254.sol";
 contract IndexRegistry is IIndexRegistry {
 
     IRegistryCoordinator public registryCoordinator;
+
+    // list of all unique registered operators
     bytes32[] public globalOperatorList;
 
+    // mapping of quorumNumber => list of operators registered for that quorum
     mapping(uint8 => bytes32[]) public quorumToOperatorList;
+    // mapping of operatorId => quorumNumber => index history of that operator
     mapping(bytes32 => mapping(uint8 => OperatorIndex[])) public operatorIdToIndexHistory;
+    // mapping of quorumNumber => history of numbers of unique registered operators
     mapping(uint8 => OperatorIndex[]) public totalOperatorsHistory;
 
     modifier onlyRegistryCoordinator() {
@@ -39,7 +44,7 @@ contract IndexRegistry is IIndexRegistry {
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             quorumToOperatorList[quorumNumber].push(operatorId);
-            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i], quorumToOperatorList[quorumNumber].length - 1);
+            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i]);
             _updateTotalOperatorHistory(quorumNumbers[i]);
         }
     }
@@ -133,7 +138,7 @@ contract IndexRegistry is IIndexRegistry {
     /// @param operatorId operatorId of the operator to update
     /// @param quorumNumber quorumNumber of the operator to update
     /// @param index the latest index of that operator in quorumToOperatorList
-    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
+    function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber) internal {
         uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
 
         //if there is a prior entry for the operator, set the previous entry's toBlocknumber
@@ -141,7 +146,7 @@ contract IndexRegistry is IIndexRegistry {
             operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = block.number;
         }
         OperatorIndex memory latestOperatorIndex;
-        latestOperatorIndex.index = index; 
+        latestOperatorIndex.index = quorumToOperatorList[quorumNumber].length - 1;
         operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -173,6 +173,9 @@ contract IndexRegistry is IIndexRegistry, Test {
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
     function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 memory operatorIdToSwap) internal {   
+        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index
+        require(totalOperatorsForQuorum(quorumNumber) - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum")
+
         // if the operator is not the last in the list, we must swap the last operator into their positon
         if(operatorId != operatorIdToSwap){
             //update the swapped operator's operatorIdToIndexHistory list with a new entry, as their index has now changed

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -165,6 +165,8 @@ contract IndexRegistry is IIndexRegistry, Test {
         OperatorIndex memory latestOperatorIndex;
         latestOperatorIndex.index = index;
         operatorIdToIndexHistory[operatorId][quorumNumber].push(latestOperatorIndex);
+
+        emit QuorumIndexUpdate(operatorId, quorumNumber, index);
     }
 
     /// @notice when we remove an operator from a quorum, we simply update the operator's index history
@@ -182,7 +184,6 @@ contract IndexRegistry is IIndexRegistry, Test {
         } 
         //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
         operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = uint32(block.number);
-        
     }
 
     /// @notice remove an operator from the globalOperatorList  
@@ -193,6 +194,7 @@ contract IndexRegistry is IIndexRegistry, Test {
         if(indexToRemove != globalOperatorListLastIndex){
             operatorIdToSwap = globalOperatorList[globalOperatorListLastIndex];
             globalOperatorList[indexToRemove] = operatorIdToSwap;
+            emit GlobalIndexUpdate(operatorIdToSwap, indexToRemove);
         }
         globalOperatorList.pop();
     }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -60,7 +60,6 @@ contract IndexRegistry is IIndexRegistry {
      */
     function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = operatorIdToIndexHistory[operatorId][quorumNumber][index];
-        
         require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
 
         if(index < operatorIdToIndexHistory[operatorId][quorumNumber].length - 1){
@@ -142,6 +141,4 @@ contract IndexRegistry is IIndexRegistry {
         }
         globalOperatorList.pop();
     }
-
-
 }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -26,6 +26,13 @@ contract IndexRegistry is IIndexRegistry {
     ){
         registryCoordinator = _registryCoordinator;
     }
+
+    /**
+     * @notice Registers the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
+     * @param operatorId is the id of the operator that is being registered
+     * @param quorumNumbers is the quorum numbers the operator is registered for
+     * @dev access restricted to the RegistryCoordinator
+     */
     function registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) external onlyRegistryCoordinator {
         //add operator to operatorList
         globalOperatorList.push(operatorId);
@@ -37,6 +44,14 @@ contract IndexRegistry is IIndexRegistry {
         }
     }
 
+    /**
+     * @notice Deregisters the operator with the specified `operatorId` for the quorums specified by `quorumBitmap`.
+     * @param operatorId is the id of the operator that is being deregistered
+     * @param quorumNumbers is the quorum numbers the operator is deregistered for
+     * @param quorumToOperatorListIndexes is an array of indexes for each quorum as witnesses for the last operators to swap for each quorum
+     * @param globalOperatorListIndex is the index of the operator that is to be removed from the list
+     * @dev access restricted to the RegistryCoordinator
+     */
     function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external onlyRegistryCoordinator {
         require(quorumNumbers.length == indexes.length, "IndexRegistry.deregisterOperator: quorumNumbers and indexes must be the same length");
         _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -32,10 +32,9 @@ contract IndexRegistry is IIndexRegistry {
         globalOperatorList.push(operatorId);
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
-            uint8 quorumNumber = quorumNumbers[i];
             quorumToOperatorList[quorumNumber].push(operatorId);
-            _updateOperatorIdToIndexHistory(operatorId, quorumNumber);
-            _updateTotalOperatorHistory(quorumNumber);
+            _updateOperatorIdToIndexHistory(operatorId, quorumNumbers[i]);
+            _updateTotalOperatorHistory(quorumNumbers[i]);
         }
     }
 
@@ -44,9 +43,8 @@ contract IndexRegistry is IIndexRegistry {
         _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
-            uint8 quorumNumber = quorumNumbers[i];
-            _removeOperatorFromQuorumToOperatorList(quorumNumber, quorumToOperatorListIndexes[i]);
-            _updateTotalOperatorHistory(quorumNumber);
+            _removeOperatorFromQuorumToOperatorList(quorumNumbers[i], quorumToOperatorListIndexes[i]);
+            _updateTotalOperatorHistory(quorumNumbers[i]);
         }
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -60,7 +60,7 @@ contract IndexRegistry is IIndexRegistry {
      */
     function getOperatorIndexForQuorumAtBlockNumberByIndex(bytes32 operatorId, uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = operatorIdToIndexHistory[operatorId][quorumNumber][index];
-        require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+        require(blockNumber <= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
         return operatorIndexToCheck.index;
     }
 
@@ -73,7 +73,7 @@ contract IndexRegistry is IIndexRegistry {
     function getTotalOperatorsForQuorumAtBlockNumberByIndex(uint8 quorumNumber, uint32 blockNumber, uint32 index) external view returns (uint32){
         OperatorIndex memory operatorIndexToCheck = totalOperatorsHistory[quorumNumber][index];
 
-        require(blockNumber >= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
+        require(blockNumber <= operatorIndexToCheck.toBlockNumber, "IndexRegistry.getTotalOperatorsForQuorumAtBlockNumberByIndex: provided index is too far in the future for provided block number");
         return operatorIndexToCheck.index;
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -96,7 +96,7 @@ contract IndexRegistry is IIndexRegistry {
 
     /// @notice Returns the current number of operators of this service.
     function totalOperators() external view returns (uint32){
-        return numOperators;
+        return uint32(globalOperatorList.length);
     }
 
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -10,10 +10,9 @@ import "../libraries/BN254.sol";
 contract IndexRegistry is IIndexRegistry {
 
     IRegistryCoordinator registryCoordinator;
-    
     bytes32[] public globalOperatorList;
-    mapping(uint8 => bytes32[]) public quorumToOperatorList;
 
+    mapping(uint8 => bytes32[]) public quorumToOperatorList;
     mapping(bytes32 => mapping(uint8 => OperatorIndex[])) operatorIdToIndexHistory;
     mapping(uint8 => OperatorIndex[]) totalOperatorsHistory;
 
@@ -42,12 +41,12 @@ contract IndexRegistry is IIndexRegistry {
 
     function deregisterOperator(bytes32 operatorId, uint8[] memory quorumNumbers, uint32[] memory quorumToOperatorListIndexes, uint32 globalOperatorListIndex) external onlyRegistryCoordinator {
         require(quorumNumbers.length == indexes.length, "IndexRegistry.deregisterOperator: quorumNumbers and indexes must be the same length");
+        _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
 
         for (uint i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = quorumNumbers[i];
 
             _removeOperatorFromQuorumToOperatorList(quorumNumber, quorumToOperatorListIndexes[i]);
-            _removeOperatorFromGlobalOperatorList(globalOperatorListIndex);  
             _updateTotalOperatorHistory(quorumNumber);
         }
     }

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -173,7 +173,8 @@ contract IndexRegistry is IIndexRegistry, Test {
     /// @param quorumNumber quorum number of the operator to remove
     /// @param indexToRemove index of the operator to remove
     function _processOperatorRemoval(bytes32 operatorId, uint8 quorumNumber, uint32 indexToRemove, bytes32 memory operatorIdToSwap) internal {   
-        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorIdToSwap][quorumNumber].length - 1].index;
+        uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
+        operatorIdToSwapIndex = operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].index;
         require(totalOperatorsForQuorum(quorumNumber) - 1 == operatorIdToSwapIndex, "IndexRegistry._processOperatorRemoval: operatorIdToSwap is not the last operator in the quorum");
 
         // if the operator is not the last in the list, we must swap the last operator into their positon
@@ -182,7 +183,7 @@ contract IndexRegistry is IIndexRegistry, Test {
             _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber, indexToRemove);
         } else {
             //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
-            operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = uint32(block.number);
+            operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = uint32(block.number);
         }
     }
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -174,6 +174,8 @@ contract IndexRegistry is IIndexRegistry {
         quorumToOperatorList[quorumNumber].pop();
     }
 
+    /// @notice remove an operator from the globalOperatorList  
+    /// @param indexToRemove index of the operator to remove
     function _removeOperatorFromGlobalOperatorList(uint32 indexToRemove) internal {
         uint32 globalOperatorListLastIndex = globalOperatorList.length - 1;
 

--- a/src/contracts/middleware/IndexRegistry.sol
+++ b/src/contracts/middleware/IndexRegistry.sol
@@ -105,8 +105,11 @@ contract IndexRegistry is IIndexRegistry {
     }
 
     function _updateOperatorIdToIndexHistory(bytes32 operatorId, uint8 quorumNumber, uint32 index) internal {
+        uint256 operatorIdToIndexHistoryLength = operatorIdToIndexHistory[operatorId][quorumNumber].length;
+
+        //if there is a prior entry for the operator, set the previous entry's toBlocknumber
         if (operatorIdToIndexHistoryLength > 0) {
-            operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length; - 1].toBlockNumber = block.number;
+            operatorIdToIndexHistory[operatorIdToSwap][quorumNumber][operatorIdToIndexHistoryLength - 1].toBlockNumber = block.number;
         }
         OperatorIndex memory latestOperatorIndex;
         latestOperatorIndex.index = index; 
@@ -120,13 +123,14 @@ contract IndexRegistry is IIndexRegistry {
 
         if(indexToRemove != quorumToOperatorListLastIndex){
             bytes32 operatorIdToSwap = quorumToOperatorList[quorumNumber][quorumToOperatorListLastIndex];
-            //update the swapped operator's
+            //update the swapped operator's operatorIdToIndexHistory list with a new entry, as their index has now changed
             _updateOperatorIdToIndexHistory(operatorIdToSwap, quorumNumber, indexToRemove);
 
             quorumToOperatorList[quorumNumber][indexToRemove] = operatorIdToSwap;
         }
         //marking the final entry in the deregistering operator's operatorIdToIndexHistory entry with the deregistration block number
         operatorIdToIndexHistory[operatorId][quorumNumber][operatorIdToIndexHistory[operatorId][quorumNumber].length - 1].toBlockNumber = block.number;
+        //removing the swapped operator from the list
         quorumToOperatorList[quorumNumber].pop();
     }
 

--- a/src/test/mocks/RegistryCoordinatorMock.sol
+++ b/src/test/mocks/RegistryCoordinatorMock.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+
+import "../../contracts/interfaces/IRegistryCoordinator.sol";
+
+
+contract RegistryCoordinatorMock is IRegistryCoordinator {
+    /// @notice Returns the bitmap of the quroums the operator is registered for.
+    function operatorIdToQuorumBitmap(bytes32 pubkeyHash) external view returns (uint256){}
+
+    /// @notice Returns the stored id for the specified `operator`.
+    function getOperatorId(address operator) external view returns (bytes32){}
+
+    /// @notice Returns task number from when `operator` has been registered.
+    function getFromTaskNumberForOperator(address operator) external view returns (uint32){}
+
+    /// @notice registers the sender as an operator for the `quorumNumbers` with additional bytes for registry interaction data
+    function registerOperator(uint8[] memory quorumNumbers, bytes calldata) external returns (bytes32){}
+
+    /// @notice deregisters the sender with additional bytes for registry interaction data
+    function deregisterOperator(bytes calldata) external returns (bytes32){}
+
+     /// @notice Returns the registry at the desired index
+    function registries(uint256) external view returns (address){}
+
+    /// @notice Returns the number of registries
+    function numRegistries() external view returns (uint256){}
+}

--- a/src/test/unit/DelayedWithdrawalRouterUnit.t.sol
+++ b/src/test/unit/DelayedWithdrawalRouterUnit.t.sol
@@ -122,6 +122,7 @@ contract DelayedWithdrawalRouterUnitTests is Test {
     }
 
     function testCreateDelayedWithdrawalZeroAddress(address podOwner) external {
+        cheats.assume(podOwner != address(proxyAdmin));
         uint224 delayedWithdrawalAmount = 0;
         address podAddress = address(eigenPodManagerMock.getPod(podOwner));
         cheats.startPrank(podAddress);

--- a/src/test/unit/IndexRegistryUnit.t.sol
+++ b/src/test/unit/IndexRegistryUnit.t.sol
@@ -73,6 +73,11 @@ contract IndexRegistryUnitTests is Test {
         cheats.startPrank(address(registryCoordinatorMock));
         indexRegistry.deregisterOperator(operatorId1, quorumNumbers, quorumToOperatorListIndexes, 0);
         cheats.stopPrank();
+
+        require(indexRegistry.totalOperators() == 1, "IndexRegistry.registerOperator: operator not registered correctly");
+        require(indexRegistry.quorumToOperatorList(1, 0) == operatorId2, "IndexRegistry.registerOperator: operator not deregistered and swapped correctly");
+        require(indexRegistry.quorumToOperatorList(2, 0) == operatorId2, "IndexRegistry.registerOperator: operator not deregistered and swapped correctly");
+        require(indexRegistry.globalOperatorList(0) == operatorId2, "IndexRegistry.registerOperator: operator not deregistered and swapped correctly");
     }
 
     function _registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) public {

--- a/src/test/unit/IndexRegistryUnit.t.sol
+++ b/src/test/unit/IndexRegistryUnit.t.sol
@@ -39,10 +39,10 @@ contract IndexRegistryUnitTests is Test {
         cheats.stopPrank();
 
        require(indexRegistry.globalOperatorList(0) == operatorId, "IndexRegistry.registerOperator: operator not registered correctly");
-       require(indexRegistry.totalOperators() == 1, "IndexRegistry.registerOperator: operator not registered correctly");
-       require(indexRegistry.totalOperatorsForQuorum(1) == 1, "IndexRegistry.registerOperator: operator not registered correctly");
+       require(indexRegistry.totalOperators() == 1, "IndexRegistry.registerOperator: total operators not updated correctly");
+       require(indexRegistry.totalOperatorsForQuorum(1) == 1, "IndexRegistry.registerOperator: total operators for quorum not updated correctly");
        (uint32 index, uint32 toBlockNumber) = indexRegistry.operatorIdToIndexHistory(operatorId, 1, 0);
-       require(index == 0, "IndexRegistry.registerOperator: operator not registered correctly");
+       require(index == 0, "IndexRegistry.registerOperator: index not 0");
        require(toBlockNumber == 0, "block number should not be set");
     }
 

--- a/src/test/unit/IndexRegistryUnit.t.sol
+++ b/src/test/unit/IndexRegistryUnit.t.sol
@@ -121,54 +121,7 @@ contract IndexRegistryUnitTests is Test {
         }
     }
 
-    function testGettingOperatorIndexForQuorumAtBlockNumber(uint32 numOperators, uint32 operatorToDeregister) external {
-        cheats.assume(numOperators > 5 && numOperators < 256);
-        cheats.assume(operatorToDeregister >= 0 && operatorToDeregister < numOperators);
 
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-
-        for (uint256 i = 0; i < numOperators; i++) {
-            bytes32 operatorId = _getRandomId(i);
-            _registerOperator(operatorId, quorumNumbers);
-        }
-        cheats.roll(block.number + 100);
-
-        bytes32 operator = _getRandomId(operatorToDeregister);
-
-        uint32[] memory quorumToOperatorListIndexes = new uint32[](1);
-        quorumToOperatorListIndexes[0] = uint32(_generateRandomNumber(operatorToDeregister, numOperators));
-        _deregisterOperator(operator, quorumNumbers, quorumToOperatorListIndexes, operatorToDeregister);
-        require(operatorToDeregister == indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(operator, defaultQuorumNumber, uint32(_generateRandomNumber(1, 100)), 0), "wrong index returned");
-
-        emit log_named_uint("quorumToOperatorListIndexes[0]", quorumToOperatorListIndexes[0]);
-        emit log_named_uint("total ops", indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber));
-        bytes32 swappedOperator = indexRegistry.quorumToOperatorList(defaultQuorumNumber, quorumToOperatorListIndexes[0]);
-        emit log_named_uint("quorumToOperatorListIndexes[0]", quorumToOperatorListIndexes[0]);
-        require(quorumToOperatorListIndexes[0] == indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(swappedOperator, defaultQuorumNumber, uint32(_generateRandomNumber(1, 100)), 0), "wrong index returned for swapped operator");
-
-    }
-
-    function testGettingTotalOperatorsForQuorumAtBlockNumber(uint32 numOperators, uint32 operatorToDeregister) external {
-        cheats.assume(numOperators > 0 && numOperators < 256);
-        cheats.assume(operatorToDeregister >= 0 && operatorToDeregister < numOperators);
-
-        bytes memory quorumNumbers = new bytes(1);
-        quorumNumbers[0] = bytes1(defaultQuorumNumber);
-
-        for (uint256 i = 0; i < numOperators; i++) {
-            bytes32 operatorId = _getRandomId(i);
-            _registerOperator(operatorId, quorumNumbers);
-        }
-        cheats.roll(block.number + 100);
-
-        bytes32 operator = _getRandomId(operatorToDeregister);
-
-        uint32[] memory quorumToOperatorListIndexes = new uint32[](1);
-        quorumToOperatorListIndexes[0] = uint32(_generateRandomNumber(operatorToDeregister, numOperators));
-        _deregisterOperator(operator, quorumNumbers, quorumToOperatorListIndexes, operatorToDeregister);
-        require(operatorToDeregister == indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(operator, defaultQuorumNumber, uint32(_generateRandomNumber(1, 100)), 0), "wrong index returned");
-    }
 
     function _registerOperator(bytes32 operatorId, bytes memory quorumNumbers) public {
         cheats.startPrank(address(registryCoordinatorMock));

--- a/src/test/unit/IndexRegistryUnit.t.sol
+++ b/src/test/unit/IndexRegistryUnit.t.sol
@@ -1,0 +1,83 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "../../contracts/interfaces/IIndexRegistry.sol";
+import "../../contracts/middleware/IndexRegistry.sol";
+import "../mocks/RegistryCoordinatorMock.sol";
+
+import "forge-std/Test.sol";
+
+
+contract IndexRegistryUnitTests is Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    IndexRegistry indexRegistry;
+    RegistryCoordinatorMock registryCoordinatorMock;
+
+
+    function setUp() public {
+        // deploy the contract
+        registryCoordinatorMock = new RegistryCoordinatorMock();
+        indexRegistry = new IndexRegistry(registryCoordinatorMock);
+    }
+
+
+    function testConstructor() public {
+        // check that the registry coordinator is set correctly
+        assertEq(address(indexRegistry.registryCoordinator()), address(registryCoordinatorMock), "IndexRegistry.constructor: registry coordinator not set correctly");
+    }
+
+    function testRegisterOperatorInIndexRegistry(bytes32 operatorId) public {
+        // register an operator
+        uint8[] memory quorumNumbers = new uint8[](1);
+        quorumNumbers[0] = 1;
+
+        cheats.startPrank(address(registryCoordinatorMock));
+       indexRegistry.registerOperator(operatorId, quorumNumbers);
+        cheats.stopPrank();
+
+       require(indexRegistry.globalOperatorList(0) == operatorId, "IndexRegistry.registerOperator: operator not registered correctly");
+       require(indexRegistry.totalOperators() == 1, "IndexRegistry.registerOperator: operator not registered correctly");
+       require(indexRegistry.totalOperatorsForQuorum(1) == 1, "IndexRegistry.registerOperator: operator not registered correctly");
+       (uint32 index, uint32 toBlockNumber) = indexRegistry.operatorIdToIndexHistory(operatorId, 1, 0);
+       require(index == 0, "IndexRegistry.registerOperator: operator not registered correctly");
+    }
+
+    function testRegisterOperatorFromNonRegisterCoordinator(address nonRegistryCoordinator) public {
+        cheats.assume(address(registryCoordinatorMock) != nonRegistryCoordinator);
+        // register an operator
+        uint8[] memory quorumNumbers = new uint8[](1);
+
+        cheats.startPrank(nonRegistryCoordinator);
+        cheats.expectRevert(bytes("IndexRegistry.onlyRegistryCoordinator: caller is not the registry coordinator"));
+        indexRegistry.registerOperator(bytes32(0), quorumNumbers);
+        cheats.stopPrank();
+    }
+
+    function testDeregisterOperatorInIndexRegistry(bytes32 operatorId1, bytes32 operatorId2) public {
+        uint8[] memory quorumNumbers = new uint8[](2);
+        quorumNumbers[0] = 1;
+        quorumNumbers[1] = 2;
+        _registerOperator(operatorId1, quorumNumbers);
+        _registerOperator(operatorId2, quorumNumbers);
+
+        require(indexRegistry.totalOperators() == 2, "IndexRegistry.registerOperator: operator not registered correctly");
+        require(indexRegistry.totalOperatorsForQuorum(1) == 2, "IndexRegistry.registerOperator: operator not registered correctly");
+        require(indexRegistry.totalOperatorsForQuorum(2) == 2, "IndexRegistry.registerOperator: operator not registered correctly");
+
+        uint32[] memory quorumToOperatorListIndexes = new uint32[](2);
+        quorumToOperatorListIndexes[0] = 0;
+        quorumToOperatorListIndexes[1] = 0;
+
+        // deregister the operatorId1, removing it from both quorum 1 and 2.
+        cheats.startPrank(address(registryCoordinatorMock));
+        indexRegistry.deregisterOperator(operatorId1, quorumNumbers, quorumToOperatorListIndexes, 0);
+        cheats.stopPrank();
+    }
+
+    function _registerOperator(bytes32 operatorId, uint8[] memory quorumNumbers) public {
+        cheats.startPrank(address(registryCoordinatorMock));
+       indexRegistry.registerOperator(operatorId, quorumNumbers);
+        cheats.stopPrank();
+    }
+}

--- a/src/test/unit/IndexRegistryUnit.t.sol
+++ b/src/test/unit/IndexRegistryUnit.t.sol
@@ -122,6 +122,34 @@ contract IndexRegistryUnitTests is Test {
     }
 
     function testGettingOperatorIndexForQuorumAtBlockNumber(uint32 numOperators, uint32 operatorToDeregister) external {
+        cheats.assume(numOperators > 5 && numOperators < 256);
+        cheats.assume(operatorToDeregister >= 0 && operatorToDeregister < numOperators);
+
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(defaultQuorumNumber);
+
+        for (uint256 i = 0; i < numOperators; i++) {
+            bytes32 operatorId = _getRandomId(i);
+            _registerOperator(operatorId, quorumNumbers);
+        }
+        cheats.roll(block.number + 100);
+
+        bytes32 operator = _getRandomId(operatorToDeregister);
+
+        uint32[] memory quorumToOperatorListIndexes = new uint32[](1);
+        quorumToOperatorListIndexes[0] = uint32(_generateRandomNumber(operatorToDeregister, numOperators));
+        _deregisterOperator(operator, quorumNumbers, quorumToOperatorListIndexes, operatorToDeregister);
+        require(operatorToDeregister == indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(operator, defaultQuorumNumber, uint32(_generateRandomNumber(1, 100)), 0), "wrong index returned");
+
+        emit log_named_uint("quorumToOperatorListIndexes[0]", quorumToOperatorListIndexes[0]);
+        emit log_named_uint("total ops", indexRegistry.totalOperatorsForQuorum(defaultQuorumNumber));
+        bytes32 swappedOperator = indexRegistry.quorumToOperatorList(defaultQuorumNumber, quorumToOperatorListIndexes[0]);
+        emit log_named_uint("quorumToOperatorListIndexes[0]", quorumToOperatorListIndexes[0]);
+        require(quorumToOperatorListIndexes[0] == indexRegistry.getOperatorIndexForQuorumAtBlockNumberByIndex(swappedOperator, defaultQuorumNumber, uint32(_generateRandomNumber(1, 100)), 0), "wrong index returned for swapped operator");
+
+    }
+
+    function testGettingTotalOperatorsForQuorumAtBlockNumber(uint32 numOperators, uint32 operatorToDeregister) external {
         cheats.assume(numOperators > 0 && numOperators < 256);
         cheats.assume(operatorToDeregister >= 0 && operatorToDeregister < numOperators);
 


### PR DESCRIPTION
Adds a separate registry for managing operators position in a list of operatorsIds both globally and on a quorum-by-quorum basis