### PR TITLE
Fix prover CI

### DIFF
--- a/.github/workflows/certora-prover.yml
+++ b/.github/workflows/certora-prover.yml
@@ -43,7 +43,7 @@ jobs:
           java-version: '11'
           java-package: 'jre'
       - name: Install certora
-        run: pip install certora-cli==3.6.4
+        run: pip install certora-cli==3.6.8.post3
       - name: Install solc
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-static-linux

--- a/certora/specs/permissions/Pausable.spec
+++ b/certora/specs/permissions/Pausable.spec
@@ -1,7 +1,7 @@
 
 methods {
     // external calls to PauserRegistry
-    isPauser() returns (bool) => DISPATCHER(true)
+    isPauser(address) returns (bool) => DISPATCHER(true)
 	unpauser() returns (address) => DISPATCHER(true)
 
     // envfree functions
@@ -10,7 +10,7 @@ methods {
     pauserRegistry() returns (address) envfree
 
     // harnessed functions
-    pauser() returns (address) envfree
+    isPauser(address) returns (bool) envfree
     unpauser() returns (address) envfree
     bitwise_not(uint256) returns (uint256) envfree
     bitwise_and(uint256, uint256) returns (uint256) envfree


### PR DESCRIPTION
This PR is intended to fix the breakages in the Certora Prover aspects of our CI that appeared with the official introduction of CVL2 by Certora.
This is an interim solution; we still need to migrate to CVL2 in the next couple months, before CVL1 support is deprecated!