### PR TITLE
Add ffi for fuzzing G2 operations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         run: forge install
 
       - name: Run tests
-        run: forge test -vvv
+        run: forge test -vvv --no-match-contract "FFI"
         env:
           RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
           CHAIN_ID: ${{ secrets.CHAIN_ID }}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/Layr-Labs/ffi
+
+go 1.20
+
+require (
+	github.com/bits-and-blooms/bitset v1.5.0 // indirect
+	github.com/consensys/bavard v0.1.13 // indirect
+	github.com/consensys/gnark-crypto v0.11.1 // indirect
+	github.com/mmcloughlin/addchain v0.4.0 // indirect
+	golang.org/x/sys v0.2.0 // indirect
+	rsc.io/tmplfunc v0.0.3 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/bits-and-blooms/bitset v1.5.0 h1:NpE8frKRLGHIcEzkR+gZhiioW1+WbYV6fKwD6ZIpQT8=
+github.com/bits-and-blooms/bitset v1.5.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
+github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
+github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
+github.com/consensys/gnark-crypto v0.11.1 h1:pt2nLbntYZA5IXnSw21vcQgoUCRPn6J/xylWQpK8gtM=
+github.com/consensys/gnark-crypto v0.11.1/go.mod h1:Iq/P3HHl0ElSjsg2E1gsMwhAyxnxoKK5nVyZKd+/KhU=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
+github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
+github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+rsc.io/tmplfunc v0.0.3 h1:53XFQh69AfOa8Tw0Jm7t+GV7KZhOi6jzsCzTtKbMvzU=
+rsc.io/tmplfunc v0.0.3/go.mod h1:AG3sTPzElb1Io3Yg4voV9AGZJuleGAwaVRxL9M49PhA=

--- a/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
+++ b/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "forge-std/Test.sol";
+import "../../contracts/middleware/BLSPublicKeyCompendium.sol";
+import "openzeppelin-contracts/contracts/utils/Strings.sol";
+
+contract BLSPublicKeyCompendiumFFITests is Test {
+    using BN254 for BN254.G1Point;
+    using Strings for uint256;
+
+    BLSPublicKeyCompendium compendium;
+
+    uint256 privKey;
+    BN254.G1Point pubKeyG1;
+    BN254.G2Point pubKeyG2;
+    BN254.G1Point signedMessageHash;
+
+    address alice = address(0x69);
+
+    function setUp() public {
+        compendium = new BLSPublicKeyCompendium();
+    }
+
+    function testRegisterBLSPublicKey(uint256 _privKey) public {
+        vm.assume(_privKey != 0);
+
+        _setKeys(_privKey);
+        signedMessageHash = _signMessage(alice);
+
+        vm.prank(alice);
+        compendium.registerBLSPublicKey(signedMessageHash, pubKeyG1, pubKeyG2);
+
+        assertEq(compendium.operatorToPubkeyHash(alice), BN254.hashG1Point(pubKeyG1), "pubkey hash not stored correctly");
+        assertEq(compendium.pubkeyHashToOperator(BN254.hashG1Point(pubKeyG1)), alice, "operator address not stored correctly");
+    }
+
+    function _setKeys(uint256 _privKey) internal {
+        privKey = _privKey;
+        pubKeyG1 = BN254.generatorG1().scalar_mul(_privKey);
+
+        string[] memory inputs = new string[](5);
+        inputs[0] = "go";
+        inputs[1] = "run";
+        inputs[2] = "src/test/ffi/g2pubkey.go";
+        inputs[3] = _privKey.toString(); 
+
+        inputs[4] = "1";
+        bytes memory res = vm.ffi(inputs);
+        pubKeyG2.X[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "2";
+        res = vm.ffi(inputs);
+        pubKeyG2.X[0] = abi.decode(res, (uint256));
+
+        inputs[4] = "3";
+        res = vm.ffi(inputs);
+        pubKeyG2.Y[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "4";
+        res = vm.ffi(inputs);
+        pubKeyG2.Y[0] = abi.decode(res, (uint256));
+    }
+
+    function _signMessage(address signer) internal view returns(BN254.G1Point memory) {
+        BN254.G1Point memory messageHash = BN254.hashToG1(keccak256(abi.encodePacked(signer, block.chainid, "EigenLayer_BN254_Pubkey_Registration")));
+        return BN254.scalar_mul(messageHash, privKey);
+    }
+}

--- a/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
+++ b/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
@@ -21,10 +21,9 @@ contract BLSPublicKeyCompendiumFFITests is G2Operations {
         compendium = new BLSPublicKeyCompendium();
     }
 
-    function testRegisterBLSPublicKey(/*uint256 _privKey*/) public {
-        // _setKeys(_privKey);
+    function testRegisterBLSPublicKey(uint256 _privKey) public {
+        _setKeys(_privKey);
 
-        _setKeys(666);
         signedMessageHash = _signMessage(alice);
 
         vm.prank(alice);

--- a/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
+++ b/src/test/ffi/BLSPubKeyCompendiumFFI.t.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import "forge-std/Test.sol";
 import "../../contracts/middleware/BLSPublicKeyCompendium.sol";
-import "openzeppelin-contracts/contracts/utils/Strings.sol";
+import "./util/G2Operations.sol";
 
-contract BLSPublicKeyCompendiumFFITests is Test {
+contract BLSPublicKeyCompendiumFFITests is G2Operations {
     using BN254 for BN254.G1Point;
     using Strings for uint256;
 
@@ -22,10 +21,10 @@ contract BLSPublicKeyCompendiumFFITests is Test {
         compendium = new BLSPublicKeyCompendium();
     }
 
-    function testRegisterBLSPublicKey(uint256 _privKey) public {
-        vm.assume(_privKey != 0);
+    function testRegisterBLSPublicKey(/*uint256 _privKey*/) public {
+        // _setKeys(_privKey);
 
-        _setKeys(_privKey);
+        _setKeys(666);
         signedMessageHash = _signMessage(alice);
 
         vm.prank(alice);
@@ -38,28 +37,7 @@ contract BLSPublicKeyCompendiumFFITests is Test {
     function _setKeys(uint256 _privKey) internal {
         privKey = _privKey;
         pubKeyG1 = BN254.generatorG1().scalar_mul(_privKey);
-
-        string[] memory inputs = new string[](5);
-        inputs[0] = "go";
-        inputs[1] = "run";
-        inputs[2] = "src/test/ffi/g2pubkey.go";
-        inputs[3] = _privKey.toString(); 
-
-        inputs[4] = "1";
-        bytes memory res = vm.ffi(inputs);
-        pubKeyG2.X[1] = abi.decode(res, (uint256));
-
-        inputs[4] = "2";
-        res = vm.ffi(inputs);
-        pubKeyG2.X[0] = abi.decode(res, (uint256));
-
-        inputs[4] = "3";
-        res = vm.ffi(inputs);
-        pubKeyG2.Y[1] = abi.decode(res, (uint256));
-
-        inputs[4] = "4";
-        res = vm.ffi(inputs);
-        pubKeyG2.Y[0] = abi.decode(res, (uint256));
+        pubKeyG2 = G2Operations.mul(_privKey);
     }
 
     function _signMessage(address signer) internal view returns(BN254.G1Point memory) {

--- a/src/test/ffi/BLSSignatureCheckerFFI.t.sol
+++ b/src/test/ffi/BLSSignatureCheckerFFI.t.sol
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "./util/G2Operations.sol";
+import "../utils/MockAVSDeployer.sol";
+import "../../contracts/middleware/BLSSignatureChecker.sol";
+
+
+contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
+
+    using BN254 for BN254.G1Point;
+
+    bytes32 msgHash = keccak256(abi.encodePacked("hello world"));
+    uint256 aggSignerPrivKey;
+    BN254.G2Point aggSignerApkG2;
+    BN254.G2Point oneHundredQuorumApkG2;
+    BN254.G1Point sigma;
+
+    BLSSignatureChecker blsSignatureChecker;
+
+    function setUp() virtual public {
+        _deployMockEigenLayerAndAVS();
+
+        blsSignatureChecker = new BLSSignatureChecker(registryCoordinator);
+    }
+
+    // this test checks that a valid signature from maxOperatorsToRegister with a random number of nonsigners is checked
+    // correctly on the BLSSignatureChecker contract when all operators are only regsitered for a single quorum and
+    // the signature is only checked for stakes on that quorum
+    function testBLSSignatureChecker_SingleQuorum_Valid(uint256 pseudoRandomNumber) public { 
+        uint256 numNonSigners = pseudoRandomNumber % (maxOperatorsToRegister - 1);
+
+        uint256 quorumBitmap = 1;
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+
+        (uint32 referenceBlockNumber, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) = 
+            _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
+
+        uint256 gasBefore = gasleft();
+        (
+            BLSSignatureChecker.QuorumStakeTotals memory quorumStakeTotals,
+            bytes32 signatoryRecordHash
+        ) = blsSignatureChecker.checkSignatures(
+            msgHash, 
+            quorumNumbers,
+            referenceBlockNumber, 
+            nonSignerStakesAndSignature
+        );
+        uint256 gasAfter = gasleft();
+        emit log_named_uint("gasUsed", gasBefore - gasAfter);
+        assertTrue(quorumStakeTotals.signedStakeForQuorum[0] > 0);
+
+        // 0 nonSigners: 159908
+        // 1 nonSigner: 178683
+        // 2 nonSigners: 197410
+    }
+
+    // this test checks that a valid signature from maxOperatorsToRegister with a random number of nonsigners is checked
+    // correctly on the BLSSignatureChecker contract when all operators are registered for the first 100 quorums
+    // and the signature is only checked for stakes on those quorums
+    function testBLSSignatureChecker_100Quorums_Valid(uint256 pseudoRandomNumber) public { 
+        uint256 numNonSigners = pseudoRandomNumber % (maxOperatorsToRegister - 1);
+
+        // 100 set bits
+        uint256 quorumBitmap = (1 << 100) - 1;
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+
+        (uint32 referenceBlockNumber, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) = 
+            _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
+
+        nonSignerStakesAndSignature.sigma = sigma.scalar_mul(quorumNumbers.length);
+        nonSignerStakesAndSignature.apkG2 = oneHundredQuorumApkG2;
+
+        uint256 gasBefore = gasleft();
+        blsSignatureChecker.checkSignatures(
+            msgHash, 
+            quorumNumbers,
+            referenceBlockNumber, 
+            nonSignerStakesAndSignature
+        );
+        uint256 gasAfter = gasleft();
+        emit log_named_uint("gasUsed", gasBefore - gasAfter);
+    }
+
+    function _setAggregatePublicKeysAndSignature(uint256 pseudoRandomNumber) internal {
+        if(pseudoRandomNumber > type(uint256).max / 100) {
+            pseudoRandomNumber = type(uint256).max / 100;
+        }
+        aggSignerPrivKey = pseudoRandomNumber;
+        aggSignerApkG2 = G2Operations.mul(aggSignerPrivKey);
+        oneHundredQuorumApkG2 = G2Operations.mul(100 * aggSignerPrivKey);
+        sigma = BN254.hashToG1(msgHash).scalar_mul(aggSignerPrivKey);
+    }
+
+    function _generateSignerAndNonSignerPrivateKeys(uint256 pseudoRandomNumber, uint256 numSigners, uint256 numNonSigners) internal returns (uint256[] memory, uint256[] memory) {
+        _setAggregatePublicKeysAndSignature(pseudoRandomNumber);
+
+        uint256[] memory signerPrivateKeys = new uint256[](numSigners);
+        // generate numSigners numbers that add up to aggSignerPrivKey mod BN254.FR_MODULUS
+        uint256 sum = 0;
+        for (uint i = 0; i < numSigners - 1; i++) {
+            signerPrivateKeys[i] = uint256(keccak256(abi.encodePacked("signerPrivateKey", pseudoRandomNumber, i))) % BN254.FR_MODULUS;
+            sum = addmod(sum, signerPrivateKeys[i], BN254.FR_MODULUS);
+        }
+        // signer private keys need to add to aggSignerPrivKey
+        signerPrivateKeys[numSigners - 1] = addmod(aggSignerPrivKey, BN254.FR_MODULUS - sum % BN254.FR_MODULUS, BN254.FR_MODULUS);
+
+        uint256[] memory nonSignerPrivateKeys = new uint256[](numNonSigners);
+        for (uint i = 0; i < numNonSigners; i++) {
+            nonSignerPrivateKeys[i] = uint256(keccak256(abi.encodePacked("nonSignerPrivateKey", pseudoRandomNumber, i))) % BN254.FR_MODULUS;
+        }
+
+        return (signerPrivateKeys, nonSignerPrivateKeys);
+    }
+
+    function _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(uint256 pseudoRandomNumber, uint256 numNonSigners, uint256 quorumBitmap) internal returns(uint32, BLSSignatureChecker.NonSignerStakesAndSignature memory) {
+        (uint256[] memory signerPrivateKeys, uint256[] memory nonSignerPrivateKeys) = _generateSignerAndNonSignerPrivateKeys(pseudoRandomNumber, maxOperatorsToRegister - numNonSigners, numNonSigners);
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+
+        // randomly combine signer and non-signer private keys
+        uint256[] memory privateKeys = new uint256[](maxOperatorsToRegister);
+        // generate addresses and public keys
+        address[] memory operators = new address[](maxOperatorsToRegister);
+        BN254.G1Point[] memory pubkeys = new BN254.G1Point[](maxOperatorsToRegister);
+        BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature;
+        nonSignerStakesAndSignature.quorumApks = new BN254.G1Point[](quorumNumbers.length);
+        nonSignerStakesAndSignature.nonSignerPubkeys = new BN254.G1Point[](numNonSigners);
+        bytes32[] memory nonSignerOperatorIds = new bytes32[](numNonSigners);
+        {
+            uint256 signerIndex = 0;
+            uint256 nonSignerIndex = 0;
+            for (uint i = 0; i < maxOperatorsToRegister; i++) {
+                uint256 randomSeed = uint256(keccak256(abi.encodePacked("privKeyCombination", i)));
+                if (randomSeed % 2 == 0 && signerIndex < signerPrivateKeys.length) {
+                    privateKeys[i] = signerPrivateKeys[signerIndex];
+                    signerIndex++;
+                } else if (nonSignerIndex < nonSignerPrivateKeys.length) {
+                    privateKeys[i] = nonSignerPrivateKeys[nonSignerIndex];
+                    nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex] = BN254.generatorG1().scalar_mul(privateKeys[i]);
+                    nonSignerOperatorIds[nonSignerIndex] = nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex].hashG1Point();
+                    nonSignerIndex++;
+                } else {
+                    privateKeys[i] = signerPrivateKeys[signerIndex];
+                    signerIndex++;
+                }
+
+                operators[i] = _incrementAddress(defaultOperator, i);
+                pubkeys[i] = BN254.generatorG1().scalar_mul(privateKeys[i]);
+
+                // add the public key to each quorum
+                for (uint j = 0; j < nonSignerStakesAndSignature.quorumApks.length; j++) {
+                    nonSignerStakesAndSignature.quorumApks[j] = nonSignerStakesAndSignature.quorumApks[j].plus(pubkeys[i]);
+                }
+            }
+        }
+
+        // register all operators for the first quorum
+        for (uint i = 0; i < maxOperatorsToRegister; i++) {
+            cheats.roll(registrationBlockNumber + blocksBetweenRegistrations * i);
+            _registerOperatorWithCoordinator(operators[i], quorumBitmap, pubkeys[i], defaultStake);
+        }
+
+        uint32 referenceBlockNumber = registrationBlockNumber + blocksBetweenRegistrations * uint32(maxOperatorsToRegister) + 1;
+        cheats.roll(referenceBlockNumber + 100);
+
+        BLSOperatorStateRetriever.CheckSignaturesIndices memory checkSignaturesIndices = operatorStateRetriever.getCheckSignaturesIndices(
+            registryCoordinator,
+            referenceBlockNumber, 
+            quorumNumbers, 
+            nonSignerOperatorIds
+        );
+
+        nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices = checkSignaturesIndices.nonSignerQuorumBitmapIndices;
+        nonSignerStakesAndSignature.apkG2 = aggSignerApkG2;
+        nonSignerStakesAndSignature.sigma = sigma;
+        nonSignerStakesAndSignature.quorumApkIndices = checkSignaturesIndices.quorumApkIndices;
+        nonSignerStakesAndSignature.totalStakeIndices = checkSignaturesIndices.totalStakeIndices;
+        nonSignerStakesAndSignature.nonSignerStakeIndices = checkSignaturesIndices.nonSignerStakeIndices;
+
+        return (referenceBlockNumber, nonSignerStakesAndSignature);
+    }
+
+}

--- a/src/test/ffi/g2pubkey.go
+++ b/src/test/ffi/g2pubkey.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"math/big"
+	"github.com/consensys/gnark-crypto/ecc/bn254"
+)
+
+func main() {
+	arg1 := os.Args[1]
+	n := new(big.Int)
+    n, _ = n.SetString(arg1, 10)
+
+	pubkey := new(bn254.G2Affine).ScalarMultiplication(GetG2Generator(), n)
+	px := pubkey.X.String()
+	py := pubkey.Y.String()
+
+	pxs := strings.Split(px, "+")	
+	pxss := strings.Split(pxs[1], "*")
+
+	pys := strings.Split(py, "+")	
+	pyss := strings.Split(pys[1], "*")
+
+	pxsInt := new(big.Int)
+	pxsInt, _ = pxsInt.SetString(pxs[0], 10)
+
+	pxssInt := new(big.Int)
+	pxssInt, _ = pxssInt.SetString(pxss[0], 10)
+
+	pysInt := new(big.Int)
+	pysInt, _ = pysInt.SetString(pys[0], 10)
+
+	pyssInt := new(big.Int)
+	pyssInt, _ = pyssInt.SetString(pyss[0], 10)
+
+	switch os.Args[2] {
+    case "1":
+        fmt.Printf("0x%x\n", pxsInt)
+    case "2":
+        fmt.Printf("0x%x\n", pxssInt)
+    case "3":
+        fmt.Printf("0x%x\n", pysInt)
+	case "4":
+		fmt.Printf("0x%x\n", pyssInt)
+    }
+}
+
+func GetG2Generator() *bn254.G2Affine {
+    g2Gen := new(bn254.G2Affine)
+    g2Gen.X.SetString("10857046999023057135944570762232829481370756359578518086990519993285655852781",
+        "11559732032986387107991004021392285783925812861821192530917403151452391805634")
+    g2Gen.Y.SetString("8495653923123431417604973247489272438418190587263600148770280649306958101930",
+        "4082367875863433681332203403145435568316851327593401208105741076214120093531")
+    return g2Gen
+}

--- a/src/test/ffi/go/g2mul.go
+++ b/src/test/ffi/go/g2mul.go
@@ -37,14 +37,15 @@ func main() {
 
 	switch os.Args[2] {
     case "1":
-        fmt.Printf("0x%x", pxsInt)
+        fmt.Printf("0x%064X", pxsInt)
     case "2":
-        fmt.Printf("0x%x", pxssInt)
+        fmt.Printf("0x%064X", pxssInt)
     case "3":
-        fmt.Printf("0x%x", pysInt)
+        fmt.Printf("0x%064X", pysInt)
 	case "4":
-		fmt.Printf("0x%x", pyssInt)
+		fmt.Printf("0x%064X", pyssInt)
     }
+
 }
 
 func GetG2Generator() *bn254.G2Affine {

--- a/src/test/ffi/go/g2mul.go
+++ b/src/test/ffi/go/g2mul.go
@@ -9,14 +9,17 @@ import (
 )
 
 func main() {
+	//parse args
 	arg1 := os.Args[1]
 	n := new(big.Int)
-    n, _ = n.SetString(arg1, 10)
+	n, _ = n.SetString(arg1, 10)
 
+	//g2 mul
 	pubkey := new(bn254.G2Affine).ScalarMultiplication(GetG2Generator(), n)
 	px := pubkey.X.String()
 	py := pubkey.Y.String()
 
+	//parse out point coords to big ints
 	pxs := strings.Split(px, "+")	
 	pxss := strings.Split(pxs[1], "*")
 
@@ -35,16 +38,17 @@ func main() {
 	pyssInt := new(big.Int)
 	pyssInt, _ = pyssInt.SetString(pyss[0], 10)
 
+	//swtich to print coord requested
 	switch os.Args[2] {
-    case "1":
-        fmt.Printf("0x%064X", pxsInt)
-    case "2":
-        fmt.Printf("0x%064X", pxssInt)
-    case "3":
-        fmt.Printf("0x%064X", pysInt)
+	case "1":
+		fmt.Printf("0x%064X", pxsInt)
+	case "2":
+		fmt.Printf("0x%064X", pxssInt)
+	case "3":
+		fmt.Printf("0x%064X", pysInt)
 	case "4":
 		fmt.Printf("0x%064X", pyssInt)
-    }
+	}
 
 }
 

--- a/src/test/ffi/go/g2mul.go
+++ b/src/test/ffi/go/g2mul.go
@@ -37,13 +37,13 @@ func main() {
 
 	switch os.Args[2] {
     case "1":
-        fmt.Printf("0x%x\n", pxsInt)
+        fmt.Printf("0x%x", pxsInt)
     case "2":
-        fmt.Printf("0x%x\n", pxssInt)
+        fmt.Printf("0x%x", pxssInt)
     case "3":
-        fmt.Printf("0x%x\n", pysInt)
+        fmt.Printf("0x%x", pysInt)
 	case "4":
-		fmt.Printf("0x%x\n", pyssInt)
+		fmt.Printf("0x%x", pyssInt)
     }
 }
 

--- a/src/test/ffi/util/G2Operations.sol
+++ b/src/test/ffi/util/G2Operations.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "forge-std/Test.sol";
+import "openzeppelin-contracts/contracts/utils/Strings.sol";
+import "../../../contracts/libraries/BN254.sol";
+
+contract G2Operations is Test {
+    using Strings for uint256;
+
+    function mul(uint256 x) public returns (BN254.G2Point memory g2Point) {
+        string[] memory inputs = new string[](5);
+        inputs[0] = "go";
+        inputs[1] = "run";
+        inputs[2] = "src/test/ffi/go/g2mul.go";
+        inputs[3] = x.toString(); 
+
+        inputs[4] = "1";
+        bytes memory res = vm.ffi(inputs);
+        g2Point.X[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "2";
+        res = vm.ffi(inputs);
+        g2Point.X[0] = abi.decode(res, (uint256));
+
+        inputs[4] = "3";
+        res = vm.ffi(inputs);
+        g2Point.Y[1] = abi.decode(res, (uint256));
+
+        inputs[4] = "4";
+        res = vm.ffi(inputs);
+        g2Point.Y[0] = abi.decode(res, (uint256));
+    }
+
+}

--- a/src/test/unit/BLSPublicKeyCompendiumUnit.t.sol
+++ b/src/test/unit/BLSPublicKeyCompendiumUnit.t.sol
@@ -3,7 +3,6 @@ pragma solidity =0.8.12;
 
 import "forge-std/Test.sol";
 import "../../contracts/middleware/BLSPublicKeyCompendium.sol";
-import "../../contracts/middleware/BLSPublicKeyCompendium.sol";
 
 contract BLSPublicKeyCompendiumUnitTests is Test {
     using BN254 for BN254.G1Point;


### PR DESCRIPTION
[Test: Use ffi to fuzz BLS Signature tests #67](https://github.com/Layr-Labs/eigenda-internal/issues/67)

Currently our tests use hardcoded G2 values as G2 operations are overly expensive within the EVM. Using [ffi](https://book.getfoundry.sh/cheatcodes/ffi) we can call out to Go code for these operations and allow for fuzzing in tests related to BLS signatures