### PR TITLE
Validator Balance update Refactor

### DIFF
--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -169,18 +169,18 @@ interface IEigenPod {
                It also verifies a merkle proof of the validator's current beacon chain balance.  
      * @param oracleTimestamp The oracleTimestamp whose state root the `proof` will be proven against.
      *        Must be within `VERIFY_BALANCE_UPDATE_WINDOW_SECONDS` of the current block.
-     * @param validatorIndex is the index of the validator being proven, refer to consensus specs 
-     * @param balanceUpdateProof is the proof of the validator's balance and validatorFields in the balance tree and the balanceRoot to prove for
+     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
+     * @param balanceUpdateProofs is the proof of the validator's balance and validatorFields in the balance tree and the balanceRoot to prove for
      *                                    the StrategyManager in case it must be removed from the list of the podOwner's strategies
      * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
      * @dev For more details on the Beacon Chain spec, see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      */
-    function verifyBalanceUpdate(
+    function verifyBalanceUpdates(
         uint64 oracleTimestamp,
-        uint40 validatorIndex,
+        uint40[] calldata validatorIndices,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.BalanceUpdateProof calldata balanceUpdateProof,
-        bytes32[] calldata validatorFields
+        BeaconChainProofs.BalanceUpdateProof[] calldata balanceUpdateProofs,
+        bytes32[][] calldata validatorFields
     ) external;
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -503,19 +503,16 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
         ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkeyHash];
 
-
-        // Verify balance update timing:
-
-        // 1. Balance updates should only be performed on "ACTIVE" validators
-        require(
-            validatorInfo.status == VALIDATOR_STATUS.ACTIVE, 
-            "EigenPod.verifyBalanceUpdate: Validator not active"
-        );
-
-        // 2. Balance updates should be more recent than the most recent update
+        // 1. Balance updates should be more recent than the most recent update
         require(
             validatorInfo.mostRecentBalanceUpdateTimestamp < oracleTimestamp,
             "EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"
+        );
+
+        // 2. Balance updates should only be performed on "ACTIVE" validators
+        require(
+            validatorInfo.status == VALIDATOR_STATUS.ACTIVE, 
+            "EigenPod.verifyBalanceUpdate: Validator not active"
         );
 
         // 4. Balance updates should only be made before a validator is fully withdrawn. 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -212,8 +212,9 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             stateRootProof: stateRootProof.proof
         });
 
+        int256 sharesDeltaGwei;
         for (uint256 i = 0; i < validatorIndices.length; i++) {
-            _verifyBalanceUpdate(
+            sharesDeltaGwei += _verifyBalanceUpdate(
                 oracleTimestamp,
                 validatorIndices[i],
                 stateRootProof.beaconStateRoot,
@@ -221,6 +222,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
                 validatorFields[i]
             );
         }
+        eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei);
     }
 
     /**
@@ -497,7 +499,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes32 beaconStateRoot,
         BeaconChainProofs.BalanceUpdateProof calldata balanceUpdateProof,
         bytes32[] calldata validatorFields
-    ) internal {
+    ) internal returns(int256){
         
         uint64 validatorBalance = balanceUpdateProof.balanceRoot.getBalanceAtIndex(validatorIndex);
         bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
@@ -559,7 +561,8 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
                 newAmountGwei: newRestakedBalanceGwei,
                 previousAmountGwei: currentRestakedBalanceGwei
             });
-            eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei * int256(GWEI_TO_WEI));
+
+            return sharesDeltaGwei * int256(GWEI_TO_WEI);
         }
     }
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -172,6 +172,11 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         emit NonBeaconChainETHReceived(msg.value);
     }
 
+//     BeaconState(epochToTimestamp(validator.withdrawableEpoch))
+//     .next_withdrawal_validator_index 
+// <= validator.Index 
+// < BeaconState(oracleTimestamp).next_withdrawal_validator_index
+
     /**
      * @notice This function records an update (either increase or decrease) in a validator's balance.
      * @param oracleTimestamp The oracleTimestamp whose state root the proof will be proven against.
@@ -189,7 +194,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         BeaconChainProofs.BalanceUpdateProof[] calldata balanceUpdateProofs,
         bytes32[][] calldata validatorFields
     ) external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE) {
-
         require(
             (validatorIndices.length == balanceUpdateProofs.length) && (balanceUpdateProofs.length == validatorFields.length),
             "EigenPod.verifyBalanceUpdate: validatorIndices and proofs must be same length"

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -181,13 +181,13 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
      * @notice This function records an update (either increase or decrease) in a validator's balance.
      * @param oracleTimestamp The oracleTimestamp whose state root the proof will be proven against.
      *        Must be within `VERIFY_BALANCE_UPDATE_WINDOW_SECONDS` of the current block.
-     * @param validatorIndex is the index of the validator being proven, refer to consensus specs 
+     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
      * @param stateRootProof proves a `beaconStateRoot` against a block root fetched from the oracle
-     * @param balanceUpdateProof proves `validatorFields` and validator balance against the `beaconStateRoot`
+     * @param balanceUpdateProofs is a list of proofs that prove `validatorFields` and validator balance against the `beaconStateRoot` for each balance update being made
      * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
      * @dev For more details on the Beacon Chain spec, see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      */
-    function verifyBalanceUpdate(
+    function verifyBalanceUpdates(
         uint64 oracleTimestamp,
         uint40[] calldata validatorIndices,
         BeaconChainProofs.StateRootProof calldata stateRootProof,

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -217,7 +217,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
                 validatorFields[i]
             );
         }
-        eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei);
+        eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei * int256(GWEI_TO_WEI));
     }
 
     /**
@@ -494,7 +494,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes32 beaconStateRoot,
         BeaconChainProofs.BalanceUpdateProof calldata balanceUpdateProof,
         bytes32[] calldata validatorFields
-    ) internal returns(int256 sharesDeltaWei){
+    ) internal returns(int256 sharesDeltaGwei){
         
         uint64 validatorBalance = balanceUpdateProof.balanceRoot.getBalanceAtIndex(validatorIndex);
         bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
@@ -556,8 +556,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
                 newAmountGwei: newRestakedBalanceGwei,
                 previousAmountGwei: currentRestakedBalanceGwei
             });
-
-            return sharesDeltaGwei * int256(GWEI_TO_WEI);
         }
     }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -786,15 +786,22 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
         // ./solidityProofGen "BalanceUpdateProof" 302913 false 0 "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_notOverCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
-        validatorFields = getValidatorFields();
-        uint40 validatorIndex = uint40(getValidatorIndex());
+        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+        validatorFieldsArray[0] = getValidatorFields();
+
+        uint40[] memory validatorIndices = new uint40[](1);
+        validatorIndices[0] = uint40(getValidatorIndex());
+
+        BeaconChainProofs.BalanceUpdateProof[] memory proofs = new BeaconChainProofs.BalanceUpdateProof[](1);
+        proofs[0] = _getBalanceUpdateProof();
+
+
         bytes32 newBeaconStateRoot = getBeaconStateRoot();
         BeaconChainOracleMock(address(beaconChainOracle)).setOracleBlockRootAtTimestamp(newBeaconStateRoot);
-        BeaconChainProofs.BalanceUpdateProof memory proofs = _getBalanceUpdateProof();
         BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();
 
         cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"));
-        newPod.verifyBalanceUpdate(uint64(block.timestamp), validatorIndex, stateRootProofStruct, proofs, validatorFields);
+        newPod.verifyBalanceUpdate(uint64(block.timestamp), validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);
     }
 
     function testDeployingEigenPodRevertsWhenPaused() external {

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -801,7 +801,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();
 
         cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"));
-        newPod.verifyBalanceUpdate(uint64(block.timestamp), validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);
+        newPod.verifyBalanceUpdates(uint64(block.timestamp), validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);
     }
 
     function testDeployingEigenPodRevertsWhenPaused() external {
@@ -922,11 +922,17 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
          // ./solidityProofGen "BalanceUpdateProof" 302913 true 0 "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "balanceUpdateProof_overCommitted_302913.json"
         setJSON("./src/test/test-data/balanceUpdateProof_overCommitted_302913.json");
-        validatorFields = getValidatorFields();
-        uint40 validatorIndex = uint40(getValidatorIndex());
+        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+        validatorFieldsArray[0] = getValidatorFields();
+
+        uint40[] memory validatorIndices = new uint40[](1);
+        validatorIndices[0] = uint40(getValidatorIndex());
+
+        BeaconChainProofs.BalanceUpdateProof[] memory proofs = new BeaconChainProofs.BalanceUpdateProof[](1);
+        proofs[0] = _getBalanceUpdateProof();
+
         bytes32 newBeaconStateRoot = getBeaconStateRoot();
         BeaconChainOracleMock(address(beaconChainOracle)).setOracleBlockRootAtTimestamp(newBeaconStateRoot);
-        BeaconChainProofs.BalanceUpdateProof memory proofs = _getBalanceUpdateProof();  
         BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();      
 
         // pause the contract
@@ -935,35 +941,46 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
 
         cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
-        newPod.verifyBalanceUpdate(0, validatorIndex, stateRootProofStruct, proofs, validatorFields);    
+        newPod.verifyBalanceUpdates(0, validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);    
     }
 
 
     function _proveOverCommittedStake(IEigenPod newPod) internal {
-        validatorFields = getValidatorFields();
-        uint40 validatorIndex = uint40(getValidatorIndex());
+        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+        validatorFieldsArray[0] = getValidatorFields();
+
+        uint40[] memory validatorIndices = new uint40[](1);
+        validatorIndices[0] = uint40(getValidatorIndex());
+
+        BeaconChainProofs.BalanceUpdateProof[] memory proofs = new BeaconChainProofs.BalanceUpdateProof[](1);
+        proofs[0] = _getBalanceUpdateProof();
+
+
         bytes32 newLatestBlockRoot = getLatestBlockRoot();
         BeaconChainOracleMock(address(beaconChainOracle)).setOracleBlockRootAtTimestamp(newLatestBlockRoot);
-        BeaconChainProofs.BalanceUpdateProof memory proofs = _getBalanceUpdateProof();
         BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();      
-        //cheats.expectEmit(true, true, true, true, address(newPod));
-        emit ValidatorBalanceUpdated(validatorIndex, uint64(block.number), _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
-        newPod.verifyBalanceUpdate(uint64(block.timestamp), validatorIndex, stateRootProofStruct, proofs, validatorFields);
+        newPod.verifyBalanceUpdates(uint64(block.timestamp), validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);
     }
 
     function _proveUnderCommittedStake(IEigenPod newPod) internal {
-        validatorFields = getValidatorFields();
-        uint40 validatorIndex = uint40(getValidatorIndex());
+        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+        validatorFieldsArray[0] = getValidatorFields();
+
+        uint40[] memory validatorIndices = new uint40[](1);
+        validatorIndices[0] = uint40(getValidatorIndex());
+
+        BeaconChainProofs.BalanceUpdateProof[] memory proofs = new BeaconChainProofs.BalanceUpdateProof[](1);
+        proofs[0] = _getBalanceUpdateProof();
+
         bytes32 newLatestBlockRoot = getLatestBlockRoot();
         BeaconChainOracleMock(address(beaconChainOracle)).setOracleBlockRootAtTimestamp(newLatestBlockRoot);
-        BeaconChainProofs.BalanceUpdateProof memory proofs = _getBalanceUpdateProof();
         BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();      
         
-        emit ValidatorBalanceUpdated(validatorIndex, uint64(block.number), _calculateRestakedBalanceGwei(Endian.fromLittleEndianUint64(validatorFields[BeaconChainProofs.VALIDATOR_BALANCE_INDEX])));
-        //cheats.expectEmit(true, true, true, true, address(newPod));
-        newPod.verifyBalanceUpdate(uint64(block.timestamp), validatorIndex, stateRootProofStruct, proofs, validatorFields);
+        newPod.verifyBalanceUpdates(uint64(block.timestamp), validatorIndices, stateRootProofStruct, proofs, validatorFieldsArray);
         require(newPod.validatorPubkeyHashToInfo(getValidatorPubkeyHash()).status == IEigenPod.VALIDATOR_STATUS.ACTIVE);
     }
+
+
 
     function testStake(bytes calldata _pubkey, bytes calldata _signature, bytes32 _depositDataRoot) public {
         // should fail if no/wrong value is provided

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -50,16 +50,6 @@ contract EigenPodMock is IEigenPod, Test {
     function validatorStatus(bytes32 pubkeyHash) external view returns(VALIDATOR_STATUS) {}
 
 
-    /**
-     * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to
-     * this contract. It also verifies the effective balance  of the validator.  It verifies the provided proof of the ETH validator against the beacon chain state
-     * root, marks the validator as 'active' in EigenLayer, and credits the restaked ETH in Eigenlayer.
-     * @param oracleTimestamp is the Beacon Chain blockNumber whose state root the `proof` will be proven against.
-     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
-     * @param withdrawalCredentialProofs is an array of proofs, where each proof proves each ETH validator's balance and withdrawal credentials against a beacon chain state root
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs 
-     * for details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
-     */
     function verifyWithdrawalCredentials(
         uint64 oracleTimestamp,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
@@ -69,33 +59,14 @@ contract EigenPodMock is IEigenPod, Test {
     ) external {}
 
     
-    /**
-     * @notice This function records an overcommitment of stake to EigenLayer on behalf of a certain ETH validator.
-     *         If successful, the overcommitted balance is penalized (available for withdrawal whenever the pod's balance allows).
-     *         The ETH validator's shares in the enshrined beaconChainETH strategy are also removed from the StrategyManager and undelegated.
-     * @param oracleTimestamp The oracleBlockNumber whose state root the `proof` will be proven against.
-     *        Must be within `VERIFY_OVERCOMMITTED_WINDOW_BLOCKS` of the current block.
-     * @param validatorIndex is the index of the validator being proven, refer to consensus specs 
-     * @param balanceUpdateProof is the proof of the validator's balance and validatorFields in the balance tree and the balanceRoot to prove for
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
-     * @dev For more details on the Beacon Chain spec, see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
-     */
-    function verifyBalanceUpdate(
+    function verifyBalanceUpdates(
         uint64 oracleTimestamp,
-        uint40 validatorIndex,
+        uint40[] calldata validatorIndices,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.BalanceUpdateProof calldata balanceUpdateProof,
-        bytes32[] calldata validatorFields
+        BeaconChainProofs.BalanceUpdateProof[] calldata balanceUpdateProofs,
+        bytes32[][] calldata validatorFields
     ) external {}
 
-    /**
-     * @notice This function records a full withdrawal on behalf of one of the Ethereum validators for this EigenPod
-     * @param oracleTimestamp is the timestamp of the oracle slot that the withdrawal is being proven against
-     * @param withdrawalProofs is the information needed to check the veracity of the block number and withdrawal being proven
-     * @param validatorFieldsProofs is the proof of the validator's fields in the validator tree
-     * @param withdrawalFields are the fields of the withdrawal being proven
-     * @param validatorFields are the fields of the validator being proven
-     */
     function verifyAndProcessWithdrawals(
         uint64 oracleTimestamp,
         BeaconChainProofs.StateRootProof calldata stateRootProof,

--- a/src/test/utils/EigenPodHarness.sol
+++ b/src/test/utils/EigenPodHarness.sol
@@ -1,7 +1,6 @@
 import "../../contracts/pods/EigenPod.sol";
 
-
-abstract contract EPInternalFunctions is EigenPod {
+contract EPInternalFunctions is EigenPod {
 
     constructor(
         IETHPOSDeposit _ethPOS,

--- a/src/test/utils/EigenPodHarness.sol
+++ b/src/test/utils/EigenPodHarness.sol
@@ -49,4 +49,25 @@ contract EPInternalFunctions is EigenPod {
             withdrawalAmountGwei
         );
     }
+
+    function verifyBalanceUpdate(
+        uint64 oracleTimestamp,
+        uint40 validatorIndex,
+        bytes32 beaconStateRoot,
+        BeaconChainProofs.BalanceUpdateProof calldata balanceUpdateProof,
+        bytes32[] calldata validatorFields,
+        uint64 mostRecentBalanceUpdateTimestamp
+    )
+        public
+    {
+        bytes32 pkhash = validatorFields[0];
+        _validatorPubkeyHashToInfo[pkhash].mostRecentBalanceUpdateTimestamp = mostRecentBalanceUpdateTimestamp;
+        _verifyBalanceUpdate(
+            oracleTimestamp,
+            validatorIndex,
+            beaconStateRoot,
+            balanceUpdateProof,
+            validatorFields
+        );
+    }
  }

--- a/src/test/utils/EigenPodHarness.sol
+++ b/src/test/utils/EigenPodHarness.sol
@@ -1,7 +1,7 @@
 import "../../contracts/pods/EigenPod.sol";
 
 
-contract EPInternalFunctions is EigenPod {
+abstract contract EPInternalFunctions is EigenPod {
 
     constructor(
         IETHPOSDeposit _ethPOS,


### PR DESCRIPTION
This PR refactors the validator balance updater to process multiple balance updates.  We allow this for verifying withdrawal credentials and withdrawals, it makes sense to do it here as well