### PR TITLE
Migrate multiple queued withdrawals

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -363,7 +363,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         emit WithdrawalCompleted(withdrawalRoot);
     }
 
-    /// @notice Migrates an existing queued withdrawal from the StrategyManager contract to this contract.
+    /// @notice Migrates an array of queued withdrawals from the StrategyManager contract to this contract.
     /// @dev This function is expected to be removed in the next upgrade, after all queued withdrawals have been migrated.
     function migrateQueuedWithdrawals(IStrategyManager.DeprecatedStruct_QueuedWithdrawal[] memory strategyManagerWithdrawalsToMigrate) external {
         for(uint256 i = 0; i < strategyManagerWithdrawalsToMigrate.length;) {

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -206,12 +206,15 @@ contract StrategyManager is
 
     /// @notice Function called by the DelegationManager as part of the process of transferring existing queued withdrawals from this contract to that contract.
     /// @dev This function is expected to be removed in the next upgrade, after all queued withdrawals have been migrated.
-    function migrateQueuedWithdrawal(bytes32 existingWithdrawalRoot) external onlyDelegationManager {
-        // check for existence
-        require(withdrawalRootPending[existingWithdrawalRoot], "StrategyManager.migrateQueuedWithdrawal: withdrawal does not exist");
-
-        // delete the withdrawal
-        withdrawalRootPending[existingWithdrawalRoot] = false;
+    function migrateQueuedWithdrawal(DeprecatedStruct_QueuedWithdrawal memory queuedWithdrawal) external onlyDelegationManager returns(bool, bytes32) {
+        bytes32 existingWithdrawalRoot = calculateWithdrawalRoot(queuedWithdrawal);
+        bool isDeleted;
+        // Delete the withdrawal root if it exists
+        if (withdrawalRootPending[existingWithdrawalRoot]) {
+            withdrawalRootPending[existingWithdrawalRoot] = false;
+            isDeleted = true;
+        }
+        return (isDeleted, existingWithdrawalRoot);
     }
 
     /**

--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -139,7 +139,7 @@ interface IStrategyManager {
         address delegatedAddress;
     }
 
-    function migrateQueuedWithdrawal(bytes32 existingWithdrawalRoot) external;
+    function migrateQueuedWithdrawal(DeprecatedStruct_QueuedWithdrawal memory queuedWithdrawal) external returns (bool, bytes32);
 
     function calculateWithdrawalRoot(DeprecatedStruct_QueuedWithdrawal memory queuedWithdrawal) external pure returns (bytes32);
 }

--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -112,7 +112,7 @@ contract StrategyManagerMock is
 
     function removeStrategiesFromDepositWhitelist(IStrategy[] calldata /*strategiesToRemoveFromWhitelist*/) external pure {}   
 
-    function migrateQueuedWithdrawal(bytes32 existingWithdrawalRoot) external {}
+    function migrateQueuedWithdrawal(DeprecatedStruct_QueuedWithdrawal memory queuedWithdrawal) external returns (bool, bytes32) {}
 
     function calculateWithdrawalRoot(DeprecatedStruct_QueuedWithdrawal memory queuedWithdrawal) external pure returns (bytes32) {}
 }


### PR DESCRIPTION
This PR updates the migrateQueuedWithdrawal function within the DM to migrate multiple queued withdrawals to easily batch multiple migrations. To handle updating multiple withdrawals without reverting, the `migrateQueuedWithdrawal` in the SM does not revert if the withdrawal has already been provided. We also remove all withdrawalRoot calculations from the DM. 

Migration tests will be added in subsequent PR. 