### PR TITLE
DelegationFaucet for M2 Testnet

### DIFF
--- a/script/whitelist/delegationFaucet/DelegationFaucet.sol
+++ b/script/whitelist/delegationFaucet/DelegationFaucet.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/contracts/interfaces/IStrategyManager.sol";
+import "src/contracts/interfaces/IStrategy.sol";
+import "src/contracts/interfaces/IDelegationManager.sol";
+import "src/contracts/interfaces/IWhitelister.sol";
+import "src/contracts/interfaces/IDelegationFaucet.sol";
+import "script/whitelist/delegationFaucet/DelegationFaucetStaker.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+import "../ERC20PresetMinterPauser.sol";
+/**
+ * @title DelegationFaucet for M2
+ * @author Layr Labs, Inc.
+ * @notice Faucet contract setup with a dummy ERC20 token and strategy for M2 testnet release.
+ * Each operator address gets a staker contract assigned to them deterministically.
+ * This contract assumes minting role of the ERC20 token and that the ERC20 token has a whitelisted strategy.
+ */
+contract DelegationFaucet is IDelegationFaucet, Ownable {
+    IStrategyManager immutable strategyManager;
+    ERC20PresetMinterPauser immutable stakeToken;
+    IStrategy immutable stakeStrategy;
+    IDelegationManager delegation;
+
+    uint256 public constant DEFAULT_AMOUNT = 100e18;
+
+    //TODO: Deploy ERC20PresetMinterPauser and a corresponding StrategyBase for it
+    //TODO: Transfer ownership of Whitelister to multisig after deployment
+    //TODO: Give mint/admin/pauser permssions of whitelistToken to Whitelister and multisig after deployment
+    //TODO: Give up mint/admin/pauser permssions of whitelistToken for deployer
+    constructor(
+        IStrategyManager _strategyManager,
+        IDelegationManager _delegation,
+        ERC20PresetMinterPauser _token,
+        IStrategy _strategy
+    ) {
+        strategyManager = _strategyManager;
+        delegation = _delegation;
+        stakeToken = _token;
+        stakeStrategy = _strategy;
+    }
+
+    /**
+     * Deploys a Staker contract if not already deployed for operator. Staker gets minted _depositAmount or
+     * DEFAULT_AMOUNT if _depositAmount is 0. Then Staker contract deposits into the strategy and delegates to operator.
+     * @param _operator The operator to delegate to
+     * @param _depositAmount The amount of stakeToken to mint to the staker and deposit into the strategy
+     */
+    function mintDepositAndDelegate(address _operator, uint256 _depositAmount) public onlyOwner {
+        address staker = getStaker(_operator);
+        // Set deposit amount
+        if (_depositAmount == 0) {
+            _depositAmount = DEFAULT_AMOUNT;
+        }
+        stakeToken.mint(staker, _depositAmount);
+
+        // Deploy staker address if not already deployed, staker constructor will approve the StrategyManager to spend the stakeToken
+        if (!Address.isContract(staker)) {
+            Create2.deploy(
+                0,
+                bytes32(uint256(uint160(_operator))),
+                abi.encodePacked(type(DelegationFaucetStaker).creationCode, abi.encode(strategyManager, stakeToken))
+            );
+        }
+
+        // deposit into stakeToken strategy
+        depositIntoStrategy(staker, stakeStrategy, stakeToken, _depositAmount);
+
+        // delegate to operator
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegateTo(_operator, signatureWithExpiry, bytes32(0));
+    }
+
+    function getStaker(address operator) public view returns (address) {
+        return
+            Create2.computeAddress(
+                bytes32(uint256(uint160(operator))), //salt
+                keccak256(
+                    abi.encodePacked(type(DelegationFaucetStaker).creationCode, abi.encode(strategyManager, stakeToken))
+                )
+            );
+    }
+
+    function depositIntoStrategy(
+        address staker,
+        IStrategy strategy,
+        IERC20 token,
+        uint256 amount
+    ) public onlyOwner returns (bytes memory) {
+        bytes memory data = abi.encodeWithSelector(
+            IStrategyManager.depositIntoStrategy.selector,
+            strategy,
+            token,
+            amount
+        );
+
+        return Staker(staker).callAddress(address(strategyManager), data);
+    }
+
+    function delegateTo(
+        address operator,
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
+    ) public onlyOwner returns (bytes memory) {
+        bytes memory data = abi.encodeWithSelector(
+            IDelegationManager.delegateTo.selector,
+            operator,
+            approverSignatureAndExpiry,
+            approverSalt
+        );
+
+        return Staker(getStaker(operator)).callAddress(address(delegation), data);
+    }
+
+    function queueWithdrawal(
+        address staker,
+        uint256[] calldata strategyIndexes,
+        IStrategy[] calldata strategies,
+        uint256[] calldata shares,
+        address withdrawer
+    ) public onlyOwner returns (bytes memory) {
+        bytes memory data = abi.encodeWithSelector(
+            IStrategyManager.queueWithdrawal.selector,
+            strategyIndexes,
+            strategies,
+            shares,
+            withdrawer
+        );
+        return Staker(staker).callAddress(address(strategyManager), data);
+    }
+
+    function completeQueuedWithdrawal(
+        address staker,
+        IStrategyManager.QueuedWithdrawal calldata queuedWithdrawal,
+        IERC20[] calldata tokens,
+        uint256 middlewareTimesIndex,
+        bool receiveAsTokens
+    ) public onlyOwner returns (bytes memory) {
+        bytes memory data = abi.encodeWithSelector(
+            IStrategyManager.completeQueuedWithdrawal.selector,
+            queuedWithdrawal,
+            tokens,
+            middlewareTimesIndex,
+            receiveAsTokens
+        );
+
+        return Staker(staker).callAddress(address(strategyManager), data);
+    }
+
+    function transfer(
+        address staker,
+        address token,
+        address to,
+        uint256 amount
+    ) public onlyOwner returns (bytes memory) {
+        bytes memory data = abi.encodeWithSelector(IERC20.transfer.selector, to, amount);
+
+        return Staker(staker).callAddress(token, data);
+    }
+
+    function callAddress(address to, bytes memory data) public payable onlyOwner returns (bytes memory) {
+        (bool ok, bytes memory res) = payable(to).call{value: msg.value}(data);
+        if (!ok) {
+            revert(string(res));
+        }
+        return res;
+    }
+}

--- a/script/whitelist/delegationFaucet/DelegationFaucet.sol
+++ b/script/whitelist/delegationFaucet/DelegationFaucet.sol
@@ -46,6 +46,8 @@ contract DelegationFaucet is IDelegationFaucet, Ownable {
      * Deploys a Staker contract if not already deployed for operator. Staker gets minted _depositAmount or
      * DEFAULT_AMOUNT if _depositAmount is 0. Then Staker contract deposits into the strategy and delegates to operator.
      * @param _operator The operator to delegate to
+     * @param _approverSignatureAndExpiry Verifies the operator approves of this delegation
+     * @param _approverSalt A unique single use value tied to an individual signature.
      * @param _depositAmount The amount to deposit into the strategy
      */
     function mintDepositAndDelegate(
@@ -122,6 +124,9 @@ contract DelegationFaucet is IDelegationFaucet, Ownable {
         return Staker(getStaker(_operator)).callAddress(address(delegation), data);
     }
 
+    /**
+     * Call queueWithdrawal through staker contract
+     */
     function queueWithdrawal(
         address staker,
         uint256[] calldata strategyIndexes,
@@ -139,6 +144,9 @@ contract DelegationFaucet is IDelegationFaucet, Ownable {
         return Staker(staker).callAddress(address(strategyManager), data);
     }
 
+    /**
+     * Call completeQueuedWithdrawal through staker contract
+     */
     function completeQueuedWithdrawal(
         address staker,
         IStrategyManager.QueuedWithdrawal calldata queuedWithdrawal,

--- a/script/whitelist/delegationFaucet/DelegationFaucetStaker.sol
+++ b/script/whitelist/delegationFaucet/DelegationFaucetStaker.sol
@@ -8,33 +8,19 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "forge-std/Test.sol";
 
 contract DelegationFaucetStaker is Ownable {
-    
-    constructor(
-        IStrategyManager strategyManager,
-        IERC20 token
-    ) Ownable() {
+    constructor(IStrategyManager strategyManager, IERC20 token) Ownable() {
         token.approve(address(strategyManager), type(uint256).max);
     }
-    
-    function callAddress(address implementation, bytes memory data) external onlyOwner returns(bytes memory) {
+
+    function callAddress(address implementation, bytes memory data) external onlyOwner returns (bytes memory) {
         uint256 length = data.length;
-        bytes memory returndata;  
-        assembly{
-            let result := call(
-                gas(),
-                implementation,
-                callvalue(),
-                add(data, 32),
-                length,
-                0,
-                0
-            )
+        bytes memory returndata;
+        assembly {
+            let result := call(gas(), implementation, callvalue(), add(data, 32), length, 0, 0)
             mstore(returndata, returndatasize())
             returndatacopy(add(returndata, 32), 0, returndatasize())
         }
 
         return returndata;
-
     }
-
 }

--- a/script/whitelist/delegationFaucet/DelegationFaucetStaker.sol
+++ b/script/whitelist/delegationFaucet/DelegationFaucetStaker.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/contracts/interfaces/IStrategyManager.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "forge-std/Test.sol";
+
+contract DelegationFaucetStaker is Ownable {
+    
+    constructor(
+        IStrategyManager strategyManager,
+        IERC20 token
+    ) Ownable() {
+        token.approve(address(strategyManager), type(uint256).max);
+    }
+    
+    function callAddress(address implementation, bytes memory data) external onlyOwner returns(bytes memory) {
+        uint256 length = data.length;
+        bytes memory returndata;  
+        assembly{
+            let result := call(
+                gas(),
+                implementation,
+                callvalue(),
+                add(data, 32),
+                length,
+                0,
+                0
+            )
+            mstore(returndata, returndatasize())
+            returndatacopy(add(returndata, 32), 0, returndatasize())
+        }
+
+        return returndata;
+
+    }
+
+}

--- a/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
+++ b/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
@@ -63,9 +63,9 @@ contract DeployDelegationFaucet is Script, DSTest {
         );
 
         // Needs to be strategyManager.strategyWhitelister() to add STK strategy
-        IStrategy[] memory _strategy = new IStrategy[](1);
-        _strategy[0] = stakeTokenStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy);
+        // IStrategy[] memory _strategy = new IStrategy[](1);
+        // _strategy[0] = stakeTokenStrat;
+        // strategyManager.addStrategiesToDepositWhitelist(_strategy);
 
         // Deploy DelegationFaucet, grant it admin/mint/pauser roles, etc.
         delegationFaucet = new DelegationFaucet(strategyManager, delegation, stakeToken, stakeTokenStrat);

--- a/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
+++ b/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/contracts/interfaces/IDelegationManager.sol";
+import "src/contracts/interfaces/IStrategyManager.sol";
+import "src/contracts/strategies/StrategyBase.sol";
+import "src/contracts/permissions/PauserRegistry.sol";
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+import "./DelegationFaucet.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/StdJson.sol";
+
+contract DeployDelegationFaucet is Script, DSTest {
+    // EigenLayer contracts
+    ProxyAdmin public eigenLayerProxyAdmin;
+    PauserRegistry public eigenLayerPauserReg;
+
+    IDelegationManager public delegation;
+    IStrategyManager public strategyManager;
+
+    // M2 testing/mock contracts
+    IERC20 public stakeToken;
+    StrategyBase public stakeTokenStrat;
+    StrategyBase public baseStrategyImplementation;
+
+    address eigenLayerProxyAdminAddress;
+    address eigenLayerPauserRegAddress;
+    address delegationAddress;
+    address strategyManagerAddress;
+    address operationsMultisig;
+    address executorMultisig;
+
+    function run() external {
+        string memory goerliDeploymentConfig = vm.readFile("script/output/M1_deployment_goerli_2023_3_23.json");
+        _setAddresses(goerliDeploymentConfig);
+
+        vm.startBroadcast(msg.sender);
+        // Deploy ERC20 stakeToken
+
+        // Deploy StrategyBase for stakeToken & whitelist it
+
+        // Deploy DelegationFaucet, grant it admin/mint/pauser roles, etc.
+
+        vm.stopBroadcast();
+    }
+
+    function _setAddresses(string memory config) internal {
+        eigenLayerProxyAdminAddress = stdJson.readAddress(config, ".addresses.eigenLayerProxyAdmin");
+        eigenLayerPauserRegAddress = stdJson.readAddress(config, ".addresses.eigenLayerPauserReg");
+        delegationAddress = stdJson.readAddress(config, ".addresses.delegation");
+        strategyManagerAddress = stdJson.readAddress(config, ".addresses.strategyManager");
+        operationsMultisig = stdJson.readAddress(config, ".parameters.operationsMultisig");
+        executorMultisig = stdJson.readAddress(config, ".parameters.executorMultisig");
+    }
+}

--- a/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
+++ b/script/whitelist/delegationFaucet/DeployDelegationFaucet.sol
@@ -39,8 +39,19 @@ contract DeployDelegationFaucet is Script, DSTest {
 
         vm.startBroadcast(msg.sender);
         // Deploy ERC20 stakeToken
+        stakeToken = new ERC20PresetMinterPauser("StakeToken", "STK");
 
         // Deploy StrategyBase for stakeToken & whitelist it
+        baseStrategyImplementation = new StrategyBase(strategyManager);
+        stakeTokenStrat = StrategyBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(baseStrategyImplementation),
+                    eigenLayerProxyAdminAddress,
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, stakeToken, eigenLayerPauserRegAddress)
+                )
+            )
+        );
 
         // Deploy DelegationFaucet, grant it admin/mint/pauser roles, etc.
 

--- a/src/contracts/interfaces/IDelegationFaucet.sol
+++ b/src/contracts/interfaces/IDelegationFaucet.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "src/contracts/interfaces/IStrategyManager.sol";
+import "src/contracts/interfaces/IStrategy.sol";
+import "src/contracts/interfaces/IDelegationManager.sol";
+import "src/contracts/interfaces/IBLSRegistry.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
+
+interface IDelegationFaucet {
+    function mintDepositAndDelegate(address operator, uint256 depositAmount) external;
+
+    function getStaker(address operator) external returns (address);
+
+    function depositIntoStrategy(
+        address staker,
+        IStrategy strategy,
+        IERC20 token,
+        uint256 amount
+    ) external returns (bytes memory);
+
+    function queueWithdrawal(
+        address staker,
+        uint256[] calldata strategyIndexes,
+        IStrategy[] calldata strategies,
+        uint256[] calldata shares,
+        address withdrawer
+    ) external returns (bytes memory);
+
+    function completeQueuedWithdrawal(
+        address staker,
+        IStrategyManager.QueuedWithdrawal calldata queuedWithdrawal,
+        IERC20[] calldata tokens,
+        uint256 middlewareTimesIndex,
+        bool receiveAsTokens
+    ) external returns (bytes memory);
+
+    function transfer(address staker, address token, address to, uint256 amount) external returns (bytes memory);
+
+    function callAddress(address to, bytes memory data) external payable returns (bytes memory);
+}

--- a/src/contracts/interfaces/IDelegationFaucet.sol
+++ b/src/contracts/interfaces/IDelegationFaucet.sol
@@ -11,7 +11,12 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 
 interface IDelegationFaucet {
-    function mintDepositAndDelegate(address operator, uint256 depositAmount) external;
+    function mintDepositAndDelegate(
+        address _operator,
+        IDelegationManager.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt,
+        uint256 _depositAmount
+    ) external;
 
     function getStaker(address operator) external returns (address);
 

--- a/src/test/DelegationFaucet.t.sol
+++ b/src/test/DelegationFaucet.t.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "script/whitelist/delegationFaucet/DelegationFaucet.sol";
+import "script/whitelist/ERC20PresetMinterPauser.sol";
+
+import "src/test/EigenLayerTestHelper.t.sol";
+
+contract DelegationFaucetTests is EigenLayerTestHelper {
+    // EigenLayer contracts
+    DelegationFaucet delegationFaucet;
+
+    // M2 testing/mock contracts
+    ERC20PresetMinterPauser public stakeToken;
+    StrategyBase public stakeTokenStrat;
+
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    uint256 public constant DEFAULT_AMOUNT = 100e18;
+    address owner = cheats.addr(1000);
+
+    function setUp() public virtual override {
+        EigenLayerDeployer.setUp();
+
+        // Deploy ERC20 stakeToken, StrategyBase, and add StrategyBase to whitelist
+        stakeToken = new ERC20PresetMinterPauser("StakeToken", "STK");
+        stakeTokenStrat = StrategyBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(baseStrategyImplementation),
+                    address(eigenLayerProxyAdmin),
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, stakeToken, eigenLayerPauserReg)
+                )
+            )
+        );
+        cheats.startPrank(strategyManager.strategyWhitelister());
+        IStrategy[] memory _strategy = new IStrategy[](1);
+        _strategy[0] = stakeTokenStrat;
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
+        cheats.stopPrank();
+
+        // Deploy DelegationFaucet, grant it admin/mint/pauser roles, etc.
+        delegationFaucet = new DelegationFaucet(strategyManager, delegation, stakeToken, stakeTokenStrat);
+        stakeToken.grantRole(MINTER_ROLE, address(delegationFaucet));
+    }
+
+    /**
+     * @notice Assertions in test
+     * - Checks for staker contract deployed
+     * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
+     * @param _depositAmount is the amount of stakeToken to mint to the staker and deposit into the strategy
+     */
+    function test_mintDepositAndDelegate_DeployStakerContract(uint8 _operatorIndex, uint256 _depositAmount) public {
+        cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
+        if (_depositAmount == 0) {
+            _depositAmount = DEFAULT_AMOUNT;
+        }
+        // Setup Operator
+        address operator = getOperatorAddress(_operatorIndex);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        assertTrue(
+            !Address.isContract(stakerContract),
+            "test_mintDepositAndDelegate_DeployStakerContract: staker contract shouldn't be deployed"
+        );
+        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
+        assertTrue(
+            Address.isContract(stakerContract),
+            "test_mintDepositAndDelegate_DeployStakerContract: staker contract not deployed"
+        );
+    }
+
+    /**
+     * @notice Assertions in test
+     * - Checks token supply before/after minting
+     * - Checks token balances are updated correctly for staker and strategy contracts
+     * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
+     * @param _depositAmount is the amount of stakeToken to mint to the staker and deposit into the strategy
+     */
+    function test_mintDepositAndDelegate_TokenBalances(uint8 _operatorIndex, uint256 _depositAmount) public {
+        cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
+        if (_depositAmount == 0) {
+            // Passing 0 as amount param defaults the amount to DEFAULT_AMOUNT constant
+            _depositAmount = DEFAULT_AMOUNT;
+        }
+        // Setup Operator
+        address operator = getOperatorAddress(_operatorIndex);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        uint256 supplyBefore = stakeToken.totalSupply();
+        uint256 stratBalanceBefore = stakeToken.balanceOf(address(stakeTokenStrat));
+        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
+        uint256 supplyAfter = stakeToken.totalSupply();
+        uint256 stratBalanceAfter = stakeToken.balanceOf(address(stakeTokenStrat));
+        // Check token supply and balances
+        assertEq(
+            supplyAfter,
+            supplyBefore + _depositAmount,
+            "test_mintDepositAndDelegate_TokenBalances: token supply not updated correctly"
+        );
+        assertEq(
+            stratBalanceAfter,
+            stratBalanceBefore + _depositAmount,
+            "test_mintDepositAndDelegate_TokenBalances: strategy balance not updated correctly"
+        );
+        assertEq(
+            stakeToken.balanceOf(stakerContract),
+            0,
+            "test_mintDepositAndDelegate_TokenBalances: staker balance should be 0"
+        );
+    }
+
+    /**
+     * @notice Check the before/after values for strategy shares and operator shares
+     * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
+     * @param _depositAmount is the amount of stakeToken to mint to the staker and deposit into the strategy
+     */
+    function test_mintDepositAndDelegate_StrategyAndOperatorShares(
+        uint8 _operatorIndex,
+        uint256 _depositAmount
+    ) public {
+        cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
+        if (_depositAmount == 0) {
+            _depositAmount = DEFAULT_AMOUNT;
+        }
+        // Setup Operator
+        address operator = getOperatorAddress(_operatorIndex);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        uint256 stakerSharesBefore = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesBefore = delegation.operatorShares(operator, stakeTokenStrat);
+        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
+
+        uint256 stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
+        assertTrue(
+            delegation.delegatedTo(stakerContract) == operator,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: delegated address not set appropriately"
+        );
+        assertTrue(
+            delegation.isDelegated(stakerContract),
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: delegated status not set appropriately"
+        );
+        assertEq(
+            stakerSharesAfter,
+            stakerSharesBefore + _depositAmount,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: staker shares not updated correctly"
+        );
+        assertEq(
+            operatorSharesAfter,
+            operatorSharesBefore + _depositAmount,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: operator shares not updated correctly"
+        );
+    }
+
+    /**
+     * @notice Invariant test the before/after values for strategy shares and operator shares from multiple runs
+     */
+    /// forge-config: default.invariant.runs = 5
+    /// forge-config: default.invariant.depth = 20
+    function invariant_test_mintDepositAndDelegate_StrategyAndOperatorShares() public {
+        // cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
+        // Setup Operator
+        address operator = getOperatorAddress(0);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        uint256 stakerSharesBefore = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesBefore = delegation.operatorShares(operator, stakeTokenStrat);
+        delegationFaucet.mintDepositAndDelegate(operator, DEFAULT_AMOUNT);
+
+        uint256 stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
+        assertTrue(
+            delegation.delegatedTo(stakerContract) == operator,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: delegated address not set appropriately"
+        );
+        assertTrue(
+            delegation.isDelegated(stakerContract),
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: delegated status not set appropriately"
+        );
+        assertEq(
+            stakerSharesAfter,
+            stakerSharesBefore + DEFAULT_AMOUNT,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: staker shares not updated correctly"
+        );
+        assertEq(
+            operatorSharesAfter,
+            operatorSharesBefore + DEFAULT_AMOUNT,
+            "test_mintDepositAndDelegate_StrategyAndOperatorShares: operator shares not updated correctly"
+        );
+    }
+
+    /**
+     * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
+     */
+    function test_mintDepositAndDelegate_RevertsIf_UnregisteredOperater(uint8 _operatorIndex) public {
+        cheats.assume(_operatorIndex < 15);
+        address operator = getOperatorAddress(_operatorIndex);
+        // Unregistered operator should revert
+        cheats.expectRevert("DelegationFaucet: Operator not registered");
+        delegationFaucet.mintDepositAndDelegate(operator, DEFAULT_AMOUNT);
+    }
+
+    function _registerOperator(address _operator) internal {
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: _operator,
+            delegationApprover: address(0),
+            stakerOptOutWindowBlocks: 0
+        });
+        _testRegisterAsOperator(_operator, operatorDetails);
+    }
+}

--- a/src/test/DelegationFaucet.t.sol
+++ b/src/test/DelegationFaucet.t.sol
@@ -40,45 +40,19 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
 
         // Deploy DelegationFaucet, grant it admin/mint/pauser roles, etc.
         delegationFaucet = new DelegationFaucet(strategyManager, delegation, stakeToken, stakeTokenStrat);
+        targetContract(address(delegationFaucet));
         stakeToken.grantRole(MINTER_ROLE, address(delegationFaucet));
     }
 
     /**
      * @notice Assertions in test
-     * - Checks for staker contract deployed
-     * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
-     * @param _depositAmount is the amount of stakeToken to mint to the staker and deposit into the strategy
-     */
-    function test_mintDepositAndDelegate_DeployStakerContract(uint8 _operatorIndex, uint256 _depositAmount) public {
-        cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
-        if (_depositAmount == 0) {
-            _depositAmount = DEFAULT_AMOUNT;
-        }
-        // Setup Operator
-        address operator = getOperatorAddress(_operatorIndex);
-        address stakerContract = delegationFaucet.getStaker(operator);
-        _registerOperator(operator);
-
-        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
-        assertTrue(
-            !Address.isContract(stakerContract),
-            "test_mintDepositAndDelegate_DeployStakerContract: staker contract shouldn't be deployed"
-        );
-        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
-        assertTrue(
-            Address.isContract(stakerContract),
-            "test_mintDepositAndDelegate_DeployStakerContract: staker contract not deployed"
-        );
-    }
-
-    /**
-     * @notice Assertions in test
+     * - Checks staker contract is deployed
      * - Checks token supply before/after minting
      * - Checks token balances are updated correctly for staker and strategy contracts
      * @param _operatorIndex is the index of the operator to use from the test-data/operators.json file
      * @param _depositAmount is the amount of stakeToken to mint to the staker and deposit into the strategy
      */
-    function test_mintDepositAndDelegate_TokenBalances(uint8 _operatorIndex, uint256 _depositAmount) public {
+    function test_mintDepositAndDelegate_CheckBalancesAndDeploys(uint8 _operatorIndex, uint256 _depositAmount) public {
         cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
         if (_depositAmount == 0) {
             // Passing 0 as amount param defaults the amount to DEFAULT_AMOUNT constant
@@ -92,24 +66,33 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
         // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
         uint256 supplyBefore = stakeToken.totalSupply();
         uint256 stratBalanceBefore = stakeToken.balanceOf(address(stakeTokenStrat));
-        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
+        assertTrue(
+            !Address.isContract(stakerContract),
+            "test_mintDepositAndDelegate_CheckBalancesAndDeploys: staker contract shouldn't be deployed"
+        );
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), _depositAmount);
+        assertTrue(
+            Address.isContract(stakerContract),
+            "test_mintDepositAndDelegate_CheckBalancesAndDeploys: staker contract not deployed"
+        );
         uint256 supplyAfter = stakeToken.totalSupply();
         uint256 stratBalanceAfter = stakeToken.balanceOf(address(stakeTokenStrat));
         // Check token supply and balances
         assertEq(
             supplyAfter,
             supplyBefore + _depositAmount,
-            "test_mintDepositAndDelegate_TokenBalances: token supply not updated correctly"
+            "test_mintDepositAndDelegate_CheckBalancesAndDeploys: token supply not updated correctly"
         );
         assertEq(
             stratBalanceAfter,
             stratBalanceBefore + _depositAmount,
-            "test_mintDepositAndDelegate_TokenBalances: strategy balance not updated correctly"
+            "test_mintDepositAndDelegate_CheckBalancesAndDeploys: strategy balance not updated correctly"
         );
         assertEq(
             stakeToken.balanceOf(stakerContract),
             0,
-            "test_mintDepositAndDelegate_TokenBalances: staker balance should be 0"
+            "test_mintDepositAndDelegate_CheckBalancesAndDeploys: staker balance should be 0"
         );
     }
 
@@ -134,7 +117,8 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
         // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
         uint256 stakerSharesBefore = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
         uint256 operatorSharesBefore = delegation.operatorShares(operator, stakeTokenStrat);
-        delegationFaucet.mintDepositAndDelegate(operator, _depositAmount);
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), _depositAmount);
 
         uint256 stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
         uint256 operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
@@ -173,7 +157,8 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
         // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
         uint256 stakerSharesBefore = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
         uint256 operatorSharesBefore = delegation.operatorShares(operator, stakeTokenStrat);
-        delegationFaucet.mintDepositAndDelegate(operator, DEFAULT_AMOUNT);
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), DEFAULT_AMOUNT);
 
         uint256 stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
         uint256 operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
@@ -205,8 +190,99 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
         address operator = getOperatorAddress(_operatorIndex);
         // Unregistered operator should revert
         cheats.expectRevert("DelegationFaucet: Operator not registered");
-        delegationFaucet.mintDepositAndDelegate(operator, DEFAULT_AMOUNT);
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), DEFAULT_AMOUNT);
     }
+
+    function test_depositIntoStrategy_IncreaseShares(uint8 _operatorIndex, uint256 _depositAmount) public {
+        cheats.assume(_operatorIndex < 15 && _depositAmount < DEFAULT_AMOUNT);
+        if (_depositAmount == 0) {
+            _depositAmount = DEFAULT_AMOUNT;
+        }
+        // Setup Operator
+        address operator = getOperatorAddress(_operatorIndex);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        uint256 stakerSharesBefore = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesBefore = delegation.operatorShares(operator, stakeTokenStrat);
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), DEFAULT_AMOUNT);
+
+        uint256 stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        uint256 operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
+        assertTrue(
+            delegation.delegatedTo(stakerContract) == operator,
+            "test_mintDepositAndDelegate_IncreaseShares: delegated address not set appropriately"
+        );
+        assertTrue(
+            delegation.isDelegated(stakerContract),
+            "test_mintDepositAndDelegate_IncreaseShares: delegated status not set appropriately"
+        );
+        assertEq(
+            stakerSharesAfter,
+            stakerSharesBefore + DEFAULT_AMOUNT,
+            "test_mintDepositAndDelegate_IncreaseShares: staker shares not updated correctly"
+        );
+        assertEq(
+            operatorSharesAfter,
+            operatorSharesBefore + DEFAULT_AMOUNT,
+            "test_mintDepositAndDelegate_IncreaseShares: operator shares not updated correctly"
+        );
+
+        // Deposit more into strategy
+        stakerSharesBefore = stakerSharesAfter;
+        operatorSharesBefore = operatorSharesAfter;
+        delegationFaucet.depositIntoStrategy(stakerContract, stakeTokenStrat, stakeToken, _depositAmount);
+        stakerSharesAfter = strategyManager.stakerStrategyShares(stakerContract, stakeTokenStrat);
+        operatorSharesAfter = delegation.operatorShares(operator, stakeTokenStrat);
+
+        assertEq(
+            stakerSharesAfter,
+            stakerSharesBefore + _depositAmount,
+            "test_mintDepositAndDelegate_IncreasesShares: staker shares not updated correctly"
+        );
+        assertEq(
+            operatorSharesAfter,
+            operatorSharesBefore + _depositAmount,
+            "test_mintDepositAndDelegate_IncreasesShares: operator shares not updated correctly"
+        );
+    }
+
+    function test_transfer_TransfersERC20(uint8 _operatorIndex, address _to, uint256 _transferAmount) public {
+        cheats.assume(_operatorIndex < 15);
+        // Setup Operator
+        address operator = getOperatorAddress(_operatorIndex);
+        address stakerContract = delegationFaucet.getStaker(operator);
+        _registerOperator(operator);
+
+        // Mint token to Staker, deposit minted amount into strategy, and delegate to operator
+        IDelegationManager.SignatureWithExpiry memory signatureWithExpiry;
+        delegationFaucet.mintDepositAndDelegate(operator, signatureWithExpiry, bytes32(0), DEFAULT_AMOUNT);
+
+
+        ERC20PresetMinterPauser mockToken = new ERC20PresetMinterPauser("MockToken", "MTK");
+        mockToken.mint(stakerContract, _transferAmount);
+
+        uint256 stakerBalanceBefore = mockToken.balanceOf(stakerContract);
+        uint256 toBalanceBefore = mockToken.balanceOf(_to);
+        delegationFaucet.transfer(stakerContract, address(mockToken), _to, _transferAmount);
+        uint256 stakerBalanceAfter = mockToken.balanceOf(stakerContract);
+        uint256 toBalanceAfter = mockToken.balanceOf(_to);
+        assertEq(
+            stakerBalanceBefore,
+            stakerBalanceAfter + _transferAmount,
+            "test_transfer_TransfersERC20: staker balance not updated correctly"
+        );
+        assertEq(
+            toBalanceBefore + _transferAmount,
+            toBalanceAfter,
+            "test_transfer_TransfersERC20: to balance not updated correctly"
+        );
+    }
+
+    
 
     function _registerOperator(address _operator) internal {
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({


### PR DESCRIPTION
Description:
- For M2, we are creating a quorum with a dummy ERC20 token. Operators can call `DelegationFaucet.mintDepositAndDelegate` which uses a `DelegationFaucetStaker` contract (deploys per-operator if it doesn't already exist) that gets minted the dummy ERC20 token and delegates to the operator.
- Copied most of the logic over from `Whitelister.sol`

Todo:
- Events
- Further testing