### PR TITLE
Permissioned operator churn

### DIFF
--- a/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -42,6 +42,8 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
 
     event OperatorSetParamsUpdated(uint8 indexed quorumNumber, OperatorSetParam operatorSetParams);
 
+    event ChurnApproverUpdated(address churnApprover);
+
     /// @notice Returns the operator set params for the given `quorumNumber`
     function getOperatorSetParams(uint8 quorumNumber) external view returns (OperatorSetParam memory);
     /// @notice the stake registry for this corrdinator is the contract itself

--- a/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
+import "./ISignatureUtils.sol";
 import "./IRegistryCoordinator.sol";
 import "./IStakeRegistry.sol";
 import "./IBLSPubkeyRegistry.sol";
@@ -10,7 +11,7 @@ import "./IIndexRegistry.sol";
  * @title Minimal interface for the `IBLSStakeRegistryCoordinator` contract.
  * @author Layr Labs, Inc.
  */
-interface IBLSRegistryCoordinatorWithIndices is IRegistryCoordinator {
+interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordinator {
     // STRUCT
 
     /**

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
+import "./ISignatureUtils.sol";
 import "./IStrategy.sol";
 
 /**
@@ -13,7 +14,7 @@ import "./IStrategy.sol";
  * - enabling any staker to delegate its stake to the operator of its choice (a given staker can only delegate to a single operator at a time)
  * - enabling a staker to undelegate its assets from the operator it is delegated to (performed as part of the withdrawal process, initiated through the StrategyManager)
  */
-interface IDelegationManager {
+interface IDelegationManager is ISignatureUtils {
     // @notice Struct used for storing information about a single operator who has registered with EigenLayer
     struct OperatorDetails {
         // @notice address to receive the rewards that the operator earns via serving applications built on EigenLayer.
@@ -66,15 +67,7 @@ interface IDelegationManager {
         // the expiration timestamp (UTC) of the signature
         uint256 expiry;
     }
-
-    // @notice Struct that bundles together a signature and an expiration time for the signature. Used primarily for stack management.
-    struct SignatureWithExpiry {
-        // the signature itself, formatted as a single bytes object
-        bytes signature;
-        // the expiration timestamp (UTC) of the signature
-        uint256 expiry;
-    }
-
+    
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, OperatorDetails operatorDetails);
 

--- a/src/contracts/interfaces/ISignatureUtils.sol
+++ b/src/contracts/interfaces/ISignatureUtils.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+/**
+ * @title The interface for common signature utilities.
+ * @author Layr Labs, Inc.
+ * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
+ */
+interface ISignatureUtils {
+    // @notice Struct that bundles together a signature and an expiration time for the signature. Used primarily for stack management.
+    struct SignatureWithExpiry {
+        // the signature itself, formatted as a single bytes object
+        bytes signature;
+        // the expiration timestamp (UTC) of the signature
+        uint256 expiry;
+    }
+}

--- a/src/contracts/interfaces/ISignatureUtils.sol
+++ b/src/contracts/interfaces/ISignatureUtils.sol
@@ -14,4 +14,14 @@ interface ISignatureUtils {
         // the expiration timestamp (UTC) of the signature
         uint256 expiry;
     }
+
+    // @notice Struct that bundles together a signature, a salt for uniqueness, and an expiration time for the signature. Used primarily for stack management.
+    struct SignatureWithSaltAndExpiry {
+        // the signature itself, formatted as a single bytes object
+        bytes signature;
+        // the salt used to generate the signature
+        bytes32 salt;
+        // the expiration timestamp (UTC) of the signature
+        uint256 expiry;
+    }
 }

--- a/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
@@ -208,7 +208,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
      * @dev only callable by the service manager owner
      */
     function setChurnApprover(address _churnApprover) external onlyServiceManagerOwner {
-        churnApprover = _churnApprover;
+        _setChurnApprover(_churnApprover);
     }
 
     /**
@@ -340,6 +340,11 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
     function _setOperatorSetParams(uint8 quorumNumber, OperatorSetParam memory operatorSetParam) internal {
         _quorumOperatorSetParams[quorumNumber] = operatorSetParam;
         emit OperatorSetParamsUpdated(quorumNumber, operatorSetParam);
+    }
+    
+    function _setChurnApprover(address newChurnApprover) internal {
+        churnApprover = newChurnApprover;
+        emit ChurnApproverUpdated(newChurnApprover);
     }
 
     /// @return numOperatorsPerQuorum is the list of number of operators per quorum in quorumNumberss

--- a/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -49,7 +49,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
         // make sure the contract intializers are disabled
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
-        registryCoordinator.initialize(churner, operatorSetParams);
+        registryCoordinator.initialize(churnApprover, operatorSetParams);
     }
 
     function testRegisterOperatorWithCoordinator_EmptyQuorumNumbers_Reverts() public {
@@ -628,7 +628,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         cheats.roll(registrationBlockNumber);
         ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, block.timestamp - 1);
         cheats.prank(operatorToRegister);
-        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnerSignatureOnOperatorChurnApproval: churner signature expired");
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignatureOnOperatorChurnApproval: churnApprover signature expired");
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
     }
 

--- a/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -71,6 +71,13 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
 
     function testSetChurnApprover_NotServiceManagerOwner_Reverts() public {
         address newChurnApprover = address(uint160(uint256(keccak256("newChurnApprover"))));
+        cheats.expectRevert("BLSRegistryCoordinatorWithIndices.onlyServiceManagerOwner: caller is not the service manager owner");
+        cheats.prank(defaultOperator);
+        registryCoordinator.setChurnApprover(newChurnApprover);
+    }
+
+    function testSetChurnApprover_Valid() public {
+        address newChurnApprover = address(uint160(uint256(keccak256("newChurnApprover"))));
         cheats.prank(serviceManagerOwner);
         cheats.expectEmit(true, true, true, true, address(registryCoordinator));
         emit ChurnApproverUpdated(newChurnApprover);

--- a/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
+++ b/src/test/unit/BLSRegistryCoordinatorWithIndicesUnit.t.sol
@@ -507,7 +507,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         emit QuorumIndexUpdate(operatorToRegisterId, defaultQuorumNumber, numOperators - 1);
 
         {
-            ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, block.timestamp + 10);
+            ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
             cheats.prank(operatorToRegister);
             uint256 gasBefore = gasleft();
             registryCoordinator.registerOperatorWithCoordinator(
@@ -560,7 +560,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(defaultQuorumNumber, operatorToRegister, defaultStake);
 
         cheats.roll(registrationBlockNumber);
-        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, block.timestamp + 10);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithCoordinator: registering operator has less than kickBIPsOfOperatorStake");
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
@@ -583,7 +583,7 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(defaultQuorumNumber, operatorToRegister, operatorToKickStake * defaultKickBIPsOfOperatorStake / 10000 + 1);
 
         cheats.roll(registrationBlockNumber);
-        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, block.timestamp + 10);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp + 10);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.registerOperatorWithCoordinator: operator to kick has more than kickBIPSOfTotalStake");
         registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
@@ -603,12 +603,13 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(defaultQuorumNumber, operatorToRegister, registeringStake);
 
         cheats.roll(registrationBlockNumber);
-        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry;
-        signatureWithExpiry.expiry = block.timestamp + 10;
-        signatureWithExpiry.signature = hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001B";
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry;
+        signatureWithSaltAndExpiry.expiry = block.timestamp + 10;
+        signatureWithSaltAndExpiry.signature = hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001B";
+        signatureWithSaltAndExpiry.salt = defaultSalt;
         cheats.prank(operatorToRegister);
         cheats.expectRevert("ECDSA: invalid signature");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testRegisterOperatorWithCoordinatorWithKicks_ExpiredSignatures_Reverts(uint256 pseudoRandomNumber) public {
@@ -626,10 +627,10 @@ contract BLSRegistryCoordinatorWithIndicesUnit is MockAVSDeployer {
         stakeRegistry.setOperatorWeight(defaultQuorumNumber, operatorToRegister, registeringStake);
 
         cheats.roll(registrationBlockNumber);
-        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, block.timestamp - 1);
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry = _signOperatorChurnApproval(operatorToRegisterId, operatorKickParams, defaultSalt, block.timestamp - 1);
         cheats.prank(operatorToRegister);
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices._verifyChurnApproverSignatureOnOperatorChurnApproval: churnApprover signature expired");
-        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithExpiry);
+        registryCoordinator.registerOperatorWithCoordinator(quorumNumbers, operatorToRegisterPubKey, defaultSocket, operatorKickParams, signatureWithSaltAndExpiry);
     }
 
     function testUpdateSocket() public {

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -201,7 +201,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
 
         cheats.expectRevert(bytes("DelegationManager._delegate: staker is already actively delegated"));
@@ -311,7 +311,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateToOperatorWhoAcceptsAllStakers(address staker, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry) public 
+    function testDelegateToOperatorWhoAcceptsAllStakers(address staker, ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) public 
         filterFuzzedAddressInputs(staker)
     {
         // register *this contract* as an operator
@@ -347,7 +347,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     /**
      * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
      */
-    function testCannotDelegateWhileDelegated(address staker, address operator, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry) public 
+    function testCannotDelegateWhileDelegated(address staker, address operator, ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) public 
         filterFuzzedAddressInputs(staker)
         filterFuzzedAddressInputs(operator)
     {
@@ -384,7 +384,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // try to delegate and check that the call reverts
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
         cheats.stopPrank();
     }
@@ -421,7 +421,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // fetch the delegationApprover's current nonce
         uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
@@ -467,7 +467,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         approverSignatureAndExpiry.expiry = expiry;
         {
             bytes32 digestHash = delegationManager.calculateCurrentDelegationApprovalDigestHash(staker, operator, expiry);
@@ -510,7 +510,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
@@ -558,7 +558,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // fetch the delegationApprover's current nonce
         uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
@@ -607,7 +607,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // create the signature struct
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         approverSignatureAndExpiry.expiry = expiry;
 
         // try to delegate from the `staker` to the operator, and check reversion
@@ -654,14 +654,14 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
         // calculate the staker signature
-        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
 
         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
         cheats.startPrank(caller);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerDelegated(staker, operator);
         // use an empty approver signature input since none is needed / the input is unchecked
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry);        
         cheats.stopPrank();
 
@@ -712,12 +712,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // fetch the delegationApprover's current nonce
         uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
         // calculate the staker signature
-        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
 
         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
         cheats.startPrank(caller);
@@ -785,12 +785,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // fetch the delegationApprover's current nonce
         uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
         // calculate the staker signature
-        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
 
         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
         cheats.startPrank(caller);
@@ -821,7 +821,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     function testDelegateBySignatureRevertsWhenStakerSignatureExpired(address staker, address operator, uint256 expiry, bytes memory signature) public{
         cheats.assume(expiry < block.timestamp);
         cheats.expectRevert(bytes("DelegationManager.delegateToBySignature: staker signature expired"));
-        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry = IDelegationManager.SignatureWithExpiry({
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = ISignatureUtils.SignatureWithExpiry({
             signature: signature,
             expiry: expiry
         });
@@ -855,10 +855,10 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, delegationApproverExpiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, delegationApproverExpiry);
 
         // calculate the staker signature
-        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, stakerExpiry);
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, stakerExpiry);
 
         // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
         cheats.startPrank(caller);
@@ -893,7 +893,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
@@ -912,7 +912,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      */
     function testUndelegateFromOperator(address staker) public {
         // register *this contract* as an operator and delegate from the `staker` to them (already filters out case when staker is the operator since it will revert)
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         testDelegateToOperatorWhoAcceptsAllStakers(staker, approverSignatureAndExpiry);
 
         cheats.startPrank(address(strategyManagerMock));
@@ -960,7 +960,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // register *this contract* as an operator
         address operator = address(this);
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
         cheats.assume(staker != operator);
 
@@ -1006,7 +1006,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.assume(strategies.length <= 64);
         // register *this contract* as an operator
         address operator = address(this);
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
         cheats.assume(staker != operator);
 
@@ -1093,7 +1093,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         slasherMock.setOperatorFrozenStatus(operator, true);
         cheats.expectRevert(bytes("DelegationManager._delegate: cannot delegate to a frozen operator"));
         cheats.startPrank(staker);
-        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry;
         delegationManager.delegateTo(operator, signatureWithExpiry);
         cheats.stopPrank();
     }
@@ -1122,7 +1122,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.stopPrank();
 
         cheats.startPrank(staker);
-        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry;
         delegationManager.delegateTo(operator, signatureWithExpiry);
         cheats.stopPrank();
 
@@ -1135,7 +1135,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     // @notice Verifies that it is not possible to delegate to an unregistered operator
     function testCannotDelegateToUnregisteredOperator(address operator) public {
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
-        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry;
         delegationManager.delegateTo(operator, signatureWithExpiry);
     }
 
@@ -1147,7 +1147,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("Pausable: index is paused"));
-        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry;
         delegationManager.delegateTo(operator, signatureWithExpiry);
         cheats.stopPrank();
     }
@@ -1251,7 +1251,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * the `staker` to delegate to `operator`, and expiring at `expiry`.
      */
     function _getApproverSignature(uint256 _delegationSignerPrivateKey, address staker, address operator, uint256 expiry)
-        internal view returns (IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry)
+        internal view returns (ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry)
     {
         approverSignatureAndExpiry.expiry = expiry;
         {
@@ -1267,7 +1267,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * the `operator`, and expiring at `expiry`.
      */
     function _getStakerSignature(uint256 _stakerPrivateKey, address operator, uint256 expiry)
-        internal view returns (IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry)
+        internal view returns (ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry)
     {
         address staker = cheats.addr(stakerPrivateKey);
         stakerSignatureAndExpiry.expiry = expiry;

--- a/src/test/utils/MockAVSDeployer.sol
+++ b/src/test/utils/MockAVSDeployer.sol
@@ -70,6 +70,9 @@ contract MockAVSDeployer is Test {
     address public pauser = address(uint160(uint256(keccak256("pauser"))));
     address public unpauser = address(uint160(uint256(keccak256("unpauser"))));
 
+    uint256 churnerPrivateKey = uint256(keccak256("churnerPrivateKey"));
+    address churner = cheats.addr(churnerPrivateKey);
+
     address defaultOperator = address(uint160(uint256(keccak256("defaultOperator"))));
     bytes32 defaultOperatorId;
     BN254.G1Point internal defaultPubKey =  BN254.G1Point(18260007818883133054078754218619977578772505796600400998181738095793040006897,3432351341799135763167709827653955074218841517684851694584291831827675065899);
@@ -238,6 +241,7 @@ contract MockAVSDeployer is Test {
                 address(registryCoordinatorImplementation),
                 abi.encodeWithSelector(
                     BLSRegistryCoordinatorWithIndices.initialize.selector,
+                    churner,
                     operatorSetParams
                 )
             );
@@ -360,5 +364,20 @@ contract MockAVSDeployer is Test {
 
     function _incrementBytes32(bytes32 start, uint256 inc) internal pure returns(bytes32) {
         return bytes32(uint256(start) + inc);
+    }
+
+    function _signOperatorChurnApproval(bytes32 registeringOperatorId, IBLSRegistryCoordinatorWithIndices.OperatorKickParam[] memory operatorKickParams, uint256 expiry) internal  returns(ISignatureUtils.SignatureWithExpiry memory) {
+        bytes32 digestHash = registryCoordinator.calculateCurrentOperatorChurnApprovalDigestHash(
+            registeringOperatorId,
+            operatorKickParams,
+            expiry
+        );
+        emit log_named_address("churner", churner);
+        emit log_named_bytes32("digestHash", digestHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(churnerPrivateKey, digestHash);
+        return ISignatureUtils.SignatureWithExpiry({
+            signature: abi.encodePacked(r, s, v),
+            expiry: expiry
+        });
     }
 }

--- a/src/test/utils/MockAVSDeployer.sol
+++ b/src/test/utils/MockAVSDeployer.sol
@@ -70,8 +70,8 @@ contract MockAVSDeployer is Test {
     address public pauser = address(uint160(uint256(keccak256("pauser"))));
     address public unpauser = address(uint160(uint256(keccak256("unpauser"))));
 
-    uint256 churnerPrivateKey = uint256(keccak256("churnerPrivateKey"));
-    address churner = cheats.addr(churnerPrivateKey);
+    uint256 churnApproverPrivateKey = uint256(keccak256("churnApproverPrivateKey"));
+    address churnApprover = cheats.addr(churnApproverPrivateKey);
 
     address defaultOperator = address(uint160(uint256(keccak256("defaultOperator"))));
     bytes32 defaultOperatorId;
@@ -241,7 +241,7 @@ contract MockAVSDeployer is Test {
                 address(registryCoordinatorImplementation),
                 abi.encodeWithSelector(
                     BLSRegistryCoordinatorWithIndices.initialize.selector,
-                    churner,
+                    churnApprover,
                     operatorSetParams
                 )
             );
@@ -372,9 +372,7 @@ contract MockAVSDeployer is Test {
             operatorKickParams,
             expiry
         );
-        emit log_named_address("churner", churner);
-        emit log_named_bytes32("digestHash", digestHash);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(churnerPrivateKey, digestHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(churnApproverPrivateKey, digestHash);
         return ISignatureUtils.SignatureWithExpiry({
             signature: abi.encodePacked(r, s, v),
             expiry: expiry

--- a/src/test/utils/MockAVSDeployer.sol
+++ b/src/test/utils/MockAVSDeployer.sol
@@ -72,6 +72,7 @@ contract MockAVSDeployer is Test {
 
     uint256 churnApproverPrivateKey = uint256(keccak256("churnApproverPrivateKey"));
     address churnApprover = cheats.addr(churnApproverPrivateKey);
+    bytes32 defaultSalt = bytes32(uint256(keccak256("defaultSalt")));
 
     address defaultOperator = address(uint160(uint256(keccak256("defaultOperator"))));
     bytes32 defaultOperatorId;
@@ -366,16 +367,18 @@ contract MockAVSDeployer is Test {
         return bytes32(uint256(start) + inc);
     }
 
-    function _signOperatorChurnApproval(bytes32 registeringOperatorId, IBLSRegistryCoordinatorWithIndices.OperatorKickParam[] memory operatorKickParams, uint256 expiry) internal  returns(ISignatureUtils.SignatureWithExpiry memory) {
-        bytes32 digestHash = registryCoordinator.calculateCurrentOperatorChurnApprovalDigestHash(
+    function _signOperatorChurnApproval(bytes32 registeringOperatorId, IBLSRegistryCoordinatorWithIndices.OperatorKickParam[] memory operatorKickParams, bytes32 salt,  uint256 expiry) internal  returns(ISignatureUtils.SignatureWithSaltAndExpiry memory) {
+        bytes32 digestHash = registryCoordinator.calculateOperatorChurnApprovalDigestHash(
             registeringOperatorId,
             operatorKickParams,
+            salt,
             expiry
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(churnApproverPrivateKey, digestHash);
-        return ISignatureUtils.SignatureWithExpiry({
+        return ISignatureUtils.SignatureWithSaltAndExpiry({
             signature: abi.encodePacked(r, s, v),
-            expiry: expiry
+            expiry: expiry,
+            salt: salt
         });
     }
 }


### PR DESCRIPTION
Added churner role and tests for it

Tests summary/updates:
- Added utility for churner to sign on OperatorChurnApprovals
- Added tests for 
    - Expired signatures
    - Invalid signatures
    - Added churner signatures to existing happy path test cases
    - Abstracted internal logic from operator kicking tests