### PR TITLE
add `numWithdrawalsQueued` function to IStrategyManager interface

### DIFF
--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -268,4 +268,7 @@ interface IStrategyManager {
 
     /// @notice Returns the number of blocks that must pass between the time a withdrawal is queued and the time it can be completed
     function withdrawalDelayBlocks() external view returns (uint256);
+
+    /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated. only increments (doesn't decrement)
+    function numWithdrawalsQueued(address staker) external view returns (uint256);
 }

--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -27,6 +27,9 @@ contract StrategyManagerMock is
     IEigenPodManager public eigenPodManager;
     ISlasher public slasher;
 
+    /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated. only increments (doesn't decrement)
+    mapping(address => uint256) public numWithdrawalsQueued;
+
     function setAddresses(IDelegationManager _delegation, IEigenPodManager _eigenPodManager, ISlasher _slasher) external
     {
        delegation = _delegation;


### PR DESCRIPTION
this is a public mapping so it has a getter function, but the function was not previously in the interface.