### PR TITLE
relax the pragmas for the libraries that we import from our interfaces

### DIFF
--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.0;
 
 import "./Merkle.sol";
 import "../libraries/Endian.sol";

--- a/src/contracts/libraries/Endian.sol
+++ b/src/contracts/libraries/Endian.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+pragma solidity ^0.8.0;
 
 library Endian {
     /**

--- a/src/contracts/libraries/Merkle.sol
+++ b/src/contracts/libraries/Merkle.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Adapted from OpenZeppelin Contracts (last updated v4.8.0) (utils/cryptography/MerkleProof.sol)
 
-pragma solidity =0.8.12;
+pragma solidity ^0.8.0;
 
 /**
  * @dev These functions deal with verification of Merkle Tree proofs.


### PR DESCRIPTION
contracts still have fixed pragma statements; I've conducted a manual review of known compiler bugs and do not believe that this should expose downstream users of these libraries to any _known_ compiler bugs