### PR TITLE
updateSocket()

### DIFF
--- a/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
@@ -275,6 +275,11 @@ contract BLSRegistryCoordinatorWithIndices is Initializable, IBLSRegistryCoordin
         _deregisterOperatorWithCoordinator(msg.sender, quorumNumbers, pubkey, operatorIdsToSwap);
     }
 
+    function updateSocket(string memory socket) external {
+        require(_operators[msg.sender].status == OperatorStatus.REGISTERED, "BLSIndexRegistryCoordinator.updateSocket: operator is not registered");
+        emit OperatorSocketUpdate(msg.sender, socket);
+    }
+
     // INTERNAL FUNCTIONS
 
     function _setOperatorSetParams(uint8 quorumNumber, OperatorSetParam memory operatorSetParam) internal {

--- a/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -674,4 +674,20 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.prank(defaultOperator);
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, pubKey, socket);
     }
+
+    function testUpdateSocket() public {
+        testRegisterOperatorWithCoordinator_PP();
+
+        cheats.prank(defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(registryCoordinator));
+        emit OperatorSocketUpdate(defaultOperator, "localhost:32004");
+        registryCoordinator.updateSocket("localhost:32004");
+
+    }
+
+    function testUpdateSocket_NotRegistered_Reverts() public {
+        cheats.prank(defaultOperator);
+        cheats.expectRevert("BLSIndexRegistryCoordinator.updateSocket: operator is not registered");
+        registryCoordinator.updateSocket("localhost:32004");
+    }
 }


### PR DESCRIPTION
Adds a function for registered operators to update their socket

[Task: Allow operators to update their sockets onchain #39](https://github.com/Layr-Labs/eigenda-internal/issues/39)

