### PR TITLE
chore: filter fuzzed inputs to fix 2 flaky test failures

### DIFF
--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -471,6 +471,8 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             //uint256 strategyTokenBalance = strategyArray[i].underlyingToken().balanceOf(address(strategyArray[i]));
             uint256 tokenBalanceDelta = (strategyTokenBalance[i] * shareAmounts[i]) / priorTotalShares[i];
 
+            // filter out unrealistic case, where the withdrawer is the strategy contract itself
+            cheats.assume(withdrawer != address(strategyArray[i]));
             require(
                 strategyArray[i].underlyingToken().balanceOf(withdrawer) == balanceBefore[i] + tokenBalanceDelta,
                 "_testCompleteQueuedWithdrawalTokens: withdrawer balance not incremented"

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -294,6 +294,8 @@ contract DelegationUnitTests is EigenLayerTestHelper {
         cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
         cheats.assume(operatorDetails.earningsReceiver != address(0));
+        // filter out case where staker *is* the operator
+        cheats.assume(staker != _operator);
 
         // register *this contract* as an operator
         IDelegationManager.OperatorDetails memory _operatorDetails = IDelegationManager.OperatorDetails({

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -160,7 +160,7 @@ contract EigenPodManagerUnitTests_Initialization_Setters is EigenPodManagerUnitT
             0 /*initialPausedStatus*/);
     }
 
-    function testFuzz_setMaxPods_revert_notUnpauser(address notUnpauser) public {
+    function testFuzz_setMaxPods_revert_notUnpauser(address notUnpauser) public filterFuzzedAddressInputs(notUnpauser) {
         cheats.assume(notUnpauser != unpauser);
         cheats.prank(notUnpauser);
         cheats.expectRevert("msg.sender is not permissioned as unpauser");


### PR DESCRIPTION
1) failure in a test that appears to be due to the fuzzed 'withdrawer' matching a Strategy's address -- see run here https://github.com/Layr-Labs/eigenlayer-contracts/actions/runs/6672856290/job/18137522930#step:5:46

2) failure in a test when the fuzzed 'staker' address matches a fixed operator address which we are using (the reverting behavior is intended in this case) -- see run here https://github.com/Layr-Labs/eigenlayer-contracts/actions/runs/6672856290/job/18137724519#step:5:116