### PR TITLE
Remove tests that were failing due to deleted slasher checks

### DIFF
--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -135,33 +135,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         cheats.stopPrank();
         //check middlewareTimes entry is correct
         require(slasher.getMiddlewareTimesIndexStalestUpdateBlock(staker, 4) == 3, "middleware updateBlock update incorrect");
-        require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 4) == 10, "middleware serveUntil update incorrect");
-
-        //move timestamp to 6, one middleware is past newServeUntilBlock but the second middleware is still using the restaked funds.
-        cheats.warp(8);
-        //Also move the current block ahead one
-        cheats.roll(4);
-        
-        cheats.startPrank(staker);
-        //when called with the correct middlewareTimesIndex the call reverts
-
-        slasher.getMiddlewareTimesIndexStalestUpdateBlock(staker, 3);
-        
-        
-        {
-        uint256 correctMiddlewareTimesIndex = 4;
-        cheats.expectRevert("DelegationManager.completeQueuedAction: pending action is still slashable");
-        delegation.completeQueuedWithdrawal(queuedWithdrawal, tokensArray, correctMiddlewareTimesIndex, false);
-        }
-
-        //When called with a stale index the call should also revert.
-        {
-        uint256 staleMiddlewareTimesIndex = 2;
-        cheats.expectRevert("DelegationManager.completeQueuedAction: pending action is still slashable");
-        delegation.completeQueuedWithdrawal(queuedWithdrawal, tokensArray, staleMiddlewareTimesIndex, false);
-        }
-        
-        
+        require(slasher.getMiddlewareTimesIndexServeUntilBlock(staker, 4) == 10, "middleware serveUntil update incorrect");        
     }
 
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -701,17 +701,11 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
     // //                     validator status should be marked as ACTIVE
 
     function testProveSingleWithdrawalCredential() public {
-        // get beaconChainETH shares
-        int256 beaconChainETHBefore = eigenPodManager.podOwnerShares(podOwner);
-
         // ./solidityProofGen "ValidatorFieldsProof" 302913 true "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "withdrawal_credential_proof_302913.json"         setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
          setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
         IEigenPod pod = _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
         bytes32 validatorPubkeyHash = getValidatorPubkeyHash();
 
-
-        int256 beaconChainETHAfter = eigenPodManager.podOwnerShares(pod.podOwner());
-        assertTrue(beaconChainETHAfter - beaconChainETHBefore == int256(_calculateRestakedBalanceGwei(pod.MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR())*GWEI_TO_WEI), "pod balance not updated correcty");
         assertTrue(pod.validatorStatus(validatorPubkeyHash) == IEigenPod.VALIDATOR_STATUS.ACTIVE, "wrong validator status");
     }
 


### PR DESCRIPTION
Removes tests that are now failing because we got rid of "onlyNotFrozen" et al.

Also fixes broken EigenPod test. The test was broken because it was using the wrong value to calculate restaked balance after verifying withdrawal credentials.

I fixed it by just removing the line entirely because, as it turns out, the helper function used to deploy the pod and prove credentials also has a test for the exact same thing, except it uses the correct value.