### PR TITLE
rename NonSignerStakesAndSignature fields to be more consistent

### DIFF
--- a/src/contracts/middleware/BLSOperatorStateRetriever.sol
+++ b/src/contracts/middleware/BLSOperatorStateRetriever.sol
@@ -19,130 +19,196 @@ contract BLSOperatorStateRetriever {
     }
 
     struct CheckSignaturesIndices {
-        uint32[] nonSignerQuorumBitmapIndices;
+        uint32[] nonSignersQuorumBitmapIndices;
         uint32[] quorumApkIndices;
-        uint32[] totalStakeIndices;  
-        uint32[][] nonSignerStakeIndices; // nonSignerStakeIndices[quorumNumberIndex][nonSignerIndex]
+        uint32[] quorumTotalStakeIndices;
+        uint32[][] quorumNonSignersStakeIndices; // nonSignerStakeIndices[quorumNumberIndex][nonSignerIndex]
     }
 
     /**
      * @notice This function is intended to to be called by AVS operators every time a new task is created (i.e.)
-     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain, 
+     * the AVS coordinator makes a request to AVS operators. Since all of the crucial information is kept onchain,
      * operators don't need to run indexers to fetch the data.
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
-     * @param operatorId the id of the operator to fetch the quorums lists 
+     * @param operatorId the id of the operator to fetch the quorums lists
      * @param blockNumber is the block number to get the operator state for
      * @return 1) the quorumBitmap of the operator at the given blockNumber
-     *         2) 2d array of Operator structs. For each quorum the provided operator 
+     *         2) 2d array of Operator structs. For each quorum the provided operator
      *            was a part of at `blockNumber`, an ordered list of operators.
      */
-    function getOperatorState(IBLSRegistryCoordinatorWithIndices registryCoordinator, bytes32 operatorId, uint32 blockNumber) external view returns (uint256, Operator[][] memory) {
+    function getOperatorState(
+        IBLSRegistryCoordinatorWithIndices registryCoordinator,
+        bytes32 operatorId,
+        uint32 blockNumber
+    ) external view returns (uint256, Operator[][] memory) {
         bytes32[] memory operatorIds = new bytes32[](1);
         operatorIds[0] = operatorId;
-        uint256 index = registryCoordinator.getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(blockNumber, operatorIds)[0];
-    
-        uint256 quorumBitmap = registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(operatorId, blockNumber, index);
+        uint256 index = registryCoordinator
+            .getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(
+                blockNumber,
+                operatorIds
+            )[0];
 
-        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(quorumBitmap);
+        uint256 quorumBitmap = registryCoordinator
+            .getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
+                operatorId,
+                blockNumber,
+                index
+            );
 
-        return (quorumBitmap, getOperatorState(registryCoordinator, quorumNumbers, blockNumber));
+        bytes memory quorumNumbers = BitmapUtils.bitmapToBytesArray(
+            quorumBitmap
+        );
+
+        return (
+            quorumBitmap,
+            getOperatorState(registryCoordinator, quorumNumbers, blockNumber)
+        );
     }
 
     /**
-     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator 
+     * @notice returns the ordered list of operators (id and stake) for each quorum. The AVS coordinator
      * may call this function directly to get the operator state for a given block number
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param quorumNumbers are the ids of the quorums to get the operator state for
      * @param blockNumber is the block number to get the operator state for
      * @return 2d array of operators. For each quorum, an ordered list of operators
      */
-    function getOperatorState(IBLSRegistryCoordinatorWithIndices registryCoordinator, bytes memory quorumNumbers, uint32 blockNumber) public view returns(Operator[][] memory) {
+    function getOperatorState(
+        IBLSRegistryCoordinatorWithIndices registryCoordinator,
+        bytes memory quorumNumbers,
+        uint32 blockNumber
+    ) public view returns (Operator[][] memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         IIndexRegistry indexRegistry = registryCoordinator.indexRegistry();
 
         Operator[][] memory operators = new Operator[][](quorumNumbers.length);
         for (uint256 i = 0; i < quorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(quorumNumbers[i]);
-            bytes32[] memory operatorIds = indexRegistry.getOperatorListForQuorumAtBlockNumber(quorumNumber, blockNumber);
+            bytes32[] memory operatorIds = indexRegistry
+                .getOperatorListForQuorumAtBlockNumber(
+                    quorumNumber,
+                    blockNumber
+                );
             operators[i] = new Operator[](operatorIds.length);
             for (uint256 j = 0; j < operatorIds.length; j++) {
                 bytes32 operatorId = bytes32(operatorIds[j]);
                 operators[i][j] = Operator({
                     operatorId: operatorId,
-                    stake: stakeRegistry.getStakeForOperatorIdForQuorumAtBlockNumber(operatorId, quorumNumber, blockNumber)
+                    stake: stakeRegistry
+                        .getStakeForOperatorIdForQuorumAtBlockNumber(
+                            operatorId,
+                            quorumNumber,
+                            blockNumber
+                        )
                 });
             }
         }
-            
+
         return operators;
     }
 
     /**
      * @notice this is called by the AVS operator to get the relevant indices for the checkSignatures function
-     * if they are not running an indexer    
+     * if they are not running an indexer
      * @param registryCoordinator is the registry coordinator to fetch the AVS registry information from
      * @param referenceBlockNumber is the block number to get the indices for
      * @param quorumNumbers are the ids of the quorums to get the operator state for
      * @param nonSignerOperatorIds are the ids of the nonsigning operators
      * @return 1) the indices of the quorumBitmaps for each of the operators in the @param nonSignerOperatorIds array at the given blocknumber
      *         2) the indices of the total stakes entries for the given quorums at the given blocknumber
-     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a 
+     *         3) the indices of the stakes of each of the nonsigners in each of the quorums they were a
      *            part of (for each nonsigner, an array of length the number of quorums they were a part of
      *            that are also part of the provided quorumNumbers) at the given blocknumber
      *         4) the indices of the quorum apks for each of the provided quorums at the given blocknumber
      */
     function getCheckSignaturesIndices(
         IBLSRegistryCoordinatorWithIndices registryCoordinator,
-        uint32 referenceBlockNumber, 
-        bytes calldata quorumNumbers, 
+        uint32 referenceBlockNumber,
+        bytes calldata quorumNumbers,
         bytes32[] calldata nonSignerOperatorIds
     ) external view returns (CheckSignaturesIndices memory) {
         IStakeRegistry stakeRegistry = registryCoordinator.stakeRegistry();
         CheckSignaturesIndices memory checkSignaturesIndices;
 
         // get the indices of the quorumBitmap updates for each of the operators in the nonSignerOperatorIds array
-        checkSignaturesIndices.nonSignerQuorumBitmapIndices = registryCoordinator.getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(referenceBlockNumber, nonSignerOperatorIds);
+        checkSignaturesIndices
+            .nonSignersQuorumBitmapIndices = registryCoordinator
+            .getQuorumBitmapIndicesByOperatorIdsAtBlockNumber(
+                referenceBlockNumber,
+                nonSignerOperatorIds
+            );
         // get the indices of the totalStake updates for each of the quorums in the quorumNumbers array
-        checkSignaturesIndices.totalStakeIndices = stakeRegistry.getTotalStakeIndicesByQuorumNumbersAtBlockNumber(referenceBlockNumber, quorumNumbers);
-        
-        checkSignaturesIndices.nonSignerStakeIndices = new uint32[][](quorumNumbers.length);
-        for (uint8 quorumNumberIndex = 0; quorumNumberIndex < quorumNumbers.length; quorumNumberIndex++) {
+        checkSignaturesIndices.quorumTotalStakeIndices = stakeRegistry
+            .getTotalStakeIndicesByQuorumNumbersAtBlockNumber(
+                referenceBlockNumber,
+                quorumNumbers
+            );
+
+        checkSignaturesIndices.quorumNonSignersStakeIndices = new uint32[][](
+            quorumNumbers.length
+        );
+        for (
+            uint8 quorumNumberIndex = 0;
+            quorumNumberIndex < quorumNumbers.length;
+            quorumNumberIndex++
+        ) {
             uint256 numNonSignersForQuorum = 0;
             // this array's length will be at most the number of nonSignerOperatorIds, this will be trimmed after it is filled
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = new uint32[](nonSignerOperatorIds.length);
+            checkSignaturesIndices.quorumNonSignersStakeIndices[
+                quorumNumberIndex
+            ] = new uint32[](nonSignerOperatorIds.length);
 
             for (uint i = 0; i < nonSignerOperatorIds.length; i++) {
                 // get the quorumBitmap for the operator at the given blocknumber and index
-                uint192 nonSignerQuorumBitmap = 
-                    registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
-                        nonSignerOperatorIds[i], 
-                        referenceBlockNumber, 
-                        checkSignaturesIndices.nonSignerQuorumBitmapIndices[i]
-                    );
-                
-                // if the operator was a part of the quorum and the quorum is a part of the provided quorumNumbers
-                if ((nonSignerQuorumBitmap >> uint8(quorumNumbers[quorumNumberIndex])) & 1 == 1) {
-                    // get the index of the stake update for the operator at the given blocknumber and quorum number
-                    checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][numNonSignersForQuorum] = stakeRegistry.getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber(
+                uint192 nonSignerQuorumBitmap = registryCoordinator
+                    .getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
                         nonSignerOperatorIds[i],
-                        uint8(quorumNumbers[quorumNumberIndex]),
-                        referenceBlockNumber
+                        referenceBlockNumber,
+                        checkSignaturesIndices.nonSignersQuorumBitmapIndices[i]
                     );
+
+                // if the operator was a part of the quorum and the quorum is a part of the provided quorumNumbers
+                if (
+                    (nonSignerQuorumBitmap >>
+                        uint8(quorumNumbers[quorumNumberIndex])) &
+                        1 ==
+                    1
+                ) {
+                    // get the index of the stake update for the operator at the given blocknumber and quorum number
+                    checkSignaturesIndices.quorumNonSignersStakeIndices[
+                        quorumNumberIndex
+                    ][numNonSignersForQuorum] = stakeRegistry
+                        .getStakeUpdateIndexForOperatorIdForQuorumAtBlockNumber(
+                            nonSignerOperatorIds[i],
+                            uint8(quorumNumbers[quorumNumberIndex]),
+                            referenceBlockNumber
+                        );
                     numNonSignersForQuorum++;
                 }
             }
 
             // resize the array to the number of nonSigners for this quorum
-            uint32[] memory nonSignerStakeIndicesForQuorum = new uint32[](numNonSignersForQuorum);
+            uint32[] memory nonSignerStakeIndicesForQuorum = new uint32[](
+                numNonSignersForQuorum
+            );
             for (uint i = 0; i < numNonSignersForQuorum; i++) {
-                nonSignerStakeIndicesForQuorum[i] = checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex][i];
+                nonSignerStakeIndicesForQuorum[i] = checkSignaturesIndices
+                    .quorumNonSignersStakeIndices[quorumNumberIndex][i];
             }
-            checkSignaturesIndices.nonSignerStakeIndices[quorumNumberIndex] = nonSignerStakeIndicesForQuorum;
+            checkSignaturesIndices.quorumNonSignersStakeIndices[
+                quorumNumberIndex
+            ] = nonSignerStakeIndicesForQuorum;
         }
 
-        IBLSPubkeyRegistry blsPubkeyRegistry = registryCoordinator.blsPubkeyRegistry();
+        IBLSPubkeyRegistry blsPubkeyRegistry = registryCoordinator
+            .blsPubkeyRegistry();
         // get the indices of the quorum apks for each of the provided quorums at the given blocknumber
-        checkSignaturesIndices.quorumApkIndices = blsPubkeyRegistry.getApkIndicesForQuorumsAtBlockNumber(quorumNumbers, referenceBlockNumber);
+        checkSignaturesIndices.quorumApkIndices = blsPubkeyRegistry
+            .getApkIndicesForQuorumsAtBlockNumber(
+                quorumNumbers,
+                referenceBlockNumber
+            );
 
         return checkSignaturesIndices;
     }

--- a/src/contracts/middleware/BLSSignatureChecker.sol
+++ b/src/contracts/middleware/BLSSignatureChecker.sol
@@ -13,19 +13,54 @@ import "../libraries/BitmapUtils.sol";
  * @notice This is the contract for checking the validity of aggregate operator signatures.
  */
 contract BLSSignatureChecker {
-    using BN254 for BN254.G1Point;    
+    using BN254 for BN254.G1Point;
 
     // DATA STRUCTURES
 
+    /*
+    NonSignerStakesAndSignature is passed as input to checkSignatures() to verify an aggregate signature.
+
+    The Registry contracts store the history of stakes and aggregate pubkeys (apks) for each operators and each quorum. These are
+    updated everytime an operator registers or deregisters with the BLSRegistryCoordinatorWithIndices.sol contract, or calls UpdateStakes() on the StakeRegistry.sol contract,
+    Each of these events push a new entry to its respective datatype array.
+
+    The 4 "indices" in NonSignerStakesAndSignature basically represent the index at which to fetch their respective data, given a blockNumber at which the task was created.
+    Note that different data types might have different indices, since for eg QuorumBitmaps are updated for operators registering/deregistering, but not for UpdateStakes.
+    One can use getCheckSignaturesIndices() in BLSOperatorStateRetriever.sol to fetch the indices given a block number.
+
+    The 4 other fields nonSignerPubkeys, quorumApks, apkG2, and sigma, however, must be computed individually.
+    apkG2 and sigma are just the aggregated signature and pubkeys of the operators who signed the task response (aggregated over all quorums, so individual signatures might be duplicated).
+    quorumApks are the G1 aggregated pubkeys of the operators who signed the task response, but one per quorum, as opposed to apkG2 which is summed over all quorums.
+    nonSignerPubkeys are the G1 pubkeys of the operators who did not sign the task response, but were opted into the quorum at the blocknumber at which the task was created.
+    Upon sending a task onchain (or receiving a NewTaskCreated Event if the tasks were sent by an external task generator), the aggregator can get the list of all operators opted into each quorum at that
+    block number by calling the getOperatorState() function of the BLSOperatorStateRetriever.sol contract.
+
+    fields:
+    @nonSignersPubkeysG1: G1 pubkey of all non-signers
+    @quorumApksG1: G1 aggregated pubkey of each quorum (aggregated over all operators opted in to the quorum at the given blocknumber)
+    @signersApkG2: aggregated G2 pubkey of the signers
+    @signersAggSigG1: aggregated signature of the signers
+    @nonSignersQuorumBitmapIndices: the indices of the quorumBitmaps for each of the operators in the @param nonSignerOperatorIds array at the given blocknumber
+    @quorumApkIndices: the indices of the quorum apks for each of the provided quorums at the given blocknumber
+    @quorumTotalStakeIndices: the indices of the total stakes entries for the given quorums at the given blocknumber
+    @quorumNonSignersStakeIndices: the indices of the stakes of each of the nonsigners in each of the quorums they were a
+                                   part of (for each nonsigner, an array of length the number of quorums they were a part of
+                                   that are also part of the provided quorumNumbers) at the given blocknumber
+    
+    Each field array can either be over signers, nonsigners, or quorums.
+    We use the first word of the variable to represent what the array is over
+      eg: []nonSignersPubkeysG1 -> array of nonSigners
+      eg: []quorumApkG1 -> array of quorums
+    */
     struct NonSignerStakesAndSignature {
-        uint32[] nonSignerQuorumBitmapIndices;
-        BN254.G1Point[] nonSignerPubkeys;
-        BN254.G1Point[] quorumApks;
-        BN254.G2Point apkG2;
-        BN254.G1Point sigma;
-        uint32[] quorumApkIndices;
-        uint32[] totalStakeIndices;  
-        uint32[][] nonSignerStakeIndices; // nonSignerStakeIndices[quorumNumberIndex][nonSignerIndex]
+        BN254.G1Point[] nonSignersPubkeysG1; // nonSignersPubkeysG1[nonSignerIndex]
+        BN254.G1Point[] quorumApksG1; // quorumApksG1[quorumIndex]
+        BN254.G2Point signersApkG2;
+        BN254.G1Point signersAggSigG1;
+        uint32[] nonSignersQuorumBitmapIndices; // nonSignersQuorumBitmapIndices[nonSignerIndex]
+        uint32[] quorumApkIndices; // quorumApkIndices[quorumIndex]
+        uint32[] quorumTotalStakeIndices; // quorumTotalStakeIndices[quorumIndex]
+        uint32[][] quorumNonSignersStakeIndices; // quorumNonSignersStakeIndices[quorumIndex][nonSignerIndex]
     }
 
     /**
@@ -39,7 +74,7 @@ contract BLSSignatureChecker {
         // total amount staked by all operators in each quorum
         uint96[] totalStakeForQuorum;
     }
-    
+
     // CONSTANTS & IMMUTABLES
 
     // gas cost of multiplying 2 pairings
@@ -64,103 +99,145 @@ contract BLSSignatureChecker {
      * The thesis of this procedure entails:
      * - getting the aggregated pubkey of all registered nodes at the time of pre-commit by the
      * disperser (represented by apk in the parameters),
-     * - subtracting the pubkeys of all the signers not in the quorum (nonSignerPubkeys) and storing 
+     * - subtracting the pubkeys of all the signers not in the quorum (nonSignerPubkeys) and storing
      * the output in apk to get aggregated pubkey of all operators that are part of quorum.
      * - use this aggregated pubkey to verify the aggregated signature under BLS scheme.
-     * 
+     *
      * @dev Before signature verification, the function verifies operator stake information.  This includes ensuring that the provided `referenceBlockNumber`
      * is correct, i.e., ensure that the stake returned from the specified block number is recent enough and that the stake is either the most recent update
      * for the total stake (or the operator) or latest before the referenceBlockNumber.
      */
     function checkSignatures(
-        bytes32 msgHash, 
+        bytes32 msgHash,
         bytes calldata quorumNumbers,
-        uint32 referenceBlockNumber, 
+        uint32 referenceBlockNumber,
         NonSignerStakesAndSignature memory nonSignerStakesAndSignature
-    ) 
-        public 
-        view
-        returns (
-            QuorumStakeTotals memory,
-            bytes32
-        )
-    {   
+    ) public view returns (QuorumStakeTotals memory, bytes32) {
         // verify the provided apk was the apk at referenceBlockNumber
         // loop through every quorumNumber and keep track of the apk
         BN254.G1Point memory apk = BN254.G1Point(0, 0);
         for (uint i = 0; i < quorumNumbers.length; i++) {
             require(
-                bytes24(nonSignerStakesAndSignature.quorumApks[i].hashG1Point()) == 
+                bytes24(
+                    nonSignerStakesAndSignature.quorumApksG1[i].hashG1Point()
+                ) ==
                     blsPubkeyRegistry.getApkHashForQuorumAtBlockNumberFromIndex(
-                        uint8(quorumNumbers[i]), 
-                        referenceBlockNumber, 
+                        uint8(quorumNumbers[i]),
+                        referenceBlockNumber,
                         nonSignerStakesAndSignature.quorumApkIndices[i]
                     ),
                 "BLSSignatureChecker.checkSignatures: quorumApk hash in storage does not match provided quorum apk"
             );
-            apk = apk.plus(nonSignerStakesAndSignature.quorumApks[i]);
+            apk = apk.plus(nonSignerStakesAndSignature.quorumApksG1[i]);
         }
-        
+
         // initialize memory for the quorumStakeTotals
         QuorumStakeTotals memory quorumStakeTotals;
-        quorumStakeTotals.totalStakeForQuorum = new uint96[](quorumNumbers.length);
-        quorumStakeTotals.signedStakeForQuorum = new uint96[](quorumNumbers.length);
+        quorumStakeTotals.totalStakeForQuorum = new uint96[](
+            quorumNumbers.length
+        );
+        quorumStakeTotals.signedStakeForQuorum = new uint96[](
+            quorumNumbers.length
+        );
         // the pubkeyHashes of the nonSigners
-        bytes32[] memory nonSignerPubkeyHashes = new bytes32[](nonSignerStakesAndSignature.nonSignerPubkeys.length);
+        bytes32[] memory nonSignerPubkeyHashes = new bytes32[](
+            nonSignerStakesAndSignature.nonSignersPubkeysG1.length
+        );
         {
             // the quorumBitmaps of the nonSigners
-            uint256[] memory nonSignerQuorumBitmaps = new uint256[](nonSignerStakesAndSignature.nonSignerPubkeys.length);
+            uint256[] memory nonSignerQuorumBitmaps = new uint256[](
+                nonSignerStakesAndSignature.nonSignersPubkeysG1.length
+            );
             {
                 // the bitmap of the quorumNumbers
-                uint256 signingQuorumBitmap = BitmapUtils.bytesArrayToBitmap(quorumNumbers);
+                uint256 signingQuorumBitmap = BitmapUtils.bytesArrayToBitmap(
+                    quorumNumbers
+                );
 
-                for (uint i = 0; i < nonSignerStakesAndSignature.nonSignerPubkeys.length; i++) {
-                    nonSignerPubkeyHashes[i] = nonSignerStakesAndSignature.nonSignerPubkeys[i].hashG1Point();
-                    
+                for (
+                    uint i = 0;
+                    i < nonSignerStakesAndSignature.nonSignersPubkeysG1.length;
+                    i++
+                ) {
+                    nonSignerPubkeyHashes[i] = nonSignerStakesAndSignature
+                        .nonSignersPubkeysG1[i]
+                        .hashG1Point();
+
                     // check that the nonSignerPubkeys are sorted and free of duplicates
                     if (i != 0) {
-                        require(uint256(nonSignerPubkeyHashes[i]) > uint256(nonSignerPubkeyHashes[i - 1]), "BLSSignatureChecker.checkSignatures: nonSignerPubkeys not sorted");
+                        require(
+                            uint256(nonSignerPubkeyHashes[i]) >
+                                uint256(nonSignerPubkeyHashes[i - 1]),
+                            "BLSSignatureChecker.checkSignatures: nonSignerPubkeys not sorted"
+                        );
                     }
 
-                    nonSignerQuorumBitmaps[i] = 
-                        registryCoordinator.getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
-                            nonSignerPubkeyHashes[i], 
-                            referenceBlockNumber, 
-                            nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices[i]
+                    nonSignerQuorumBitmaps[i] = registryCoordinator
+                        .getQuorumBitmapByOperatorIdAtBlockNumberByIndex(
+                            nonSignerPubkeyHashes[i],
+                            referenceBlockNumber,
+                            nonSignerStakesAndSignature
+                                .nonSignersQuorumBitmapIndices[i]
                         );
-                    
+
                     // subtract the nonSignerPubkey from the running apk to get the apk of all signers
                     apk = apk.plus(
-                        nonSignerStakesAndSignature.nonSignerPubkeys[i]
+                        nonSignerStakesAndSignature
+                            .nonSignersPubkeysG1[i]
                             .negate()
                             .scalar_mul_tiny(
-                                BitmapUtils.countNumOnes(nonSignerQuorumBitmaps[i] & signingQuorumBitmap) // we subtract the nonSignerPubkey from each quorum that they are a part of, TODO: 
+                                BitmapUtils.countNumOnes(
+                                    nonSignerQuorumBitmaps[i] &
+                                        signingQuorumBitmap
+                                ) // we subtract the nonSignerPubkey from each quorum that they are a part of, TODO:
                             )
                     );
                 }
             }
             // loop through each quorum number
-            for (uint8 quorumNumberIndex = 0; quorumNumberIndex < quorumNumbers.length;) {
+            for (
+                uint8 quorumNumberIndex = 0;
+                quorumNumberIndex < quorumNumbers.length;
+
+            ) {
                 // get the quorum number
                 uint8 quorumNumber = uint8(quorumNumbers[quorumNumberIndex]);
                 // get the totalStake for the quorum at the referenceBlockNumber
-                quorumStakeTotals.totalStakeForQuorum[quorumNumberIndex] = 
-                    stakeRegistry.getTotalStakeAtBlockNumberFromIndex(quorumNumber, referenceBlockNumber, nonSignerStakesAndSignature.totalStakeIndices[quorumNumberIndex]);
+                quorumStakeTotals.totalStakeForQuorum[
+                    quorumNumberIndex
+                ] = stakeRegistry.getTotalStakeAtBlockNumberFromIndex(
+                    quorumNumber,
+                    referenceBlockNumber,
+                    nonSignerStakesAndSignature.quorumTotalStakeIndices[
+                        quorumNumberIndex
+                    ]
+                );
                 // copy total stake to signed stake
-                quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] = quorumStakeTotals.totalStakeForQuorum[quorumNumberIndex];
+                quorumStakeTotals.signedStakeForQuorum[
+                    quorumNumberIndex
+                ] = quorumStakeTotals.totalStakeForQuorum[quorumNumberIndex];
                 // loop through all nonSigners, checking that they are a part of the quorum via their quorumBitmap
                 // if so, load their stake at referenceBlockNumber and subtract it from running stake signed
-                for (uint32 i = 0; i < nonSignerStakesAndSignature.nonSignerPubkeys.length; i++) {
+                for (
+                    uint32 i = 0;
+                    i < nonSignerStakesAndSignature.nonSignersPubkeysG1.length;
+                    i++
+                ) {
                     // keep track of the nonSigners index in the quorum
                     uint32 nonSignerForQuorumIndex = 0;
                     // if the nonSigner is a part of the quorum, subtract their stake from the running total
-                    if (nonSignerQuorumBitmaps[i] >> quorumNumber & 1 == 1) {
-                        quorumStakeTotals.signedStakeForQuorum[quorumNumberIndex] -=
-                            stakeRegistry.getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(
+                    if ((nonSignerQuorumBitmaps[i] >> quorumNumber) & 1 == 1) {
+                        quorumStakeTotals.signedStakeForQuorum[
+                            quorumNumberIndex
+                        ] -= stakeRegistry
+                            .getStakeForQuorumAtBlockNumberFromOperatorIdAndIndex(
                                 quorumNumber,
                                 referenceBlockNumber,
                                 nonSignerPubkeyHashes[i],
-                                nonSignerStakesAndSignature.nonSignerStakeIndices[quorumNumberIndex][nonSignerForQuorumIndex]
+                                nonSignerStakesAndSignature
+                                    .quorumNonSignersStakeIndices[quorumNumberIndex][
+                                        nonSignerForQuorumIndex
+                                    ]
                             );
                         unchecked {
                             ++nonSignerForQuorumIndex;
@@ -175,15 +252,30 @@ contract BLSSignatureChecker {
         }
         {
             // verify the signature
-            (bool pairingSuccessful, bool sigantureIsValid) = trySignatureAndApkVerification(msgHash, apk, nonSignerStakesAndSignature.apkG2, nonSignerStakesAndSignature.sigma);
-            require(pairingSuccessful, "BLSSignatureChecker.checkSignatures: pairing precompile call failed");
-            require(sigantureIsValid, "BLSSignatureChecker.checkSignatures: signature is invalid");
+            (
+                bool pairingSuccessful,
+                bool sigantureIsValid
+            ) = trySignatureAndApkVerification(
+                    msgHash,
+                    apk,
+                    nonSignerStakesAndSignature.signersApkG2,
+                    nonSignerStakesAndSignature.signersAggSigG1
+                );
+            require(
+                pairingSuccessful,
+                "BLSSignatureChecker.checkSignatures: pairing precompile call failed"
+            );
+            require(
+                sigantureIsValid,
+                "BLSSignatureChecker.checkSignatures: signature is invalid"
+            );
         }
         // set signatoryRecordHash variable used for fraudproofs
-        bytes32 signatoryRecordHash = MiddlewareUtils.computeSignatoryRecordHash(
-            referenceBlockNumber,
-            nonSignerPubkeyHashes
-        );
+        bytes32 signatoryRecordHash = MiddlewareUtils
+            .computeSignatoryRecordHash(
+                referenceBlockNumber,
+                nonSignerPubkeyHashes
+            );
 
         // return the total stakes that signed for each quorum, and a hash of the information required to prove the exact signers and stake
         return (quorumStakeTotals, signatoryRecordHash);
@@ -203,16 +295,30 @@ contract BLSSignatureChecker {
         BN254.G1Point memory apk,
         BN254.G2Point memory apkG2,
         BN254.G1Point memory sigma
-    ) public view returns(bool pairingSuccessful, bool siganatureIsValid) {
+    ) public view returns (bool pairingSuccessful, bool siganatureIsValid) {
         // gamma = keccak256(abi.encodePacked(msgHash, apk, apkG2, sigma))
-        uint256 gamma = uint256(keccak256(abi.encodePacked(msgHash, apk.X, apk.Y, apkG2.X[0], apkG2.X[1], apkG2.Y[0], apkG2.Y[1], sigma.X, sigma.Y))) % BN254.FR_MODULUS;
+        uint256 gamma = uint256(
+            keccak256(
+                abi.encodePacked(
+                    msgHash,
+                    apk.X,
+                    apk.Y,
+                    apkG2.X[0],
+                    apkG2.X[1],
+                    apkG2.Y[0],
+                    apkG2.Y[1],
+                    sigma.X,
+                    sigma.Y
+                )
+            )
+        ) % BN254.FR_MODULUS;
         // verify the signature
         (pairingSuccessful, siganatureIsValid) = BN254.safePairing(
-                sigma.plus(apk.scalar_mul(gamma)),
-                BN254.negGeneratorG2(),
-                BN254.hashToG1(msgHash).plus(BN254.generatorG1().scalar_mul(gamma)),
-                apkG2,
-                PAIRING_EQUALITY_CHECK_GAS
-            );
+            sigma.plus(apk.scalar_mul(gamma)),
+            BN254.negGeneratorG2(),
+            BN254.hashToG1(msgHash).plus(BN254.generatorG1().scalar_mul(gamma)),
+            apkG2,
+            PAIRING_EQUALITY_CHECK_GAS
+        );
     }
 }

--- a/src/test/ffi/BLSSignatureCheckerFFI.t.sol
+++ b/src/test/ffi/BLSSignatureCheckerFFI.t.sol
@@ -68,8 +68,8 @@ contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
         (uint32 referenceBlockNumber, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) = 
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
 
-        nonSignerStakesAndSignature.sigma = sigma.scalar_mul(quorumNumbers.length);
-        nonSignerStakesAndSignature.apkG2 = oneHundredQuorumApkG2;
+        nonSignerStakesAndSignature.signersAggSigG1 = sigma.scalar_mul(quorumNumbers.length);
+        nonSignerStakesAndSignature.signersApkG2 = oneHundredQuorumApkG2;
 
         uint256 gasBefore = gasleft();
         blsSignatureChecker.checkSignatures(
@@ -123,8 +123,8 @@ contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
         address[] memory operators = new address[](maxOperatorsToRegister);
         BN254.G1Point[] memory pubkeys = new BN254.G1Point[](maxOperatorsToRegister);
         BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature;
-        nonSignerStakesAndSignature.quorumApks = new BN254.G1Point[](quorumNumbers.length);
-        nonSignerStakesAndSignature.nonSignerPubkeys = new BN254.G1Point[](numNonSigners);
+        nonSignerStakesAndSignature.quorumApksG1 = new BN254.G1Point[](quorumNumbers.length);
+        nonSignerStakesAndSignature.nonSignersPubkeysG1 = new BN254.G1Point[](numNonSigners);
         bytes32[] memory nonSignerOperatorIds = new bytes32[](numNonSigners);
         {
             uint256 signerIndex = 0;
@@ -136,8 +136,8 @@ contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
                     signerIndex++;
                 } else if (nonSignerIndex < nonSignerPrivateKeys.length) {
                     privateKeys[i] = nonSignerPrivateKeys[nonSignerIndex];
-                    nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex] = BN254.generatorG1().scalar_mul(privateKeys[i]);
-                    nonSignerOperatorIds[nonSignerIndex] = nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex].hashG1Point();
+                    nonSignerStakesAndSignature.nonSignersPubkeysG1[nonSignerIndex] = BN254.generatorG1().scalar_mul(privateKeys[i]);
+                    nonSignerOperatorIds[nonSignerIndex] = nonSignerStakesAndSignature.nonSignersPubkeysG1[nonSignerIndex].hashG1Point();
                     nonSignerIndex++;
                 } else {
                     privateKeys[i] = signerPrivateKeys[signerIndex];
@@ -148,8 +148,8 @@ contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
                 pubkeys[i] = BN254.generatorG1().scalar_mul(privateKeys[i]);
 
                 // add the public key to each quorum
-                for (uint j = 0; j < nonSignerStakesAndSignature.quorumApks.length; j++) {
-                    nonSignerStakesAndSignature.quorumApks[j] = nonSignerStakesAndSignature.quorumApks[j].plus(pubkeys[i]);
+                for (uint j = 0; j < nonSignerStakesAndSignature.quorumApksG1.length; j++) {
+                    nonSignerStakesAndSignature.quorumApksG1[j] = nonSignerStakesAndSignature.quorumApksG1[j].plus(pubkeys[i]);
                 }
             }
         }
@@ -170,12 +170,12 @@ contract BLSSignatureCheckerFFITests is MockAVSDeployer, G2Operations {
             nonSignerOperatorIds
         );
 
-        nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices = checkSignaturesIndices.nonSignerQuorumBitmapIndices;
-        nonSignerStakesAndSignature.apkG2 = aggSignerApkG2;
-        nonSignerStakesAndSignature.sigma = sigma;
+        nonSignerStakesAndSignature.nonSignersQuorumBitmapIndices = checkSignaturesIndices.nonSignersQuorumBitmapIndices;
+        nonSignerStakesAndSignature.signersApkG2 = aggSignerApkG2;
+        nonSignerStakesAndSignature.signersAggSigG1 = sigma;
         nonSignerStakesAndSignature.quorumApkIndices = checkSignaturesIndices.quorumApkIndices;
-        nonSignerStakesAndSignature.totalStakeIndices = checkSignaturesIndices.totalStakeIndices;
-        nonSignerStakesAndSignature.nonSignerStakeIndices = checkSignaturesIndices.nonSignerStakeIndices;
+        nonSignerStakesAndSignature.quorumTotalStakeIndices = checkSignaturesIndices.quorumTotalStakeIndices;
+        nonSignerStakesAndSignature.quorumNonSignersStakeIndices = checkSignaturesIndices.quorumNonSignersStakeIndices;
 
         return (referenceBlockNumber, nonSignerStakesAndSignature);
     }

--- a/src/test/unit/BLSOperatorStateRetrieverUnit.t.sol
+++ b/src/test/unit/BLSOperatorStateRetrieverUnit.t.sol
@@ -104,16 +104,16 @@ contract BLSOperatorStateRetrieverUnitTests is MockAVSDeployer {
                 nonSignerOperatorIds
             );
 
-        assertEq(checkSignaturesIndices.nonSignerQuorumBitmapIndices.length, 0, "nonSignerQuorumBitmapIndices should be empty if no nonsigners");
+        assertEq(checkSignaturesIndices.nonSignersQuorumBitmapIndices.length, 0, "nonSignerQuorumBitmapIndices should be empty if no nonsigners");
         assertEq(checkSignaturesIndices.quorumApkIndices.length, allInclusiveQuorumNumbers.length, "quorumApkIndices should be the number of quorums queried for");
-        assertEq(checkSignaturesIndices.totalStakeIndices.length, allInclusiveQuorumNumbers.length, "totalStakeIndices should be the number of quorums queried for");
-        assertEq(checkSignaturesIndices.nonSignerStakeIndices.length, allInclusiveQuorumNumbers.length, "nonSignerStakeIndices should be the number of quorums queried for");
+        assertEq(checkSignaturesIndices.quorumTotalStakeIndices.length, allInclusiveQuorumNumbers.length, "totalStakeIndices should be the number of quorums queried for");
+        assertEq(checkSignaturesIndices.quorumNonSignersStakeIndices.length, allInclusiveQuorumNumbers.length, "nonSignerStakeIndices should be the number of quorums queried for");
 
         // assert the indices are the number of registered operators for the quorum minus 1
         for (uint8 i = 0; i < allInclusiveQuorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(allInclusiveQuorumNumbers[i]);
             assertEq(checkSignaturesIndices.quorumApkIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "quorumApkIndex should be the number of registered operators for the quorum minus 1");
-            assertEq(checkSignaturesIndices.totalStakeIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "totalStakeIndex should be the number of registered operators for the quorum minus 1");
+            assertEq(checkSignaturesIndices.quorumTotalStakeIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "totalStakeIndex should be the number of registered operators for the quorum minus 1");
         }
     }
 
@@ -147,25 +147,25 @@ contract BLSOperatorStateRetrieverUnitTests is MockAVSDeployer {
                 nonSignerOperatorIds
             );
 
-        assertEq(checkSignaturesIndices.nonSignerQuorumBitmapIndices.length, nonSignerOperatorIds.length, "nonSignerQuorumBitmapIndices should be the number of nonsigners");
+        assertEq(checkSignaturesIndices.nonSignersQuorumBitmapIndices.length, nonSignerOperatorIds.length, "nonSignerQuorumBitmapIndices should be the number of nonsigners");
         assertEq(checkSignaturesIndices.quorumApkIndices.length, allInclusiveQuorumNumbers.length, "quorumApkIndices should be the number of quorums queried for");
-        assertEq(checkSignaturesIndices.totalStakeIndices.length, allInclusiveQuorumNumbers.length, "totalStakeIndices should be the number of quorums queried for");
-        assertEq(checkSignaturesIndices.nonSignerStakeIndices.length, allInclusiveQuorumNumbers.length, "nonSignerStakeIndices should be the number of quorums queried for");
+        assertEq(checkSignaturesIndices.quorumTotalStakeIndices.length, allInclusiveQuorumNumbers.length, "quorumTotalStakeIndices should be the number of quorums queried for");
+        assertEq(checkSignaturesIndices.quorumNonSignersStakeIndices.length, allInclusiveQuorumNumbers.length, "quorumNonSignersStakeIndices should be the number of quorums queried for");
 
         // assert the indices are the number of registered operators for the quorum minus 1
         for (uint8 i = 0; i < allInclusiveQuorumNumbers.length; i++) {
             uint8 quorumNumber = uint8(allInclusiveQuorumNumbers[i]);
             assertEq(checkSignaturesIndices.quorumApkIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "quorumApkIndex should be the number of registered operators for the quorum minus 1");
-            assertEq(checkSignaturesIndices.totalStakeIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "totalStakeIndex should be the number of registered operators for the quorum minus 1");
+            assertEq(checkSignaturesIndices.quorumTotalStakeIndices[i], expectedOperatorOverallIndices[quorumNumber].length - 1, "quorumTotalStakeIndices should be the number of registered operators for the quorum minus 1");
         }
 
         // assert the quorum bitmap and stake indices are zero because there have been no kicks or stake updates
         for (uint i = 0; i < nonSignerOperatorIds.length; i++) {
-            assertEq(checkSignaturesIndices.nonSignerQuorumBitmapIndices[i], 0, "nonSignerQuorumBitmapIndices should be zero because there have been no kicks");
+            assertEq(checkSignaturesIndices.nonSignersQuorumBitmapIndices[i], 0, "nonSignersQuorumBitmapIndices should be zero because there have been no kicks");
         }
-        for (uint i = 0; i < checkSignaturesIndices.nonSignerStakeIndices.length; i++) {
-            for (uint j = 0; j < checkSignaturesIndices.nonSignerStakeIndices[i].length; j++) {
-                assertEq(checkSignaturesIndices.nonSignerStakeIndices[i][j], 0, "nonSignerStakeIndices should be zero because there have been no stake updates past the first one");
+        for (uint i = 0; i < checkSignaturesIndices.quorumNonSignersStakeIndices.length; i++) {
+            for (uint j = 0; j < checkSignaturesIndices.quorumNonSignersStakeIndices[i].length; j++) {
+                assertEq(checkSignaturesIndices.quorumNonSignersStakeIndices[i][j], 0, "quorumNonSignersStakeIndices should be zero because there have been no stake updates past the first one");
             }
         }
     }

--- a/src/test/unit/BLSSignatureCheckerUnit.t.sol
+++ b/src/test/unit/BLSSignatureCheckerUnit.t.sol
@@ -59,8 +59,8 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         (uint32 referenceBlockNumber, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) = 
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
 
-        nonSignerStakesAndSignature.sigma = sigma.scalar_mul(quorumNumbers.length);
-        nonSignerStakesAndSignature.apkG2 = oneHundredQuorumApkG2;
+        nonSignerStakesAndSignature.signersAggSigG1 = sigma.scalar_mul(quorumNumbers.length);
+        nonSignerStakesAndSignature.signersApkG2 = oneHundredQuorumApkG2;
 
         uint256 gasBefore = gasleft();
         blsSignatureChecker.checkSignatures(
@@ -83,10 +83,10 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
         
         // record a quorumBitmap update
-        registryCoordinator.recordOperatorQuorumBitmapUpdate(nonSignerStakesAndSignature.nonSignerPubkeys[0].hashG1Point(), uint192(quorumBitmap | 2));
+        registryCoordinator.recordOperatorQuorumBitmapUpdate(nonSignerStakesAndSignature.nonSignersPubkeysG1[0].hashG1Point(), uint192(quorumBitmap | 2));
 
         // set the nonSignerQuorumBitmapIndices to a different value
-        nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices[0] = 1;
+        nonSignerStakesAndSignature.nonSignersQuorumBitmapIndices[0] = 1;
 
         cheats.expectRevert("BLSRegistryCoordinatorWithIndices.getQuorumBitmapByOperatorIdAtBlockNumberByIndex: quorumBitmapUpdate is from after blockNumber");
         blsSignatureChecker.checkSignatures(
@@ -107,7 +107,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
         
         // set the totalStakeIndices to a different value
-        nonSignerStakesAndSignature.totalStakeIndices[0] = 0;
+        nonSignerStakesAndSignature.quorumTotalStakeIndices[0] = 0;
 
         cheats.expectRevert("StakeRegistry._validateOperatorStakeAtBlockNumber: there is a newer operatorStakeUpdate available before blockNumber");
         blsSignatureChecker.checkSignatures(
@@ -127,7 +127,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         (uint32 referenceBlockNumber, BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature) = 
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
 
-        bytes32 nonSignerOperatorId = nonSignerStakesAndSignature.nonSignerPubkeys[0].hashG1Point();
+        bytes32 nonSignerOperatorId = nonSignerStakesAndSignature.nonSignersPubkeysG1[0].hashG1Point();
         
         // record a stake update
         stakeRegistry.recordOperatorStakeUpdate(
@@ -141,7 +141,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
         );
         
         // set the nonSignerStakeIndices to a different value
-        nonSignerStakesAndSignature.nonSignerStakeIndices[0][0] = 1;
+        nonSignerStakesAndSignature.quorumNonSignersStakeIndices[0][0] = 1;
 
         cheats.expectRevert("StakeRegistry._validateOperatorStakeAtBlockNumber: operatorStakeUpdate is from after blockNumber");
         blsSignatureChecker.checkSignatures(
@@ -184,7 +184,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
         
         // set the quorumApk to a different value
-        nonSignerStakesAndSignature.quorumApks[0] = nonSignerStakesAndSignature.quorumApks[0].negate();
+        nonSignerStakesAndSignature.quorumApksG1[0] = nonSignerStakesAndSignature.quorumApksG1[0].negate();
 
         cheats.expectRevert("BLSSignatureChecker.checkSignatures: quorumApk hash in storage does not match provided quorum apk");
         blsSignatureChecker.checkSignatures(
@@ -205,7 +205,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
         
         // set the sigma to a different value
-        nonSignerStakesAndSignature.sigma = nonSignerStakesAndSignature.sigma.negate();
+        nonSignerStakesAndSignature.signersAggSigG1 = nonSignerStakesAndSignature.signersAggSigG1.negate();
 
         cheats.expectRevert("BLSSignatureChecker.checkSignatures: signature is invalid");
         blsSignatureChecker.checkSignatures(
@@ -226,7 +226,7 @@ contract BLSSignatureCheckerUnitTests is BLSMockAVSDeployer {
             _registerSignatoriesAndGetNonSignerStakeAndSignatureRandom(pseudoRandomNumber, numNonSigners, quorumBitmap);
         
         // set the sigma to a different value
-        nonSignerStakesAndSignature.sigma.X++;
+        nonSignerStakesAndSignature.signersAggSigG1.X++;
 
         // expect a non-specific low-level revert, since this call will ultimately fail as part of the precompile call
         cheats.expectRevert();

--- a/src/test/utils/BLSMockAVSDeployer.sol
+++ b/src/test/utils/BLSMockAVSDeployer.sol
@@ -71,8 +71,8 @@ contract BLSMockAVSDeployer is MockAVSDeployer {
         address[] memory operators = new address[](maxOperatorsToRegister);
         BN254.G1Point[] memory pubkeys = new BN254.G1Point[](maxOperatorsToRegister);
         BLSSignatureChecker.NonSignerStakesAndSignature memory nonSignerStakesAndSignature;
-        nonSignerStakesAndSignature.quorumApks = new BN254.G1Point[](quorumNumbers.length);
-        nonSignerStakesAndSignature.nonSignerPubkeys = new BN254.G1Point[](numNonSigners);
+        nonSignerStakesAndSignature.quorumApksG1 = new BN254.G1Point[](quorumNumbers.length);
+        nonSignerStakesAndSignature.nonSignersPubkeysG1 = new BN254.G1Point[](numNonSigners);
         bytes32[] memory nonSignerOperatorIds = new bytes32[](numNonSigners);
         {
             uint256 signerIndex = 0;
@@ -84,8 +84,8 @@ contract BLSMockAVSDeployer is MockAVSDeployer {
                     signerIndex++;
                 } else if (nonSignerIndex < nonSignerPrivateKeys.length) {
                     privateKeys[i] = nonSignerPrivateKeys[nonSignerIndex];
-                    nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex] = BN254.generatorG1().scalar_mul(privateKeys[i]);
-                    nonSignerOperatorIds[nonSignerIndex] = nonSignerStakesAndSignature.nonSignerPubkeys[nonSignerIndex].hashG1Point();
+                    nonSignerStakesAndSignature.nonSignersPubkeysG1[nonSignerIndex] = BN254.generatorG1().scalar_mul(privateKeys[i]);
+                    nonSignerOperatorIds[nonSignerIndex] = nonSignerStakesAndSignature.nonSignersPubkeysG1[nonSignerIndex].hashG1Point();
                     nonSignerIndex++;
                 } else {
                     privateKeys[i] = signerPrivateKeys[signerIndex];
@@ -96,8 +96,8 @@ contract BLSMockAVSDeployer is MockAVSDeployer {
                 pubkeys[i] = BN254.generatorG1().scalar_mul(privateKeys[i]);
 
                 // add the public key to each quorum
-                for (uint j = 0; j < nonSignerStakesAndSignature.quorumApks.length; j++) {
-                    nonSignerStakesAndSignature.quorumApks[j] = nonSignerStakesAndSignature.quorumApks[j].plus(pubkeys[i]);
+                for (uint j = 0; j < nonSignerStakesAndSignature.quorumApksG1.length; j++) {
+                    nonSignerStakesAndSignature.quorumApksG1[j] = nonSignerStakesAndSignature.quorumApksG1[j].plus(pubkeys[i]);
                 }
             }
         }
@@ -118,12 +118,12 @@ contract BLSMockAVSDeployer is MockAVSDeployer {
             nonSignerOperatorIds
         );
 
-        nonSignerStakesAndSignature.nonSignerQuorumBitmapIndices = checkSignaturesIndices.nonSignerQuorumBitmapIndices;
-        nonSignerStakesAndSignature.apkG2 = aggSignerApkG2;
-        nonSignerStakesAndSignature.sigma = sigma;
+        nonSignerStakesAndSignature.nonSignersQuorumBitmapIndices = checkSignaturesIndices.nonSignersQuorumBitmapIndices;
+        nonSignerStakesAndSignature.signersApkG2 = aggSignerApkG2;
+        nonSignerStakesAndSignature.signersAggSigG1 = sigma;
         nonSignerStakesAndSignature.quorumApkIndices = checkSignaturesIndices.quorumApkIndices;
-        nonSignerStakesAndSignature.totalStakeIndices = checkSignaturesIndices.totalStakeIndices;
-        nonSignerStakesAndSignature.nonSignerStakeIndices = checkSignaturesIndices.nonSignerStakeIndices;
+        nonSignerStakesAndSignature.quorumTotalStakeIndices = checkSignaturesIndices.quorumTotalStakeIndices;
+        nonSignerStakesAndSignature.quorumNonSignersStakeIndices = checkSignaturesIndices.quorumNonSignersStakeIndices;
 
         return (referenceBlockNumber, nonSignerStakesAndSignature);
     }


### PR DESCRIPTION
Renamed the fields of NonSignerStakesAndSignature to be more consistent and added a huge comment describing how it's meant to be used above, since it was definitely the trickiest part to understand when writing an avs.

Talked to @gpsanant about this offline. This doesn't need to be merged now (since this would trickle down to a lot of needed offchain code changes), but leaving here as a suggestion, and we can merge this whenever. I personally think it would make this struct easier to understand, but I'm open to changing some of these.

Currently I followed the convention:
```
    Each field array can either be over signers, nonsigners, or quorums.
    We use the first word of the variable to represent what the array is over
      eg: []nonSignersPubkeysG1 -> array of nonSigners
      eg: []quorumApkG1 -> array of quorums
```
But we could also potentially use a `per...` suffix convention
```
nonSignersPubkeysG1 -> pubkeysG1PerNonSigners
quorumApkG1 -> apkG1PerQuorum
```

### Tests
Some unit tests are failing, but I don't think it's related to my changes.