### PR TITLE
Further changes to newpodchanges

### DIFF
--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -112,6 +112,7 @@ interface IEigenPod {
     function verifyWithdrawalCredentials(
         uint64 oracleBlockNumber,
         uint40[] calldata validatorIndices,
+        bytes[] calldata validatorPubkeys,
         BeaconChainProofs.WithdrawalCredentialProofs[] calldata proofs,
         bytes32[][] calldata validatorFields
     ) external;

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -357,7 +357,7 @@ library BeaconChainProofs {
      *  hh.Reset()
      */
     function hashValidatorBLSPubkey(bytes memory validatorPubkey) internal pure returns (bytes32 pubkeyHash) {
-        require(validatorPubkey.length == 48, "Input should be 32 bytes in length");
+        require(validatorPubkey.length == 48, "Input should be 48 bytes in length");
         bytes memory padding = new bytes(16);
         bytes memory result = new bytes(64);
 

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -213,6 +213,10 @@ library BeaconChainProofs {
         * Therefore, the index of the balance of a validator is validatorIndex/4
         */
         uint256 balanceIndex = uint256(validatorIndex/4);
+        /**
+        * Note: Merkleization of the balance root tree uses MerkleizeWithMixin, i.e., the length of the array is hashed with the root of 
+        * the array.  Thus we shift the BALANCE_INDEX over by BALANCE_TREE_HEIGHT + 1 and not just BALANCE_TREE_HEIGHT.
+        */
         balanceIndex = (BALANCE_INDEX << (BALANCE_TREE_HEIGHT + 1)) | balanceIndex;
 
         require(Merkle.verifyInclusionSha256({proof: validatorBalanceProof, root: beaconStateRoot, leaf: balanceRoot, index: balanceIndex}),
@@ -327,6 +331,10 @@ library BeaconChainProofs {
             * intermediate root indexes from the bottom of the sub trees (the withdrawal container) to the top, the blockHeaderRoot.
             * Then we calculate merkleize the withdrawalFields container to calculate the the withdrawalRoot.
             * Finally we verify the withdrawalRoot against the executionPayloadRoot.
+            *
+            *
+            * Note: Merkleization of the withdrawals root tree uses MerkleizeWithMixin, i.e., the length of the array is hashed with the root of 
+            * the array.  Thus we shift the WITHDRAWALS_INDEX over by WITHDRAWALS_TREE_HEIGHT + 1 and not just WITHDRAWALS_TREE_HEIGHT.
             */
             uint256 withdrawalIndex = WITHDRAWALS_INDEX << (WITHDRAWALS_TREE_HEIGHT + 1) | uint256(withdrawalProofs.withdrawalIndex);
             bytes32 withdrawalRoot = Merkle.merkleizeSha256(withdrawalFields);

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -349,4 +349,26 @@ library BeaconChainProofs {
         }
     }
 
+    /**
+     * @notice This function replicates the ssz hashing of a validator's pubkey, outlined below:
+     *  hh := ssz.NewHasher()
+     *  hh.PutBytes(validatorPubkey[:])
+     *  validatorPubkeyHash := hh.Hash()
+     *  hh.Reset()
+     */
+    function hashValidatorBLSPubkey(bytes memory validatorPubkey) internal pure returns (bytes32 pubkeyHash) {
+        require(validatorPubkey.length == 48, "Input should be 32 bytes in length");
+        bytes memory padding = new bytes(16);
+        bytes memory result = new bytes(64);
+
+        for (uint i = 0; i < validatorPubkey.length; i++) {
+            result[i] = validatorPubkey[i];
+        }
+        for (uint i = 0; i < padding.length; i++) {
+            result[i + validatorPubkey.length] = padding[i];
+        }
+        
+        return sha256(abi.encodePacked(result));
+    }
+
 }

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -361,10 +361,10 @@ library BeaconChainProofs {
         bytes memory padding = new bytes(16);
         bytes memory result = new bytes(64);
 
-        for (uint i = 0; i < validatorPubkey.length; i++) {
+        for (uint256 i = 0; i < validatorPubkey.length; i++) {
             result[i] = validatorPubkey[i];
         }
-        for (uint i = 0; i < padding.length; i++) {
+        for (uint256 i = 0; i < padding.length; i++) {
             result[i + validatorPubkey.length] = padding[i];
         }
         

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -358,17 +358,7 @@ library BeaconChainProofs {
      */
     function hashValidatorBLSPubkey(bytes memory validatorPubkey) internal pure returns (bytes32 pubkeyHash) {
         require(validatorPubkey.length == 48, "Input should be 48 bytes in length");
-        bytes memory padding = new bytes(16);
-        bytes memory result = new bytes(64);
-
-        for (uint256 i = 0; i < validatorPubkey.length; i++) {
-            result[i] = validatorPubkey[i];
-        }
-        for (uint256 i = 0; i < padding.length; i++) {
-            result[i + validatorPubkey.length] = padding[i];
-        }
-        
-        return sha256(abi.encodePacked(result));
+        return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
     }
 
 }

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -373,7 +373,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             "EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
         nonBeaconChainETHBalanceWei -= amountToWithdraw;
         emit NonBeaconChainETHWithdrawn(recipient, amountToWithdraw);
-        AddressUpgradeable.sendValue(payable(recipient), amountToWithdraw);
+        _sendETH_AsDelayedWithdrawal(recipient, amountToWithdraw);
     }
 
     /// @notice called by owner of a pod to remove any ERC20s deposited in the pod

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -467,7 +467,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     {
         bytes32 validatorPubkeyHash = validatorFields[BeaconChainProofs.VALIDATOR_PUBKEY_INDEX];
 
-        require(validatorPubkeyHash == _hashPubkey(validatorPubkey),
+        require(validatorPubkeyHash == BeaconChainProofs.hashValidatorBLSPubkey(validatorPubkey),
             "EigenPod._verifyWithdrawalCredentials: validatorPubkeyHash does not match validatorPubkey");
 
         ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkeyHash];
@@ -717,31 +717,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     function _computeTimestampAtSlot(uint64 slot) internal view returns (uint64) {
         return uint64(GENESIS_TIME + slot * SECONDS_PER_SLOT);
     }
-
-    /**
-     * @notice This function replicates the ssz hashing of a validator's pubkey, outlined below:
-     *  hh := ssz.NewHasher()
-     *  hh.PutBytes(validatorPubkey[:])
-     *  validatorPubkeyHash := hh.Hash()
-     *  hh.Reset()
-     */
-    function _hashPubkey(bytes memory validatorPubkey) internal pure returns (bytes32 pubkeyHash) {
-        require(validatorPubkey.length == 48, "Input should be 32 bytes in length");
-        bytes memory padding = new bytes(16);
-        bytes memory result = new bytes(64);
-
-        for (uint i = 0; i < validatorPubkey.length; i++) {
-            result[i] = validatorPubkey[i];
-        }
-        for (uint i = 0; i < padding.length; i++) {
-            result[i + validatorPubkey.length] = padding[i];
-        }
-        
-        return sha256(abi.encodePacked(result));
-    }
-
-
-
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -155,6 +155,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             "EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp");
         _;
     }
+    
 
     /**
      * @notice Based on 'Pausable' code, but uses the storage of the EigenPodManager instead of this contract. This construction

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -103,13 +103,13 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     /// @notice Emitted when an ETH validator's  balance is proven to be updated.  Here newValidatorBalanceGwei
     //  is the validator's balance that is credited on EigenLayer.
-    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 timestamp, uint64 newValidatorBalanceGwei);
+    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 balanceTimestamp, uint64 newValidatorBalanceGwei);
     
     /// @notice Emitted when an ETH validator is prove to have withdrawn from the beacon chain
-    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 withdrawalAmountGwei);
+    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 withdrawalTimestamp, address indexed recipient, uint64 withdrawalAmountGwei);
 
     /// @notice Emitted when a partial withdrawal claim is successfully redeemed
-    event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
+    event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 withdrawalTimestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
 
     /// @notice Emitted when restaked beacon chain ETH is withdrawn from the eigenPod.
     event RestakedBeaconChainETHWithdrawn(address indexed recipient, uint256 amount);

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -106,7 +106,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 timestamp, uint64 newValidatorBalanceGwei);
     
     /// @notice Emitted when an ETH validator is prove to have withdrawn from the beacon chain
-    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint256 withdrawalAmountWei);
+    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 withdrawalAmountGwei);
 
     /// @notice Emitted when a partial withdrawal claim is successfully redeemed
     event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
@@ -155,7 +155,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             "EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp");
         _;
     }
-    
+
 
     /**
      * @notice Based on 'Pausable' code, but uses the storage of the EigenPodManager instead of this contract. This construction
@@ -580,7 +580,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
         _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;
 
-        emit FullWithdrawalRedeemed(validatorIndex, withdrawalHappenedTimestamp, recipient, withdrawalAmountGwei * GWEI_TO_WEI);
+        emit FullWithdrawalRedeemed(validatorIndex, withdrawalHappenedTimestamp, recipient, withdrawalAmountGwei);
 
         // send ETH to the `recipient` via the DelayedWithdrawalRouter, if applicable
         if (amountToSend != 0) {

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -143,7 +143,6 @@ contract EigenPodManager is
     function restakeBeaconChainETH(address podOwner, uint256 amountWei) 
         external 
         onlyEigenPod(podOwner) 
-        onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS)
         onlyNotFrozen(podOwner)
         nonReentrant
     {

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -64,6 +64,8 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     uint64 internal constant GENESIS_TIME = 1616508000;
     uint64 internal constant SECONDS_PER_SLOT = 12;
 
+    bytes validatorPubkey = hex"93a0dd04ccddf3f1b419fdebf99481a2182c17d67cf14d32d6e50fc4bf8effc8db4a04b7c2f3a5975c1b9b74e2841888";
+
 
     // EIGENPODMANAGER EVENTS
     /// @notice Emitted to notify the update of the beaconChainOracle address
@@ -290,12 +292,14 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         proofsArray[0] = _getWithdrawalCredentialProof();
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(getValidatorIndex());
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
 
 
         cheats.startPrank(podOwner);
         cheats.warp(timestamp += 1);
         cheats.expectRevert(bytes("EigenPod.hasEnabledRestaking: restaking is not enabled"));
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -316,11 +320,13 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         proofsArray[0] = _getWithdrawalCredentialProof();
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(getValidatorIndex());
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
 
 
         cheats.startPrank(podOwner);
         cheats.expectRevert(bytes("EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp"));
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -576,6 +582,8 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         proofsArray[0] = _getWithdrawalCredentialProof();
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(validatorIndex0);
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
 
 
         cheats.startPrank(podOwner);
@@ -583,7 +591,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         newPod.activateRestaking();
         cheats.warp(timestamp += 1);
         cheats.expectRevert(bytes("EigenPod.verifyCorrectWithdrawalCredentials: Proof is not for this EigenPod"));
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -605,10 +613,12 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         proofsArray[0] = _getWithdrawalCredentialProof();
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(validatorIndex0);
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
 
         cheats.startPrank(nonPodOwnerAddress);
         cheats.expectRevert(bytes("EigenPod.onlyEigenPodOwner: not podOwner"));
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -626,10 +636,12 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         proofsArray[0] = _getWithdrawalCredentialProof();
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(getValidatorIndex());
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
 
         cheats.startPrank(podOwner);
         cheats.expectRevert(bytes("EigenPod.verifyCorrectWithdrawalCredentials: Validator must be inactive to prove withdrawal credentials"));
-        pod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        pod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -840,9 +852,12 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(getValidatorIndex());
 
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
+
         cheats.startPrank(podOwner);
         cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
     }
 
@@ -1199,6 +1214,9 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         uint40[] memory validatorIndices = new uint40[](1);
         validatorIndices[0] = uint40(getValidatorIndex());
 
+        bytes[] memory validatorPubkeys = new bytes[](1);
+        validatorPubkeys[0] = validatorPubkey;
+
         uint256 beaconChainETHSharesBefore = eigenPodManager.podOwnerShares(_podOwner);
 
         cheats.startPrank(_podOwner);
@@ -1206,7 +1224,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         newPod.activateRestaking();
         emit log_named_bytes32("restaking activated", BeaconChainOracleMock(address(beaconChainOracle)).mockBeaconChainStateRoot());
         cheats.warp(timestamp += 1);
-        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, proofsArray, validatorFieldsArray);
+        newPod.verifyWithdrawalCredentials(timestamp, validatorIndices, validatorPubkeys, proofsArray, validatorFieldsArray);
         cheats.stopPrank();
 
         uint256 beaconChainETHSharesAfter = eigenPodManager.podOwnerShares(_podOwner);

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -383,7 +383,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
         IEigenPod newPod = eigenPodManager.getPod(podOwner);
 
-        // ./solidityProofGen "WithdrawalFieldsProof" 302913 1048 true false "data/withdrawal_proof_goerli/goerli_slot_6399999.json" "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "data/withdrawal_proof_goerli/block_header_6399000.json" "data/withdrawal_proof_goerli/block_6399000.json" "fullWithdrawalProof_Latest.json"
+        //./solidityProofGen "WithdrawalFieldsProof" 302913 146 8092 true true "data/withdrawal_proof_goerli/goerli_slot_6399999.json" "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "data/withdrawal_proof_goerli/goerli_slot_6397852.json" "data/withdrawal_proof_goerli/goerli_block_header_6397852.json" "data/withdrawal_proof_goerli/goerli_block_6397852.json" "fullWithdrawalProof_HistoricalSummaryFixed.json"
         // To get block header: curl -H "Accept: application/json" 'https://eigenlayer.spiceai.io/goerli/beacon/eth/v1/beacon/headers/6399000?api_key\="343035|f6ebfef661524745abb4f1fd908a76e8"' > block_header_6399000.json
         // To get block:  curl -H "Accept: application/json" 'https://eigenlayer.spiceai.io/goerli/beacon/eth/v2/beacon/blocks/6399000?api_key\="343035|f6ebfef661524745abb4f1fd908a76e8"' > block_6399000.json
         setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
@@ -439,7 +439,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         
 
         //generate partialWithdrawalProofs.json with: 
-        // ./solidityProofGen "WithdrawalFieldsProof" 302913 1048 true true  "data/withdrawal_proof_goerli/goerli_slot_6399999.json" "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "data/withdrawal_proof_goerli/block_header_6399000.json" "data/withdrawal_proof_goerli/block_6399000.json" "partialWithdrawalProof_latest.json"
+        // ./solidityProofGen "WithdrawalFieldsProof" 302913 146 8092 true true "data/withdrawal_proof_goerli/goerli_slot_6399999.json" "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "data/withdrawal_proof_goerli/goerli_slot_6397852.json" "data/withdrawal_proof_goerli/goerli_block_header_6397852.json" "data/withdrawal_proof_goerli/goerli_block_6397852.json" "PartialWithdrawalProof_HistoricalSummaryFixed.json"
         setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
         withdrawalFields = getWithdrawalFields();
         validatorFields = getValidatorFields();

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -89,14 +89,14 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     event ValidatorRestaked(uint40 validatorIndex);
 
     /// @notice Emitted when an ETH validator's balance is updated in EigenLayer
-    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 slotNumber, uint64 newBalanceGwei);
+    event ValidatorBalanceUpdated(uint40 validatorIndex, uint64 balanceTimestamp, uint64 newBalanceGwei);
 
     
     /// @notice Emitted when an ETH validator is prove to have withdrawn from the beacon chain
-    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 withdrawalAmountGwei);
+    event FullWithdrawalRedeemed(uint40 validatorIndex, uint64 withdrawalTimestamp, address indexed recipient, uint64 withdrawalAmountGwei);
 
     /// @notice Emitted when a partial withdrawal claim is successfully redeemed
-    event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 timestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
+    event PartialWithdrawalRedeemed(uint40 validatorIndex, uint64 withdrawalTimestamp, address indexed recipient, uint64 partialWithdrawalAmountGwei);
 
     /// @notice Emitted when restaked beacon chain ETH is withdrawn from the eigenPod.
     event RestakedBeaconChainETHWithdrawn(address indexed recipient, uint256 amount);

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -61,6 +61,7 @@ contract EigenPodMock is IEigenPod, Test {
     function verifyWithdrawalCredentials(
         uint64 oracleBlockNumber,
         uint40[] calldata validatorIndices,
+        bytes[] calldata validatorPubkeys,
         BeaconChainProofs.WithdrawalCredentialProofs[] calldata proofs,
         bytes32[][] calldata validatorFields
     ) external {}

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -155,22 +155,6 @@ contract EigenPodManagerUnitTests is Test, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
-    function testRestakeBeaconChainETHFailsWhenDepositsPaused() public {
-        uint256 amount = 1e18;
-        address staker = address(this);
-        IEigenPod eigenPod = _deployEigenPodForStaker(staker);
-
-        // pause deposits
-        cheats.startPrank(pauser);
-        eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_CREDENTIALS);
-        cheats.stopPrank();
-
-        cheats.startPrank(address(eigenPod));
-        cheats.expectRevert(bytes("Pausable: index is paused"));
-        eigenPodManager.restakeBeaconChainETH(staker, amount);
-        cheats.stopPrank();
-    }
-
     function testRestakeBeaconChainETHFailsWhenStakerFrozen() public {
         uint256 amount = 1e18;
         address staker = address(this);


### PR DESCRIPTION
There are several small tasks we need to accomplish once the "newpodchanges" branch is merged into master:

- [x] We need to order the functions in EigenPods according to this:
- - external callable by anyone
- - external callable by pod owner
- - external callable by EPM
- - internal state changing
- - internal pure
- [x] More explicit comments explaining every one of the constructed beacon chain proof indicies. These are particularly hard to understand why they are the way they are so comments are helpful here.
- [x] Route ETH withdrawn via the withdrawNonBeaconChainETHBalanceWei() function through Delayed Withdrawal Router.
- [x] Change events tfrom validatorIndex to validatorPKHash
- [x] Change naming of timestamp field in events to be more specific

The ticket covering this is https://github.com/Layr-Labs/eignlayr-contracts/issues/962