### PR TITLE
DO NOT MERGE - feat: BROKEN implementation of prioritizing paying down "share debt" …

### DIFF
--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -269,11 +269,11 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         int256 newShareAmount = eigenPodManager.podOwnerShares(podOwner) + withdrawalSummary.sharesDeltaGwei;
         if (newShareAmount < 0) {
             // check if the `amountToSendGwei` is enough to pay off the existing share debt. pay off all debt if possible, or only some of it if not.
-            if (withdrawalSummary.amountToSendGwei >= (-newShareAmount)) {
-                withdrawalSummary.amountToSendGwei += newShareAmount;
-                verifiedWithdrawal.sharesDeltaGwei -= newShareAmount;
+            if (withdrawalSummary.amountToSendGwei >= uint256(-newShareAmount)) {
+                withdrawalSummary.amountToSendGwei -= uint256(-newShareAmount);
+                withdrawalSummary.sharesDeltaGwei -= newShareAmount;
             } else {
-                verifiedWithdrawal.sharesDeltaGwei += withdrawalSummary.amountToSendGwei;
+                withdrawalSummary.sharesDeltaGwei += int256(withdrawalSummary.amountToSendGwei);
                 withdrawalSummary.amountToSendGwei = 0;
             }
         }


### PR DESCRIPTION
…with partial withdrawals

note that this change introduces a path by which a user can unfairly increase their beacon chain ETH shares:
- queue withdrawal (of "beacon chain ETH shares") in EigenLayer
- get slashed on beacon chain
- prove balance update (decrease) to EigenLayer, end up with negative beacon chain ETH shares
- prove some partial withdrawals (could be old or new), which would then "pay off" the negative beacon chain ETH share balance
- complete the withdrawal "as shares", getting credited with the full, original amount of "beacon chain ETH shares"

end result is that the user has more "beacon chain ETH shares" than the combined balances of their validators