### PR TITLE
Move VoteWeigherBase inheritance from StakeRegistryStorage

### DIFF
--- a/src/contracts/middleware/StakeRegistry.sol
+++ b/src/contracts/middleware/StakeRegistry.sol
@@ -7,6 +7,7 @@ import "../interfaces/IStakeRegistry.sol";
 import "../interfaces/IRegistryCoordinator.sol";
 import "../libraries/BitmapUtils.sol";
 import "./StakeRegistryStorage.sol";
+import "./VoteWeigherBase.sol";
 
 /**
  * @title A `Registry` that keeps track of stakes of operators for up to 256 quorums.
@@ -17,7 +18,7 @@ import "./StakeRegistryStorage.sol";
  * It allows an additional functionality (in addition to registering and deregistering) to update the stake of an operator.
  * @author Layr Labs, Inc.
  */
-contract StakeRegistry is StakeRegistryStorage {
+contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
     /// @notice requires that the caller is the RegistryCoordinator
     modifier onlyRegistryCoordinator() {
         require(
@@ -31,12 +32,7 @@ contract StakeRegistry is StakeRegistryStorage {
         IRegistryCoordinator _registryCoordinator,
         IStrategyManager _strategyManager,
         IServiceManager _serviceManager
-    )
-        StakeRegistryStorage(_registryCoordinator, _strategyManager, _serviceManager)
-    // solhint-disable-next-line no-empty-blocks
-    {
-
-    }
+    ) VoteWeigherBase(_strategyManager, _serviceManager) StakeRegistryStorage(_registryCoordinator) {}
 
     /**
      * @notice Sets the minimum stake for each quorum and adds `_quorumStrategiesConsideredAndMultipliers` for each
@@ -74,7 +70,10 @@ contract StakeRegistry is StakeRegistryStorage {
      * @param operatorId The id of the operator of interest.
      * @param quorumNumber The quorum number to get the stake for.
      */
-    function getOperatorIdToStakeHistory(bytes32 operatorId, uint8 quorumNumber) external view returns (OperatorStakeUpdate[] memory) {
+    function getOperatorIdToStakeHistory(
+        bytes32 operatorId,
+        uint8 quorumNumber
+    ) external view returns (OperatorStakeUpdate[] memory) {
         return operatorIdToStakeHistory[operatorId][quorumNumber];
     }
 

--- a/src/contracts/middleware/StakeRegistryStorage.sol
+++ b/src/contracts/middleware/StakeRegistryStorage.sol
@@ -4,14 +4,13 @@ pragma solidity =0.8.12;
 import "../interfaces/IServiceManager.sol";
 import "../interfaces/IStakeRegistry.sol";
 import "../interfaces/IRegistryCoordinator.sol";
-import "./VoteWeigherBase.sol";
 
 /**
  * @title Storage variables for the `StakeRegistry` contract.
  * @author Layr Labs, Inc.
  * @notice This storage contract is separate from the logic to simplify the upgrade process.
  */
-abstract contract StakeRegistryStorage is VoteWeigherBase, IStakeRegistry {
+abstract contract StakeRegistryStorage is IStakeRegistry {
     /// @notice the coordinator contract that this registry is associated with
     IRegistryCoordinator public immutable registryCoordinator;
 
@@ -25,13 +24,7 @@ abstract contract StakeRegistryStorage is VoteWeigherBase, IStakeRegistry {
     /// @notice mapping from operator's operatorId to the history of their stake updates
     mapping(bytes32 => mapping(uint8 => OperatorStakeUpdate[])) internal operatorIdToStakeHistory;
 
-    constructor(
-        IRegistryCoordinator _registryCoordinator,
-        IStrategyManager _strategyManager,
-        IServiceManager _serviceManager
-    ) VoteWeigherBase(_strategyManager, _serviceManager)
-    // solhint-disable-next-line no-empty-blocks
-    {
+    constructor(IRegistryCoordinator _registryCoordinator) {
         registryCoordinator = _registryCoordinator;
     }
 


### PR DESCRIPTION
For better readability and consistency for Storage contracts in general, moving the VoteWeigherBase contract inheritance from the  StakeRegistryStorage contract directly to StakeRegistry.

So instead we have the following
```
contract StakeRegistry is VoteWeigherBase, StakeRegistryStorage {
```