### PR TITLE
chore: remove never-used storage at end of storage layout and increas…

### DIFF
--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -64,12 +64,6 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      */
     mapping(address => int256) public podOwnerShares;
 
-    /// @notice Mapping: podOwner => cumulative number of queued withdrawals of beaconchainETH they have ever initiated. only increments (doesn't decrement)
-    mapping(address => uint256) public cumulativeWithdrawalsQueued;
-
-    /// @notice Mapping: hash of withdrawal inputs, aka 'withdrawalRoot' => whether the withdrawal is pending
-    mapping(bytes32 => bool) public withdrawalRootPending;
-
     constructor(
         IETHPOSDeposit _ethPOS,
         IBeacon _eigenPodBeacon,
@@ -89,5 +83,5 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[43] private __gap;
+    uint256[45] private __gap;
 }


### PR DESCRIPTION
…e __gap size to compensate

This storage is at the end of the used slots in the storage layout, and was never used either on testnet or mainnet. Therefore, it should be able to be safety deleted without consequence. This commit also increases the size of the __gap variable to compensate for the removed storage.