### PR TITLE
ServiceManagerBase implementation + minor change to IServiceManager interface

### DIFF
--- a/src/contracts/interfaces/IServiceManager.sol
+++ b/src/contracts/interfaces/IServiceManager.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.5.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "./IDelegationManager.sol";
+import "./ISlasher.sol";
 
 /**
  * @title Interface for a `ServiceManager`-type contract.
@@ -10,23 +10,30 @@ import "./IDelegationManager.sol";
  * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
  */
 interface IServiceManager {
+
+    // ServiceManager proxies to the slasher
+    function slasher() external view returns (ISlasher);
+
     /// @notice Returns the current 'taskNumber' for the middleware
     function taskNumber() external view returns (uint32);
 
-    /// @notice Permissioned function that causes the ServiceManager to freeze the operator on EigenLayer, through a call to the Slasher contract
+    /// @notice function that causes the ServiceManager to freeze the operator on EigenLayer, through a call to the Slasher contract
+    /// @dev this function should contain slashing logic, to make sure operators are not needlessly being slashed
     function freezeOperator(address operator) external;
 
-    /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording an initial stake update (on operator registration)
+    /// @notice proxy call to the slasher, recording an initial stake update (on operator registration)
     function recordFirstStakeUpdate(address operator, uint32 serveUntilBlock) external;
 
-    /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a stake update
+    /// @notice proxy call to the slasher, recording a stake update
     function recordStakeUpdate(address operator, uint32 updateBlock, uint32 serveUntilBlock, uint256 prevElement) external;
 
-    /// @notice Permissioned function to have the ServiceManager forward a call to the slasher, recording a final stake update (on operator deregistration)
+    /// @notice proxy call to the slasher, recording a final stake update (on operator deregistration)
     function recordLastStakeUpdateAndRevokeSlashingAbility(address operator, uint32 serveUntilBlock) external;
 
-    /// @notice Returns the latest block until which operators must serve.
+    /// @notice Returns the latest block until which operators must serve (could be in the past or future).
+    /// @dev this should be called and the response passed to the recordStakeUpdate functionss' serveUntilBlock parameter
     function latestServeUntilBlock() external view returns (uint32);
 
+    /// @notice required since the registry contract will call this function to permission its upgrades to be done by the same owner as the service manager
     function owner() external view returns (address);
 }

--- a/src/contracts/middleware/ServiceManagerBase.sol
+++ b/src/contracts/middleware/ServiceManagerBase.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import "./BLSSignatureChecker.sol";
+import "../permissions/Pausable.sol";
+
+import "../interfaces/IDelegationManager.sol";
+import "../interfaces/IServiceManager.sol";
+import "../interfaces/IStrategyManager.sol";
+
+/**
+ * @title Base implementation of `IServiceManager` interface, designed to be inherited from by more complex ServiceManagers.
+ * @author Layr Labs, Inc.
+ * @notice This contract is used for:
+ * - proxying calls to the Slasher contract
+ * - implementing the two most important functionalities of a ServiceManager:
+ *  - freezing operators as the result of various "challenges"
+ *  - defining the latestServeUntilBlock which is used by the Slasher to determine whether a withdrawal can be completed
+ */
+abstract contract ServiceManagerBase is
+    IServiceManager,
+    Initializable,
+    OwnableUpgradeable,
+    BLSSignatureChecker,
+    Pausable
+{
+    /// @notice Called in the event of challenge resolution, in order to forward a call to the Slasher, which 'freezes' the `operator`.
+    /// @dev This function should contain slashing logic, to make sure operators are not needlessly being slashed
+    //       hence it is marked as virtual and must be implemented in each avs' respective service manager contract
+    function freezeOperator(address operatorAddr) external virtual;
+
+    /// @notice Returns the block until which operators must serve.
+    /// @dev The block until which the stake accounted for in stake updates is slashable by this middleware
+    function latestServeUntilBlock() public view virtual returns (uint32);
+
+    ISlasher public immutable slasher;
+
+    /// @notice when applied to a function, ensures that the function is only callable by the `registryCoordinator`.
+    modifier onlyRegistryCoordinator() {
+        require(
+            msg.sender == address(registryCoordinator),
+            "onlyRegistryCoordinator: not from registry coordinator"
+        );
+        _;
+    }
+
+    /// @notice when applied to a function, ensures that the function is only callable by the `registryCoordinator`.
+    /// or by StakeRegistry
+    modifier onlyRegistryCoordinatorOrStakeRegistry() {
+        require(
+            (msg.sender == address(registryCoordinator)) ||
+                (msg.sender ==
+                    address(
+                        IBLSRegistryCoordinatorWithIndices(
+                            address(registryCoordinator)
+                        ).stakeRegistry()
+                    )),
+            "onlyRegistryCoordinatorOrStakeRegistry: not from registry coordinator or stake registry"
+        );
+        _;
+    }
+
+    constructor(
+        IBLSRegistryCoordinatorWithIndices _registryCoordinator,
+        ISlasher _slasher
+    ) BLSSignatureChecker(_registryCoordinator) {
+        slasher = _slasher;
+        _disableInitializers();
+    }
+
+    function initialize(
+        IPauserRegistry _pauserRegistry,
+        address initialOwner
+    ) public initializer {
+        _initializePauser(_pauserRegistry, UNPAUSE_ALL);
+        _transferOwnership(initialOwner);
+    }
+
+    // PROXY CALLS TO EQUIVALENT SLASHER FUNCTIONS
+
+    /**
+     * @notice Called by the Registry in the event of a new registration, to forward a call to the Slasher
+     * @param operator The operator whose stake is being updated
+     */
+    function recordFirstStakeUpdate(
+        address operator,
+        uint32 serveUntilBlock
+    ) external virtual onlyRegistryCoordinator {
+        slasher.recordFirstStakeUpdate(operator, serveUntilBlock);
+    }
+
+    /**
+     * @notice Called by the registryCoordinator, in order to forward a call to the Slasher, informing it of a stake update
+     * @param operator The operator whose stake is being updated
+     * @param updateBlock The block at which the update is being made
+     * @param prevElement The value of the previous element in the linked list of stake updates (generated offchain)
+     */
+    function recordStakeUpdate(
+        address operator,
+        uint32 updateBlock,
+        uint32 serveUntilBlock,
+        uint256 prevElement
+    ) external virtual onlyRegistryCoordinatorOrStakeRegistry {
+        slasher.recordStakeUpdate(
+            operator,
+            updateBlock,
+            serveUntilBlock,
+            prevElement
+        );
+    }
+
+    /**
+     * @notice Called by the registryCoordinator in the event of deregistration, to forward a call to the Slasher
+     * @param operator The operator being deregistered
+     */
+    function recordLastStakeUpdateAndRevokeSlashingAbility(
+        address operator,
+        uint32 serveUntilBlock
+    ) external virtual onlyRegistryCoordinator {
+        slasher.recordLastStakeUpdateAndRevokeSlashingAbility(
+            operator,
+            serveUntilBlock
+        );
+    }
+
+    // VIEW FUNCTIONS
+
+    /// @dev need to override function here since its defined in both these contracts
+    function owner()
+        public
+        view
+        override(OwnableUpgradeable, IServiceManager)
+        returns (address)
+    {
+        return OwnableUpgradeable.owner();
+    }
+}

--- a/src/test/mocks/ServiceManagerMock.sol
+++ b/src/test/mocks/ServiceManagerMock.sol
@@ -41,11 +41,6 @@ contract ServiceManagerMock is IServiceManager, DSTest {
         return IERC20(address(0));
     }
 
-    /// @notice The Delegation contract of EigenLayer.
-    function delegationManager() external pure returns (IDelegationManager) {
-        return IDelegationManager(address(0));
-    }
-
     /// @notice Returns the `latestServeUntilBlock` until which operators must serve.
     function latestServeUntilBlock() external pure returns (uint32) {
         return type(uint32).max;


### PR DESCRIPTION
We add a ServiceManagerBase abstract class that implements all of the "trivial" functions that just proxy to the slasher, and only leave for implementation:
- latestServeUntilBlock
- freezeOperator
- taskNumber

This way, AVS teams can derive their service manager from this base implementation without having to write a lot of redundant proxy contract calls.

This ServiceManagerBase depends on our registry contracts (registryCoordinator and stakeRegistry) so any team that uses their own registry will still need to implement their service manager from scratch. We could have an even more barebone ServiceManagerBase contract, but not sure how useful it would be.


There's one more change included in this PR, which is that I removed the `latestServeUntil` parameter from all the recordStakeUpdate calls in the IServiceManager interface, since all call sites were doing something like
```
uint32 latestServeUntilBlock = serviceManager.latestServeUntilBlock();
serviceManager.recordLastStakeUpdateAndRevokeSlashingAbility(operator, latestServeUntilBlock);
```
and I figured instead of doing these multiple separate calls to serviceManager, might as well instead of the serviceManager call its own `latestServeUntilBlock()` implementation. I left `latestServeUntilBlock` in the interface to make it explicit that the servicemanager should implement this public function, but I think it only makes sense to be called internally, so wondering whether to remove it entirely from the interface.