### PR TITLE
update specs to include "nondet" summary of the calls to `ServiceMana…

### DIFF
--- a/certora/specs/core/DelegationManager.spec
+++ b/certora/specs/core/DelegationManager.spec
@@ -6,6 +6,9 @@ methods {
     function decreaseDelegatedShares(address,address,uint256) external;
 	function increaseDelegatedShares(address,address,uint256) external;
 
+    // external calls from DelegationManager to ServiceManager
+    function _.updateStakes(address[]) external => NONDET;
+
 	// external calls to Slasher
     function _.isFrozen(address) external => DISPATCHER(true);
 	function _.canWithdraw(address,uint32,uint256) external => DISPATCHER(true);

--- a/certora/specs/core/StrategyManager.spec
+++ b/certora/specs/core/StrategyManager.spec
@@ -10,6 +10,9 @@ methods {
 	function _.decreaseDelegatedShares(address,address,uint256) external => DISPATCHER(true);
 	function _.increaseDelegatedShares(address,address,uint256) external => DISPATCHER(true);
 
+    // external calls from DelegationManager to ServiceManager
+    function _.updateStakes(address[]) external => NONDET;
+
 	// external calls to Slasher
     function _.isFrozen(address) external => DISPATCHER(true);
 	function _.canWithdraw(address,uint32,uint256) external => DISPATCHER(true);

--- a/certora/specs/pods/EigenPodManager.spec
+++ b/certora/specs/pods/EigenPodManager.spec
@@ -6,6 +6,9 @@ methods {
     function _.decreaseDelegatedShares(address,address,uint256) external;
 	function _.increaseDelegatedShares(address,address,uint256) external;
 
+    // external calls from DelegationManager to ServiceManager
+    function _.updateStakes(address[]) external => NONDET;
+
 	// external calls to Slasher
     function _.isFrozen(address) external => DISPATCHER(true);
 	function _.canWithdraw(address,uint32,uint256) external => DISPATCHER(true);


### PR DESCRIPTION
…ger.updateStakes`

This basically means treating the function as 'view' -- see documentation here https://docs.certora.com/en/latest/docs/cvl/methods.html#summaries Seems like a reasonable assumption to add.