### PR TITLE
require cannot q withdrawal for 0 strategies and update docs

### DIFF
--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -241,7 +241,7 @@ The withdrawal can be completed by the `withdrawer` after `withdrawalDelayBlocks
 *Requirements*:
 * Pause status MUST NOT be set: `PAUSED_ENTER_WITHDRAWAL_QUEUE`
 * `strategies.length` MUST equal `shares.length`
-* `strategies.length` MUST be not equal to 0
+* `strategies.length` MUST NOT be equal to 0
 * The `withdrawer` MUST NOT be 0
 * See [`EigenPodManager.removeShares`](./EigenPodManager.md#eigenpodmanagerremoveshares)
 * See [`StrategyManager.removeShares`](./StrategyManager.md#removeshares)

--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -191,6 +191,7 @@ Note that becoming an Operator is irreversible! Although Operators can withdraw,
 *Effects*: 
 * Any shares held by the Staker in the `EigenPodManager` and `StrategyManager` are removed from the Operator's delegated shares.
 * The Staker is undelegated from the Operator
+* If the Staker has no delegatable shares, there is no withdrawal queued or further effects
 * A `Withdrawal` is queued for the Staker, tracking the strategies and shares being withdrawn
     * The Staker's withdrawal nonce is increased
     * The hash of the `Withdrawal` is marked as "pending"
@@ -240,6 +241,7 @@ The withdrawal can be completed by the `withdrawer` after `withdrawalDelayBlocks
 *Requirements*:
 * Pause status MUST NOT be set: `PAUSED_ENTER_WITHDRAWAL_QUEUE`
 * `strategies.length` MUST equal `shares.length`
+* `strategies.length` MUST be not equal to 0
 * The `withdrawer` MUST NOT be 0
 * See [`EigenPodManager.removeShares`](./EigenPodManager.md#eigenpodmanagerremoveshares)
 * See [`StrategyManager.removeShares`](./StrategyManager.md#removeshares)

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -254,14 +254,19 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         emit StakerUndelegated(staker, operator);
         delegatedTo[staker] = address(0);
 
-        // Remove all strategies/shares from staker and operator and place into queue
-        return _removeSharesAndQueueWithdrawal({
-            staker: staker,
-            operator: operator,
-            withdrawer: staker,
-            strategies: strategies,
-            shares: shares
-        });
+        // if no delegatable shares, return zero root, and don't queue a withdrawal
+        if (strategies.length == 0) {
+            return bytes32(0);
+        } else {
+            // Remove all strategies/shares from staker and operator and place into queue
+            return _removeSharesAndQueueWithdrawal({
+                staker: staker,
+                operator: operator,
+                withdrawer: staker,
+                strategies: strategies,
+                shares: shares
+            });
+        }
     }
 
      /**
@@ -678,7 +683,8 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         uint256[] memory shares
     ) internal returns (bytes32) {
         require(staker != address(0), "DelegationManager._removeSharesAndQueueWithdrawal: staker cannot be zero address");
-
+        require(strategies.length != 0, "DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
+    
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
         for (uint256 i = 0; i < strategies.length;) {

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1360,6 +1360,10 @@ contract DelegationUnitTests is EigenLayerTestHelper {
 
         (bytes32 returnValue) = delegationManager.undelegate(staker);
 
+        if (strategies.length == 0) {
+            withdrawalRoot = bytes32(0);
+        }
+
         // check that the return value is the withdrawal root
         require(returnValue == withdrawalRoot, "contract returned wrong return value");
         cheats.stopPrank();


### PR DESCRIPTION
Make it so that withdrawals for 0 strats cannot occur

Special case:
- return bytes32(0) if undelegating with no delegatable shares