### PR TITLE
Update inline commenting for RegistryCoordinator

### DIFF
--- a/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/interfaces/IBLSRegistryCoordinatorWithIndices.sol
@@ -46,7 +46,7 @@ interface IBLSRegistryCoordinatorWithIndices is ISignatureUtils, IRegistryCoordi
 
     /// @notice Returns the operator set params for the given `quorumNumber`
     function getOperatorSetParams(uint8 quorumNumber) external view returns (OperatorSetParam memory);
-    /// @notice the stake registry for this corrdinator is the contract itself
+    /// @notice the Stake registry contract that will keep track of operators' stakes
     function stakeRegistry() external view returns (IStakeRegistry);
     /// @notice the BLS Pubkey Registry contract that will keep track of operators' BLS public keys
     function blsPubkeyRegistry() external view returns (IBLSPubkeyRegistry);

--- a/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
+++ b/src/contracts/middleware/BLSRegistryCoordinatorWithIndices.sol
@@ -20,7 +20,7 @@ import "forge-std/Test.sol";
 
 /**
  * @title A `RegistryCoordinator` that has three registries:
- *      1) a `StakeRegistry` that keeps track of operators' stakes (this is actually the contract itself, via inheritance)
+ *      1) a `StakeRegistry` that keeps track of operators' stakes
  *      2) a `BLSPubkeyRegistry` that keeps track of operators' BLS public keys and aggregate BLS public keys for each quorum
  *      3) an `IndexRegistry` that keeps track of an ordered list of operators for each quorum
  * 
@@ -90,7 +90,7 @@ contract BLSRegistryCoordinatorWithIndices is EIP712, Initializable, IBLSRegistr
         _setChurnApprover(_churnApprover);
         // set the ejector
         _setEjector(_ejector);
-        // the stake registry is this contract itself
+        // add registry contracts to the registries array
         registries.push(address(stakeRegistry));
         registries.push(address(blsPubkeyRegistry));
         registries.push(address(indexRegistry));


### PR DESCRIPTION
Removed comments mentioning that the `BLSRegistryCoordinatorWithIndices ` contract is the `StakeRegistry` itself via inheritance.
Updated for clarity.