### PR TITLE
initial write of AVSViewer

### DIFF
--- a/src/contracts/interfaces/IAVSStateViewer.sol
+++ b/src/contracts/interfaces/IAVSStateViewer.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./IStrategy.sol";
+
+/**
+ * @title Interface for an AVS viewer which should implement all of the functions required to display the AVS details on the EigenLayer UI.
+ * @author Layr Labs, Inc.
+ * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
+ */
+interface IAVSStateViewer {
+    /**
+     * @notice Returns 
+     * 1) an array of the quorums that are being served by an operator
+     * 2) an array of strategies for each quorum in sequence in a 2 dimensional array
+     * @param operator the address of the operator to get the quorum details for
+     */
+    function strategiesStakedForEachQuorum(address operator) external view returns (uint256[] memory, IStrategy[][] memory);
+}

--- a/src/contracts/interfaces/IServiceManager.sol
+++ b/src/contracts/interfaces/IServiceManager.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.5.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IDelegationManager.sol";
+import "./IAVSStateViewer.sol";
 
 /**
  * @title Interface for a `ServiceManager`-type contract.
@@ -10,6 +10,13 @@ import "./IDelegationManager.sol";
  * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
  */
 interface IServiceManager {
+    // EVENTS
+    event AVSStateViewerUpdated(address prevAVSStateViewer, address newAVSStateViewer);
+
+    // FUNCTIONS
+    /// @notice Returns the AVSStateViewer contract address for this AVS
+    function avsStateViewer() external view returns (IAVSStateViewer);
+
     /// @notice Returns the current 'taskNumber' for the middleware
     function taskNumber() external view returns (uint32);
 

--- a/src/contracts/middleware/AVSViewer.sol
+++ b/src/contracts/middleware/AVSViewer.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+
+import "../interfaces/IStrategyManager.sol";
+import "../interfaces/IDelegationManager.sol";
+import "../interfaces/ISlasher.sol";
+import "../interfaces/IBLSRegistryCoordinatorWithIndices.sol";
+import "../interfaces/IAVSStateViewer.sol";
+import "../interfaces/IVoteWeigher.sol";
+
+import "../libraries/BitmapUtils.sol";
+
+/**
+ * @title Contract for an AVS viewer which should implement all of the functions required to display the AVS details on the EigenLayer UI.
+ * @author Layr Labs, Inc.
+ * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
+ */
+abstract contract AVSStateViewer is Initializable, IAVSStateViewer {
+
+    IBLSRegistryCoordinatorWithIndices public immutable registryCoordinator;
+
+    IVoteWeigher public immutable voteWeigher;
+
+    constructor(
+        IBLSRegistryCoordinatorWithIndices _registryCoordinator
+    ) {
+        registryCoordinator = _registryCoordinator;
+        voteWeigher = IVoteWeigher(address(_registryCoordinator.stakeRegistry()));
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Returns 
+     * 1) an array of the quorums that are being served by an operator
+     * 2) an array of strategies for each quorum in sequence in a 2 dimensional array
+     * @param operator the address of the operator to get the quorum details for
+     */
+    function strategiesStakedForEachQuorum(address operator) external view returns (uint256[] memory, IStrategy[][] memory) {
+        // get the operator id for the operator address
+        bytes32 operatorId = registryCoordinator.getOperatorId(operator);
+        // get the current quorum bitmap for the operator
+        uint256 quorumBitmap = registryCoordinator.getCurrentQuorumBitmapByOperatorId(operatorId);
+        // convert the quorum bitmap to an array of uint256s
+        bytes memory quorumNumberBytes = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+        uint256[] memory quorumNumbers = new uint256[](quorumNumberBytes.length);
+        for (uint256 i = 0; i < quorumNumberBytes.length; i++) {
+            quorumNumbers[i] = uint256(uint8(quorumNumberBytes[i]));
+        }
+
+        // get the strategies for each quorum
+        IStrategy[][] memory strategies = new IStrategy[][](quorumNumbers.length);
+        for (uint256 i = 0; i < quorumNumbers.length; i++) {
+            // get the number of strategies for the quorum
+            uint256 strategiesAndWeightedMultipliers = voteWeigher.strategiesConsideredAndMultipliersLength(uint8(quorumNumbers[i]));
+            strategies[i] = new IStrategy[](strategiesAndWeightedMultipliers);
+            // get the strategies for the quorum
+            for (uint j = 0; j < strategiesAndWeightedMultipliers; j++) {
+                strategies[i][j] = voteWeigher.strategyAndWeightingMultiplierForQuorumByIndex(uint8(quorumNumbers[i]), j).strategy;
+            }
+        }
+
+        return (quorumNumbers, strategies);
+    }
+}

--- a/src/contracts/middleware/ServiceManagerBase.sol
+++ b/src/contracts/middleware/ServiceManagerBase.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+
+import "../interfaces/IStrategyManager.sol";
+import "../interfaces/IDelegationManager.sol";
+import "../interfaces/ISlasher.sol";
+import "../interfaces/IBLSRegistryCoordinatorWithIndices.sol";
+import "../interfaces/IServiceManager.sol";
+
+/**
+ * @title Abstract contract for implementing some of the Service Manager functionality that will be used by AVSs.
+ * @author Layr Labs, Inc.
+ * @notice This contract has mostly disabled functionality.
+ */
+abstract contract ServiceManagerBase is Initializable, OwnableUpgradeable, IServiceManager {
+
+    IStrategyManager public immutable strategyManager;
+
+    IDelegationManager public immutable delegationManager;
+
+    ISlasher public immutable slasher;
+
+    IAVSStateViewer public immutable avsStateViewer;
+
+    IBLSRegistryCoordinatorWithIndices public immutable registryCoordinator;
+
+    /// @notice when applied to a function, ensures that the function is only callable by the `registryCoordinator`.
+    modifier onlyRegistryCoordinator() {
+        require(msg.sender == address(registryCoordinator), "onlyRegistryCoordinator: not from registry coordinator");
+        _;
+    }
+
+    constructor(
+        IStrategyManager _strategyManager,
+        IDelegationManager _delegationMananger,
+        ISlasher _slasher,
+        IAVSStateViewer _avsStateViewer,
+        IBLSRegistryCoordinatorWithIndices _registryCoordinator
+    ) {
+        strategyManager = _strategyManager;
+        delegationManager = _delegationMananger;
+        slasher = _slasher;
+        avsStateViewer = _avsStateViewer;
+        registryCoordinator = _registryCoordinator;
+        _disableInitializers();
+    }
+
+    function _initialize(
+        address initialOwner
+    )
+        public
+        initializer
+    {
+        _transferOwnership(initialOwner);
+    }
+
+    /// @notice Called in the event of challenge resolution, in order to forward a call to the Slasher, which 'freezes' the `operator`.
+    function freezeOperator(address /*operator*/) external pure {
+        revert("EigenDAServiceManager.freezeOperator: not implemented");
+        // require(
+        //     msg.sender == address(eigenDAChallenge)
+        //         || msg.sender == address(eigenDABombVerifier),
+        //     "EigenDAServiceManager.freezeOperator: Only challenge resolvers can slash operators"
+        // );
+        // slasher.freezeOperator(operator);
+    }
+
+    /**
+     * @notice Called by the Registry in the event of a new registration, to forward a call to the Slasher
+     * @param operator The operator whose stake is being updated
+     * @param serveUntilBlock The block until which the stake accounted for in the first update is slashable by this middleware
+     */ 
+    function recordFirstStakeUpdate(address operator, uint32 serveUntilBlock) external onlyRegistryCoordinator {
+        // slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
+    }
+
+    /** 
+     * @notice Called by the registryCoordinator, in order to forward a call to the Slasher, informing it of a stake update
+     * @param operator The operator whose stake is being updated
+     * @param updateBlock The block at which the update is being made
+     * @param serveUntilBlock The block until which the stake withdrawn from the operator in this update is slashable by this middleware
+     * @param prevElement The value of the previous element in the linked list of stake updates (generated offchain)
+     */
+    function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 prevElement) external onlyRegistryCoordinator {
+        // slasher.recordStakeUpdate(operator, updateBlock, serveUntilBlock, prevElement);
+    }
+
+    /**
+     * @notice Called by the registryCoordinator in the event of deregistration, to forward a call to the Slasher
+     * @param operator The operator being deregistered
+     * @param serveUntilBlock The block until which the stake delegated to the operator is slashable by this middleware
+     */ 
+    function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntilBlock) external onlyRegistryCoordinator {
+        // slasher.recordLastStakeUpdateAndRevokeSlashingAbility(operator, serveUntilBlock);
+    }
+
+    // VIEW Functions
+
+    /// @dev need to override function here since its defined in both these contracts
+    function owner() public view override(OwnableUpgradeable, IServiceManager) returns (address) {
+        return OwnableUpgradeable.owner();
+    }
+}

--- a/src/test/mocks/ServiceManagerMock.sol
+++ b/src/test/mocks/ServiceManagerMock.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.12;
 
 import "forge-std/Test.sol";
 import "../../contracts/interfaces/IServiceManager.sol";
+import "../../contracts/interfaces/IDelegationManager.sol";
 import "../../contracts/interfaces/ISlasher.sol";
 
 import "forge-std/Test.sol";
@@ -39,6 +40,10 @@ contract ServiceManagerMock is IServiceManager, DSTest {
     /// @notice Token used for placing guarantee on challenges & payment commits
     function paymentChallengeToken() external pure returns (IERC20) {
         return IERC20(address(0));
+    }
+
+    function avsStateViewer() external pure returns (IAVSStateViewer) {
+        return IAVSStateViewer(address(0));
     }
 
     /// @notice The Delegation contract of EigenLayer.


### PR DESCRIPTION
This PR 
- Creates a base service manager for AVS teams to inherit and use
- Introduces an AVSViewer contract that all service managers must have that is used for fetching values needed on the eigenlayer frontend