### PR TITLE
StakeRegistry: Implementing Outlined Unit Tests

### DIFF
--- a/src/contracts/middleware/StakeRegistry.sol
+++ b/src/contracts/middleware/StakeRegistry.sol
@@ -357,9 +357,8 @@ contract StakeRegistry is StakeRegistryStorage {
      * stake updates. These operator's individual stake updates will have a 0 stake value for the latest update.
      */
     function _deregisterOperator(bytes32 operatorId, bytes memory quorumNumbers) internal {
-        // check the operator is registering for only valid quorums
+        // check the operator is degistering for only valid quorums
         require(uint8(quorumNumbers[quorumNumbers.length - 1]) < quorumCount, "StakeRegistry._deregisterOperator: greatest quorumNumber must be less than quorumCount");
-        // check the operator is deregistering from only valid quorums
         OperatorStakeUpdate memory _operatorStakeUpdate;
         // add the `updateBlockNumber` info
         _operatorStakeUpdate.updateBlockNumber = uint32(block.number);

--- a/src/contracts/middleware/StakeRegistry.sol
+++ b/src/contracts/middleware/StakeRegistry.sol
@@ -357,6 +357,8 @@ contract StakeRegistry is StakeRegistryStorage {
      * stake updates. These operator's individual stake updates will have a 0 stake value for the latest update.
      */
     function _deregisterOperator(bytes32 operatorId, bytes memory quorumNumbers) internal {
+        // check the operator is registering for only valid quorums
+        require(uint8(quorumNumbers[quorumNumbers.length - 1]) < quorumCount, "StakeRegistry._deregisterOperator: greatest quorumNumber must be less than quorumCount");
         // check the operator is deregistering from only valid quorums
         OperatorStakeUpdate memory _operatorStakeUpdate;
         // add the `updateBlockNumber` info

--- a/src/test/unit/StakeRegistryUnit.t.sol
+++ b/src/test/unit/StakeRegistryUnit.t.sol
@@ -507,7 +507,9 @@ contract StakeRegistryTest is Test {
 
         // deregister the operator from a subset of the quorums
         uint256 deregistrationQuroumBitmap = quorumBitmap & deregistrationQuorumsFlag;
-        _deregisterOperatorValid(operatorIdToDeregister, deregistrationQuroumBitmap);
+        if (deregistrationQuroumBitmap != 0) {
+            _deregisterOperatorValid(operatorIdToDeregister, deregistrationQuroumBitmap);
+        }
 
         // for each bit in each quorumBitmap, increment the number of operators in that quorum
         uint32[] memory numOperatorsInQuorum = new uint32[](MAX_QUORUMS_TO_REGISTER_FOR);

--- a/src/test/unit/StakeRegistryUnit.t.sol
+++ b/src/test/unit/StakeRegistryUnit.t.sol
@@ -201,7 +201,29 @@ contract StakeRegistryTest is Test {
         stakeRegistry.registerOperator(DEFAULT_OPERATOR, DEFAULT_OPERATOR_ID, quorumNumbers);
     }
 
+    function test_RevertsIf_OperatorAlreadyRegistered_RegisterOperator() public {
+        stakeRegistry.setOperatorWeight(DEFAULT_QUORUM_NUMBER, DEFAULT_OPERATOR, 1);
+        stakeRegistry.updateOperatorStake(DEFAULT_OPERATOR, DEFAULT_OPERATOR_ID, DEFAULT_QUORUM_NUMBER );
+        vm.prank(SERVICE_MANAGER_OWNER);
+        stakeRegistry.setMinimumStakeForQuorum(DEFAULT_QUORUM_NUMBER, 0);
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(DEFAULT_QUORUM_NUMBER);
+        vm.startPrank(address(registryCoordinatorMock));
+        stakeRegistry.registerOperator(DEFAULT_OPERATOR, DEFAULT_OPERATOR_ID, quorumNumbers);
+        vm.expectRevert();
+        stakeRegistry.registerOperator(DEFAULT_OPERATOR, DEFAULT_OPERATOR_ID, quorumNumbers);
+    }
+
     function test_RevertsIf_NotRegistryCoordinator_RegisterOperator() public {
+        bytes memory quorumNumbers = new bytes(1);
+        quorumNumbers[0] = bytes1(DEFAULT_QUORUM_NUMBER);
+        // expect that it reverts when you register
+        vm.expectRevert(ONLY_REGISTRY_COORDINATOR);
+        vm.prank(address(SERVICE_MANAGER_OWNER));
+        stakeRegistry.registerOperator(DEFAULT_OPERATOR, DEFAULT_OPERATOR_ID, quorumNumbers);
+    }
+
+    function test_RevertsIf_MoreQuorumsThanQuorumCounter_RegisterOperator() public {
         bytes memory quorumNumbers = new bytes(MAX_QUORUMS_TO_REGISTER_FOR+1);
         for (uint i = 0; i < quorumNumbers.length; i++) {
             quorumNumbers[i] = bytes1(uint8(i));


### PR DESCRIPTION
- Implementing the unit tests outlined in `src/test/unit/StakeRegistry.tree`
- Currently able to call `registerOperator` multiple times without reverting
- Add more inline comments and one line summary for the file