### PR TITLE
Fix erc20mock transfer not minting

### DIFF
--- a/src/test/mocks/ERC20Mock.sol
+++ b/src/test/mocks/ERC20Mock.sol
@@ -138,6 +138,7 @@ contract ERC20Mock is Context, IERC20 {
         _beforeTokenTransfer(from, to, amount);
 
         _mint(from, amount);
+        uint256 fromBalance = _balances[from];
         unchecked {
             _balances[from] = fromBalance - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by

--- a/src/test/mocks/ERC20Mock.sol
+++ b/src/test/mocks/ERC20Mock.sol
@@ -138,9 +138,8 @@ contract ERC20Mock is Context, IERC20 {
         _beforeTokenTransfer(from, to, amount);
 
         _mint(from, amount);
-        uint256 fromBalance = _balances[from];
         unchecked {
-            _balances[from] = fromBalance - amount;
+            _balances[from] = _balances[from] - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by
             // decrementing then incrementing.
             _balances[to] += amount;

--- a/src/test/mocks/ERC20Mock.sol
+++ b/src/test/mocks/ERC20Mock.sol
@@ -113,7 +113,6 @@ contract ERC20Mock is Context, IERC20 {
      * `amount`.
      */
     function transferFrom(address from, address to, uint256 amount) public virtual override returns (bool) {
-        _mint(from, amount);
         _transfer(from, to, amount);
         return true;
     }
@@ -138,8 +137,7 @@ contract ERC20Mock is Context, IERC20 {
 
         _beforeTokenTransfer(from, to, amount);
 
-        uint256 fromBalance = _balances[from];
-        require(fromBalance >= amount, "ERC20: transfer amount exceeds balance");
+        _mint(from, amount);
         unchecked {
             _balances[from] = fromBalance - amount;
             // Overflow not possible: the sum of all balances is capped by totalSupply, and the sum is preserved by


### PR DESCRIPTION
moving _mint function to _transfer since it was currently only being applied in transferFrom and not transfer

Let me know if this was intended behavior and not a bug.

