### PR TITLE
Transition validator status to WITHDRAWN

### DIFF
--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -535,6 +535,9 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         // now that the validator has been proven to be withdrawn, we can set their restaked balance to 0
         _validatorPubkeyHashToInfo[validatorPubkeyHash].restakedBalanceGwei = 0;
 
+        // update the validator's status to WITHDRAWN
+        _validatorPubkeyHashToInfo[validatorPubkeyHash].status = VALIDATOR_STATUS.WITHDRAWN;
+
         provenWithdrawal[validatorPubkeyHash][withdrawalHappenedSlot] = true;
 
         emit FullWithdrawalRedeemed(validatorIndex, recipient, withdrawalAmountGwei * GWEI_TO_WEI);


### PR DESCRIPTION
The latest merge into master seems to have removed all references to VALIDATOR_STATUS.WITHDRAWN within the EigenPod contract. Since it was not removed from the interface's enum like VALIDATOR_STATUS.OVERCOMMITTED, I'm guessing this was an accident.