### PR TITLE
Integration testing ideas

### DIFF
--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -145,10 +145,9 @@ contract DelegationTests is EigenLayerTestHelper {
         _testDelegation(operator, staker, ethAmount, eigenAmount);
 
         (IStrategy[] memory strategyArray, uint256[] memory shareAmounts) = strategyManager.getDeposits(staker);
-        uint256[] memory strategyIndexes = new uint256[](strategyArray.length);
 
         // withdraw shares
-        _testQueueWithdrawal(staker, strategyIndexes, strategyArray, shareAmounts, staker /*withdrawer*/);
+        _testQueueWithdrawal(staker, strategyArray, shareAmounts, staker /*withdrawer*/);
 
         cheats.startPrank(staker);
         delegation.undelegate(staker);

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.12;
 
 import "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
 import "src/contracts/interfaces/ISignatureUtils.sol";
+import "src/test/mocks/StakeRegistryStub.sol";
 
 import "../test/EigenLayerTestHelper.t.sol";
 

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -14,7 +14,6 @@ contract DelegationTests is EigenLayerTestHelper {
 
     address public registryCoordinator = address(uint160(uint256(keccak256("registryCoordinator"))));
     StakeRegistryStub public stakeRegistry;
-    uint8 defaultQuorumNumber = 0;
     bytes32 defaultOperatorId = bytes32(uint256(0));
 
     modifier fuzzedAmounts(uint256 ethAmount, uint256 eigenAmount) {
@@ -71,10 +70,6 @@ contract DelegationTests is EigenLayerTestHelper {
         cheats.assume(ethAmount >= 1);
         cheats.assume(eigenAmount >= 2);
 
-        // Set weights ahead of the helper function call
-        bytes memory quorumNumbers = new bytes(2);
-        quorumNumbers[0] = bytes1(uint8(0));
-        quorumNumbers[0] = bytes1(uint8(1));
         _testDelegation(operator, staker, ethAmount, eigenAmount);
     }
 

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -26,6 +26,13 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         return _testDepositWeth(defaultStaker, amountToDeposit);
     }
 
+    function testQueueWithdrawal_Weth() public returns (Staker memory /*stakerStateAfter*/) {
+        uint256 amountToDeposit = 10e18;
+        Staker memory stakerStateBefore = testWethDeposit_abstractStakerStruct(amountToDeposit);
+        // queue the withdrawal to the staker themself
+        return _testQueueWithdraw_AllShares(stakerStateBefore, stakerStateBefore.staker);
+    }
+
 
 
 

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -6,36 +6,6 @@ import "./mocks/ERC20_OneWeiFeeOnTransfer.sol";
 
 contract DepositWithdrawTests is EigenLayerTestHelper {
     uint256[] public emptyUintArray;
-    Staker public defaultStaker;
-
-    function setUp() public virtual override {
-        EigenLayerDeployer.setUp();
-        // minimal set up for staker object. just give it an address
-        defaultStaker.staker = address(1234567);
-    }
-
-    /**
-     * @notice Verifies that it is possible to deposit WETH
-     * @param amountToDeposit Fuzzed input for amount of WETH to deposit
-     */
-    function testWethDeposit_abstractStakerStruct(uint256 amountToDeposit) public returns (Staker memory /*stakerStateAfter*/) {
-        // if first deposit amount to base strategy is too small, it will revert. ignore that case here.
-        cheats.assume(amountToDeposit >= 1);
-        // sanity-limiting on fuzzed input size
-        cheats.assume(amountToDeposit <= wethInitialSupply);
-        return _testDepositWeth(defaultStaker, amountToDeposit);
-    }
-
-    function testQueueWithdrawal_Weth() public returns (Staker memory /*stakerStateAfter*/) {
-        uint256 amountToDeposit = 10e18;
-        Staker memory stakerStateBefore = testWethDeposit_abstractStakerStruct(amountToDeposit);
-        // queue the withdrawal to the staker themself
-        return _testQueueWithdraw_AllShares(stakerStateBefore, stakerStateBefore.staker);
-    }
-
-
-
-
 
     /**
      * @notice Verifies that it is possible to deposit WETH

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -35,8 +35,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         {
         uint256[] memory shareAmounts = new uint256[](1);
         shareAmounts[0] = depositAmount - 1 gwei; //leave some shares behind so we don't get undelegation issues
-        uint256[] memory strategyIndexes = new uint256[](1);
-        strategyIndexes[0] = 0;
         address withdrawer = staker;
         
         {   
@@ -98,7 +96,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
                                 strategyArray,
                                 tokensArray,
                                 shareAmounts,
-                                strategyIndexes,
                                 withdrawer
                                 );
         
@@ -232,7 +229,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
      /**
      * @notice Modified from existing _createQueuedWithdrawal, skips delegation and deposit steps so that we can isolate the withdrawal step
      * @notice Creates a queued withdrawal from `staker`, queues a withdrawal using
-     * `delegation.queueWithdrawal(strategyIndexes, strategyArray, tokensArray, shareAmounts, withdrawer)`
+     * `delegation.queueWithdrawal(strategyArray, tokensArray, shareAmounts, withdrawer)`
      * @notice After initiating a queued withdrawal, this test checks that `delegation.canCompleteQueuedWithdrawal` immediately returns the correct
      * response depending on whether `staker` is delegated or not.
      * @param staker The address to initiate the queued withdrawal
@@ -245,7 +242,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         IStrategy[] memory strategyArray,
         IERC20[] memory /*tokensArray*/,
         uint256[] memory shareAmounts,
-        uint256[] memory /*strategyIndexes*/,
         address withdrawer
     )
         internal returns(bytes32 withdrawalRoot, IDelegationManager.Withdrawal memory queuedWithdrawal)

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -38,7 +38,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         address withdrawer = staker;
         
         {   
-            assertTrue(!delegation.isDelegated(staker), "_createQueuedWithdrawal: staker is already delegated");
+            assertTrue(!delegation.isDelegated(staker), "staker is already delegated");
             IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
                 earningsReceiver: staker,
                 delegationApprover: address(0),
@@ -46,7 +46,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             });
             _testRegisterAsOperator(staker, operatorDetails);
             assertTrue(
-                delegation.isDelegated(staker), "_createQueuedWithdrawal: staker isn't delegated when they should be"
+                delegation.isDelegated(staker), "staker isn't delegated when they should be"
             );
         
             //make deposit in WETH strategy
@@ -227,7 +227,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
 
 
      /**
-     * @notice Modified from existing _createQueuedWithdrawal, skips delegation and deposit steps so that we can isolate the withdrawal step
+     * @notice Modified from existing _createOnlyQueuedWithdrawal, skips delegation and deposit steps so that we can isolate the withdrawal step
      * @notice Creates a queued withdrawal from `staker`, queues a withdrawal using
      * `delegation.queueWithdrawal(strategyArray, tokensArray, shareAmounts, withdrawer)`
      * @notice After initiating a queued withdrawal, this test checks that `delegation.canCompleteQueuedWithdrawal` immediately returns the correct
@@ -246,7 +246,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
     )
         internal returns(bytes32 withdrawalRoot, IDelegationManager.Withdrawal memory queuedWithdrawal)
     {
-        require(amountToDeposit >= shareAmounts[0], "_createQueuedWithdrawal: sanity check failed");
+        require(amountToDeposit >= shareAmounts[0], "_createOnlyQueuedWithdrawal: sanity check failed");
 
         queuedWithdrawal = IDelegationManager.Withdrawal({
             strategies: strategyArray,

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -2,11 +2,33 @@
 pragma solidity =0.8.12;
 
 import "./EigenLayerTestHelper.t.sol";
-import "../contracts/core/StrategyManagerStorage.sol";
 import "./mocks/ERC20_OneWeiFeeOnTransfer.sol";
 
 contract DepositWithdrawTests is EigenLayerTestHelper {
     uint256[] public emptyUintArray;
+    Staker public defaultStaker;
+
+    function setUp() public virtual override {
+        EigenLayerDeployer.setUp();
+        // minimal set up for staker object. just give it an address
+        defaultStaker.staker = address(1234567);
+    }
+
+    /**
+     * @notice Verifies that it is possible to deposit WETH
+     * @param amountToDeposit Fuzzed input for amount of WETH to deposit
+     */
+    function testWethDeposit_abstractStakerStruct(uint256 amountToDeposit) public returns (Staker memory /*stakerStateAfter*/) {
+        // if first deposit amount to base strategy is too small, it will revert. ignore that case here.
+        cheats.assume(amountToDeposit >= 1);
+        // sanity-limiting on fuzzed input size
+        cheats.assume(amountToDeposit <= wethInitialSupply);
+        return _testDepositWeth(defaultStaker, amountToDeposit);
+    }
+
+
+
+
 
     /**
      * @notice Verifies that it is possible to deposit WETH

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -25,7 +25,6 @@ import "../contracts/permissions/PauserRegistry.sol";
 
 import "./utils/Operators.sol";
 
-import "./mocks/LiquidStakingToken.sol";
 import "./mocks/EmptyContract.sol";
 import "./mocks/ETHDepositMock.sol";
 import "./mocks/BeaconChainOracleMock.sol";
@@ -71,8 +70,6 @@ contract EigenLayerDeployer is Operators {
 
     uint256 wethInitialSupply = 10e50;
     uint256 public constant eigenTotalSupply = 1000e18;
-    uint256 nonce = 69;
-    uint256 public gasLimit = 750000;
     uint32 PARTIAL_WITHDRAWAL_FRAUD_PROOF_PERIOD_BLOCKS = 7 days / 12 seconds;
     uint256 REQUIRED_BALANCE_WEI = 32 ether;
     uint64 MAX_PARTIAL_WTIHDRAWAL_AMOUNT_GWEI = 1 ether / 1e9;
@@ -85,7 +82,6 @@ contract EigenLayerDeployer is Operators {
     address operator = address(0x4206904396bF2f8b173350ADdEc5007A52664293); //sk: e88d9d864d5d731226020c5d2f02b62a4ce2a4534a39c225d32d3db795f83319
     address acct_0 = cheats.addr(uint256(priv_key_0));
     address acct_1 = cheats.addr(uint256(priv_key_1));
-    address _challenger = address(0x6966904396bF2f8b173350bCcec5007A52669873);
     address public eigenLayerReputedMultisig = address(this);
 
     address eigenLayerProxyAdminAddress;
@@ -101,8 +97,6 @@ contract EigenLayerDeployer is Operators {
     address emptyContractAddress;
     address operationsMultisig;
     address executorMultisig;
-
-    uint256 public initialBeaconChainOracleThreshold = 3;
 
     string internal goerliDeploymentConfig = vm.readFile("script/output/M1_deployment_goerli_2023_3_23.json");
 

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -80,8 +80,6 @@ contract EigenLayerDeployer is Operators {
     bytes32 priv_key_0 = 0x1234567812345678123456781234567812345678123456781234567812345678;
     bytes32 priv_key_1 = 0x1234567812345678123456781234567812345698123456781234567812348976;
 
-    //strategy indexes for undelegation (see commitUndelegation function)
-    uint256[] public strategyIndexes;
     address[2] public stakers;
     address sample_registrant = cheats.addr(436364636);
 

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -34,29 +34,6 @@ import "forge-std/Test.sol";
 contract EigenLayerDeployer is Operators {
     Vm cheats = Vm(HEVM_ADDRESS);
 
-    struct Staker {
-        // the Staker's own address
-        address staker;
-        // all strategies that the Staker has deposits in
-        IStrategy[] strategies;
-        // the amount of shares that the Staker has in each of the `strategies`
-        uint256[] shares;
-        // the operator who the staker is delegatedTo (zero address if not delegated)
-        address delegatedTo;
-        // list of all _uncompleted_ withdrawals created by the Staker
-        IDelegationManager.Withdrawal[] queuedWithdrawals;
-    }
-
-    struct Operator {
-        // the Operator's own address
-        address operator;
-        // info about the operator stored in the DelegationManager
-        IDelegationManager.OperatorDetails operatorDetails;
-        // list of all stakers who are delegated to the operator. Should include the Operator themself.
-        address[] delegatedStakers;
-        // TODO: info about AVS registrations
-    }
-
     // EigenLayer contracts
     ProxyAdmin public eigenLayerProxyAdmin;
     PauserRegistry public eigenLayerPauserReg;

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -35,6 +35,8 @@ contract EigenLayerDeployer is Operators {
     Vm cheats = Vm(HEVM_ADDRESS);
 
     struct Staker {
+        // the Staker's own address
+        address staker;
         // all strategies that the Staker has deposits in
         IStrategy[] strategies;
         // the amount of shares that the Staker has in each of the `strategies`
@@ -46,6 +48,8 @@ contract EigenLayerDeployer is Operators {
     }
 
     struct Operator {
+        // the Operator's own address
+        address operator;
         // info about the operator stored in the DelegationManager
         IDelegationManager.OperatorDetails operatorDetails;
         // list of all stakers who are delegated to the operator. Should include the Operator themself.

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -34,6 +34,25 @@ import "forge-std/Test.sol";
 contract EigenLayerDeployer is Operators {
     Vm cheats = Vm(HEVM_ADDRESS);
 
+    struct Staker {
+        // all strategies that the Staker has deposits in
+        IStrategy[] strategies;
+        // the amount of shares that the Staker has in each of the `strategies`
+        uint256[] shares;
+        // the operator who the staker is delegatedTo (zero address if not delegated)
+        address delegatedTo;
+        // list of all _uncompleted_ withdrawals created by the Staker
+        IDelegationManager.Withdrawal[] queuedWithdrawals;
+    }
+
+    struct Operator {
+        // info about the operator stored in the DelegationManager
+        IDelegationManager.OperatorDetails operatorDetails;
+        // list of all stakers who are delegated to the operator. Should include the Operator themself.
+        address[] delegatedStakers;
+        // TODO: info about AVS registrations
+    }
+
     // EigenLayer contracts
     ProxyAdmin public eigenLayerProxyAdmin;
     PauserRegistry public eigenLayerPauserReg;

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -12,6 +12,16 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
     uint256[] priorTotalShares;
     uint256[] strategyTokenBalance;
 
+    // takes in a Staker struct and modifies it in place
+    function _updateStakerState(Staker memory staker) internal view {
+        (IStrategy[] memory stakerStrategies, uint256[] memory stakerShares) = strategyManager.getDeposits(staker.staker);
+        staker.strategies = stakerStrategies;
+        staker.shares = stakerShares;
+        staker.delegatedTo = delegation.delegatedTo(staker.staker);
+
+        // TODO: add some invariant checks?
+    }
+
     /**
      * @notice Register 'sender' as an operator, setting their 'OperatorDetails' in DelegationManager to 'operatorDetails', verifies
      * that the storage of DelegationManager contract is updated appropriately

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -7,10 +7,6 @@ import "../contracts/interfaces/ISignatureUtils.sol";
 import "./mocks/StakeRegistryStub.sol";
 
 contract EigenLayerTestHelper is EigenLayerDeployer {
-    uint8 durationToInit = 2;
-    uint256 public SECP256K1N_MODULUS = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
-    uint256 public SECP256K1N_MODULUS_HALF = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
-
     uint256[] sharesBefore;
     uint256[] balanceBefore;
     uint256[] priorTotalShares;
@@ -307,24 +303,6 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
         //queue the withdrawal
         withdrawalRoot = _testQueueWithdrawal(staker, strategyIndexes, strategyArray, shareAmounts, withdrawer);
         return (withdrawalRoot, queuedWithdrawal);
-    }
-
-    /**
-     * Helper for ECDSA signatures: combines V and S into VS - if S is greater than SECP256K1N_MODULUS_HALF, then we
-     * get the modulus, so that the leading bit of s is always 0.  Then we set the leading
-     * bit to be either 0 or 1 based on the value of v, which is either 27 or 28
-     */
-    function getVSfromVandS(uint8 v, bytes32 s) internal view returns (bytes32) {
-        if (uint256(s) > SECP256K1N_MODULUS_HALF) {
-            s = bytes32(SECP256K1N_MODULUS - uint256(s));
-        }
-
-        bytes32 vs = s;
-        if (v == 28) {
-            vs = bytes32(uint256(s) ^ (1 << 255));
-        }
-
-        return vs;
     }
 
     /// @notice registers a fixed address as an operator, delegates to it from a second address,

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -30,7 +30,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
         return updatedState;
     }
 
-    function _strategyInStakerList(Staker memory staker, IStrategy strategy) internal view returns (bool) {
+    function _strategyInStakerList(Staker memory staker, IStrategy strategy) internal pure returns (bool) {
         for (uint256 i = 0; i < staker.strategies.length; ++i) {
             if (staker.strategies[i] == strategy) {
                 return true;
@@ -39,7 +39,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
         return false;
     }
 
-    function _stakerShares(Staker memory staker, IStrategy strategy)  internal view returns (uint256) {
+    function _stakerShares(Staker memory staker, IStrategy strategy)  internal pure returns (uint256) {
         for (uint256 i = 0; i < staker.strategies.length; ++i) {
             if (staker.strategies[i] == strategy) {
                 return staker.shares[i];
@@ -94,7 +94,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
 
         // whitelist the strategy for deposit, in the case where it wasn't before
         {
-            if (strategyManager.strategyIsWhitelistedForDeposit(stratToDepositTo)) {
+            if (!strategyManager.strategyIsWhitelistedForDeposit(stratToDepositTo)) {
                 IStrategy[] memory _strategy = new IStrategy[](1);
                 _strategy[0] = stratToDepositTo;
                 cheats.prank(strategyManager.strategyWhitelister());
@@ -188,7 +188,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
 
         // whitelist the strategy for deposit, in the case where it wasn't before
         {
-            if (strategyManager.strategyIsWhitelistedForDeposit(stratToDepositTo)) {
+            if (!strategyManager.strategyIsWhitelistedForDeposit(stratToDepositTo)) {
                 IStrategy[] memory _strategy = new IStrategy[](1);
                 _strategy[0] = stratToDepositTo;
                 cheats.prank(strategyManager.strategyWhitelister());

--- a/src/test/ExampleIntegrationTest.t.sol
+++ b/src/test/ExampleIntegrationTest.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "./utils/User.sol";
+
+contract ExampleIntegrationTest is EigenLayerDeployer {
+
+    function testDepositAndWithdrawWethAsShares() public {
+        // create a new user
+        User staker = new User();
+
+        uint256 amountToDeposit = 10e18;
+        uint256 amountToWithdraw = 5e18;
+
+        // give staker funds to deposit
+        weth.transfer(staker.user(), amountToDeposit);
+
+        staker.depositToStrategy(amountToDeposit, weth, wethStrat);
+
+        uint256 userSharesBeforeWithdrawal = strategyManager.stakerStrategyShares(staker.user(), wethStrat);
+
+        IStrategy[] memory strategies = new IStrategy[](1);
+        strategies[0] = wethStrat;
+        uint256[] memory shares = new uint256[](1);
+        shares[0] = amountToWithdraw;
+        address withdrawer = staker.user();
+
+        staker.queueWithdrawal(strategies, shares, withdrawer);
+
+        staker.completeOldestQueuedWithdrawalAsShares();
+
+        uint256 userSharesAfterWithdrawal = strategyManager.stakerStrategyShares(staker.user(), wethStrat);
+
+        assertEq(userSharesBeforeWithdrawal, userSharesAfterWithdrawal, "user shares changed inappropriately");
+    }
+}

--- a/src/test/Withdrawals.t.sol
+++ b/src/test/Withdrawals.t.sol
@@ -81,12 +81,9 @@ contract WithdrawalTests is EigenLayerTestHelper {
             dataForTestWithdrawal.nonce = 0;
         }
 
-        uint256[] memory strategyIndexes = new uint256[](2);
         IERC20[] memory tokensArray = new IERC20[](2);
         {
             // hardcoded values
-            strategyIndexes[0] = 0;
-            strategyIndexes[1] = 0;
             tokensArray[0] = weth;
             tokensArray[1] = eigenToken;
         }
@@ -96,7 +93,6 @@ contract WithdrawalTests is EigenLayerTestHelper {
 
         _testQueueWithdrawal(
             depositor,
-            strategyIndexes,
             dataForTestWithdrawal.delegatorStrategies,
             dataForTestWithdrawal.delegatorShares,
             withdrawer
@@ -182,12 +178,9 @@ contract WithdrawalTests is EigenLayerTestHelper {
             dataForTestWithdrawal.nonce = 0;
         }
 
-        uint256[] memory strategyIndexes = new uint256[](2);
         IERC20[] memory tokensArray = new IERC20[](2);
         {
             // hardcoded values
-            strategyIndexes[0] = 0;
-            strategyIndexes[1] = 0;
             tokensArray[0] = weth;
             tokensArray[1] = eigenToken;
         }
@@ -197,7 +190,6 @@ contract WithdrawalTests is EigenLayerTestHelper {
 
         _testQueueWithdrawal(
             depositor,
-            strategyIndexes,
             dataForTestWithdrawal.delegatorStrategies,
             dataForTestWithdrawal.delegatorShares,
             dataForTestWithdrawal.withdrawer
@@ -301,10 +293,6 @@ contract WithdrawalTests is EigenLayerTestHelper {
     //     (IStrategy[] memory updatedStrategies, uint256[] memory updatedShares) =
     //         strategyManager.getDeposits(staker);
 
-    //     uint256[] memory strategyIndexes = new uint256[](2);
-    //     strategyIndexes[0] = 0;
-    //     strategyIndexes[1] = 1;
-
     //     IERC20[] memory tokensArray = new IERC20[](2);
     //     tokensArray[0] = weth;
     //     tokensArray[0] = eigenToken;
@@ -313,7 +301,7 @@ contract WithdrawalTests is EigenLayerTestHelper {
     //     cheats.expectRevert(
     //         bytes("StrategyManager.onlyNotFrozen: staker has been frozen and may be subject to slashing")
     //     );
-    //     _testQueueWithdrawal(staker, strategyIndexes, updatedStrategies, updatedShares, staker);
+    //     _testQueueWithdrawal(staker, updatedStrategies, updatedShares, staker);
     // }
 
     // Helper function to begin a delegation

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -416,6 +416,9 @@ contract EigenPodUnitTests_VerifyWithdrawalCredentialsTests is EigenPodHarnessSe
     }
 
     function testFuzz_revert_invalidValidatorFields(address wrongWithdrawalAddress) public {
+        // filter fuzzed input; the call will pass in the event that these two addresses collide
+        cheats.assume(wrongWithdrawalAddress != address(eigenPodHarness));
+
         // Set JSON and params
         setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
         _setWithdrawalCredentialParams();

--- a/src/test/utils/User.sol
+++ b/src/test/utils/User.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "../EigenLayerDeployer.t.sol";
+
+contract User is Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    EigenLayerDeployer public immutable globalState;
+    address public immutable user;
+
+
+    // TODO: decide if the following storage is useful
+    // list of all _uncompleted_ withdrawals created by the user
+    IDelegationManager.Withdrawal[] public queuedWithdrawals;
+
+    // list of all stakers who are delegated to the user, _if_ they are an operator. Should include the Operator themself.
+    address[] public delegatedStakers;
+    // TODO: info about AVS registrations
+
+    // testing/mock contracts
+    // IERC20 public eigenToken;
+    // IERC20 public weth;
+    // StrategyBase public wethStrat;
+    // StrategyBase public eigenStrat;
+    // StrategyBase public baseStrategyImplementation;
+    // EmptyContract public emptyContract;
+
+    constructor(EigenLayerDeployer globalStateContract) {
+        globalState = globalStateContract;
+        user = address(this);
+    }
+
+    function eigenLayerProxyAdmin() public view returns(ProxyAdmin) {
+        return globalState.eigenLayerProxyAdmin();
+    }
+    function eigenLayerPauserReg() public view returns(PauserRegistry) {
+        return globalState.eigenLayerPauserReg();
+    }
+    function slasher() public view returns(Slasher) {
+        return globalState.slasher();
+    }
+    function delegation() public view returns(DelegationManager) {
+        return globalState.delegation();
+    }
+    function strategyManager() public view returns(StrategyManager) {
+        return globalState.strategyManager();
+    }
+    function eigenPodManager() public view returns(EigenPodManager) {
+        return globalState.eigenPodManager();
+    }
+    function pod() public view returns(IEigenPod) {
+        return globalState.pod();
+    }
+    function delayedWithdrawalRouter() public view returns(IDelayedWithdrawalRouter) {
+        return globalState.delayedWithdrawalRouter();
+    }
+    function ethPOSDeposit() public view returns(IETHPOSDeposit) {
+        return globalState.ethPOSDeposit();
+    }
+    function eigenPodBeacon() public view returns(IBeacon) {
+        return globalState.eigenPodBeacon();
+    }
+
+    function strategyInStakerList(IStrategy strategy) public view returns (bool) {
+        (IStrategy[] memory strategies, /* uint256[] memory shares */) = strategyManager().getDeposits(user);
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            if (strategies[i] == strategy) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function stakerShares(IStrategy strategy) public view returns (uint256) {
+        (IStrategy[] memory strategies, uint256[] memory shares) = strategyManager().getDeposits(user);
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            if (strategies[i] == strategy) {
+                return shares[i];
+            }
+        }
+        return 0;
+    }
+
+    /*
+     * @notice Register this contract as an operator, setting their 'OperatorDetails' in DelegationManager to 'operatorDetails', verifies
+     * that the storage of DelegationManager contract is updated appropriately
+     */
+    function registerAsOperator(
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) public {
+        string memory emptyStringForMetadataURI;
+
+        cheats.prank(user);
+        delegation().registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+
+        assertTrue(delegation().isOperator(user), "testRegisterAsOperator: user is not a operator");
+        assertTrue(
+            keccak256(abi.encode(delegation().operatorDetails(user))) == keccak256(abi.encode(operatorDetails)),
+            "_testRegisterAsOperator: operatorDetails not set appropriately"
+        );
+        assertTrue(delegation().isDelegated(user), "_testRegisterAsOperator: user not marked as actively delegated");
+    }
+
+    /**
+     * @notice Default version of `registerAsOperator`. Does not set a `delegationApprover`.
+     */
+    function registerAsOperator() public {
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: user,
+            delegationApprover: address(0),
+            stakerOptOutWindowBlocks: uint32(0)
+        });
+        
+        registerAsOperator(operatorDetails);
+    }
+
+    // @notice Deposits `amountToDeposit` of `underlyingToken` from this contract into `stratToDepositTo`.
+    function depositToStrategy(
+        uint256 amountToDeposit,
+        IERC20 underlyingToken,
+        IStrategy stratToDepositTo
+    ) internal {
+        // deposits will revert when amountToDeposit is 0
+        require(amountToDeposit != 0, "bad usage of depositToStrategy helper function");
+
+        // whitelist the strategy for deposit, in the case where it wasn't before
+        {
+            if (!strategyManager().strategyIsWhitelistedForDeposit(stratToDepositTo)) {
+                IStrategy[] memory _strategy = new IStrategy[](1);
+                _strategy[0] = stratToDepositTo;
+                cheats.prank(strategyManager().strategyWhitelister());
+                strategyManager().addStrategiesToDepositWhitelist(_strategy);
+            }
+        }
+
+        // store prior state
+        uint256 stakerSharesBefore = strategyManager().stakerStrategyShares(user, stratToDepositTo);
+        uint256 stakerStrategyListLengthBefore = strategyManager().stakerStrategyListLength(user);
+        if (stakerSharesBefore != 0) {
+            assertTrue(strategyInStakerList(stratToDepositTo), "strategy somehow not in staker strategy array");
+        }
+        // calculate the expected output
+        uint256 expectedSharesOut = stratToDepositTo.underlyingToShares(amountToDeposit);
+
+        // perform the action itself
+        // assumes this contract already has the underlying token!
+        uint256 contractBalance = underlyingToken.balanceOf(address(this));
+        // logging and error for misusing this function (see assumption above)
+        if (amountToDeposit > contractBalance) {
+            emit log("amountToDeposit > contractBalance");
+            emit log_named_uint("amountToDeposit is", amountToDeposit);
+            emit log_named_uint("while contractBalance is", contractBalance);
+            revert("depositToStrategy test helper misuse");
+        } else {
+            underlyingToken.transfer(user, amountToDeposit);
+            cheats.startPrank(user);
+            underlyingToken.approve(address(strategyManager()), type(uint256).max);
+            strategyManager().depositIntoStrategy(stratToDepositTo, underlyingToken, amountToDeposit);
+            cheats.stopPrank();
+        }
+
+        // fetch post-action state
+        uint256 stakerSharesAfter = strategyManager().stakerStrategyShares(user, stratToDepositTo);
+        uint256 stakerStrategyListLengthAfter = strategyManager().stakerStrategyListLength(user);
+
+        // check if staker had zero shares before, that it is added correctly to stakerStrategyList array.
+        if (stakerSharesBefore == 0) {
+            assertTrue(
+                strategyManager().stakerStrategyList(user, stakerStrategyListLengthAfter - 1) ==
+                    stratToDepositTo,
+                "_testDepositToStrategy: stakerStrategyList array updated incorrectly"
+            );
+            assertEq(stakerStrategyListLengthAfter, stakerStrategyListLengthBefore + 1,
+                "strategy list did not update correctly");
+        // otherwise check that the list length was unmodified
+        } else {
+            assertEq(stakerStrategyListLengthAfter, stakerStrategyListLengthBefore,
+                "strategy list updated incorrectly");
+        }
+
+        // check that the shares difference matches the expected amount out
+        assertEq(
+            stakerSharesAfter - stakerSharesBefore, expectedSharesOut,
+            "_testDepositToStrategy: actual shares out should match expected shares out"
+        );
+        assertTrue(strategyInStakerList(stratToDepositTo), "strategy somehow not in staker strategy array");
+    }
+
+    // function _testQueueWithdrawal(
+    //     Staker memory stakerStateBefore,
+    //     IStrategy[] memory strategies,
+    //     uint256[] memory shares,
+    //     address withdrawer
+    // ) internal returns (Staker memory stakerStateAfter) {
+    //     // prepare struct for call
+    //     IDelegationManager.QueuedWithdrawalParams[] memory withdrawalParams =
+    //         new IDelegationManager.QueuedWithdrawalParams[](1);
+    //     withdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+    //         strategies: strategies,
+    //         shares: shares,
+    //         withdrawer: withdrawer
+    //     });
+
+    //     // actually make the call to queue the withdrawal
+    //     cheats.prank(stakerStateBefore.staker);
+    //     delegation.queueWithdrawals(withdrawalParams);
+
+    //     // update the Staker struct appropriately
+    //     stakerStateAfter = _updateStakerState(stakerStateBefore);
+    //     stakerStateAfter.queuedWithdrawals =
+    //         new IDelegationManager.Withdrawal[](stakerStateBefore.queuedWithdrawals.length + 1);
+    //     for (uint256 i = 0; i < stakerStateBefore.queuedWithdrawals.length; ++i) {
+    //         stakerStateAfter.queuedWithdrawals[i] = stakerStateBefore.queuedWithdrawals[i];
+    //     }
+    //     IDelegationManager.Withdrawal memory newWithdrawal = IDelegationManager.Withdrawal({
+    //         staker: stakerStateBefore.staker,
+    //         delegatedTo: stakerStateBefore.delegatedTo,
+    //         withdrawer: withdrawer,
+    //         nonce: delegation.stakerNonce(stakerStateBefore.staker),
+    //         startBlock: uint32(block.number),
+    //         strategies: strategies,
+    //         shares: shares
+    //     });
+    //     stakerStateAfter.queuedWithdrawals[stakerStateAfter.queuedWithdrawals.length - 1] = newWithdrawal;
+
+    //     // return the updated Staker struct
+    //     return stakerStateAfter;
+    // }
+
+    // // @notice queue a withdrawal from the Staker starting with `stakerStateBefore`, for all of their deposits, to `withdrawer`
+    // function _testQueueWithdraw_AllShares(Staker memory stakerStateBefore, address withdrawer)
+    //     internal returns (Staker memory stakerStateAfter)
+    // {
+    //     return _testQueueWithdrawal({
+    //         stakerStateBefore: stakerStateBefore,
+    //         strategies: stakerStateBefore.strategies,
+    //         shares: stakerStateBefore.shares,
+    //         withdrawer: withdrawer
+    //     });
+    // }
+
+}


### PR DESCRIPTION
Marking this as a draft initially.
Combines some cleanup of low-level deployment + helper functionality, and some ~scaffolding of ideas around abstract-ifying users.

Adding some thoughts after making a few more commits:

- I feel like it would be ~quite annoying to set up, and create perhaps a bit of a learning curve for using/writing tests, _but_ am feeling like this level of abstraction is closer to the “right” level, and that it would ultimately help to make our tests more modular + clearer, with more consistent (if redundant) checks on system properties + behavior.
- The present implementation stores everything in memory, which is just...super slow. We probably want to switch to using storage instead if we decide to go this route.
- This is also using a kind of awkward syntax at the moment -- it would be nice if we could support syntax like `Staker.updateState()` or `Staker.deposit(strategies, shares, withdrawer)` instead -- perhaps we should make 'Staker' a contract type instead of just a struct.
- my intuition is that this level of abstraction does not work the best when we want to check that reversion occurs. maybe a good, compatible solution is out there though.

Update (as of https://github.com/Layr-Labs/eigenlayer-contracts/pull/333/commits/674473377b8a68381a353aa7a17dae980accad50):
This now uses storage and abstracts users (a Staker and/or Operator) into a "User" contract. Feels better to me, at least.