### PR TITLE
add `forge install` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Flow Docs
 
 ### Installation
 
-`foundryup`
+```
+foundryup
+
+forge install
+```
 
 This repository uses Foundry as a smart contract development toolchain.
 


### PR DESCRIPTION
IDK how this was missing, it's in the C4 contest repo. Installing dependencies is obviously important.