### PR TITLE
chore: use a fixed prover version

### DIFF
--- a/.github/workflows/certora-prover.yml
+++ b/.github/workflows/certora-prover.yml
@@ -43,7 +43,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Install certora
-        run: pip install certora-cli
+        run: pip install certora-cli==4.13.1
       - name: Install solc
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-static-linux


### PR DESCRIPTION
Certora will be introducing v5 soon, which is expected to include breaking changes. Fixing the version at v4.13.1 should allow continuity until we make changes to upgrade.