### PR TITLE
Add `bool isPartialWithdrawal` to DelayedWithdrawalRouter struct

### DIFF
--- a/src/contracts/interfaces/IDelayedWithdrawalRouter.sol
+++ b/src/contracts/interfaces/IDelayedWithdrawalRouter.sol
@@ -4,8 +4,9 @@ pragma solidity >=0.5.0;
 interface IDelayedWithdrawalRouter {
     // struct used to pack data into a single storage slot
     struct DelayedWithdrawal {
-        uint224 amount;
+        uint216 amount;
         uint32 blockCreated;
+        bool isPartialWithdrawal;
     }
 
     // struct used to store a single users delayedWithdrawal data
@@ -15,7 +16,7 @@ interface IDelayedWithdrawalRouter {
     }
 
      /// @notice event for delayedWithdrawal creation
-    event DelayedWithdrawalCreated(address podOwner, address recipient, uint256 amount, uint256 index);
+    event DelayedWithdrawalCreated(address podOwner, address recipient, uint216 amount, uint256 index, bool isPartialWithdrawal);
 
     /// @notice event for the claiming of delayedWithdrawals
     event DelayedWithdrawalsClaimed(address recipient, uint256 amountClaimed, uint256 delayedWithdrawalsCompleted);
@@ -27,7 +28,7 @@ interface IDelayedWithdrawalRouter {
      * @notice Creates an delayed withdrawal for `msg.value` to the `recipient`.
      * @dev Only callable by the `podOwner`'s EigenPod contract.
      */
-    function createDelayedWithdrawal(address podOwner, address recipient) external payable;
+    function createDelayedWithdrawal(address podOwner, address recipient, bool isPartialWithdrawal) external payable;
 
     /**
      * @notice Called in order to withdraw delayed withdrawals made to the `recipient` that have passed the `withdrawalDelayBlocks` period.

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -44,7 +44,8 @@ interface IEigenPod {
      */
     struct VerifiedWithdrawal {
         // amount to send to a podOwner from a proven withdrawal
-        uint256 amountToSendGwei;
+        uint248 amountToSendGwei;
+        bool isPartialWithdrawal;
         // difference in shares to be recorded in the eigenPodManager, as a result of the withdrawal
         int256 sharesDeltaGwei;
     }

--- a/src/contracts/pods/DelayedWithdrawalRouter.sol
+++ b/src/contracts/pods/DelayedWithdrawalRouter.sol
@@ -66,24 +66,27 @@ contract DelayedWithdrawalRouter is
      */
     function createDelayedWithdrawal(
         address podOwner,
-        address recipient
+        address recipient,
+        bool isPartialWithdrawal
     ) external payable onlyEigenPod(podOwner) onlyWhenNotPaused(PAUSED_DELAYED_WITHDRAWAL_CLAIMS) {
         require(
             recipient != address(0),
             "DelayedWithdrawalRouter.createDelayedWithdrawal: recipient cannot be zero address"
         );
-        uint224 withdrawalAmount = uint224(msg.value);
+        uint216 withdrawalAmount = uint216(msg.value);
         if (withdrawalAmount != 0) {
             DelayedWithdrawal memory delayedWithdrawal = DelayedWithdrawal({
                 amount: withdrawalAmount,
-                blockCreated: uint32(block.number)
+                blockCreated: uint32(block.number),
+                isPartialWithdrawal: isPartialWithdrawal
             });
             _userWithdrawals[recipient].delayedWithdrawals.push(delayedWithdrawal);
             emit DelayedWithdrawalCreated(
                 podOwner,
                 recipient,
                 withdrawalAmount,
-                _userWithdrawals[recipient].delayedWithdrawals.length - 1
+                _userWithdrawals[recipient].delayedWithdrawals.length - 1,
+                isPartialWithdrawal
             );
         }
     }


### PR DESCRIPTION
This PR adds a bool `isPartialWithdrawal` to the `DelayedWithdrawal` struct and modifies the necessary EigenPod logic and tests.  The goal is to specify whether a `DelayedWithdrawal` pertains to partial or full withdrawal ETH which is helpful for proof of reserves for protocols that leverage native restaking.