### PR TITLE
Use default RPC and chain id during tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To generate the docs, run `npx hardhat docgen` (you may need to run `npm install
 
 ### Run Tests
 
-Prior to running tests, you should set up your environment. At present this repository contains fork tests against ETH mainnet; your environment will need an `RPC_MAINNET` key to run these tests. See the `.env.example` file for an example -- two simple options are to  copy the LlamaNodes RPC url to your `env` or use your own infura API key in the provided format.
+Prior to running tests, you should set up your environment. At present this repository contains fork tests against ETH mainnet; your environment will use an `RPC_MAINNET` key to run these tests. See the `.env.example` file for an example -- two simple options are to  copy the LlamaNodes RPC url to your `env` or use your own infura API key in the provided format. If you don't set the `RPC_MAINNET` key then the test cases will default to LlamaNodes RPC url when fork testing.
 
 The main command to run tests is:
 

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -464,8 +464,12 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         uint64 amountToDeposit = 1e12;
 
         // shadow-fork mainnet
-        uint256 forkId = cheats.createFork("mainnet");
-        cheats.selectFork(forkId);
+        try cheats.createFork("mainnet") returns (uint256 forkId) {
+            cheats.selectFork(forkId);
+        // If RPC_MAINNET ENV not set, default to this mainnet RPC endpoint
+        } catch  {
+            cheats.createSelectFork("https://eth.llamarpc.com");
+        }
 
         // cast mainnet stETH address to IERC20 interface
         // IERC20 steth = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -130,11 +130,15 @@ contract EigenLayerDeployer is Operators {
     //performs basic deployment before each test
     // for fork tests run:  forge test -vv --fork-url https://eth-goerli.g.alchemy.com/v2/demo   -vv
     function setUp() public virtual {
-        if(vm.envUint("CHAIN_ID") == 31337) {
+        try vm.envUint("CHAIN_ID") returns (uint256 chainId) {
+            if (chainId == 31337) {
+                _deployEigenLayerContractsLocal();
+            } else if (chainId == 5) {
+                _deployEigenLayerContractsGoerli();
+            }
+        // If CHAIN_ID ENV is not set, assume local deployment on 31337
+        } catch {
             _deployEigenLayerContractsLocal();
-
-        }else if(vm.envUint("CHAIN_ID") == 5) {
-            _deployEigenLayerContractsGoerli();
         }
 
         fuzzedAddressMapping[address(0)] = true;


### PR DESCRIPTION
Description:
Tests fail if `RPC_MAINNET` and `CHAIN_ID` are not set prior to running tests. 
Updated setUp() functions to use try catch blocks if env vars are not defined.
- `CHAIN_ID` defaults to local 31337
- `RPC_MAINNET` defaults to LlamaNodes RPC url