### PR TITLE
add shares getter in IStrategy.sol

### DIFF
--- a/src/contracts/interfaces/IStrategy.sol
+++ b/src/contracts/interfaces/IStrategy.sol
@@ -54,6 +54,12 @@ interface IStrategy {
      */
     function userUnderlying(address user) external returns (uint256);
 
+    /**
+     * @notice convenience function for fetching the current total shares of `user` in this strategy, by
+     * querying the `strategyManager` contract
+     */
+    function shares(address user) external view returns (uint256);
+
      /**
      * @notice Used to convert a number of shares to the equivalent amount of underlying tokens for this strategy.
      * @notice In contrast to `sharesToUnderlying`, this function guarantees no state modifications


### PR DESCRIPTION
Added the shares() view function to the strategy interface, only the userUnderlying() method exists currently.