### PR TITLE
Further Eigen Pod Changes

### DIFF
--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -189,50 +189,18 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         podOwner = _podOwner;
     }
 
-    /// @notice Called by EigenPodManager when the owner wants to create another ETH validator.
-    function stake(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable onlyEigenPodManager {
-        // stake on ethpos
-        require(msg.value == 32 ether, "EigenPod.stake: must initially stake for any validator with 32 ether");
-        ethPOS.deposit{value : 32 ether}(pubkey, _podWithdrawalCredentials(), signature, depositDataRoot);
-        emit EigenPodStaked(pubkey);
+    function validatorPubkeyHashToInfo(bytes32 validatorPubkeyHash) external view returns(ValidatorInfo memory) {
+        return _validatorPubkeyHashToInfo[validatorPubkeyHash];
     }
 
-    /**
-     * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to
-     * this contract. It also verifies the effective balance  of the validator.  It verifies the provided proof of the ETH validator against the beacon chain state
-     * root, marks the validator as 'active' in EigenLayer, and credits the restaked ETH in Eigenlayer.
-     * @param oracleTimestamp is the Beacon Chain timestamp whose state root the `proof` will be proven against.
-     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
-     * @param proofs is an array of proofs, where each proof proves each ETH validator's balance and withdrawal credentials against a beacon chain state root
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs 
-     * for details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
-     */
-    function verifyWithdrawalCredentials(
-        uint64 oracleTimestamp,
-        uint40[] calldata validatorIndices,
-        BeaconChainProofs.WithdrawalCredentialProofs[] calldata proofs,
-        bytes32[][] calldata validatorFields
-    ) external 
-        onlyEigenPodOwner
-        onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS)
-        // check that the provided `oracleTimestamp` is after the `mostRecentWithdrawalTimestamp`
-        proofIsForValidTimestamp(oracleTimestamp)
-        // ensure that caller has previously enabled restaking by calling `activateRestaking()`
-        hasEnabledRestaking
-    {
-        // ensure that the timestamp being proven against is not "too stale", i.e. that the validator's effective balance *recently* changed.
-        require(oracleTimestamp + VERIFY_BALANCE_UPDATE_WINDOW_SECONDS >= block.timestamp,
-            "EigenPod.verifyWithdrawalCredentials: specified timestamp is too far in past");
+    function validatorStatus(bytes32 pubkeyHash) external view returns (VALIDATOR_STATUS) {
+        return _validatorPubkeyHashToInfo[pubkeyHash].status;
+    }
 
-        require((validatorIndices.length == proofs.length) && (proofs.length == validatorFields.length), "EigenPod.verifyWithdrawalCredentials: validatorIndices and proofs must be same length");
-        
-        uint256 totalAmountToBeRestakedWei;
-        for (uint256 i = 0; i < validatorIndices.length; i++) {
-            totalAmountToBeRestakedWei += _verifyWithdrawalCredentials(oracleTimestamp, validatorIndices[i], proofs[i], validatorFields[i]);
-        }
-
-         // virtually deposit for new ETH validator(s)
-        eigenPodManager.restakeBeaconChainETH(podOwner, totalAmountToBeRestakedWei);
+    /// @notice payable fallback function that receives ether deposited to the eigenpods contract
+    receive() external payable {
+        nonBeaconChainETHBalanceWei += msg.value;
+        emit NonBeaconChainETHReceived(msg.value);
     }
 
 
@@ -343,6 +311,86 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         }
     }
 
+        /// @notice Called by EigenPodManager when the owner wants to create another ETH validator.
+    function stake(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable onlyEigenPodManager {
+        // stake on ethpos
+        require(msg.value == 32 ether, "EigenPod.stake: must initially stake for any validator with 32 ether");
+        ethPOS.deposit{value : 32 ether}(pubkey, _podWithdrawalCredentials(), signature, depositDataRoot);
+        emit EigenPodStaked(pubkey);
+    }
+
+    /**
+     * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to
+     * this contract. It also verifies the effective balance  of the validator.  It verifies the provided proof of the ETH validator against the beacon chain state
+     * root, marks the validator as 'active' in EigenLayer, and credits the restaked ETH in Eigenlayer.
+     * @param oracleTimestamp is the Beacon Chain timestamp whose state root the `proof` will be proven against.
+     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
+     * @param proofs is an array of proofs, where each proof proves each ETH validator's balance and withdrawal credentials against a beacon chain state root
+     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs 
+     * for details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     */
+    function verifyWithdrawalCredentials(
+        uint64 oracleTimestamp,
+        uint40[] calldata validatorIndices,
+        BeaconChainProofs.WithdrawalCredentialProofs[] calldata proofs,
+        bytes32[][] calldata validatorFields
+    ) external 
+        onlyEigenPodOwner
+        onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS)
+        // check that the provided `oracleTimestamp` is after the `mostRecentWithdrawalTimestamp`
+        proofIsForValidTimestamp(oracleTimestamp)
+        // ensure that caller has previously enabled restaking by calling `activateRestaking()`
+        hasEnabledRestaking
+    {
+        // ensure that the timestamp being proven against is not "too stale", i.e. that the validator's effective balance *recently* changed.
+        require(oracleTimestamp + VERIFY_BALANCE_UPDATE_WINDOW_SECONDS >= block.timestamp,
+            "EigenPod.verifyWithdrawalCredentials: specified timestamp is too far in past");
+
+        require((validatorIndices.length == proofs.length) && (proofs.length == validatorFields.length), "EigenPod.verifyWithdrawalCredentials: validatorIndices and proofs must be same length");
+        
+        uint256 totalAmountToBeRestakedWei;
+        for (uint256 i = 0; i < validatorIndices.length; i++) {
+            totalAmountToBeRestakedWei += _verifyWithdrawalCredentials(oracleTimestamp, validatorIndices[i], proofs[i], validatorFields[i]);
+        }
+
+         // virtually deposit for new ETH validator(s)
+        eigenPodManager.restakeBeaconChainETH(podOwner, totalAmountToBeRestakedWei);
+    }
+
+     /**
+     * @notice Called by the pod owner to activate restaking by withdrawing 
+     * all existing ETH from the pod and preventing further withdrawals via 
+     * "withdrawBeforeRestaking()"
+    */ 
+    function activateRestaking() external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS) onlyEigenPodOwner hasNeverRestaked {
+        hasRestaked = true;
+        _processWithdrawalBeforeRestaking(podOwner);
+
+        emit RestakingActivated(podOwner);
+    }
+
+    /// @notice Called by the pod owner to withdraw the balance of the pod when `hasRestaked` is set to false
+    function withdrawBeforeRestaking() external onlyEigenPodOwner hasNeverRestaked {
+        _processWithdrawalBeforeRestaking(podOwner);
+    }
+
+    /// @notice Called by the pod owner to withdraw the nonBeaconChainETHBalanceWei
+    function withdrawNonBeaconChainETHBalanceWei(address recipient, uint256 amountToWithdraw) external onlyEigenPodOwner {
+        require(amountToWithdraw <= nonBeaconChainETHBalanceWei,
+            "EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
+        nonBeaconChainETHBalanceWei -= amountToWithdraw;
+        emit NonBeaconChainETHWithdrawn(recipient, amountToWithdraw);
+        AddressUpgradeable.sendValue(payable(recipient), amountToWithdraw);
+    }
+
+    /// @notice called by owner of a pod to remove any ERC20s deposited in the pod
+    function withdrawTokenSweep(IERC20[] memory tokenList, uint256[] memory amountsToWithdraw, address recipient) external onlyEigenPodOwner {
+        require(tokenList.length == amountsToWithdraw.length, "EigenPod.withdrawTokenSweep: tokenList and amountsToWithdraw must be same length");
+        for (uint256 i = 0; i < tokenList.length; i++) {
+            tokenList[i].safeTransfer(recipient, amountsToWithdraw[i]);
+        }
+    }
+
     /**
      * @notice This function is called to decrement withdrawableRestakedExecutionLayerGwei when a validator queues a withdrawal.
      * @param amountWei is the amount of ETH in wei to decrement withdrawableRestakedExecutionLayerGwei by
@@ -361,6 +409,26 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         uint64 amountGwei = uint64(amountWei / GWEI_TO_WEI);
         withdrawableRestakedExecutionLayerGwei += amountGwei;
     }
+
+    /**
+     * @notice Transfers `amountWei` in ether from this contract to the specified `recipient` address
+     * @notice Called by EigenPodManager to withdrawBeaconChainETH that has been added to the EigenPod's balance due to a withdrawal from the beacon chain.
+     * @dev Called during withdrawal or slashing.
+     */
+    function withdrawRestakedBeaconChainETH(
+        address recipient,
+        uint256 amountWei
+    )
+        external
+        onlyEigenPodManager
+    {
+        emit RestakedBeaconChainETHWithdrawn(recipient, amountWei);
+        // transfer ETH from pod to `recipient` directly
+        _sendETH(recipient, amountWei);
+    }
+
+
+    // INTERNAL FUNCTIONS
 
     /**
      * @notice internal function that proves an individual validator's withdrawal credentials
@@ -573,77 +641,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         _sendETH_AsDelayedWithdrawal(recipient, uint256(partialWithdrawalAmountGwei) * uint256(GWEI_TO_WEI));
     }
 
-    /**
-     * @notice Transfers `amountWei` in ether from this contract to the specified `recipient` address
-     * @notice Called by EigenPodManager to withdrawBeaconChainETH that has been added to the EigenPod's balance due to a withdrawal from the beacon chain.
-     * @dev Called during withdrawal or slashing.
-     */
-    function withdrawRestakedBeaconChainETH(
-        address recipient,
-        uint256 amountWei
-    )
-        external
-        onlyEigenPodManager
-    {
-        emit RestakedBeaconChainETHWithdrawn(recipient, amountWei);
-        // transfer ETH from pod to `recipient` directly
-        _sendETH(recipient, amountWei);
-    }
-
-
-    /**
-     * @notice Called by the pod owner to activate restaking by withdrawing 
-     * all existing ETH from the pod and preventing further withdrawals via 
-     * "withdrawBeforeRestaking()"
-    */ 
-    function activateRestaking() external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS) onlyEigenPodOwner hasNeverRestaked {
-        hasRestaked = true;
-        _processWithdrawalBeforeRestaking(podOwner);
-
-        emit RestakingActivated(podOwner);
-    }
-
-    /// @notice Called by the pod owner to withdraw the balance of the pod when `hasRestaked` is set to false
-    function withdrawBeforeRestaking() external onlyEigenPodOwner hasNeverRestaked {
-        _processWithdrawalBeforeRestaking(podOwner);
-    }
-
-    function validatorPubkeyHashToInfo(bytes32 validatorPubkeyHash) external view returns(ValidatorInfo memory) {
-        return _validatorPubkeyHashToInfo[validatorPubkeyHash];
-    }
-
-    function validatorStatus(bytes32 pubkeyHash) external view returns (VALIDATOR_STATUS) {
-        return _validatorPubkeyHashToInfo[pubkeyHash].status;
-    }
-
-    /// @notice payable fallback function that receives ether deposited to the eigenpods contract
-    receive() external payable {
-        nonBeaconChainETHBalanceWei += msg.value;
-        emit NonBeaconChainETHReceived(msg.value);
-    }
-
-    /// @notice Called by the pod owner to withdraw the nonBeaconChainETHBalanceWei
-    function withdrawNonBeaconChainETHBalanceWei(address recipient, uint256 amountToWithdraw) external onlyEigenPodOwner {
-        require(amountToWithdraw <= nonBeaconChainETHBalanceWei,
-            "EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
-        nonBeaconChainETHBalanceWei -= amountToWithdraw;
-        emit NonBeaconChainETHWithdrawn(recipient, amountToWithdraw);
-        AddressUpgradeable.sendValue(payable(recipient), amountToWithdraw);
-    }
-
-    /// @notice called by owner of a pod to remove any ERC20s deposited in the pod
-    function withdrawTokenSweep(IERC20[] memory tokenList, uint256[] memory amountsToWithdraw, address recipient) external onlyEigenPodOwner {
-        require(tokenList.length == amountsToWithdraw.length, "EigenPod.withdrawTokenSweep: tokenList and amountsToWithdraw must be same length");
-        for (uint256 i = 0; i < tokenList.length; i++) {
-            tokenList[i].safeTransfer(recipient, amountsToWithdraw[i]);
-        }
-    }
-
-    // INTERNAL FUNCTIONS
-    function _podWithdrawalCredentials() internal view returns(bytes memory) {
-        return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(this));
-    }
-
     function _processWithdrawalBeforeRestaking(address _podOwner) internal {
         mostRecentWithdrawalTimestamp = uint32(block.timestamp);
         _sendETH_AsDelayedWithdrawal(_podOwner, address(this).balance);
@@ -671,13 +668,17 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return uint64(MathUpgradeable.min(MAX_VALIDATOR_BALANCE_GWEI, effectiveBalanceGwei));
     }
 
-    function _calculateSharesDelta(uint256 newAmountWei, uint256 currentAmountWei) internal pure returns(int256){
-        return (int256(newAmountWei) - int256(currentAmountWei));
-    }
-
-    // reference: https://github.com/ethereum/consensus-specs/blob/ce240ca795e257fc83059c4adfd591328c7a7f21/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
+        // reference: https://github.com/ethereum/consensus-specs/blob/ce240ca795e257fc83059c4adfd591328c7a7f21/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
     function _computeTimestampAtSlot(uint64 slot) internal view returns (uint64) {
         return uint64(GENESIS_TIME + slot * SECONDS_PER_SLOT);
+    }
+
+    function _podWithdrawalCredentials() internal view returns(bytes memory) {
+        return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(this));
+    }
+
+    function _calculateSharesDelta(uint256 newAmountWei, uint256 currentAmountWei) internal pure returns(int256){
+        return (int256(newAmountWei) - int256(currentAmountWei));
     }
 
 


### PR DESCRIPTION
There are several small tasks we need to accomplish once the "newpodchanges" branch is merged into master:

- We need to order the functions in EigenPods according to this:
- - external callable by anyone
- - external callable by pod owner
- - external callable by EPM
- - internal state changing
- - internal pure
- More explicit comments explaining every one of the constructed beacon chain proof indicies. These are particularly hard to understand why they are the way they are so comments are helpful here.
- Move events to interfaces for EigenPod and Delegation Manager from the actual contract.
- Route ETH withdrawn via the withdrawNonBeaconChainETHBalanceWei() function through Delayed Withdrawal Router.

The ticket covering this is https://github.com/Layr-Labs/eignlayr-contracts/issues/962