### PR TITLE
deprecate broken rule and add a new one

### DIFF
--- a/certora/harnesses/StrategyManagerHarness.sol
+++ b/certora/harnesses/StrategyManagerHarness.sol
@@ -49,6 +49,10 @@ contract StrategyManagerHarness is StrategyManager {
     }
 
     function totalShares(address strategy) public view returns (uint256) {
-        return  IStrategy(strategy).totalShares();
+        return IStrategy(strategy).totalShares();
+    }
+
+    function get_stakerStrategyShares(address staker, IStrategy strategy) public view returns (uint256) {
+        return stakerStrategyShares[staker][strategy];
     }
 }


### PR DESCRIPTION
Remove the `totalSharesGeqSumOfShares` invariant, since the way we are enforcing this is now split between the StrategyManager + DelegationManager (rather than being solely enforced by the StrategyManager). Add  a new `newSharesIncreaseTotalShares` rule in its place, which verifies the modified behavior around share changes, and in particular verifies that the StrategyManager still exhibits the same behavior as before, when considered in isolation of the DelegationManager (i.e. ignoring the new `removeShares` + `addShares` functions)