### PR TITLE
Assorted EigenPod Fixes/Cleanup

### DIFF
--- a/docs/EigenLayer-deposit-flow.md
+++ b/docs/EigenLayer-deposit-flow.md
@@ -32,7 +32,7 @@ After depositing ETH, the depositor waits for the Beacon Chain state root to be 
 ![Depositing ETH Into the Beacon Chain Through the EigenPodManager Part 2](images/EL_depositing_BeaconChainETH_2.png?raw=true "Title")
 
 1. The depositor calls EigenPod.verifyWithdrawalCredentials on the EigenPod deployed for them above
-2. The EigenPod gets the most recent Beacon Chain state root from the EigenPodManager by calling `EigenPodManager.getBeaconChainStateRootAtTimestamp` (the EigenPodManager further passes this query along to the BeaconChainOracle, prior to returning the most recently-posted state root).
+2. The EigenPod gets the most recent Beacon Chain state root from the EigenPodManager by calling `EigenPodManager.getBlockRootAtTimestamp` (the EigenPodManager further passes this query along to the BeaconChainOracle, prior to returning the most recently-posted state root).
 3. The EigenPod calls `EigenPodManager.updateBeaconChainBalance` to update the EigenPodManager's accounting of EigenPod balances
 4. The EigenPodManager fetches the Slasher's address from the StrategyManager
 4. *If the operator has been slashed on the Beacon Chain* (and this is reflected in the latest BeaconChainOracle update), then the EigenPodManager calls `Slasher.freezeOperator` to freeze the staker

--- a/script/M1_Deploy.s.sol
+++ b/script/M1_Deploy.s.sol
@@ -79,6 +79,7 @@ contract Deployer_M1 is Script, Test {
     uint256 REQUIRED_BALANCE_WEI;
     uint256 MAX_VALIDATOR_BALANCE_GWEI;
     uint256 EFFECTIVE_RESTAKED_BALANCE_OFFSET_GWEI;
+    uint64 GENESIS_TIME = 1616508000;
 
     // OTHER DEPLOYMENT PARAMETERS
     uint256 STRATEGY_MANAGER_INIT_PAUSED_STATUS;
@@ -176,7 +177,8 @@ contract Deployer_M1 is Script, Test {
             delayedWithdrawalRouter,
             eigenPodManager,
             uint64(MAX_VALIDATOR_BALANCE_GWEI),
-            uint64(EFFECTIVE_RESTAKED_BALANCE_OFFSET_GWEI)
+            uint64(EFFECTIVE_RESTAKED_BALANCE_OFFSET_GWEI),
+            GENESIS_TIME
         );
 
         eigenPodBeacon = new UpgradeableBeacon(address(eigenPodImplementation));

--- a/script/misc/GoerliUpgrade1.s.sol
+++ b/script/misc/GoerliUpgrade1.s.sol
@@ -73,7 +73,8 @@ contract GoerliUpgrade1 is Script, Test {
                 delayedWithdrawalRouter,
                 eigenPodManager,
                 32e9,
-                75e7
+                75e7,
+                1616508000
             )
         );
 

--- a/script/testing/M2_Deploy_From_Scratch.s.sol
+++ b/script/testing/M2_Deploy_From_Scratch.s.sol
@@ -79,6 +79,7 @@ contract Deployer_M2 is Script, Test {
     // IMMUTABLES TO SET
     uint64 MAX_VALIDATOR_BALANCE_GWEI;
     uint64 RESTAKED_BALANCE_OFFSET_GWEI;
+    uint64 GENESIS_TIME = 1616508000;
 
     // OTHER DEPLOYMENT PARAMETERS
     uint256 STRATEGY_MANAGER_INIT_PAUSED_STATUS;
@@ -176,7 +177,8 @@ contract Deployer_M2 is Script, Test {
             delayedWithdrawalRouter,
             eigenPodManager,
             MAX_VALIDATOR_BALANCE_GWEI,
-            RESTAKED_BALANCE_OFFSET_GWEI
+            RESTAKED_BALANCE_OFFSET_GWEI,
+            GENESIS_TIME
         );
 
         eigenPodBeacon = new UpgradeableBeacon(address(eigenPodImplementation));

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -44,8 +44,8 @@ interface IEigenPod {
         uint64 validatorIndex;
         // amount of beacon chain ETH restaked on EigenLayer in gwei
         uint64 restakedBalanceGwei;
-        //slot number of the validator's most recent balance update
-        uint64 mostRecentBalanceUpdateSlot;
+        //timestamp of the validator's most recent balance update
+        uint64 mostRecentBalanceUpdateTimestamp;
         // status of the validator
         VALIDATOR_STATUS status;
     }

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -137,8 +137,8 @@ interface IEigenPodManager is IPausable {
     /// @notice Oracle contract that provides updates to the beacon chain's state
     function beaconChainOracle() external view returns(IBeaconChainOracle);    
 
-    /// @notice Returns the Beacon Chain state root at `timestamp`. Reverts if the Beacon Chain state root at `timestamp` has not yet been finalized.
-    function getBeaconChainStateRootAtTimestamp(uint64 timestamp) external view returns(bytes32);
+    /// @notice Returns the beacon block root at `timestamp`. Reverts if the Beacon block root at `timestamp` has not yet been finalized.
+    function getBlockRootAtTimestamp(uint64 timestamp) external view returns(bytes32);
 
     /// @notice EigenLayer's StrategyManager contract
     function strategyManager() external view returns(IStrategyManager);

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -282,6 +282,8 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawalProofs: timestampProof has incorrect length");
 
         if(proofs.proveHistoricalRoot){
+            require(proofs.historicalSummaryBlockRootProof.length == 32 * (BEACON_STATE_FIELD_TREE_HEIGHT + (HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT)),
+            "BeaconChainProofs.verifyWithdrawalProofs: historicalSummaryBlockRootProof has incorrect length");
             /**
             * Note: Here, the "1" in "1 + (BLOCK_ROOTS_TREE_HEIGHT)" signifies that extra step of choosing the "block_root_summary" within the individual 
             * "historical_summary". Everywhere else it signifies merkelize_with_mixin, where the length of an array is hashed with the root of the array,

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -283,11 +283,10 @@ library BeaconChainProofs {
 
         if(proofs.proveHistoricalRoot){
             uint256 historicalBlockHeaderIndex = HISTORICAL_SUMMARIES_INDEX << ((HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT)) | 
+                                                uint256(proofs.historicalSummaryIndex) << 1 + (BLOCK_ROOTS_TREE_HEIGHT) |
                                                 BLOCK_SUMMARY_ROOT_INDEX << (BLOCK_ROOTS_TREE_HEIGHT) | uint256(proofs.blockHeaderRootIndex);
             require(Merkle.verifyInclusionSha256(proofs.historicalSummaryBlockRootProof, beaconStateRoot, proofs.blockHeaderRoot, historicalBlockHeaderIndex), 
                 "BeaconChainProofs.verifyWithdrawalProofs: Invalid historicalsummary merkle proof");
-            
-
         } else {
             /**
             * Computes the block_header_index relative to the beaconStateRoot.  It concatenates the indexes of all the

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -282,6 +282,11 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawalProofs: timestampProof has incorrect length");
 
         if(proofs.proveHistoricalRoot){
+            /**
+            * Note: Here, the "1" in "1 + (BLOCK_ROOTS_TREE_HEIGHT)" signifies that extra step of choosing the "block_root_summary" within the individual 
+            * "historical_summary". Everywhere else it signifies merkelize_with_mixin, where the length of an array is hashed with the root of the array,
+            * but not here.
+            */
             uint256 historicalBlockHeaderIndex = HISTORICAL_SUMMARIES_INDEX << ((HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT)) | 
                                                 uint256(proofs.historicalSummaryIndex) << 1 + (BLOCK_ROOTS_TREE_HEIGHT) |
                                                 BLOCK_SUMMARY_ROOT_INDEX << (BLOCK_ROOTS_TREE_HEIGHT) | uint256(proofs.blockHeaderRootIndex);

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -136,9 +136,7 @@ library BeaconChainProofs {
         bytes latestBlockHeaderProof;
         bytes validatorBalanceProof;
         bytes validatorFieldsProof;
-        bytes slotProof;
         bytes32 balanceRoot;
-        bytes32 slotRoot;
     }
 
     // @notice This struct contains the merkle proofs and leaves needed to verify a validator's withdrawal credential

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -281,7 +281,14 @@ library BeaconChainProofs {
         require(proofs.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT),
             "BeaconChainProofs.verifyWithdrawalProofs: timestampProof has incorrect length");
 
-        {
+        if(proofs.proveHistoricalRoot){
+            uint256 historicalBlockHeaderIndex = HISTORICAL_SUMMARIES_INDEX << ((HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT)) | 
+                                                BLOCK_SUMMARY_ROOT_INDEX << (BLOCK_ROOTS_TREE_HEIGHT) | uint256(proofs.blockHeaderRootIndex);
+            require(Merkle.verifyInclusionSha256(proofs.historicalSummaryBlockRootProof, beaconStateRoot, proofs.blockHeaderRoot, historicalBlockHeaderIndex), 
+                "BeaconChainProofs.verifyWithdrawalProofs: Invalid historicalsummary merkle proof");
+            
+
+        } else {
             /**
             * Computes the block_header_index relative to the beaconStateRoot.  It concatenates the indexes of all the
             * intermediate root indexes from the bottom of the sub trees (the block header container) to the top of the tree

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -190,7 +190,7 @@ library BeaconChainProofs {
         bytes32 validatorRoot = Merkle.merkleizeSha256(validatorFields);
 
         // verify the proof of the validatorRoot against the beaconStateRoot
-        require(Merkle.verifyInclusionSha256(proof, beaconStateRoot, validatorRoot, index), "BeaconChainProofs.verifyValidatorFields: Invalid merkle proof");
+        require(Merkle.verifyInclusionSha256({proof: proof, root: beaconStateRoot, leaf: validatorRoot, index: index}), "BeaconChainProofs.verifyValidatorFields: Invalid merkle proof");
     }
 
     /**
@@ -215,7 +215,7 @@ library BeaconChainProofs {
         uint256 balanceIndex = uint256(validatorIndex/4);
         balanceIndex = (BALANCE_INDEX << (BALANCE_TREE_HEIGHT + 1)) | balanceIndex;
 
-        require(Merkle.verifyInclusionSha256(proof, beaconStateRoot, balanceRoot, balanceIndex), "BeaconChainProofs.verifyValidatorBalance: Invalid merkle proof");
+        require(Merkle.verifyInclusionSha256({proof: proof, root: beaconStateRoot, leaf: balanceRoot, index: balanceIndex}), "BeaconChainProofs.verifyValidatorBalance: Invalid merkle proof");
     }
 
     /**
@@ -232,7 +232,7 @@ library BeaconChainProofs {
     ) internal view {
         require(proof.length == 32 * (BEACON_STATE_FIELD_TREE_HEIGHT), "BeaconChainProofs.verifySlotRoot: Proof has incorrect length");
         //Next we verify the slot against the blockHeaderRoot
-        require(Merkle.verifyInclusionSha256(proof, beaconStateRoot, slotRoot, BEACON_STATE_SLOT_INDEX), "BeaconChainProofs.verifySlotRoot: Invalid slot merkle proof");
+        require(Merkle.verifyInclusionSha256({proof: proof, root: beaconStateRoot, leaf: slotRoot, index: BEACON_STATE_SLOT_INDEX}), "BeaconChainProofs.verifySlotRoot: Invalid slot merkle proof");
     }
 
     /**
@@ -249,7 +249,7 @@ library BeaconChainProofs {
     ) internal view {
         require(proof.length == 32 * (BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT), "BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot: Proof has incorrect length");
         //Next we verify the slot against the blockHeaderRoot
-        require(Merkle.verifyInclusionSha256(proof, latestBlockHeaderRoot, beaconStateRoot, STATE_ROOT_INDEX),
+        require(Merkle.verifyInclusionSha256({proof: proof, root: latestBlockHeaderRoot, leaf: beaconStateRoot, index: STATE_ROOT_INDEX}),
             "BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot: Invalid latest block header root merkle proof");
     }
 
@@ -285,7 +285,7 @@ library BeaconChainProofs {
             uint256 historicalBlockHeaderIndex = HISTORICAL_SUMMARIES_INDEX << ((HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT)) | 
                                                 uint256(proofs.historicalSummaryIndex) << 1 + (BLOCK_ROOTS_TREE_HEIGHT) |
                                                 BLOCK_SUMMARY_ROOT_INDEX << (BLOCK_ROOTS_TREE_HEIGHT) | uint256(proofs.blockHeaderRootIndex);
-            require(Merkle.verifyInclusionSha256(proofs.historicalSummaryBlockRootProof, beaconStateRoot, proofs.blockHeaderRoot, historicalBlockHeaderIndex), 
+            require(Merkle.verifyInclusionSha256({proof: proofs.historicalSummaryBlockRootProof, root: beaconStateRoot, leaf: proofs.blockHeaderRoot, index: historicalBlockHeaderIndex}), 
                 "BeaconChainProofs.verifyWithdrawalProofs: Invalid historicalsummary merkle proof");
         } else {
             /**
@@ -294,22 +294,22 @@ library BeaconChainProofs {
             */
             uint256 blockHeaderIndex = BLOCK_ROOTS_INDEX << (BLOCK_ROOTS_TREE_HEIGHT)  | uint256(proofs.blockHeaderRootIndex);
             // Verify the blockHeaderRoot against the beaconStateRoot            
-            require(Merkle.verifyInclusionSha256(proofs.blockHeaderProof, beaconStateRoot, proofs.blockHeaderRoot, blockHeaderIndex),
+            require(Merkle.verifyInclusionSha256({proof: proofs.blockHeaderProof, root: beaconStateRoot, leaf: proofs.blockHeaderRoot, index: blockHeaderIndex}),
                 "BeaconChainProofs.verifyWithdrawalProofs: Invalid block header merkle proof");
         }
 
         //Next we verify the slot against the blockHeaderRoot
-        require(Merkle.verifyInclusionSha256(proofs.slotProof, proofs.blockHeaderRoot, proofs.slotRoot, SLOT_INDEX), "BeaconChainProofs.verifyWithdrawalProofs: Invalid slot merkle proof");
+        require(Merkle.verifyInclusionSha256({proof: proofs.slotProof, root: proofs.blockHeaderRoot, leaf: proofs.slotRoot, index: SLOT_INDEX}), "BeaconChainProofs.verifyWithdrawalProofs: Invalid slot merkle proof");
         
         {
             // Next we verify the executionPayloadRoot against the blockHeaderRoot
             uint256 executionPayloadIndex = BODY_ROOT_INDEX << (BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT)| EXECUTION_PAYLOAD_INDEX ;
-            require(Merkle.verifyInclusionSha256(proofs.executionPayloadProof, proofs.blockHeaderRoot, proofs.executionPayloadRoot, executionPayloadIndex),
+            require(Merkle.verifyInclusionSha256({proof: proofs.executionPayloadProof, root: proofs.blockHeaderRoot, leaf: proofs.executionPayloadRoot, index: executionPayloadIndex}),
                 "BeaconChainProofs.verifyWithdrawalProofs: Invalid executionPayload merkle proof");
         }
 
         // Next we verify the timestampRoot against the executionPayload root
-        require(Merkle.verifyInclusionSha256(proofs.timestampProof, proofs.executionPayloadRoot, proofs.timestampRoot, TIMESTAMP_INDEX),
+        require(Merkle.verifyInclusionSha256({proof: proofs.timestampProof, root: proofs.executionPayloadRoot, leaf: proofs.timestampRoot, index: TIMESTAMP_INDEX}),
             "BeaconChainProofs.verifyWithdrawalProofs: Invalid blockNumber merkle proof");
 
 
@@ -323,7 +323,7 @@ library BeaconChainProofs {
             */
             uint256 withdrawalIndex = WITHDRAWALS_INDEX << (WITHDRAWALS_TREE_HEIGHT + 1) | uint256(proofs.withdrawalIndex);
             bytes32 withdrawalRoot = Merkle.merkleizeSha256(withdrawalFields);
-            require(Merkle.verifyInclusionSha256(proofs.withdrawalProof, proofs.executionPayloadRoot, withdrawalRoot, withdrawalIndex),
+            require(Merkle.verifyInclusionSha256({proof: proofs.withdrawalProof, root: proofs.executionPayloadRoot, leaf: withdrawalRoot, index: withdrawalIndex}),
                 "BeaconChainProofs.verifyWithdrawalProofs: Invalid withdrawal merkle proof");
         }
     }

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -102,7 +102,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     /// @notice Emitted when an ETH validator's  balance is proven to be updated.  Here newValidatorBalanceGwei
     //  is the validator's balance that is credited on EigenLayer.
-    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 slotNumber, uint64 newValidatorBalanceGwei);
+    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 timestamp, uint64 newValidatorBalanceGwei);
     
     /// @notice Emitted when an ETH validator is prove to have withdrawn from the beacon chain
     event FullWithdrawalRedeemed(uint40 validatorIndex, address indexed recipient, uint256 withdrawalAmountWei);
@@ -305,14 +305,15 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
         //update the most recent balance update slot
         uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
-        validatorInfo.mostRecentBalanceUpdateTimestamp = _computeTimestampAtSlot(slotNumber);
+        uint64 timestamp = _computeTimestampAtSlot(slotNumber);
+        validatorInfo.mostRecentBalanceUpdateTimestamp = timestamp;
 
         //record validatorInfo update in storage
         _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;
         
 
         if (newRestakedBalanceGwei != currentRestakedBalanceGwei){
-            emit ValidatorBalanceUpdated(validatorIndex, slotNumber, newRestakedBalanceGwei);
+            emit ValidatorBalanceUpdated(validatorIndex, timestamp, newRestakedBalanceGwei);
 
             int256 sharesDelta = _calculateSharesDelta(newRestakedBalanceGwei * GWEI_TO_WEI, currentRestakedBalanceGwei* GWEI_TO_WEI);
             // update shares in strategy manager

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -20,7 +20,6 @@ import "../interfaces/IPausable.sol";
 
 import "./EigenPodPausingConstants.sol";
 
-import "forge-std/Test.sol";
 /**
  * @title The implementation contract used for restaking beacon chain ETH on EigenLayer 
  * @author Layr Labs, Inc.
@@ -35,7 +34,7 @@ import "forge-std/Test.sol";
  * @dev Note that all beacon chain balances are stored as gwei within the beacon chain datastructures. We choose
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
  */
-contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants, Test {
+contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants {
     using BytesLib for bytes;
     using SafeERC20 for IERC20;
 
@@ -412,15 +411,12 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         // verify that the provided state root is verified against the oracle-provided latest block header
         BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({beaconStateRoot: proofs.beaconStateRoot, latestBlockHeaderRoot: latestBlockHeaderRoot, proof: proofs.latestBlockHeaderProof});
 
-        emit log_named_uint("gas", gasleft());
-        uint g = gasleft();
         BeaconChainProofs.verifyValidatorFields({
             beaconStateRoot: proofs.beaconStateRoot,
             validatorFields: validatorFields,
             proof: proofs.validatorFieldsProof,
             validatorIndex: validatorIndex
         });
-        emit log_named_uint("gas", g - gasleft());
 
         // set the status to active
         validatorInfo.status = VALIDATOR_STATUS.ACTIVE;

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -411,6 +411,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
         // set the status to active
         validatorInfo.status = VALIDATOR_STATUS.ACTIVE;
+        validatorInfo.validatorIndex = validatorIndex;
 
         emit ValidatorRestaked(validatorIndex);
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -421,11 +421,13 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         // set the status to active
         validatorInfo.status = VALIDATOR_STATUS.ACTIVE;
         validatorInfo.validatorIndex = validatorIndex;
-
-        emit ValidatorRestaked(validatorIndex);
+        validatorInfo.mostRecentBalanceUpdateTimestamp = oracleTimestamp;
 
         //record validator's new restaked balance
         validatorInfo.restakedBalanceGwei = _calculateRestakedBalanceGwei(validatorEffectiveBalanceGwei);
+
+        emit ValidatorRestaked(validatorIndex);
+        emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, validatorInfo.restakedBalanceGwei);
 
         //record validatorInfo update in storage
         _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -20,8 +20,6 @@ import "../interfaces/IPausable.sol";
 
 import "./EigenPodPausingConstants.sol";
 
-import "forge-std/Test.sol";
-
 /**
  * @title The implementation contract used for restaking beacon chain ETH on EigenLayer 
  * @author Layr Labs, Inc.
@@ -36,7 +34,7 @@ import "forge-std/Test.sol";
  * @dev Note that all beacon chain balances are stored as gwei within the beacon chain datastructures. We choose
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
  */
-contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants, Test {
+contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants {
     using BytesLib for bytes;
     using SafeERC20 for IERC20;
 
@@ -265,8 +263,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
         require(validatorInfo.status == VALIDATOR_STATUS.ACTIVE, "EigenPod.verifyBalanceUpdate: Validator not active");
         //checking that the balance update being made is strictly after the previous balance update
-        emit log_named_uint("mostRecentBalanceUpdateTimestamp", validatorInfo.mostRecentBalanceUpdateTimestamp);
-        emit log_named_uint("oracleTimestamp", oracleTimestamp);
+
         require(validatorInfo.mostRecentBalanceUpdateTimestamp < oracleTimestamp,"EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this slot");
 
         {

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -265,14 +265,14 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         require(validatorInfo.status == VALIDATOR_STATUS.ACTIVE, "EigenPod.verifyBalanceUpdate: Validator not active");
         //checking that the balance update being made is strictly after the previous balance update
         require(validatorInfo.mostRecentBalanceUpdateTimestamp < _computeTimestampAtSlot(Endian.fromLittleEndianUint64(proofs.slotRoot)),
-            "EigenPod.verifyBalanceUpdate: Validator's balance has already been updated for this slot");
+            "EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this slot");
         
         // deserialize the balance field from the balanceRoot
         uint64 validatorNewBalanceGwei = BeaconChainProofs.getBalanceFromBalanceRoot(validatorIndex, proofs.balanceRoot);        
 
         {
             // verify ETH validator proof
-            bytes32 latestBlockHeaderRoot = eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp);
+            bytes32 latestBlockHeaderRoot = eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp);
 
             // verify that the provided state root is verified against the oracle-provided latest block header
             BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({beaconStateRoot: proofs.beaconStateRoot, latestBlockHeaderRoot: latestBlockHeaderRoot, proof: proofs.latestBlockHeaderProof});
@@ -285,7 +285,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             validatorIndex: validatorIndex
         });
  
-        // verify ETH validator's current balance, which is stored in the `balances` container of the beacon state
+        // verify ETH validators current balance, which is stored in the `balances` container of the beacon state
         BeaconChainProofs.verifyValidatorBalance({
             beaconStateRoot: proofs.beaconStateRoot,
             balanceRoot: proofs.balanceRoot,
@@ -410,7 +410,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         uint64 validatorEffectiveBalanceGwei = Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX]);
 
         // verify ETH validator proof
-        bytes32 latestBlockHeaderRoot = eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp);
+        bytes32 latestBlockHeaderRoot = eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp);
 
         // verify that the provided state root is verified against the oracle-provided latest block header
         BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({beaconStateRoot: proofs.beaconStateRoot, latestBlockHeaderRoot: latestBlockHeaderRoot, proof: proofs.latestBlockHeaderProof});
@@ -479,7 +479,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         // verify that the provided state root is verified against the oracle-provided latest block header
         BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({
             beaconStateRoot: withdrawalProofs.beaconStateRoot,
-            latestBlockHeaderRoot: eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp),
+            latestBlockHeaderRoot: eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp),
             proof: withdrawalProofs.latestBlockHeaderProof
         });
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -66,7 +66,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     */
     uint64 public immutable RESTAKED_BALANCE_OFFSET_GWEI;
 
-    //this is the genesis time of the beacon state, to help us calculate conversions between slot and timestamp
+    /// @notice This is the genesis time of the beacon state, to help us calculate conversions between slot and timestamp
     uint64 public immutable GENESIS_TIME;
 
     // STORAGE VARIABLES
@@ -466,12 +466,12 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         require(validatorInfo.status != VALIDATOR_STATUS.INACTIVE,
             "EigenPod._verifyAndProcessWithdrawal: Validator never proven to have withdrawal credentials pointed to this contract");
 
-        {
-            require(!provenWithdrawal[validatorPubkeyHash][withdrawalHappenedTimestamp],
-                "EigenPod._verifyAndProcessWithdrawal: withdrawal has already been proven for this slot");
+        
+        require(!provenWithdrawal[validatorPubkeyHash][withdrawalHappenedTimestamp],
+            "EigenPod._verifyAndProcessWithdrawal: withdrawal has already been proven for this slot");
 
-            provenWithdrawal[validatorPubkeyHash][withdrawalHappenedTimestamp] = true;
-        }
+        provenWithdrawal[validatorPubkeyHash][withdrawalHappenedTimestamp] = true;
+        
     
         // verify that the provided state root is verified against the oracle-provided latest block header
         BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({
@@ -501,7 +501,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             if (Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX]) <= slot/BeaconChainProofs.SLOTS_PER_EPOCH) {
                 _processFullWithdrawal(validatorIndex, validatorPubkeyHash, withdrawalHappenedTimestamp, podOwner, withdrawalAmountGwei, validatorInfo);
             } else {
-                _processPartialWithdrawal(validatorIndex, slot, podOwner, withdrawalAmountGwei);
+                _processPartialWithdrawal(validatorIndex, withdrawalHappenedTimestamp, podOwner, withdrawalAmountGwei);
             }
         }
     }
@@ -570,11 +570,11 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     function _processPartialWithdrawal(
         uint40 validatorIndex,
-        uint64 withdrawalHappenedSlot,
+        uint64 withdrawalHappenedTimestamp,
         address recipient,
         uint64 partialWithdrawalAmountGwei
     ) internal {
-        emit PartialWithdrawalRedeemed(validatorIndex, _computeTimestampAtSlot(withdrawalHappenedSlot), recipient, partialWithdrawalAmountGwei);
+        emit PartialWithdrawalRedeemed(validatorIndex, withdrawalHappenedTimestamp, recipient, partialWithdrawalAmountGwei);
 
         // send the ETH to the `recipient` via the DelayedWithdrawalRouter
         _sendETH_AsDelayedWithdrawal(recipient, uint256(partialWithdrawalAmountGwei) * uint256(GWEI_TO_WEI));

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -546,10 +546,14 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         }  else {
             revert("EigenPod.verifyBeaconChainFullWithdrawal: VALIDATOR_STATUS is invalid VALIDATOR_STATUS");
         }
+
+        uint64 withdrawalHappenedTimestamp = _computeTimestampAtSlot(withdrawalHappenedSlot);
         // now that the validator has been proven to be withdrawn, we can set their restaked balance to 0
         _validatorPubkeyHashToInfo[validatorPubkeyHash].restakedBalanceGwei = 0;
+        _validatorPubkeyHashToInfo[validatorPubkeyHash].status = VALIDATOR_STATUS.WITHDRAWN;
+        _validatorPubkeyHashToInfo[validatorPubkeyHash].mostRecentBalanceUpdateTimestamp = withdrawalHappenedTimestamp;
 
-        provenWithdrawal[validatorPubkeyHash][_computeTimestampAtSlot(withdrawalHappenedSlot)] = true;
+        provenWithdrawal[validatorPubkeyHash][withdrawalHappenedTimestamp] = true;
 
         emit FullWithdrawalRedeemed(validatorIndex, recipient, withdrawalAmountGwei * GWEI_TO_WEI, _computeTimestampAtSlot(withdrawalHappenedSlot));
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -497,7 +497,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             */
             // reference: uint64 withdrawableEpoch = Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX]);
             if (Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX]) <= slot/BeaconChainProofs.SLOTS_PER_EPOCH) {
-                _processFullWithdrawal(validatorIndex, validatorPubkeyHash, slot, podOwner, withdrawalAmountGwei, validatorInfo);
+                _processFullWithdrawal(validatorIndex, validatorPubkeyHash, withdrawalHappenedTimestamp, podOwner, withdrawalAmountGwei, validatorInfo);
             } else {
                 _processPartialWithdrawal(validatorIndex, slot, podOwner, withdrawalAmountGwei);
             }
@@ -507,7 +507,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     function _processFullWithdrawal(
         uint40 validatorIndex,
         bytes32 validatorPubkeyHash,
-        uint64 withdrawalHappenedSlot,
+        uint64 withdrawalHappenedTimestamp,
         address recipient,
         uint64 withdrawalAmountGwei,
         ValidatorInfo memory validatorInfo
@@ -551,7 +551,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             revert("EigenPod.verifyBeaconChainFullWithdrawal: VALIDATOR_STATUS is invalid VALIDATOR_STATUS");
         }
 
-        uint64 withdrawalHappenedTimestamp = _computeTimestampAtSlot(withdrawalHappenedSlot);
         // now that the validator has been proven to be withdrawn, we can set their restaked balance to 0
         validatorInfo.restakedBalanceGwei = 0;
         validatorInfo.status = VALIDATOR_STATUS.WITHDRAWN;

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -303,9 +303,8 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         //update the balance
         validatorInfo.restakedBalanceGwei = newRestakedBalanceGwei;
 
-        //update the most recent balance update slot
-        uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
-        uint64 timestamp = _computeTimestampAtSlot(slotNumber);
+        //update the most recent balance update timestamp from the slot
+        uint64 timestamp = _computeTimestampAtSlot(Endian.fromLittleEndianUint64(proofs.slotRoot));
         validatorInfo.mostRecentBalanceUpdateTimestamp = timestamp;
 
         //record validatorInfo update in storage

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -271,29 +271,29 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             bytes32 latestBlockHeaderRoot = eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp);
 
             // verify that the provided state root is verified against the oracle-provided latest block header
-            BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot(proofs.beaconStateRoot, latestBlockHeaderRoot, proofs.latestBlockHeaderProof);
+            BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({beaconStateRoot: proofs.beaconStateRoot, latestBlockHeaderRoot: latestBlockHeaderRoot, proof: proofs.latestBlockHeaderProof});
         }
         // verify validator fields
-        BeaconChainProofs.verifyValidatorFields(
-            proofs.beaconStateRoot,
-            validatorFields,            
-            proofs.validatorFieldsProof,
-            validatorIndex
-        );
+        BeaconChainProofs.verifyValidatorFields({
+            beaconStateRoot: proofs.beaconStateRoot,
+            validatorFields: validatorFields,            
+            proof: proofs.validatorFieldsProof,
+            validatorIndex: validatorIndex
+        });
  
         // verify ETH validator's current balance, which is stored in the `balances` container of the beacon state
-        BeaconChainProofs.verifyValidatorBalance(
-            proofs.beaconStateRoot,
-            proofs.balanceRoot,
-            proofs.validatorBalanceProof,
-            validatorIndex
-        );
+        BeaconChainProofs.verifyValidatorBalance({
+            beaconStateRoot: proofs.beaconStateRoot,
+            balanceRoot: proofs.balanceRoot,
+            proof: proofs.validatorBalanceProof,
+            validatorIndex: validatorIndex
+        });
         //verify provided slot is valid against beaconStateRoot
-        BeaconChainProofs.verifySlotRoot(
-            proofs.beaconStateRoot,
-            proofs.slotRoot,
-            proofs.slotProof
-        );
+        BeaconChainProofs.verifySlotRoot({
+            beaconStateRoot: proofs.beaconStateRoot,
+            slotRoot: proofs.slotRoot,
+            proof: proofs.slotProof
+        });
 
         uint64 currentRestakedBalanceGwei = validatorInfo.restakedBalanceGwei;
 
@@ -410,14 +410,14 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes32 latestBlockHeaderRoot = eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp);
 
         // verify that the provided state root is verified against the oracle-provided latest block header
-        BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot(proofs.beaconStateRoot, latestBlockHeaderRoot, proofs.latestBlockHeaderProof);
+        BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({beaconStateRoot: proofs.beaconStateRoot, latestBlockHeaderRoot: latestBlockHeaderRoot, proof: proofs.latestBlockHeaderProof});
 
-        BeaconChainProofs.verifyValidatorFields(
-            proofs.beaconStateRoot,
-            validatorFields,
-            proofs.validatorFieldsProof,
-            validatorIndex
-        );
+        BeaconChainProofs.verifyValidatorFields({
+            beaconStateRoot: proofs.beaconStateRoot,
+            validatorFields: validatorFields,
+            proof: proofs.validatorFieldsProof,
+            validatorIndex: validatorIndex
+        });
 
         // set the status to active
         validatorInfo.status = VALIDATOR_STATUS.ACTIVE;
@@ -471,17 +471,17 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     
         // verify that the provided state root is verified against the oracle-provided latest block header
-        BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot(
-            withdrawalProofs.beaconStateRoot,
-            eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp),
-            withdrawalProofs.latestBlockHeaderProof
-        );
+        BeaconChainProofs.verifyStateRootAgainstLatestBlockHeaderRoot({
+            beaconStateRoot: withdrawalProofs.beaconStateRoot,
+            latestBlockHeaderRoot: eigenPodManager.getBeaconChainStateRootAtTimestamp(oracleTimestamp),
+            proof: withdrawalProofs.latestBlockHeaderProof
+        });
 
 
         // Verifying the withdrawal as well as the slot
-        BeaconChainProofs.verifyWithdrawalProofs(withdrawalProofs.beaconStateRoot, withdrawalFields, withdrawalProofs);
+        BeaconChainProofs.verifyWithdrawalProofs({beaconStateRoot: withdrawalProofs.beaconStateRoot, withdrawalFields: withdrawalFields, proofs: withdrawalProofs});
         // Verifying the validator fields, specifically the withdrawable epoch
-        BeaconChainProofs.verifyValidatorFields(withdrawalProofs.beaconStateRoot, validatorFields, validatorFieldsProof, validatorIndex);
+        BeaconChainProofs.verifyValidatorFields({beaconStateRoot: withdrawalProofs.beaconStateRoot, validatorFields: validatorFields, proof: validatorFieldsProof, validatorIndex: validatorIndex});
 
         {
             uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(withdrawalFields[BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]);

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -701,10 +701,10 @@ contract EigenPodManager is
         return address(ownerToPod[podOwner]) != address(0);
     }
 
-    /// @notice Returns the Beacon Chain state root at `timestamp`. Reverts if the Beacon Chain state root at `timestamp` has not yet been finalized.
-    function getBeaconChainStateRootAtTimestamp(uint64 timestamp) external view returns(bytes32) {
+    /// @notice Returns the Beacon block root at `timestamp`. Reverts if the Beacon block root at `timestamp` has not yet been finalized.
+    function getBlockRootAtTimestamp(uint64 timestamp) external view returns(bytes32) {
         bytes32 stateRoot = beaconChainOracle.beaconStateRootAtBlockNumber(timestamp);
-        require(stateRoot != bytes32(0), "EigenPodManager.getBeaconChainStateRootAtTimestamp: state root at timestamp not yet finalized");
+        require(stateRoot != bytes32(0), "EigenPodManager.getBlockRootAtTimestamp: state root at timestamp not yet finalized");
         return stateRoot;
     }
 

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -575,7 +575,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         }
 
         ethPOSDeposit = new ETHPOSDepositMock();
-        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET);
+        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET, GENESIS_TIME);
 
         eigenPodBeacon = new UpgradeableBeacon(address(pod));
 

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -82,6 +82,7 @@ contract EigenLayerDeployer is Operators {
     uint64 MAX_PARTIAL_WTIHDRAWAL_AMOUNT_GWEI = 1 ether / 1e9;
     uint64 MAX_VALIDATOR_BALANCE_GWEI = 32e9;
     uint64 EFFECTIVE_RESTAKED_BALANCE_OFFSET = 75e7;
+    uint64 GENESIS_TIME = 1616508000;
 
     address pauser;
     address unpauser;
@@ -167,7 +168,7 @@ contract EigenLayerDeployer is Operators {
         beaconChainOracle = new BeaconChainOracle(eigenLayerReputedMultisig, initialBeaconChainOracleThreshold, initialOracleSignersArray);
 
         ethPOSDeposit = new ETHPOSDepositMock();
-        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET);
+        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET, GENESIS_TIME);
 
         eigenPodBeacon = new UpgradeableBeacon(address(pod));
 
@@ -250,7 +251,7 @@ contract EigenLayerDeployer is Operators {
         beaconChainOracle = new BeaconChainOracle(eigenLayerReputedMultisig, initialBeaconChainOracleThreshold, initialOracleSignersArray);
 
         ethPOSDeposit = new ETHPOSDepositMock();
-        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET);
+        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_VALIDATOR_BALANCE_GWEI, EFFECTIVE_RESTAKED_BALANCE_OFFSET, GENESIS_TIME);
 
         eigenPodBeacon = new UpgradeableBeacon(address(pod));
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -91,10 +91,10 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
     
     /// @notice Emitted when an ETH validator is prove to have withdrawn from the beacon chain
-    event FullWithdrawalRedeemed(uint40 validatorIndex, address indexed recipient, uint64 withdrawalAmountGwei, uint64 timestamp);
+    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 withdrawalAmountGwei);
 
     /// @notice Emitted when a partial withdrawal claim is successfully redeemed
-    event PartialWithdrawalRedeemed(uint40 validatorIndex, address indexed recipient, uint64 partialWithdrawalAmountGwei, uint64 timestamp);
+    event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
 
     /// @notice Emitted when restaked beacon chain ETH is withdrawn from the eigenPod.
     event RestakedBeaconChainETHWithdrawn(address indexed recipient, uint256 amount);
@@ -413,7 +413,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
             // uint64 timestamp = _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofsArray[0].slotRoot));
 
             //cheats.expectEmit(true, true, true, true, address(newPod));
-            emit FullWithdrawalRedeemed(validatorIndex, podOwner, withdrawalAmountGwei, _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofsArray[0].slotRoot)));
+            emit FullWithdrawalRedeemed(validatorIndex, _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofsArray[0].slotRoot)), podOwner, withdrawalAmountGwei);
             newPod.verifyAndProcessWithdrawals(withdrawalProofsArray, validatorFieldsProofArray, validatorFieldsArray, withdrawalFieldsArray, 0);
         }
         require(newPod.withdrawableRestakedExecutionLayerGwei() -  restakedExecutionLayerGweiBefore == _calculateRestakedBalanceGwei(newPod.MAX_VALIDATOR_BALANCE_GWEI()),
@@ -463,7 +463,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
             uint256 delayedWithdrawalRouterContractBalanceBefore = address(delayedWithdrawalRouter).balance;
             cheats.expectEmit(true, true, true, true, address(newPod));
-            emit PartialWithdrawalRedeemed(validatorIndex, podOwner, withdrawalAmountGwei, _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofs.slotRoot)));
+            emit PartialWithdrawalRedeemed(validatorIndex, _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofs.slotRoot)), podOwner, withdrawalAmountGwei);
             newPod.verifyAndProcessWithdrawals(withdrawalProofsArray, validatorFieldsProofArray, validatorFieldsArray, withdrawalFieldsArray, 0);
             require(newPod.provenWithdrawal(validatorFields[0], _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofs.slotRoot))), "provenPartialWithdrawal should be true");
             withdrawalAmountGwei = uint64(withdrawalAmountGwei*GWEI_TO_WEI);

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -730,7 +730,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         BeaconChainOracleMock(address(beaconChainOracle)).setBeaconChainStateRoot(newBeaconStateRoot);
         BeaconChainProofs.BalanceUpdateProofs memory proofs = _getBalanceUpdateProofs();
 
-        cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: Validator's balance has already been updated for this slot"));
+        cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this slot"));
         newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
     }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -673,6 +673,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         // ./solidityProofGen "BalanceUpdateProof" 302913 true 0 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_overCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_overCommitted_302913.json");
         // prove overcommitted balance
+        cheats.roll(block.number + 1);
         _proveOverCommittedStake(newPod);
 
         uint256 validatorRestakedBalanceAfter = newPod.validatorPubkeyHashToInfo(validatorPubkeyHash).restakedBalanceGwei;
@@ -697,11 +698,13 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
          // ./solidityProofGen "BalanceUpdateProof" 302913 true 0 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_overCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_overCommitted_302913.json");
         // prove overcommitted balance
+        cheats.roll(block.number + 1);
         _proveOverCommittedStake(newPod);
 
         cheats.roll(block.number + 1);
         // ./solidityProofGen "BalanceUpdateProof" 302913 false 100 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_notOverCommitted_302913_incrementedBlockBy100.json"
         setJSON("./src/test/test-data/balanceUpdateProof_notOverCommitted_302913_incrementedBlockBy100.json");
+        cheats.roll(block.number + 1);
         _proveUnderCommittedStake(newPod);
 
         uint256 validatorRestakedBalanceAfter = newPod.validatorPubkeyHashToInfo(validatorPubkeyHash).restakedBalanceGwei;
@@ -722,6 +725,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         // ./solidityProofGen "BalanceUpdateProof" 302913 true 0 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_overCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_overCommitted_302913.json");
         // prove overcommitted balance
+        cheats.roll(block.number + 1);
         _proveOverCommittedStake(newPod);
 
         // ./solidityProofGen "BalanceUpdateProof" 302913 false 0 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_notOverCommitted_302913.json"
@@ -874,7 +878,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         //cheats.expectEmit(true, true, true, true, address(newPod));
         uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
         emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
-        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number) + 1);
+        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
     }
 
     function _proveUnderCommittedStake(IEigenPod newPod) internal {
@@ -887,7 +891,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
         emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
         //cheats.expectEmit(true, true, true, true, address(newPod));
-        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number) + 1);
+        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
         require(newPod.validatorPubkeyHashToInfo(getValidatorPubkeyHash()).status == IEigenPod.VALIDATOR_STATUS.ACTIVE);
     }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -541,6 +541,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
         IEigenPod newPod = eigenPodManager.getPod(podOwner);
 
+        cheats.roll(block.number + 1);
         // ./solidityProofGen "BalanceUpdateProof" 302913 true 0 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_overCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_overCommitted_302913.json");
         _proveOverCommittedStake(newPod);
@@ -698,6 +699,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         // prove overcommitted balance
         _proveOverCommittedStake(newPod);
 
+        cheats.roll(block.number + 1);
         // ./solidityProofGen "BalanceUpdateProof" 302913 false 100 "data/withdrawal_proof_goerli/goerli_slot_6399999.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_notOverCommitted_302913_incrementedBlockBy100.json"
         setJSON("./src/test/test-data/balanceUpdateProof_notOverCommitted_302913_incrementedBlockBy100.json");
         _proveUnderCommittedStake(newPod);
@@ -872,7 +874,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         //cheats.expectEmit(true, true, true, true, address(newPod));
         uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
         emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
-        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
+        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number) + 1);
     }
 
     function _proveUnderCommittedStake(IEigenPod newPod) internal {
@@ -885,7 +887,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
         emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
         //cheats.expectEmit(true, true, true, true, address(newPod));
-        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
+        newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number) + 1);
         require(newPod.validatorPubkeyHashToInfo(getValidatorPubkeyHash()).status == IEigenPod.VALIDATOR_STATUS.ACTIVE);
     }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -61,6 +61,9 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     uint32 WITHDRAWAL_DELAY_BLOCKS = 7 days / 12 seconds;
     uint64  MAX_VALIDATOR_BALANCE_GWEI = 32e9;
     uint64  RESTAKED_BALANCE_OFFSET_GWEI = 75e7;
+    uint64 internal constant GENESIS_TIME = 1616508000;
+    uint64 internal constant SECONDS_PER_SLOT = 12;
+
 
     // EIGENPODMANAGER EVENTS
     /// @notice Emitted to notify the update of the beaconChainOracle address
@@ -460,7 +463,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
             cheats.expectEmit(true, true, true, true, address(newPod));
             emit PartialWithdrawalRedeemed(validatorIndex, podOwner, withdrawalAmountGwei);
             newPod.verifyAndProcessWithdrawals(withdrawalProofsArray, validatorFieldsProofArray, validatorFieldsArray, withdrawalFieldsArray, 0);
-            require(newPod.provenWithdrawal(validatorFields[0], Endian.fromLittleEndianUint64(withdrawalProofs.slotRoot)), "provenPartialWithdrawal should be true");
+            require(newPod.provenWithdrawal(validatorFields[0], _computeTimestampAtSlot(Endian.fromLittleEndianUint64(withdrawalProofs.slotRoot))), "provenPartialWithdrawal should be true");
             withdrawalAmountGwei = uint64(withdrawalAmountGwei*GWEI_TO_WEI);
             require(address(delayedWithdrawalRouter).balance - delayedWithdrawalRouterContractBalanceBefore == withdrawalAmountGwei,
                 "pod delayed withdrawal balance hasn't been updated correctly");
@@ -1332,6 +1335,11 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint64 effectiveBalanceGwei = uint64((amountGwei - RESTAKED_BALANCE_OFFSET_GWEI) / GWEI_TO_WEI * GWEI_TO_WEI);
         return uint64(MathUpgradeable.min(MAX_VALIDATOR_BALANCE_GWEI, effectiveBalanceGwei));
     }
+
+    function _computeTimestampAtSlot(uint64 slot) internal pure returns (uint64) {
+        return uint64(GENESIS_TIME + slot * SECONDS_PER_SLOT);
+    }
+
 
  }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -361,7 +361,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
     function testFullWithdrawalProof() public {
         setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        BeaconChainProofs.WithdrawalProofs memory proofs = _getWithdrawalProof();
+        BeaconChainProofs.WithdrawalProofs memory proofs = _getWithdrawalProof(false);
         withdrawalFields = getWithdrawalFields();   
         validatorFields = getValidatorFields();
 
@@ -398,7 +398,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint256 delayedWithdrawalRouterContractBalanceBefore = address(delayedWithdrawalRouter).balance;
         {
             BeaconChainProofs.WithdrawalProofs[] memory withdrawalProofsArray = new BeaconChainProofs.WithdrawalProofs[](1);
-            withdrawalProofsArray[0] = _getWithdrawalProof();
+            withdrawalProofsArray[0] = _getWithdrawalProof(false);
             bytes[] memory validatorFieldsProofArray = new bytes[](1);
             validatorFieldsProofArray[0] = abi.encodePacked(getValidatorProof());
             bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
@@ -438,7 +438,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
         withdrawalFields = getWithdrawalFields();
         validatorFields = getValidatorFields();
-        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof();
+        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof(false);
         bytes memory validatorFieldsProof = abi.encodePacked(getValidatorProof());
 
         BeaconChainOracleMock(address(beaconChainOracle)).setBeaconChainStateRoot(getLatestBlockHeaderRoot());
@@ -477,7 +477,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     function testProvingMultiplePartialWithdrawalsForSameSlot(/*uint256 numPartialWithdrawals*/) public {
         IEigenPod newPod = testPartialWithdrawalFlow();
 
-        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof();
+        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof(false);
         bytes memory validatorFieldsProof = abi.encodePacked(getValidatorProof());
         withdrawalFields = getWithdrawalFields();   
         validatorFields = getValidatorFields();
@@ -498,7 +498,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     /// @notice verifies that multiple full withdrawals for a single validator fail
     function testDoubleFullWithdrawal() public returns(IEigenPod newPod) {
         newPod = testFullWithdrawalFlow();
-        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof();
+        BeaconChainProofs.WithdrawalProofs memory withdrawalProofs = _getWithdrawalProof(false);
         bytes memory validatorFieldsProof = abi.encodePacked(getValidatorProof());
         withdrawalFields = getWithdrawalFields();   
         validatorFields = getValidatorFields();
@@ -1250,7 +1250,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     }
 
     /// @notice this function just generates a valid proof so that we can test other functionalities of the withdrawal flow
-    function _getWithdrawalProof() internal returns(BeaconChainProofs.WithdrawalProofs memory) {
+    function _getWithdrawalProof(bool proveHistoricalRoot) internal returns(BeaconChainProofs.WithdrawalProofs memory) {
         IEigenPod newPod = eigenPodManager.getPod(podOwner);
 
         //make initial deposit
@@ -1272,17 +1272,11 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
             bytes32 timestampRoot = getTimestampRoot();
             bytes32 executionPayloadRoot = getExecutionPayloadRoot();
 
-
-
-            uint256 withdrawalIndex = getWithdrawalIndex();
-            uint256 blockHeaderRootIndex = getBlockHeaderRootIndex();
-
             // TODO: @Sidu28 to get these values correctly
             bytes memory historicalSummaryBlockRootProof;
             uint64 historicalSummaryIndex;
-            bool proveHistoricalRoot;
 
-            BeaconChainProofs.WithdrawalProofs memory proofs = BeaconChainProofs.WithdrawalProofs(
+            return BeaconChainProofs.WithdrawalProofs(
                 beaconStateRoot,
                 abi.encodePacked(getStateRootAgainstLatestBlockHeaderProof()),
                 abi.encodePacked(getBlockHeaderProof()),
@@ -1291,9 +1285,9 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
                 abi.encodePacked(getExecutionPayloadProof()),
                 abi.encodePacked(getTimestampProof()),
                 historicalSummaryBlockRootProof,
-                uint64(blockHeaderRootIndex),
+                uint64(getBlockHeaderRootIndex()),
                 historicalSummaryIndex,
-                uint64(withdrawalIndex),
+                uint64(getWithdrawalIndex()),
                 blockHeaderRoot,
                 blockBodyRoot,
                 slotRoot,
@@ -1301,7 +1295,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
                 executionPayloadRoot,
                 proveHistoricalRoot
             );
-            return proofs;
+
         }
     }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -876,8 +876,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         BeaconChainOracleMock(address(beaconChainOracle)).setBeaconChainStateRoot(newLatestBlockHeaderRoot);
         BeaconChainProofs.BalanceUpdateProofs memory proofs = _getBalanceUpdateProofs();
         //cheats.expectEmit(true, true, true, true, address(newPod));
-        uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
-        emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
+        emit ValidatorBalanceUpdated(validatorIndex, uint64(block.number), _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
         newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
     }
 
@@ -888,8 +887,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         BeaconChainOracleMock(address(beaconChainOracle)).setBeaconChainStateRoot(newLatestBlockHeaderRoot);
         BeaconChainProofs.BalanceUpdateProofs memory proofs = _getBalanceUpdateProofs();
         
-        uint64 slotNumber = Endian.fromLittleEndianUint64(proofs.slotRoot);
-        emit ValidatorBalanceUpdated(validatorIndex, slotNumber, _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
+        emit ValidatorBalanceUpdated(validatorIndex, uint64(block.number), _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
         //cheats.expectEmit(true, true, true, true, address(newPod));
         newPod.verifyBalanceUpdate(validatorIndex, proofs, validatorFields, uint64(block.number));
         require(newPod.validatorPubkeyHashToInfo(getValidatorPubkeyHash()).status == IEigenPod.VALIDATOR_STATUS.ACTIVE);
@@ -1246,15 +1244,12 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         bytes32 beaconStateRoot = getBeaconStateRoot();
 
         bytes32 balanceRoot = getBalanceRoot();
-        bytes32 slotRoot = getSlotRoot();
         BeaconChainProofs.BalanceUpdateProofs memory proofs = BeaconChainProofs.BalanceUpdateProofs(
             beaconStateRoot,
             abi.encodePacked(getStateRootAgainstLatestBlockHeaderProof()),
             abi.encodePacked(getValidatorBalanceProof()),
             abi.encodePacked(getWithdrawalCredentialProof()),  //technically this is to verify validator pubkey in the validator fields, but the WC proof is effectively the same so we use it here again.
-            abi.encodePacked(getBalanceUpdateSlotProof()),
-            balanceRoot,
-            slotRoot
+            balanceRoot
         );
 
         return proofs;

--- a/src/test/SigP/EigenPodManagerNEW.sol
+++ b/src/test/SigP/EigenPodManagerNEW.sol
@@ -29,7 +29,7 @@ import "../../contracts/interfaces/IBeaconChainOracle.sol";
  * - withdrawing eth when withdrawals are initiated
  */
 contract EigenPodManagerNEW is Initializable, OwnableUpgradeable, IEigenPodManager {
-    function getBeaconChainStateRootAtTimestamp(uint64 timestamp) external view returns(bytes32) {}
+    function getBlockRootAtTimestamp(uint64 timestamp) external view returns(bytes32) {}
 
     function pause(uint256 newPausedStatus) external {}    
 
@@ -230,8 +230,8 @@ contract EigenPodManagerNEW is Initializable, OwnableUpgradeable, IEigenPodManag
         return address(getPod(podOwner)).code.length > 0;
     }
 
-    function getBeaconChainStateRootAtTimestamp() external view returns(bytes32) {
-        // return beaconChainOracle.getBeaconChainStateRootAtTimestamp();
+    function getBlockRootAtTimestamp() external view returns(bytes32) {
+        // return beaconChainOracle.getBlockRootAtTimestamp();
     }
 
     function podOwnerShares(address podOwner) external returns (uint256){

--- a/src/test/mocks/BeaconChainOracleMock.sol
+++ b/src/test/mocks/BeaconChainOracleMock.sol
@@ -9,7 +9,7 @@ contract BeaconChainOracleMock is IBeaconChainOracleMock {
 
     bytes32 public mockBeaconChainStateRoot;
 
-    function getBeaconChainStateRootAtTimestamp() external view returns(bytes32) {
+    function getBlockRootAtTimestamp() external view returns(bytes32) {
         return mockBeaconChainStateRoot;
     }
 

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -33,7 +33,7 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
         return IBeaconChainOracle(address(0));
     }   
 
-    function getBeaconChainStateRootAtTimestamp(uint64 /*timestamp*/) external pure returns(bytes32) {
+    function getBlockRootAtTimestamp(uint64 /*timestamp*/) external pure returns(bytes32) {
         return bytes32(0);
     }
 


### PR DESCRIPTION
This PR is to add historical summary proofs to our withdrawal verification to prove older withdrawals.


It also addresses some comments in the "newpodchanges" PR.

- update validatorIndex in the validatorInfo struct
- I think that mostRecentBalanceUpdateSlot doesn't need to be set when you verify your withdrawal credentials.  0 here seems fine to me, but I will let the reviewers see if they agree.
- Switch from slot to timestamp in storage and events
- Syntax change in call to verifyProof functions to spedify individual inputs

