### PR TITLE
change apkupdate storage

### DIFF
--- a/src/contracts/interfaces/IBLSPubkeyRegistry.sol
+++ b/src/contracts/interfaces/IBLSPubkeyRegistry.sol
@@ -25,8 +25,8 @@ interface IBLSPubkeyRegistry is IRegistry {
 
     /// @notice Data structure used to track the history of the Aggregate Public Key of all operators
     struct ApkUpdate {
-        // keccak256(apk_x0, apk_x1, apk_y0, apk_y1)
-        bytes32 apkHash;
+        // first 24 bytes of keccak256(apk_x0, apk_x1, apk_y0, apk_y1)
+        bytes24 apkHash;
         // block number at which the update occurred
         uint32 updateBlockNumber;
         // block number at which the next update occurred
@@ -70,11 +70,11 @@ interface IBLSPubkeyRegistry is IRegistry {
     function getApkUpdateForQuorumByIndex(uint8 quorumNumber, uint256 index) external view returns (ApkUpdate memory);
 
     /**
-     * @notice get hash of the apk of `quorumNumber` at `blockNumber` using the provided `index`;
+     * @notice get 24 byte hash of the apk of `quorumNumber` at `blockNumber` using the provided `index`;
      * called by checkSignatures in BLSSignatureChecker.sol.
      * @param quorumNumber is the quorum whose ApkHash is being retrieved
      * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
      * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
      */
-    function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes32);
+    function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes24);
 }

--- a/src/contracts/middleware/BLSPubkeyRegistry.sol
+++ b/src/contracts/middleware/BLSPubkeyRegistry.sol
@@ -108,7 +108,7 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
      * @param blockNumber is the number of the block for which the latest ApkHash will be retrieved
      * @param index is the index of the apkUpdate being retrieved from the list of quorum apkUpdates in storage
      */
-    function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes32){
+    function getApkHashForQuorumAtBlockNumberFromIndex(uint8 quorumNumber, uint32 blockNumber, uint256 index) external view returns (bytes24){
         ApkUpdate memory quorumApkUpdate = quorumApkUpdates[quorumNumber][index];
         _validateApkHashForQuorumAtBlockNumber(quorumApkUpdate, blockNumber);
         return quorumApkUpdate.apkHash;
@@ -132,7 +132,7 @@ contract BLSPubkeyRegistry is IBLSPubkeyRegistry, Test {
             quorumApk[quorumNumber] = apkAfterUpdate;
             //create new ApkUpdate to add to the mapping
             ApkUpdate memory latestApkUpdate;
-            latestApkUpdate.apkHash = BN254.hashG1Point(apkAfterUpdate);
+            latestApkUpdate.apkHash = bytes24(BN254.hashG1Point(apkAfterUpdate));
             latestApkUpdate.updateBlockNumber = uint32(block.number);
             quorumApkUpdates[quorumNumber].push(latestApkUpdate);
 

--- a/src/test/unit/BLSPubkeyRegistryUnit.t.sol
+++ b/src/test/unit/BLSPubkeyRegistryUnit.t.sol
@@ -196,18 +196,18 @@ contract BLSPubkeyRegistryUnitTests is Test {
         cheats.assume(blockGap < 100);
 
         BN254.G1Point memory quorumApk = BN254.G1Point(0,0);
-        bytes32 quorumApkHash;
+        bytes24 quorumApkHash;
         for (uint256 i = 0; i < numRegistrants; i++) {
             bytes32 pk = _getRandomPk(i);
             testRegisterOperatorBLSPubkey(defaultOperator, pk);
             quorumApk = quorumApk.plus(BN254.hashToG1(pk));
-            quorumApkHash = BN254.hashG1Point(quorumApk);
+            quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
             require(quorumApkHash == blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap) , i), "incorrect quorum aok updates");
             cheats.roll(block.number + 100);
             if(_generateRandomNumber(i) % 2 == 0){
                _deregisterOperator(pk);
                quorumApk = quorumApk.plus(BN254.hashToG1(pk).negate());
-               quorumApkHash = BN254.hashG1Point(quorumApk);
+               quorumApkHash = bytes24(BN254.hashG1Point(quorumApk));
                 require(quorumApkHash == blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(defaultQuorumNumber, uint32(block.number + blockGap) , i + 1), "incorrect quorum aok updates");
                 cheats.roll(block.number + 100);
                 i++;


### PR DESCRIPTION
update storage to include a bytes24 instead of a bytes32 to save on storage. this doesn't effect security since ethereum has 20 byte addresses.