### PR TITLE
Switch from nonces to salts for DelegationApprovals

### DIFF
--- a/script/DepositAndDelegate.s.sol
+++ b/script/DepositAndDelegate.s.sol
@@ -30,7 +30,7 @@ contract DepositAndDelegate is Script, DSTest, EigenLayerParser {
         weth.approve(address(strategyManager), wethAmount);
         strategyManager.depositIntoStrategy(wethStrat, weth, wethAmount);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(dlnAddr, signatureWithExpiry);
+        delegation.delegateTo(dlnAddr, signatureWithExpiry, bytes32(0));
         vm.stopBroadcast();
     }
 }

--- a/script/whitelist/Staker.sol
+++ b/script/whitelist/Staker.sol
@@ -22,7 +22,7 @@ contract Staker is Ownable {
         token.approve(address(strategyManager), type(uint256).max);
         strategyManager.depositIntoStrategy(strategy, token, amount);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(operator, signatureWithExpiry);
+        delegation.delegateTo(operator, signatureWithExpiry, bytes32(0));
     }
     
     function callAddress(address implementation, bytes memory data) external onlyOwner returns(bytes memory) {

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -22,7 +22,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
 
     /// @notice The EIP-712 typehash for the `DelegationApproval` struct used by the contract
     bytes32 public constant DELEGATION_APPROVAL_TYPEHASH =
-        keccak256("DelegationApproval(address staker,address operator,uint256 nonce,uint256 expiry)");
+        keccak256("DelegationApproval(address staker,address operator,bytes32 salt,uint256 expiry)");
 
     /**
      * @notice Original EIP-712 Domain separator for this contract.
@@ -59,11 +59,11 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     mapping(address => uint256) public stakerNonce;
 
     /**
-     * @notice Mapping: delegationApprover => number of signed delegation messages (used in `delegateTo` and `delegateToBySignature` from the delegationApprover
-     * that this contract has already checked.
-     * @dev Note that these functions only delegationApprover signatures if the operator being delegated to has specified a nonzero address as their `delegationApprover`
+     * @notice Mapping: delegationApprover => 32-byte salt => whether or not the salt has already been used by the delegationApprover.
+     * @dev Salts are used in the `delegateTo` and `delegateToBySignature` functions. Note that these functions only process the delegationApprover's
+     * signature + the provided salt if the operator being delegated to has specified a nonzero address as their `delegationApprover`.
      */
-    mapping(address => uint256) public delegationApproverNonce;
+    mapping(address => mapping(bytes32 => bool)) public delegationApproverSaltIsSpent;
 
     constructor(IStrategyManager _strategyManager, ISlasher _slasher) {
         strategyManager = _strategyManager;

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -61,8 +61,8 @@ interface IDelegationManager {
         address staker;
         // the operator being delegated to
         address operator;
-        // the operator's nonce
-        uint256 nonce;
+        // the operator's provided salt
+        bytes32 salt;
         // the expiration timestamp (UTC) of the signature
         uint256 expiry;
     }
@@ -129,8 +129,9 @@ interface IDelegationManager {
      * is the `msg.sender`, then approval is assumed.
      * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
+     * @param approverSalt Is a salt used to help guarantee signature uniqueness. Each salt can only be used once by a given approver.
      */
-    function delegateTo(address operator, SignatureWithExpiry memory approverSignatureAndExpiry) external;
+    function delegateTo(address operator, SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt) external;
 
     /**
      * @notice Delegates from @param staker to @param operator.
@@ -145,12 +146,14 @@ interface IDelegationManager {
      * is the `msg.sender`, then approval is assumed.
      * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
+     * @param approverSalt Is a salt used to help guarantee signature uniqueness. Each salt can only be used once by a given approver.
      */
     function delegateToBySignature(
         address staker,
         address operator,
         SignatureWithExpiry memory stakerSignatureAndExpiry,
-        SignatureWithExpiry memory approverSignatureAndExpiry
+        SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
     ) external;
 
     /**
@@ -225,11 +228,11 @@ interface IDelegationManager {
     function stakerNonce(address staker) external view returns (uint256);
 
     /**
-     * @notice Mapping: delegationApprover => number of signed delegation messages (used in `delegateTo` and `delegateToBySignature` from the delegationApprover
-     * that this contract has already checked.
-     * @dev Note that these functions only delegationApprover signatures if the operator being delegated to has specified a nonzero address as their `delegationApprover`
+     * @notice Mapping: delegationApprover => 32-byte salt => whether or not the salt has already been used by the delegationApprover.
+     * @dev Salts are used in the `delegateTo` and `delegateToBySignature` functions. Note that these functions only process the delegationApprover's
+     * signature + the provided salt if the operator being delegated to has specified a nonzero address as their `delegationApprover`.
      */
-    function delegationApproverNonce(address delegationApprover) external view returns (uint256);
+    function delegationApproverSaltIsSpent(address delegationApprover, bytes32 salt) external view returns (bool);
 
     /**
      * @notice External function that calculates the digestHash for a `staker` to sign in order to approve their delegation to an `operator`,
@@ -250,27 +253,21 @@ interface IDelegationManager {
     function calculateStakerDelegationDigestHash(address staker, uint256 stakerNonce, address operator, uint256 expiry) external view returns (bytes32);
 
     /**
-     * @notice Exneral function that calculates the digestHash for the `operator`'s "delegationApprover" to sign in order to approve the
-     * delegation of `staker` to the `operator`, using the approver's current nonce and specifying an expiration of `expiry`
-     * @param staker The staker who is delegating to the operator
-     * @param operator The operator who is being delegated to
-     * @param expiry The desired expiry time of the approver's signature
-     */
-    function calculateCurrentDelegationApprovalDigestHash(address staker, address operator, uint256 expiry) external view returns (bytes32);
-
-    /**
-     * @notice Public function for the the approver signature hash calculation in the `_delegate` function
+     * @notice Public function for the the approver signature hash calculation in the internal `_delegate` function, which is called by both
+     * the `delegateTo` and `delegateToBySignature` functions.
+     * Calculates the digestHash for the `operator`'s "delegationApprover" to sign in order to approve the
+     * delegation of `staker` to the `operator`, using the approver's provided `salt` and specifying an expiration of `expiry`
      * @param staker The staker who is delegating to the operator
      * @param operator The operator who is being delegated to
      * @param _delegationApprover the operator's `delegationApprover` who will be signing the delegationHash (in general)
-     * @param approverNonce The nonce of the approver. In practice we use the approver's current nonce, stored at `delegationApproverNonce[_delegationApprover]`
+     * @param approverSalt The salt provided by the approver. Each salt can only be used once by a given approver.
      * @param expiry The desired expiry time of the approver's signature
      */
     function calculateDelegationApprovalDigestHash(
         address staker,
         address operator,
         address _delegationApprover,
-        uint256 approverNonce,
+        bytes32 approverSalt,
         uint256 expiry
     ) external view returns (bytes32);
 

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -232,7 +232,7 @@ contract DelegationTests is EigenLayerTestHelper {
             signature: signature,
             expiry: expiry
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, bytes32(0));
         if (expiry >= block.timestamp) {
             assertTrue(delegation.isDelegated(staker) == true, "testDelegation: staker is not delegate");
             assertTrue(nonceBefore + 1 == delegation.stakerNonce(staker), "nonce not incremented correctly");
@@ -270,7 +270,7 @@ contract DelegationTests is EigenLayerTestHelper {
             signature: signature,
             expiry: type(uint256).max
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, bytes32(0));
         assertTrue(delegation.isDelegated(staker) == true, "testDelegation: staker is not delegate");
         assertTrue(nonceBefore + 1 == delegation.stakerNonce(staker), "nonce not incremented correctly");
         assertTrue(delegation.delegatedTo(staker) == operator, "staker delegated to wrong operator");
@@ -309,7 +309,7 @@ contract DelegationTests is EigenLayerTestHelper {
             signature: signature,
             expiry: type(uint256).max
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, bytes32(0));
     }
 
     /// @notice  tries delegating using a wallet that does not comply with EIP 1271
@@ -336,7 +336,7 @@ contract DelegationTests is EigenLayerTestHelper {
             signature: signature,
             expiry: type(uint256).max
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, bytes32(0));
     }
 
     /// @notice tests delegation to EigenLayer via an ECDSA signatures with invalid signature
@@ -363,7 +363,7 @@ contract DelegationTests is EigenLayerTestHelper {
             signature: signature,
             expiry: type(uint256).max
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, bytes32(0));
     }
 
     /// @notice registers a fixed address as a delegate, delegates to it from a second address,
@@ -444,7 +444,7 @@ contract DelegationTests is EigenLayerTestHelper {
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
         cheats.startPrank(getOperatorAddress(1));
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(delegate, signatureWithExpiry);
+        delegation.delegateTo(delegate, signatureWithExpiry, bytes32(0));
         cheats.stopPrank();
     }
 
@@ -492,9 +492,9 @@ contract DelegationTests is EigenLayerTestHelper {
         vm.startPrank(_staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(_unregisteredOperator, signatureWithExpiry);
+        delegation.delegateTo(_unregisteredOperator, signatureWithExpiry, bytes32(0));
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
-        delegation.delegateTo(_staker, signatureWithExpiry);
+        delegation.delegateTo(_staker, signatureWithExpiry, bytes32(0));
         cheats.stopPrank();
         
     }
@@ -519,7 +519,7 @@ contract DelegationTests is EigenLayerTestHelper {
         delegation.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
         vm.prank(_staker);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(_operator, signatureWithExpiry);
+        delegation.delegateTo(_operator, signatureWithExpiry, bytes32(0));
 
         //operators cannot undelegate from themselves
         vm.prank(address(strategyManager));

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -196,7 +196,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
 
         cheats.startPrank(staker);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(operator, signatureWithExpiry);
+        delegation.delegateTo(operator, signatureWithExpiry, bytes32(0));
         cheats.stopPrank();
 
         assertTrue(

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1123,7 +1123,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
         cheats.startPrank(sender);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegation.delegateTo(operator, signatureWithExpiry);
+        delegation.delegateTo(operator, signatureWithExpiry, bytes32(0));
         cheats.stopPrank();
 
         assertTrue(

--- a/src/test/mocks/DelegationMock.sol
+++ b/src/test/mocks/DelegationMock.sol
@@ -18,7 +18,7 @@ contract DelegationMock is IDelegationManager, Test {
     
     function updateOperatorMetadataURI(string calldata /*metadataURI*/) external pure {}
 
-    function delegateTo(address operator, SignatureWithExpiry memory /*approverSignatureAndExpiry*/) external {
+    function delegateTo(address operator, SignatureWithExpiry memory /*approverSignatureAndExpiry*/, bytes32 /*approverSalt*/) external {
         delegatedTo[msg.sender] = operator;
     }
 
@@ -28,7 +28,8 @@ contract DelegationMock is IDelegationManager, Test {
         address /*staker*/,
         address /*operator*/,
         SignatureWithExpiry memory /*stakerSignatureAndExpiry*/,
-        SignatureWithExpiry memory /*approverSignatureAndExpiry*/
+        SignatureWithExpiry memory /*approverSignatureAndExpiry*/,
+        bytes32 /*approverSalt*/
     ) external pure {}
 
     function undelegate(address staker) external {
@@ -74,19 +75,17 @@ contract DelegationMock is IDelegationManager, Test {
 
     function stakerNonce(address /*staker*/) external pure returns (uint256) {}
 
-    function delegationApproverNonce(address /*operator*/) external pure returns (uint256) {}
+    function delegationApproverSaltIsSpent(address /*delegationApprover*/, bytes32 /*salt*/) external pure returns (bool) {}
 
     function calculateCurrentStakerDelegationDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/) external view returns (bytes32) {}
 
     function calculateStakerDelegationDigestHash(address /*staker*/, uint256 /*stakerNonce*/, address /*operator*/, uint256 /*expiry*/) external view returns (bytes32) {}
 
-    function calculateCurrentDelegationApprovalDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/) external view returns (bytes32) {}
-
     function calculateDelegationApprovalDigestHash(
         address /*staker*/,
         address /*operator*/,
         address /*_delegationApprover*/,
-        uint256 /*approverNonce*/,
+        bytes32 /*approverSalt*/,
         uint256 /*expiry*/
     ) external view returns (bytes32) {}
 

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -27,6 +27,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     // empty string reused across many tests
     string emptyStringForMetadataURI;
 
+    // "empty" / zero salt, reused across many tests
+    bytes32 emptySalt;
+
+    // reused in various tests. in storage to help handle stack-too-deep errors
+    address _operator = address(this);
+
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, IDelegationManager.OperatorDetails operatorDetails);
 
@@ -194,18 +200,17 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.assume(operatorDetails.earningsReceiver != address(0));
 
         // register *this contract* as an operator
-        address operator = address(this);
         IDelegationManager.OperatorDetails memory _operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
+            earningsReceiver: _operator,
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });
-        testRegisterAsOperator(operator, _operatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, _operatorDetails, emptyStringForMetadataURI);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(_operator, approverSignatureAndExpiry, emptySalt);        
 
         cheats.expectRevert(bytes("DelegationManager._delegate: staker is already actively delegated"));
         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
@@ -226,12 +231,11 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         IDelegationManager.OperatorDetails memory initialOperatorDetails,
         IDelegationManager.OperatorDetails memory modifiedOperatorDetails
     ) public {
-        address operator = address(this);
-        testRegisterAsOperator(operator, initialOperatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, initialOperatorDetails, emptyStringForMetadataURI);
         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
         cheats.assume(modifiedOperatorDetails.earningsReceiver != address(0));
 
-        cheats.startPrank(operator);
+        cheats.startPrank(_operator);
 
         // either it fails for trying to set the stakerOptOutWindowBlocks
         if (modifiedOperatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS()) {
@@ -240,13 +244,13 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // or the transition is allowed,
         } else if (modifiedOperatorDetails.stakerOptOutWindowBlocks >= initialOperatorDetails.stakerOptOutWindowBlocks) {
             cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorDetailsModified(operator, modifiedOperatorDetails);
+            emit OperatorDetailsModified(_operator, modifiedOperatorDetails);
             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
 
-            require(modifiedOperatorDetails.earningsReceiver == delegationManager.earningsReceiver(operator), "earningsReceiver not set correctly");
-            require(modifiedOperatorDetails.delegationApprover == delegationManager.delegationApprover(operator), "delegationApprover not set correctly");
-            require(modifiedOperatorDetails.stakerOptOutWindowBlocks == delegationManager.stakerOptOutWindowBlocks(operator), "stakerOptOutWindowBlocks not set correctly");
-            require(delegationManager.delegatedTo(operator) == operator, "operator not delegated to self");
+            require(modifiedOperatorDetails.earningsReceiver == delegationManager.earningsReceiver(_operator), "earningsReceiver not set correctly");
+            require(modifiedOperatorDetails.delegationApprover == delegationManager.delegationApprover(_operator), "delegationApprover not set correctly");
+            require(modifiedOperatorDetails.stakerOptOutWindowBlocks == delegationManager.stakerOptOutWindowBlocks(_operator), "stakerOptOutWindowBlocks not set correctly");
+            require(delegationManager.delegatedTo(_operator) == _operator, "operator not delegated to self");
         // or else the transition is disallowed
         } else {
             cheats.expectRevert(bytes("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased"));
@@ -259,28 +263,26 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     // @notice Tests that an operator who calls `updateOperatorMetadataURI` will correctly see an `OperatorMetadataURIUpdated` event emitted with their input
     function testUpdateOperatorMetadataURI(string memory metadataURI) public {
         // register *this contract* as an operator
-        address operator = address(this);
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
+            earningsReceiver: _operator,
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });
-        testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, operatorDetails, emptyStringForMetadataURI);
 
         // call `updateOperatorMetadataURI` and check for event
-        cheats.startPrank(operator);
+        cheats.startPrank(_operator);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorMetadataURIUpdated(operator, metadataURI);
+        emit OperatorMetadataURIUpdated(_operator, metadataURI);
         delegationManager.updateOperatorMetadataURI(metadataURI);
         cheats.stopPrank();
     }
 
     // @notice Tests that an address which is not an operator cannot successfully call `updateOperatorMetadataURI`.
     function testCannotUpdateOperatorMetadataURIWithoutRegisteringFirst() public {
-        address operator = address(this);
-        require(!delegationManager.isOperator(operator), "bad test setup");
+        require(!delegationManager.isOperator(_operator), "bad test setup");
 
-        cheats.startPrank(operator);
+        cheats.startPrank(_operator);
         cheats.expectRevert(bytes("DelegationManager.updateOperatorMetadataURI: caller must be an operator"));
         delegationManager.updateOperatorMetadataURI(emptyStringForMetadataURI);
         cheats.stopPrank();
@@ -292,13 +294,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      */
     function testCannotModifyEarningsReceiverAddressToZeroAddress() public {
         // register *this contract* as an operator
-        address operator = address(this);
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
+            earningsReceiver: _operator,
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });
-        testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, operatorDetails, emptyStringForMetadataURI);
 
         operatorDetails.earningsReceiver = address(0);
         cheats.expectRevert(bytes("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address"));
@@ -314,43 +315,42 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateToOperatorWhoAcceptsAllStakers(address staker, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry) public 
+    function testDelegateToOperatorWhoAcceptsAllStakers(address staker, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 salt) public 
         filterFuzzedAddressInputs(staker)
     {
         // register *this contract* as an operator
-        address operator = address(this);
         // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != operator);
+        cheats.assume(staker != _operator);
 
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
+            earningsReceiver: _operator,
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });
-        testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(_operator), salt), "salt somehow spent too early?");
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, operator);
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        emit StakerDelegated(staker, _operator);
+        delegationManager.delegateTo(_operator, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
 
         require(delegationManager.isDelegated(staker), "staker not delegated correctly");
-        require(delegationManager.delegatedTo(staker) == operator, "staker delegated to the wrong address");
+        require(delegationManager.delegatedTo(staker) == _operator, "staker delegated to the wrong address");
         require(!delegationManager.isOperator(staker), "staker incorrectly registered as operator");
 
-        require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-            "delegationApprover nonce incremented inappropriately");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(_operator), salt), "salt somehow spent too early?");
     }
 
     /**
      * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
      */
-    function testCannotDelegateWhileDelegated(address staker, address operator, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry) public 
+    function testCannotDelegateWhileDelegated(address staker, address operator, IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 salt) public 
         filterFuzzedAddressInputs(staker)
         filterFuzzedAddressInputs(operator)
     {
@@ -358,7 +358,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.assume(staker != operator);
 
         // delegate from the staker to an operator
-        testDelegateToOperatorWhoAcceptsAllStakers(staker, approverSignatureAndExpiry);
+        testDelegateToOperatorWhoAcceptsAllStakers(staker, approverSignatureAndExpiry, salt);
 
         // register another operator
         // filter out this contract, since we already register it as an operator in the above step
@@ -373,7 +373,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // try to delegate again and check that the call reverts
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: staker is already actively delegated"));
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
     }
 
@@ -388,7 +388,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
     }
 
@@ -401,7 +401,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateToOperatorWhoRequiresECDSASignature(address staker, uint256 expiry) public 
+    function testDelegateToOperatorWhoRequiresECDSASignature(address staker, bytes32 salt, uint256 expiry) public 
         filterFuzzedAddressInputs(staker)
     {
         // filter to only valid `expiry` values
@@ -421,16 +421,16 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         });
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too early?");
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, salt, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerDelegated(staker, operator);
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
 
         require(delegationManager.isDelegated(staker), "staker not delegated correctly");
@@ -438,11 +438,11 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         require(!delegationManager.isOperator(staker), "staker incorrectly registered as operator");
 
         if (staker == operator || staker == delegationManager.delegationApprover(operator)) {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-                "delegationApprover nonce incremented inappropriately");
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too incorrectly?");
         } else {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce + 1,
-                "delegationApprover nonce did not increment");
+            // verify that the salt is marked as used
+            require(delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent not spent?");
         }
     }
 
@@ -473,7 +473,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
         approverSignatureAndExpiry.expiry = expiry;
         {
-            bytes32 digestHash = delegationManager.calculateCurrentDelegationApprovalDigestHash(staker, operator, expiry);
+            bytes32 digestHash =
+                delegationManager.calculateDelegationApprovalDigestHash(staker, operator, delegationManager.delegationApprover(operator), emptySalt, expiry);
             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(delegationSignerPrivateKey, digestHash);
             // mess up the signature by flipping v's parity
             v = (v == 27 ? 28 : 27);
@@ -483,14 +484,14 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // try to delegate from the `staker` to the operator, and check reversion
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer"));
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
     }
 
     /**
      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an invalid expiry on purpose and checking that reversion occurs
      */
-    function testDelegateToOperatorWhoRequiresECDSASignature_RevertsWithExpiredDelegationApproverSignature(address staker, uint256 expiry)  public 
+    function testDelegateToOperatorWhoRequiresECDSASignature_RevertsWithExpiredDelegationApproverSignature(address staker, bytes32 salt, uint256 expiry)  public 
         filterFuzzedAddressInputs(staker)
     {
         // roll to a very late timestamp
@@ -513,12 +514,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, salt, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: approver signature expired"));
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
     }
 
@@ -532,7 +533,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateToOperatorWhoRequiresEIP1271Signature(address staker, uint256 expiry) public 
+    function testDelegateToOperatorWhoRequiresEIP1271Signature(address staker, bytes32 salt, uint256 expiry) public 
         filterFuzzedAddressInputs(staker)
     {
         // filter to only valid `expiry` values
@@ -558,16 +559,16 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         });
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too early?");
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, salt, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerDelegated(staker, operator);
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
 
         require(delegationManager.isDelegated(staker), "staker not delegated correctly");
@@ -576,11 +577,11 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // check that the nonce incremented appropriately
         if (staker == operator || staker == delegationManager.delegationApprover(operator)) {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-                "delegationApprover nonce incremented inappropriately");
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too incorrectly?");
         } else {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce + 1,
-                "delegationApprover nonce did not increment");
+            // verify that the salt is marked as used
+            require(delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent not spent?");
         }
     }
 
@@ -618,7 +619,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // because the ERC1271MaliciousMock contract returns the wrong amount of data, we get a low-level "EvmError: Revert" message here rather than the error message bubbling up
         // cheats.expectRevert(bytes("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed"));
         cheats.expectRevert();
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
     }
 
@@ -632,7 +633,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateBySignatureToOperatorWhoAcceptsAllStakers(address caller, uint256 expiry) public 
+    function testDelegateBySignatureToOperatorWhoAcceptsAllStakers(address caller, bytes32 salt, uint256 expiry) public 
         filterFuzzedAddressInputs(caller)
     {
         // filter to only valid `expiry` values
@@ -652,8 +653,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         });
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too early?");
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
         // calculate the staker signature
@@ -665,7 +666,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         emit StakerDelegated(staker, operator);
         // use an empty approver signature input since none is needed / the input is unchecked
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry);        
+        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
 
         // check all the delegation status changes
@@ -676,9 +677,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // check that the staker nonce incremented appropriately
         require(delegationManager.stakerNonce(staker) == currentStakerNonce + 1,
             "staker nonce did not increment");
-        // check that the delegationApprover nonce did not increment
-        require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-            "delegationApprover nonce incremented inappropriately");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too incorrectly?");
     }
 
     /**
@@ -691,7 +691,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateBySignatureToOperatorWhoRequiresECDSASignature(address caller, uint256 expiry) public 
+    function testDelegateBySignatureToOperatorWhoRequiresECDSASignature(address caller, bytes32 salt, uint256 expiry) public 
         filterFuzzedAddressInputs(caller)
     {
         // filter to only valid `expiry` values
@@ -712,10 +712,10 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         });
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too early?");
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, salt, expiry);
 
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
@@ -726,7 +726,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.startPrank(caller);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerDelegated(staker, operator);
-        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry);        
+        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
 
         require(delegationManager.isDelegated(staker), "staker not delegated correctly");
@@ -735,11 +735,11 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // check that the delegationApprover nonce incremented appropriately
         if (caller == operator || caller == delegationManager.delegationApprover(operator)) {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-                "delegationApprover nonce incremented inappropriately");
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent too incorrectly?");
         } else {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce + 1,
-                "delegationApprover nonce did not increment");
+            // verify that the salt is marked as used
+            require(delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(operator), salt), "salt somehow spent not spent?");
         }
 
         // check that the staker nonce incremented appropriately
@@ -758,7 +758,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * Reverts if the staker is already delegated (to the operator or to anyone else)
      * Reverts if the ‘operator’ is not actually registered as an operator
      */
-    function testDelegateBySignatureToOperatorWhoRequiresEIP1271Signature(address caller, uint256 expiry) public 
+    function testDelegateBySignatureToOperatorWhoRequiresEIP1271Signature(address caller, bytes32 salt, uint256 expiry) public 
         filterFuzzedAddressInputs(caller)
     {
         // filter to only valid `expiry` values
@@ -768,9 +768,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         address delegationSigner = cheats.addr(delegationSignerPrivateKey);
 
         // register *this contract* as an operator
-        address operator = address(this);
         // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != operator);
+        cheats.assume(staker != _operator);
 
         /**
          * deploy a ERC1271WalletMock contract with the `delegationSigner` address as the owner,
@@ -779,40 +778,40 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         ERC1271WalletMock wallet = new ERC1271WalletMock(delegationSigner);
 
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
+            earningsReceiver: _operator,
             delegationApprover: address(wallet),
             stakerOptOutWindowBlocks: 0
         });
-        testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
+        testRegisterAsOperator(_operator, operatorDetails, emptyStringForMetadataURI);
 
-        // fetch the delegationApprover's current nonce
-        uint256 currentApproverNonce = delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator));
+        // verify that the salt hasn't been used before
+        require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(_operator), salt), "salt somehow spent too early?");
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, _operator, salt, expiry);
 
         // fetch the staker's current nonce
         uint256 currentStakerNonce = delegationManager.stakerNonce(staker);
         // calculate the staker signature
-        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, _operator, expiry);
 
         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
         cheats.startPrank(caller);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, operator);
-        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry);        
+        emit StakerDelegated(staker, _operator);
+        delegationManager.delegateToBySignature(staker, _operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, salt);        
         cheats.stopPrank();
 
         require(delegationManager.isDelegated(staker), "staker not delegated correctly");
-        require(delegationManager.delegatedTo(staker) == operator, "staker delegated to the wrong address");
+        require(delegationManager.delegatedTo(staker) == _operator, "staker delegated to the wrong address");
         require(!delegationManager.isOperator(staker), "staker incorrectly registered as operator");
 
         // check that the delegationApprover nonce incremented appropriately
-        if (caller == operator || caller == delegationManager.delegationApprover(operator)) {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce,
-                "delegationApprover nonce incremented inappropriately");
+        if (caller == _operator || caller == delegationManager.delegationApprover(_operator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            require(!delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(_operator), salt), "salt somehow spent too incorrectly?");
         } else {
-            require(delegationManager.delegationApproverNonce(delegationManager.delegationApprover(operator)) == currentApproverNonce + 1,
-                "delegationApprover nonce did not increment");
+            // verify that the salt is marked as used
+            require(delegationManager.delegationApproverSaltIsSpent(delegationManager.delegationApprover(_operator), salt), "salt somehow spent not spent?");
         }
 
         // check that the staker nonce incremented appropriately
@@ -828,7 +827,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
             signature: signature,
             expiry: expiry
         });
-        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry);
+        delegation.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, emptySalt);
     }
 
     // @notice Checks that `DelegationManager.delegateToBySignature` reverts if the delegationApprover's signature has expired and their signature is checked
@@ -858,7 +857,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, delegationApproverExpiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry =
+            _getApproverSignature(delegationSignerPrivateKey, staker, operator, emptySalt, delegationApproverExpiry);
 
         // calculate the staker signature
         IDelegationManager.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(stakerPrivateKey, operator, stakerExpiry);
@@ -866,7 +866,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
         cheats.startPrank(caller);
         cheats.expectRevert(bytes("DelegationManager._delegate: approver signature expired"));
-        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry);        
+        delegationManager.delegateToBySignature(staker, operator, stakerSignatureAndExpiry, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
     }
 
@@ -896,12 +896,13 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         testRegisterAsOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
         // calculate the delegationSigner's signature
-        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(delegationSignerPrivateKey, staker, operator, expiry);
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry =
+            _getApproverSignature(delegationSignerPrivateKey, staker, operator, emptySalt, expiry);
 
         // delegate from the `staker` to the operator
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: approver signature expired"));
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
         cheats.stopPrank();
     }
 
@@ -916,7 +917,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     function testUndelegateFromOperator(address staker) public {
         // register *this contract* as an operator and delegate from the `staker` to them (already filters out case when staker is the operator since it will revert)
         IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry;
-        testDelegateToOperatorWhoAcceptsAllStakers(staker, approverSignatureAndExpiry);
+        testDelegateToOperatorWhoAcceptsAllStakers(staker, approverSignatureAndExpiry, emptySalt);
 
         cheats.startPrank(address(strategyManagerMock));
         cheats.expectEmit(true, true, true, true, address(delegationManager));
@@ -979,7 +980,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
             cheats.startPrank(staker);
             cheats.expectEmit(true, true, true, true, address(delegationManager));
             emit StakerDelegated(staker, operator);
-            delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+            delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
             cheats.stopPrank();            
         }
 
@@ -1025,7 +1026,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
             cheats.startPrank(staker);
             cheats.expectEmit(true, true, true, true, address(delegationManager));
             emit StakerDelegated(staker, operator);
-            delegationManager.delegateTo(operator, approverSignatureAndExpiry);        
+            delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);        
             cheats.stopPrank();            
         }
 
@@ -1097,7 +1098,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.expectRevert(bytes("DelegationManager._delegate: cannot delegate to a frozen operator"));
         cheats.startPrank(staker);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegationManager.delegateTo(operator, signatureWithExpiry);
+        delegationManager.delegateTo(operator, signatureWithExpiry, emptySalt);
         cheats.stopPrank();
     }
 
@@ -1126,12 +1127,12 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         cheats.startPrank(staker);
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegationManager.delegateTo(operator, signatureWithExpiry);
+        delegationManager.delegateTo(operator, signatureWithExpiry, emptySalt);
         cheats.stopPrank();
 
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("DelegationManager._delegate: staker is already actively delegated"));
-        delegationManager.delegateTo(operator2, signatureWithExpiry);
+        delegationManager.delegateTo(operator2, signatureWithExpiry, emptySalt);
         cheats.stopPrank();
     }
 
@@ -1139,7 +1140,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     function testCannotDelegateToUnregisteredOperator(address operator) public {
         cheats.expectRevert(bytes("DelegationManager._delegate: operator is not registered in EigenLayer"));
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegationManager.delegateTo(operator, signatureWithExpiry);
+        delegationManager.delegateTo(operator, signatureWithExpiry, emptySalt);
     }
 
     // @notice Verifies that delegating is not possible when the "new delegations paused" switch is flipped
@@ -1151,7 +1152,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.startPrank(staker);
         cheats.expectRevert(bytes("Pausable: index is paused"));
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegationManager.delegateTo(operator, signatureWithExpiry);
+        delegationManager.delegateTo(operator, signatureWithExpiry, emptySalt);
         cheats.stopPrank();
     }
 
@@ -1162,7 +1163,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
      * @notice Verifies that the `forceUndelegation` function properly calls `strategyManager.forceTotalWithdrawal`
      * @param callFromOperatorOrApprover -- calls from the operator if 'false' and the 'approver' if true
      */
-    function testForceUndelegation(address staker, bool callFromOperatorOrApprover) public
+    function testForceUndelegation(address staker, bytes32 salt, bool callFromOperatorOrApprover) public
         fuzzedAddress(staker)
     {
         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
@@ -1173,7 +1174,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // register this contract as an operator and delegate from the staker to it
         uint256 expiry = type(uint256).max;
-        testDelegateToOperatorWhoRequiresECDSASignature(staker, expiry);
+        testDelegateToOperatorWhoRequiresECDSASignature(staker, salt, expiry);
 
         address caller;
         if (callFromOperatorOrApprover) {
@@ -1212,7 +1213,7 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         // register this contract as an operator and delegate from the staker to it
         uint256 expiry = type(uint256).max;
-        testDelegateToOperatorWhoRequiresECDSASignature(staker, expiry);
+        testDelegateToOperatorWhoRequiresECDSASignature(staker, emptySalt, expiry);
 
         // try to call the `forceUndelegation` function and check for reversion
         cheats.startPrank(caller);
@@ -1250,15 +1251,45 @@ contract DelegationUnitTests is EigenLayerTestHelper {
     }
 
     /**
-     * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
-     * the `staker` to delegate to `operator`, and expiring at `expiry`.
+     * @notice Verifies that the reversion occurs when trying to reuse an 'approverSalt'
      */
-    function _getApproverSignature(uint256 _delegationSignerPrivateKey, address staker, address operator, uint256 expiry)
+    function test_Revert_WhenTryingToReuseSalt(address staker_one, address staker_two, bytes32 salt) public
+        fuzzedAddress(staker_one)
+        fuzzedAddress(staker_two)
+    {
+        // address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+        address operator = address(this);
+
+        // filtering since you can't delegate to yourself after registering as an operator
+        cheats.assume(staker_one != operator);
+        cheats.assume(staker_two != operator);
+
+        // register this contract as an operator and delegate from `staker_one` to it, using the `salt`
+        uint256 expiry = type(uint256).max;
+        testDelegateToOperatorWhoRequiresECDSASignature(staker_one, salt, expiry);
+
+        // calculate the delegationSigner's signature
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry =
+            _getApproverSignature(delegationSignerPrivateKey, staker_two, operator, salt, expiry);
+
+        // try to delegate to the operator from `staker_two`, and verify that the call reverts for the proper reason (trying to reuse a salt)
+        cheats.startPrank(staker_two);
+        cheats.expectRevert(bytes("DelegationManager._delegate: approverSalt already spent"));
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
+     * the `staker` to delegate to `operator`, with the specified `salt`, and expiring at `expiry`.
+     */
+    function _getApproverSignature(uint256 _delegationSignerPrivateKey, address staker, address operator, bytes32 salt, uint256 expiry)
         internal view returns (IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry)
     {
         approverSignatureAndExpiry.expiry = expiry;
         {
-            bytes32 digestHash = delegationManager.calculateCurrentDelegationApprovalDigestHash(staker, operator, expiry);
+            bytes32 digestHash =
+                delegationManager.calculateDelegationApprovalDigestHash(staker, operator, delegationManager.delegationApprover(operator), salt, expiry);
             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_delegationSignerPrivateKey, digestHash);
             approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
         }

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -1002,7 +1002,7 @@ contract StrategyManagerUnitTests is Test, Utils {
     function testQueueWithdrawal_WithdrawEverything_DontUndelegate(uint256 amount) external {
         // delegate to self
         IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
-        delegationMock.delegateTo(address(this), signatureWithExpiry);
+        delegationMock.delegateTo(address(this), signatureWithExpiry, bytes32(0));
         require(delegationMock.isDelegated(address(this)), "delegation mock setup failed");
         bool undelegateIfPossible = false;
         // deposit and withdraw the same amount, don't undelegate


### PR DESCRIPTION
See issue for some context: https://github.com/Layr-Labs/eigenlayer-contracts/issues/117 This commit also adds a simple test to verify that salt-reuse is properly disallowed, and modifies existing tests to work with the updated interface.