### PR TITLE
remove global apk tracking

### DIFF
--- a/src/contracts/interfaces/IBLSPubkeyRegistry.sol
+++ b/src/contracts/interfaces/IBLSPubkeyRegistry.sol
@@ -10,20 +10,14 @@ import "../libraries/BN254.sol";
  */
 interface IBLSPubkeyRegistry is IRegistry {
     // EVENTS
-    // Emitted when a new operator pubkey is registered
-    event PubkeyAdded(
+    // Emitted when a new operator pubkey is registered for a set of quorums
+    event PubkeyAddedToQuorums(
         address operator,
-        BN254.G1Point pubkey
-    );
-
-    // Emitted when an operator pubkey is deregistered
-    event PubkeyRemoved(
-        address operator,
-        BN254.G1Point pubkey
+        bytes quorumNumbers
     );
 
     // Emitted when an operator pubkey is removed from a set of quorums
-    event PubkeyRemoveFromQuorums(
+    event PubkeyRemovedFromQuorums(
         address operator, 
         bytes quorumNumbers
     );
@@ -56,7 +50,6 @@ interface IBLSPubkeyRegistry is IRegistry {
     /**
      * @notice Deregisters the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to deregister.
-     * @param completeDeregistration Whether the operator is deregistering from all quorums or just some.
      * @param quorumNumbers The quorum numbers the operator is deregistering from, where each byte is an 8 bit integer quorumNumber.
      * @param pubkey The public key of the operator.
      * @dev access restricted to the RegistryCoordinator
@@ -68,7 +61,7 @@ interface IBLSPubkeyRegistry is IRegistry {
      *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
      *         6) `pubkey` is the same as the parameter used when registering
      */ 
-    function deregisterOperator(address operator, bool completeDeregistration, bytes calldata quorumNumbers, BN254.G1Point memory pubkey) external returns(bytes32);
+    function deregisterOperator(address operator, bytes calldata quorumNumbers, BN254.G1Point memory pubkey) external returns(bytes32);
     
     /// @notice Returns the current APK for the provided `quorumNumber `
     function getApkForQuorum(uint8 quorumNumber) external view returns (BN254.G1Point memory);
@@ -84,18 +77,4 @@ interface IBLSPubkeyRegistry is IRegistry {
      * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
      */
     function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes32);
-
-	/**
-     * @notice get hash of the apk among all quorums at `blockNumber` using the provided `index`;
-     * called by checkSignatures in BLSSignatureChecker.sol.
-     * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
-     * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
-     */
-    function getGlobalApkHashAtBlockNumberFromIndex(uint32 blockNumber, uint256 index) external view returns (bytes32);
-    
-    /// @notice Returns the length of ApkUpdates for the provided `quorumNumber`
-    function getQuorumApkHistoryLength(uint8 quorumNumber) external view returns(uint32);
-
-    /// @notice Returns the length of ApkUpdates for the global APK
-    function getGlobalApkHistoryLength() external view returns(uint32);
 }

--- a/src/contracts/middleware/BLSPubkeyRegistry.sol
+++ b/src/contracts/middleware/BLSPubkeyRegistry.sol
@@ -16,15 +16,11 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
 
     /// @notice the hash of the zero pubkey aka BN254.G1Point(0,0)
     bytes32 internal constant ZERO_PK_HASH = hex"ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5";
-    /// @notice the current aggregate pubkey of all operators registered in this contract, regardless of quorum
-    BN254.G1Point public globalApk;
     /// @notice the registry coordinator contract
     IRegistryCoordinator public immutable registryCoordinator;
     /// @notice the BLSPublicKeyCompendium contract against which pubkey ownership is checked
     IBLSPublicKeyCompendium public immutable pubkeyCompendium;
 
-    // list of all updates made to the global aggregate pubkey
-    ApkUpdate[] public globalApkUpdates;
     // mapping of quorumNumber => ApkUpdate[], tracking the aggregate pubkey updates of every quorum
     mapping(uint8 => ApkUpdate[]) public quorumApkUpdates;
     // mapping of quorumNumber => current aggregate pubkey of quorum
@@ -63,18 +59,15 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
         //ensure that the operator owns their public key by referencing the BLSPubkeyCompendium
         require(pubkeyCompendium.pubkeyHashToOperator(pubkeyHash) == operator,"BLSPubkeyRegistry.registerOperator: operator does not own pubkey");
         // update each quorum's aggregate pubkey
-        _processQuorumApkUpdate(operator, quorumNumbers, pubkey);
-        // update the global aggregate pubkey
-        _processGlobalApkUpdate(pubkey);
+        _processQuorumApkUpdate(quorumNumbers, pubkey);
         // emit event so offchain actors can update their state
-        emit PubkeyAdded(operator, pubkey);
+        emit PubkeyAddedToQuorums(operator, quorumNumbers);
         return pubkeyHash;
     }
 
     /**
      * @notice Deregisters the `operator`'s pubkey for the specified `quorumNumbers`.
      * @param operator The address of the operator to deregister.
-     * @param completeDeregistration Whether the operator is deregistering from all quorums or just some.
      * @param quorumNumbers The quorum numbers the operator is deregistering from, where each byte is an 8 bit integer quorumNumber.
      * @param pubkey The public key of the operator.
      * @dev access restricted to the RegistryCoordinator
@@ -86,20 +79,15 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
      *         5) `quorumNumbers` is a subset of the quorumNumbers that the operator is registered for
      *         6) `pubkey` is the same as the parameter used when registering
      */   
-    function deregisterOperator(address operator, bool completeDeregistration, bytes memory quorumNumbers, BN254.G1Point memory pubkey) external onlyRegistryCoordinator returns(bytes32){
+    function deregisterOperator(address operator, bytes memory quorumNumbers, BN254.G1Point memory pubkey) external onlyRegistryCoordinator returns(bytes32){
         bytes32 pubkeyHash = BN254.hashG1Point(pubkey);
 
         require(pubkeyCompendium.pubkeyHashToOperator(pubkeyHash) == operator,"BLSPubkeyRegistry.registerOperator: operator does not own pubkey");
 
         // update each quorum's aggregate pubkey
-        _processQuorumApkUpdate(operator, quorumNumbers, pubkey.negate());
+        _processQuorumApkUpdate(quorumNumbers, pubkey.negate());
         
-        if(completeDeregistration){
-            // update the global aggregate pubkey
-            _processGlobalApkUpdate(pubkey.negate());
-            // emit event so offchain actors can update their state
-            emit PubkeyRemoved(operator, pubkey);
-        }
+        emit PubkeyRemovedFromQuorums(operator, quorumNumbers);
         return pubkeyHash;
     }
 
@@ -126,42 +114,7 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
         return quorumApkUpdate.apkHash;
     }
 
-	/**
-     * @notice get hash of the global apk among all quorums at `blockNumber` using the provided `index`;
-     * called by checkSignatures in BLSSignatureChecker.sol.
-     */
-    function getGlobalApkHashAtBlockNumberFromIndex(uint32 blockNumber, uint256 index) external view returns (bytes32){
-        ApkUpdate memory globalApkUpdate = globalApkUpdates[index];
-        _validateApkHashForQuorumAtBlockNumber(globalApkUpdate, blockNumber);
-        return globalApkUpdate.apkHash;
-    }
-    /// @notice Returns the length of ApkUpdates for the provided `quorumNumber`
-    function getQuorumApkHistoryLength(uint8 quorumNumber) external view returns(uint32){
-        return uint32(quorumApkUpdates[quorumNumber].length);
-    }
-    /// @notice Returns the length of ApkUpdates for the global APK
-    function getGlobalApkHistoryLength() external view returns(uint32){
-        return uint32(globalApkUpdates.length);
-    }
-
-    function _processGlobalApkUpdate(BN254.G1Point memory point) internal {
-        // load and store in memory in case we need to access the length again
-        uint256 globalApkUpdatesLength = globalApkUpdates.length;
-        // update the nextUpdateBlockNumber of the previous update
-        if (globalApkUpdatesLength > 0) {
-            globalApkUpdates[globalApkUpdatesLength - 1].nextUpdateBlockNumber = uint32(block.number);
-        }
-
-        // accumulate the given point into the globalApk
-        globalApk = globalApk.plus(point);
-        // add this update to the list of globalApkUpdates
-        ApkUpdate memory latestGlobalApkUpdate;
-        latestGlobalApkUpdate.apkHash = BN254.hashG1Point(globalApk);
-        latestGlobalApkUpdate.updateBlockNumber = uint32(block.number);
-        globalApkUpdates.push(latestGlobalApkUpdate);
-    }
-
-    function _processQuorumApkUpdate(address operator, bytes memory quorumNumbers, BN254.G1Point memory point) internal {
+    function _processQuorumApkUpdate(bytes memory quorumNumbers, BN254.G1Point memory point) internal {
         BN254.G1Point memory apkAfterUpdate;
 
         for (uint i = 0; i < quorumNumbers.length;) {
@@ -187,8 +140,6 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
                 ++i;
             }
         }
-
-        emit PubkeyRemoveFromQuorums(operator, quorumNumbers);
     }
 
     function _validateApkHashForQuorumAtBlockNumber(ApkUpdate memory apkUpdate, uint32 blockNumber) internal pure {

--- a/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
@@ -321,7 +321,7 @@ contract BLSRegistryCoordinatorWithIndices is Initializable, IBLSRegistryCoordin
         bool completeDeregistration = quorumBitmapBeforeUpdate == quorumsToRemoveBitmap;
         
         // deregister the operator from the BLSPubkeyRegistry
-        blsPubkeyRegistry.deregisterOperator(operator, completeDeregistration, quorumNumbers, pubkey);
+        blsPubkeyRegistry.deregisterOperator(operator, quorumNumbers, pubkey);
 
         // deregister the operator from the StakeRegistry
         stakeRegistry.deregisterOperator(operatorId, quorumNumbers);


### PR DESCRIPTION
Proposal and PR to remove tracking of the Global Apk. This is a bunch more uneeded gas for operators and we would basically never use it. The only place we would use it is iff we were checking signatures for 255 quorums and wanted to subtract 1 quorum apk from the global instead of adding the 255 quorum APKs.