### PR TITLE
Removed references to the slasher (left state variables alone)

### DIFF
--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -78,9 +78,6 @@ Registers the caller as an Operator in EigenLayer. The new Operator provides the
 * `stakerOptOutWindowBlocks <= MAX_STAKER_OPT_OUT_WINDOW_BLOCKS`: (~180 days)
 * Pause status MUST NOT be set: `PAUSED_NEW_DELEGATION`
 
-*As of M2*:
-* `require(!slasher.isFrozen(operator))` is currently a no-op
-
 #### `modifyOperatorDetails`
 
 ```solidity
@@ -137,9 +134,6 @@ Allows the caller (a Staker) to delegate their shares to an Operator. Delegation
 * The `operator` MUST already be an Operator
 * If the `operator` has a `delegationApprover`, the caller MUST provide a valid `approverSignatureAndExpiry` and `approverSalt`
 
-*As of M2*:
-* `require(!slasher.isFrozen(operator))` is currently a no-op
-
 #### `delegateToBySignature`
 
 ```solidity
@@ -163,9 +157,6 @@ Allows a Staker to delegate to an Operator by way of signature. This function ca
 *Requirements*: See `delegateTo` above. Additionally:
 * If caller is either the Operator's `delegationApprover` or the Operator, the `approverSignatureAndExpiry` and `approverSalt` can be empty
 * `stakerSignatureAndExpiry` MUST be a valid, unexpired signature over the correct hash and nonce
-
-*As of M2*:
-* `require(!slasher.isFrozen(operator))` is currently a no-op
 
 ---
 
@@ -311,8 +302,7 @@ For each strategy/share pair in the `Withdrawal`:
     * See [`EigenPodManager.addShares`](./EigenPodManager.md#eigenpodmanageraddshares)
 
 *As of M2*:
-* `slasher.canWithdraw` is currently a no-op
-* The `middlewareTimesIndex` parameter has to do with the Slasher, which currently does nothing. As of M2, this parameter has no bearing on anything and can be ignored. It is passed into a call to the Slasher, but the call is a no-op.
+* The `middlewareTimesIndex` parameter has to do with the Slasher, which currently does nothing. As of M2, this parameter has no bearing on anything and can be ignored.
 
 #### `completeQueuedWithdrawals`
 

--- a/docs/core/EigenPodManager.md
+++ b/docs/core/EigenPodManager.md
@@ -469,9 +469,6 @@ Whether each withdrawal is a full or partial withdrawal is determined by the val
     * `BeaconChainProofs.verifyWithdrawal` MUST verify the provided `withdrawalFields` against the provided `beaconStateRoot`
     * `BeaconChainProofs.verifyValidatorFields` MUST verify the provided `validatorFields` against the `beaconStateRoot`
 
-*As of M2*:
-* The `onlyNotFrozen` modifier is currently a no-op
-
 #### `DelayedWithdrawalRouter.createDelayedWithdrawal`
 
 TODO

--- a/docs/core/StrategyManager.md
+++ b/docs/core/StrategyManager.md
@@ -74,9 +74,6 @@ If the Staker is delegated to an Operator, the Operator's delegated shares are i
 * `strategy` in question MUST be whitelisted for deposits. 
 * See [`StrategyBaseTVLLimits.deposit`](#strategybasetvllimitsdeposit)
 
-*As of M2*:
-* The `onlyNotFrozen` modifier is currently a no-op
-
 #### `depositIntoStrategyWithSignature`
 
 ```solidity
@@ -100,9 +97,6 @@ function depositIntoStrategyWithSignature(
 
 *Requirements*: See `depositIntoStrategy` above. Additionally:
 * Caller MUST provide a valid, unexpired signature over the correct fields
-
-*As of M2*:
-* The `onlyNotFrozen` modifier is currently a no-op
 
 ---
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -99,11 +99,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         _;
     }
 
-    modifier onlyNotFrozen() {
-        require(!eigenPodManager.slasher().isFrozen(podOwner), "EigenPod.onlyNotFrozen: pod owner is frozen");
-        _;
-    }
-
     modifier hasNeverRestaked() {
         require(!hasRestaked, "EigenPod.hasNeverRestaked: restaking is enabled");
         _;
@@ -288,7 +283,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes[] calldata validatorFieldsProofs,
         bytes32[][] calldata validatorFields,
         bytes32[][] calldata withdrawalFields
-    ) external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_WITHDRAWAL) onlyNotFrozen {
+    ) external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_WITHDRAWAL) {
         require(
             (validatorFields.length == validatorFieldsProofs.length) &&
                 (validatorFieldsProofs.length == withdrawalProofs.length) &&

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -36,29 +36,11 @@ contract EigenPodManager is
         _;
     }
 
-    modifier onlyStrategyManager() {
-        require(msg.sender == address(strategyManager), "EigenPodManager.onlyStrategyManager: not strategyManager");
-        _;
-    }
-
     modifier onlyDelegationManager() {
         require(
             msg.sender == address(delegationManager),
             "EigenPodManager.onlyDelegationManager: not the DelegationManager"
         );
-        _;
-    }
-
-    modifier onlyNotFrozen(address staker) {
-        require(
-            !slasher.isFrozen(staker),
-            "EigenPodManager.onlyNotFrozen: staker has been frozen and may be subject to slashing"
-        );
-        _;
-    }
-
-    modifier onlyFrozen(address staker) {
-        require(slasher.isFrozen(staker), "EigenPodManager.onlyFrozen: staker has not been frozen");
         _;
     }
 


### PR DESCRIPTION
Reasoning - these are just simple method calls. We can always add them back in a future upgrade, even without a migration.

I'm removing them now because people (auditors, bounty hunters, ...) find them confusing and because the code has changed so much that it's no longer clear that the slasher will work the way it was intended to when these modifiers were added.