### PR TITLE
Add function to bitmap utils library

### DIFF
--- a/src/contracts/libraries/BitmapUtils.sol
+++ b/src/contracts/libraries/BitmapUtils.sol
@@ -275,4 +275,9 @@ library BitmapUtils {
         }
         return count;
     }
+
+    // @notice returns 'true' if `numberToCheckForInclusion` is in `bitmap` and 'false' otherwise.
+    function numberIsInBitmap(uint256 bitmap, uint8 numberToCheckForInclusion) internal pure returns (bool) {
+        return (((bitmap >> numberToCheckForInclusion) & 1) == 1);
+    }
 }

--- a/src/contracts/libraries/BitmapUtils.sol
+++ b/src/contracts/libraries/BitmapUtils.sol
@@ -267,7 +267,7 @@ library BitmapUtils {
     }
 
     /// @return count number of ones in binary representation of `n`
-    function countNumOnes(uint256 n) public pure returns (uint16) {
+    function countNumOnes(uint256 n) internal pure returns (uint16) {
         uint16 count = 0;
         while (n > 0) {
             n &= (n - 1);

--- a/src/contracts/middleware/BLSSignatureChecker.sol
+++ b/src/contracts/middleware/BLSSignatureChecker.sol
@@ -126,7 +126,7 @@ contract BLSSignatureChecker is IBLSSignatureChecker {
                     // keep track of the nonSigners index in the quorum
                     uint32 nonSignerForQuorumIndex = 0;
                     // if the nonSigner is a part of the quorum, subtract their stake from the running total
-                    if (nonSignerQuorumBitmaps[i] >> quorumNumber & 1 == 1) {
+                    if (BitmapUtils.numberIsInBitmap(nonSignerQuorumBitmaps[i], quorumNumber)) {
                         quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] -=
                             stakeRegistry.getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(
                                 quorumNumber,

--- a/src/contracts/middleware/StakeRegistry.sol
+++ b/src/contracts/middleware/StakeRegistry.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../interfaces/IServiceManager.sol";
 import "../interfaces/IStakeRegistry.sol";
 import "../interfaces/IRegistryCoordinator.sol";
+import "../libraries/BitmapUtils.sol";
 import "./StakeRegistryStorage.sol";
 
 /**
@@ -254,7 +255,7 @@ contract StakeRegistry is StakeRegistryStorage {
                     continue;
                 }
                 // if the operator is a part of the quorum
-                if (quorumBitmap >> quorumNumber & 1 == 1) {
+                if (BitmapUtils.numberIsInBitmap(quorumBitmap, quorumNumber)) {
                     // if the total stake has not been loaded yet, load it
                     if (totalStakeUpdate.updateBlockNumber == 0) {
                         totalStakeUpdate = _totalStakeHistory[quorumNumber][_totalStakeHistory[quorumNumber].length - 1];

--- a/src/test/harnesses/BitmapUtilsWrapper.sol
+++ b/src/test/harnesses/BitmapUtilsWrapper.sol
@@ -34,4 +34,8 @@ contract BitmapUtilsWrapper is Test {
     function countNumOnes(uint256 n) external pure returns (uint16) {
         return BitmapUtils.countNumOnes(n);
     }
+
+    function numberIsInBitmap(uint256 bitmap, uint8 numberToCheckForInclusion) external pure returns (bool) {
+        return BitmapUtils.numberIsInBitmap(bitmap, numberToCheckForInclusion);
+    }
 }

--- a/src/test/unit/BitmapUtils.t.sol
+++ b/src/test/unit/BitmapUtils.t.sol
@@ -165,4 +165,16 @@ contract BitmapUtilsUnitTests is Test {
         }
         require(libraryOutput == numOnes, "inconsistency in countNumOnes function");
     }
+
+    // @notice some simple sanity checks on the `numberIsInBitmap` function
+    function testNumberIsInBitmap() public view {
+        require(bitmapUtilsWrapper.numberIsInBitmap(2 ** 6, 6), "numberIsInBitmap function is broken 0");
+        require(bitmapUtilsWrapper.numberIsInBitmap(1, 0), "numberIsInBitmap function is broken 1");
+        require(bitmapUtilsWrapper.numberIsInBitmap(255, 7), "numberIsInBitmap function is broken 2");
+        require(bitmapUtilsWrapper.numberIsInBitmap(1024, 10), "numberIsInBitmap function is broken 3");
+        for (uint256 i = 0; i < 256; ++i) {
+            require(bitmapUtilsWrapper.numberIsInBitmap(type(uint256).max, uint8(i)), "numberIsInBitmap function is broken 4");
+            require(!bitmapUtilsWrapper.numberIsInBitmap(0, uint8(i)), "numberIsInBitmap function is broken 5");
+        }
+    }
 }


### PR DESCRIPTION
adds a new function `BitmapUtils.numberIsInBitmap`, inspired by [this comment](https://github.com/Layr-Labs/eigenlayer-contracts/pull/35#discussion_r1336399266)
Unit test coverage and usage of the function are also added