### PR TITLE
fix orderedBytesArrayToBitmap_Yul function

### DIFF
--- a/src/contracts/libraries/BitmapUtils.sol
+++ b/src/contracts/libraries/BitmapUtils.sol
@@ -152,12 +152,12 @@ library BitmapUtils {
     /**
      * @notice Converts an array of bytes into a bitmap. Optimized, Yul-heavy version of `bytesArrayToBitmap`.
      * @param bytesArray The array of bytes to convert/compress into a bitmap.
-     * @return The resulting bitmap.
+     * @return bitmap The resulting bitmap.
      * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap.
      * @dev This function will eventually revert in the event that the `bytesArray` is not properly ordered (in ascending order).
      * @dev This function will also revert if the `bytesArray` input contains any duplicate entries (i.e. duplicate bytes).
      */
-    function bytesArrayToBitmap_Yul(bytes calldata bytesArray) internal pure returns (uint256) {
+    function bytesArrayToBitmap_Yul(bytes calldata bytesArray) internal pure returns (uint256 bitmap) {
         // sanity-check on input. a too-long input would fail later on due to having duplicate entry(s)
         require(bytesArray.length <= MAX_BYTE_ARRAY_LENGTH,
             "BitmapUtils.bytesArrayToBitmap: bytesArray is too long");
@@ -169,7 +169,7 @@ library BitmapUtils {
 
         assembly {
             // get first entry in bitmap (single byte => single-bit mask)
-            let bitmap :=
+            bitmap :=
                 shl(
                     // extract single byte to get the correct value for the left shift
                     shr(
@@ -204,9 +204,6 @@ library BitmapUtils {
                 // update the bitmap by adding the single bit in the mask
                 bitmap := or(bitmap, bitMask)
             }
-            // after the loop is complete, store the bitmap at the value encoded at the free memory pointer, then return it
-            mstore(mload(0x40), bitmap)
-            return(mload(0x40), 32)
         }
     }
 

--- a/src/contracts/libraries/BitmapUtils.sol
+++ b/src/contracts/libraries/BitmapUtils.sol
@@ -94,12 +94,12 @@ library BitmapUtils {
     /**
      * @notice Converts an ordered array of bytes into a bitmap. Optimized, Yul-heavy version of `orderedBytesArrayToBitmap`.
      * @param orderedBytesArray The array of bytes to convert/compress into a bitmap. Must be in strictly ascending order.
-     * @return The resulting bitmap.
+     * @return bitmap The resulting bitmap.
      * @dev Each byte in the input is processed as indicating a single bit to flip in the bitmap.
      * @dev This function will eventually revert in the event that the `orderedBytesArray` is not properly ordered (in ascending order).
      * @dev This function will also revert if the `orderedBytesArray` input contains any duplicate entries (i.e. duplicate bytes).
      */
-    function orderedBytesArrayToBitmap_Yul(bytes calldata orderedBytesArray) internal pure returns (uint256) {
+    function orderedBytesArrayToBitmap_Yul(bytes calldata orderedBytesArray) internal pure returns (uint256 bitmap) {
         // sanity-check on input. a too-long input would fail later on due to having duplicate entry(s)
         require(orderedBytesArray.length <= MAX_BYTE_ARRAY_LENGTH,
             "BitmapUtils.orderedBytesArrayToBitmap: orderedBytesArray is too long");
@@ -111,7 +111,7 @@ library BitmapUtils {
 
         assembly {
             // get first entry in bitmap (single byte => single-bit mask)
-            let bitmap :=
+            bitmap :=
                 shl(
                     // extract single byte to get the correct value for the left shift
                     shr(
@@ -146,9 +146,6 @@ library BitmapUtils {
                 // update the bitmap by adding the single bit in the mask
                 bitmap := or(bitmap, bitMask)
             }
-            // after the loop is complete, store the bitmap at the value encoded at the free memory pointer, then return it
-            mstore(mload(0x40), bitmap)
-            return(mload(0x40), 32)
         }
     }
 


### PR DESCRIPTION
Function was using the `return` bytecode, which not only returns from the present function, but returns the entire transaction (pops the entire stack). Therefore, upstream functions would just not finish their execution, which would cause bugs.

My specific bug was when trying to register my operator with the `BLSRegistryCoordinatorWithIndices`.The [call to the bitmap function](https://github.com/Layr-Labs/eigenlayer-contracts/blob/378ae85785f970208bafc824180419b00b9dfe41/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol#L291) would simply exit the current execution, causing the operator not to be able to register.

I haven't ran any tests though, so please do make sure this fix doesn't break other things if we do have tests.

Reference for return bytecode semantic:
- https://ethereum.stackexchange.com/questions/49614/returning-values-from-solidity-function-that-does-not-define-a-return/49621#49621
- https://docs.soliditylang.org/en/latest/yul.html#evm-dialect
