### PR TITLE
Draft: Integration Test Architecture

### DIFF
--- a/src/test/integration/GlobalRefs.sol
+++ b/src/test/integration/GlobalRefs.sol
@@ -6,9 +6,9 @@ import "src/contracts/core/StrategyManager.sol";
 import "src/contracts/pods/EigenPodManager.sol";
 
 contract GlobalRefs {
-    EigenPodManager eigenPodManager;
-    DelegationManager delegationManager;
-    StrategyManager strategyManager;
+    EigenPodManager public eigenPodManager;
+    DelegationManager public delegationManager;
+    StrategyManager public strategyManager;
 
     constructor(EigenPodManager _eigenPodManager, DelegationManager _delegationManager, StrategyManager _strategyManager) {
         eigenPodManager = _eigenPodManager;

--- a/src/test/integration/GlobalRefs.sol
+++ b/src/test/integration/GlobalRefs.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/contracts/core/DelegationManager.sol";
+import "src/contracts/core/StrategyManager.sol";
+import "src/contracts/pods/EigenPodManager.sol";
+
+contract GlobalRefs {
+    EigenPodManager eigenPodManager;
+    DelegationManager delegationManager;
+    StrategyManager strategyManager;
+
+    constructor(EigenPodManager _eigenPodManager, DelegationManager _delegationManager, StrategyManager _strategyManager) {
+        eigenPodManager = _eigenPodManager;
+        delegationManager = _delegationManager;
+        strategyManager = _strategyManager;
+    }
+}

--- a/src/test/integration/IntegrationTestRunner.t.sol
+++ b/src/test/integration/IntegrationTestRunner.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+// Imports
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/IBeacon.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import "forge-std/Test.sol";
+
+import "src/contracts/core/DelegationManager.sol";
+import "src/contracts/core/StrategyManager.sol";
+import "src/contracts/core/Slasher.sol";
+import "src/contracts/strategies/StrategyBase.sol";
+import "src/contracts/pods/EigenPodManager.sol";
+import "src/contracts/pods/EigenPod.sol";
+import "src/contracts/pods/DelayedWithdrawalRouter.sol";
+import "src/contracts/permissions/PauserRegistry.sol";
+
+import "src/test/mocks/EmptyContract.sol";
+import "src/test/mocks/ETHDepositMock.sol";
+import "src/test/mocks/BeaconChainOracleMock.sol";
+
+abstract contract IntegrationTestRunner is Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    // Core contracts to deploy
+    PauserRegistry public pauserRegistry;
+    DelegationManager public delegationManager;
+    StrategyManager public strategyManager;
+    Slasher public slasher;
+    EigenPodManager public eigenPodManager;
+    IBeacon public eigenPodBeacon;
+    EigenPod public pod;
+    DelayedWithdrawalRouter public delayedWithdrawalRouter;
+    
+    // Mock Contracts to deploy
+    ETHPOSDepositMock public ethPOSDeposit;
+    BeaconChainOracleMock public beaconChainOracle;
+    
+    // ProxyAdmin
+    ProxyAdmin public eigenLayerProxyAdmin;
+
+    // Admin Addresses
+    address public eigenLayerReputedMultisig = address(this); // admin address
+    address public constant pauser = address(555);
+    address public constant unpauser = address(556);
+
+    // Constants
+    uint64 public constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
+    uint64 public constant GOERLI_GENESIS_TIME = 1616508000;
+
+    // Filter fuzz address utils
+    mapping(address => bool) public addressIsExcludedFromFuzzedInputs;
+    modifier filterFuzzedAddressInputs(address fuzzedAddress) {
+        cheats.assume(!addressIsExcludedFromFuzzedInputs[fuzzedAddress]);
+        _;
+    }
+
+    function setUp() public virtual {
+        // Deploy ProxyAdmin
+        eigenLayerProxyAdmin = new ProxyAdmin();
+
+        // Deploy PauserRegistry
+        address[] memory pausers = new address[](1);
+        pausers[0] = pauser;
+        pauserRegistry = new PauserRegistry(pausers, unpauser);
+
+        // Deploy mocks
+        EmptyContract emptyContract = new EmptyContract();
+        ethPOSDeposit = new ETHPOSDepositMock();
+        beaconChainOracle = new BeaconChainOracleMock();
+
+        /**
+         * First, deploy upgradeable proxy contracts that **will point** to the implementations. Since the implementation contracts are
+         * not yet deployed, we give these proxies an empty contract as the initial implementation, to act as if they have no code.
+         */
+        delegationManager = DelegationManager(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
+        strategyManager = StrategyManager(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
+        slasher = Slasher(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
+        eigenPodManager = EigenPodManager(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
+        delayedWithdrawalRouter = DelayedWithdrawalRouter(
+            address(new TransparentUpgradeableProxy(address(emptyContract), address(eigenLayerProxyAdmin), ""))
+        );
+
+        // Deploy EigenPod Contracts
+        pod = new EigenPod(
+            ethPOSDeposit,
+            delayedWithdrawalRouter,
+            eigenPodManager,
+            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
+            GOERLI_GENESIS_TIME
+        );
+
+        eigenPodBeacon = new UpgradeableBeacon(address(pod));
+
+        // Second, deploy the *implementation* contracts, using the *proxy contracts* as inputs
+        DelegationManager delegationImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
+        StrategyManager strategyManagerImplementation = new StrategyManager(delegationManager, eigenPodManager, slasher);
+        Slasher slasherImplementation = new Slasher(strategyManager, delegationManager);
+        EigenPodManager eigenPodManagerImplementation = new EigenPodManager(
+            ethPOSDeposit,
+            eigenPodBeacon,
+            strategyManager,
+            slasher,
+            delegationManager
+        );
+        DelayedWithdrawalRouter delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
+
+        // Third, upgrade the proxy contracts to point to the implementations
+        // DelegationManager
+        eigenLayerProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(delegationManager))),
+            address(delegationImplementation),
+            abi.encodeWithSelector(
+                DelegationManager.initialize.selector,
+                eigenLayerReputedMultisig, // initialOwner
+                pauserRegistry,
+                0 // initialPausedStatus
+            )
+        );
+        // StrategyManager
+        eigenLayerProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(strategyManager))),
+            address(strategyManagerImplementation),
+            abi.encodeWithSelector(
+                StrategyManager.initialize.selector,
+                eigenLayerReputedMultisig, //initialOwner
+                eigenLayerReputedMultisig, //initial whitelister
+                pauserRegistry,
+                0 // initialPausedStatus
+            )
+        );
+        // Slasher
+        eigenLayerProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(slasher))),
+            address(slasherImplementation),
+            abi.encodeWithSelector(
+                Slasher.initialize.selector,
+                eigenLayerReputedMultisig,
+                pauserRegistry,
+                0 // initialPausedStatus
+            )
+        );
+        // EigenPodManager
+        eigenLayerProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(eigenPodManager))),
+            address(eigenPodManagerImplementation),
+            abi.encodeWithSelector(
+                EigenPodManager.initialize.selector,
+                type(uint256).max, // maxPods
+                address(beaconChainOracle),
+                eigenLayerReputedMultisig, // initialOwner
+                pauserRegistry,
+                0 // initialPausedStatus
+            )
+        );
+        // Delayed Withdrawal Router
+        uint256 withdrawalDelayBlocks = 7 days / 12 seconds;
+        eigenLayerProxyAdmin.upgradeAndCall(
+            TransparentUpgradeableProxy(payable(address(delayedWithdrawalRouter))),
+            address(delayedWithdrawalRouterImplementation),
+            abi.encodeWithSelector(
+                DelayedWithdrawalRouter.initialize.selector,
+                eigenLayerReputedMultisig, // initialOwner
+                pauserRegistry,
+                0, // initialPausedStatus
+                withdrawalDelayBlocks
+            )
+        );
+    }
+}

--- a/src/test/integration/Operator.sol
+++ b/src/test/integration/Operator.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "forge-std/Test.sol";
+
+import "src/test/integration/GlobalRefs.sol";
+
+contract Operator is Test {
+    // Pointer to global reference contract
+    GlobalRefs globalRefs;
+
+    // Array of addresses who are delegated to staker
+    address[] public delegatedStaker;
+    mapping(address => bool) public isDelegatedStaker;
+
+
+    address operator = address(this);
+
+    // Delegation Signer Private Key
+    uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+
+    constructor(GlobalRefs _globalRefs) {
+        globalRefs = _globalRefs;
+    }
+
+    // Registration Functions
+    function register() public {
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: address(this),
+            delegationApprover: address(0),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(operatorDetails);
+    }
+
+    function _registerOperator(
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) internal {
+        string memory emptyStringForMetadataURI;
+        globalRefs.delegationManager().registerAsOperator(operatorDetails, emptyStringForMetadataURI); 
+
+        // Checks
+        assertEq(
+            operatorDetails.earningsReceiver,
+            globalRefs.delegationManager().earningsReceiver(operator),
+            "earningsReceiver not set correctly"
+        );
+        assertEq(
+            operatorDetails.delegationApprover,
+            globalRefs.delegationManager().delegationApprover(operator),
+            "delegationApprover not set correctly"
+        );
+        assertEq(
+            operatorDetails.stakerOptOutWindowBlocks,
+            globalRefs.delegationManager().stakerOptOutWindowBlocks(operator),
+            "stakerOptOutWindowBlocks not set correctly"
+        );
+        assertEq(globalRefs.delegationManager().delegatedTo(operator), operator, "operator not delegated to self");       
+    }
+
+    // Helper functions to update stakers that are delegated to this operator
+    function addDelegatedStaker(address staker) public {
+        if (!isDelegatedStaker[staker]) {
+            isDelegatedStaker[staker] = true;
+            delegatedStaker.push(staker);
+        }
+    }
+
+    function removeDelegatedStaker(address staker) public {
+        if (isDelegatedStaker[staker]) {
+            isDelegatedStaker[staker] = false;
+            for (uint256 i = 0; i < delegatedStaker.length; i++) {
+                if (delegatedStaker[i] == staker) {
+                    delegatedStaker[i] = delegatedStaker[delegatedStaker.length - 1];
+                    delegatedStaker.pop();
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/test/integration/Operator.sol
+++ b/src/test/integration/Operator.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import "forge-std/Test.sol";
-
+import "src/test/integration/Staker.sol";
 import "src/test/integration/GlobalRefs.sol";
 
-contract Operator is Test {
-    // Pointer to global reference contract
-    GlobalRefs globalRefs;
-
+contract Operator is Staker {
     // Array of addresses who are delegated to staker
     address[] public delegatedStaker;
     mapping(address => bool) public isDelegatedStaker;
@@ -19,9 +15,7 @@ contract Operator is Test {
     // Delegation Signer Private Key
     uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
 
-    constructor(GlobalRefs _globalRefs) {
-        globalRefs = _globalRefs;
-    }
+    constructor(GlobalRefs _globalRefs) Staker (_globalRefs){}
 
     // Registration Functions
     function register() public {
@@ -56,6 +50,11 @@ contract Operator is Test {
             "stakerOptOutWindowBlocks not set correctly"
         );
         assertEq(globalRefs.delegationManager().delegatedTo(operator), operator, "operator not delegated to self");       
+    }
+
+    // Override staker functions that operator shouldn't call
+    function delegate(address operator) public override {
+        revert("Operator cannot delegate since it's delegated to itself");
     }
 
     // Helper functions to update stakers that are delegated to this operator

--- a/src/test/integration/Operator.sol
+++ b/src/test/integration/Operator.sol
@@ -26,7 +26,7 @@ contract Operator is Test {
     // Registration Functions
     function register() public {
         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: address(this),
+            earningsReceiver: operator,
             delegationApprover: address(0),
             stakerOptOutWindowBlocks: 0
         });

--- a/src/test/integration/Scenario.t.sol
+++ b/src/test/integration/Scenario.t.sol
@@ -36,7 +36,7 @@ contract TestScenario is IntegrationTestRunner {
         // Queue Withdrawal for entire strategy balance
         staker.queueFullWithdrawal(strategy1);
 
-        // Complete Queued Withdrawal
-        staker.completeQueuedWithdrawal();
+        // Complete first (0-indexed) queued withdrawal
+        staker.completeQueuedWithdrawal(0);
     }
 }

--- a/src/test/integration/Scenario.t.sol
+++ b/src/test/integration/Scenario.t.sol
@@ -28,7 +28,8 @@ contract TestScenario is IntegrationTestRunner {
         operator.register();
 
         // Delegate To Operator
-        staker.delegate(operator);
+        staker.delegate(address(operator));
+        operator.addDelegatedStaker(address(staker));
 
         // Deposit into strategy
         staker.depositIntoStrategy(strategy1, strategy1Token, 1000);

--- a/src/test/integration/Scenario.t.sol
+++ b/src/test/integration/Scenario.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/test/integration/IntegrationTestRunner.t.sol";
+import "src/test/integration/Staker.sol";
+import "src/test/integration/GlobalRefs.sol";
+
+contract TestScenario is IntegrationTestRunner {
+
+    GlobalRefs globalRefs;
+    Staker staker;
+
+    function setUp() public override {
+        // Setup parent
+        IntegrationTestRunner.setUp();
+
+        // Deploy Global Reference Contract
+        globalRefs = new GlobalRefs(eigenPodManager, delegationManager, strategyManager);
+
+        // Deploy Staker Contract
+        staker = new Staker(globalRefs);
+    }
+    function test_flow1() public {
+        assertTrue(true);
+    }
+}

--- a/src/test/integration/Scenario.t.sol
+++ b/src/test/integration/Scenario.t.sol
@@ -2,13 +2,14 @@
 pragma solidity =0.8.12;
 
 import "src/test/integration/IntegrationTestRunner.t.sol";
+import "src/test/integration/Operator.sol";
 import "src/test/integration/Staker.sol";
 import "src/test/integration/GlobalRefs.sol";
 
 contract TestScenario is IntegrationTestRunner {
-
     GlobalRefs globalRefs;
     Staker staker;
+    Operator operator;
 
     function setUp() public override {
         // Setup parent
@@ -17,10 +18,25 @@ contract TestScenario is IntegrationTestRunner {
         // Deploy Global Reference Contract
         globalRefs = new GlobalRefs(eigenPodManager, delegationManager, strategyManager);
 
-        // Deploy Staker Contract
+        // Deploy Staker and Operator contracts
         staker = new Staker(globalRefs);
+        operator = new Operator(globalRefs);
     }
+
     function test_flow1() public {
-        assertTrue(true);
+        // Register Operator
+        operator.register();
+
+        // Delegate To Operator
+        staker.delegate(operator);
+
+        // Deposit into strategy
+        staker.depositIntoStrategy(strategy1, strategy1Token, 1000);
+
+        // Queue Withdrawal for entire strategy balance
+        staker.queueFullWithdrawal(strategy1);
+
+        // Complete Queued Withdrawal
+        staker.completeQueuedWithdrawal();
     }
 }

--- a/src/test/integration/Staker.sol
+++ b/src/test/integration/Staker.sol
@@ -1,20 +1,103 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.12;
 
-import "src/test/integration/GlobalRefs.sol";
+import "forge-std/Test.sol";
 
-contract Staker {
+import "src/contracts/interfaces/IDelegationManager.sol";
+
+import "src/test/integration/GlobalRefs.sol";
+import "src/test/integration/Operator.sol";
+
+contract Staker is Test {
+    // Pointer to global reference contract
     GlobalRefs globalRefs;
+
+    // Local Storage
+    IDelegationManager.Withdrawal[] public queuedWithdrawals;
+
+    // Staker Address
+    address staker = address(this);
 
     constructor(GlobalRefs _globalRefs) {
         globalRefs = _globalRefs;
     }
 
-    function depositIntoStrategy() public {}
+    function delegate(Operator operator) public {
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        bytes32 emptySalt;
+        _delegate(operator, approverSignatureAndExpiry, emptySalt);
+    }
 
-    function delegate() public {}
+    function _delegate(Operator operator, ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt) internal {
+        //TODO: get operator shares before and operator shares after and compare
+        globalRefs.delegationManager().delegateTo(address(operator), approverSignatureAndExpiry, approverSalt);
 
-    function queueWithdrawal() public {}
+        // Checks
+        assertEq(globalRefs.delegationManager().delegatedTo(staker), address(operator), "staker delegated to the wrong address");
+        
+        // Update operator's delegatedStaker array
+        operator.addDelegatedStaker(address(this));
+    }
 
-    function completeQueuedWithdrawal() public {} 
+    function delegateWithSig() public {}
+
+    function depositIntoStrategy(IStrategy strategy, IERC20 token, uint256 amount) public {
+        _dealTokenToStaker(token, amount);
+        token.approve(address(globalRefs.strategyManager()), amount);
+
+        uint256 shares = globalRefs.strategyManager().depositIntoStrategy(strategy, token, amount);
+
+        // TODO: checks
+    }
+
+    function queueFullWithdrawal(IStrategy strategy) public {
+        queueWithdrawal(strategy, globalRefs.strategyManager().stakerStrategyShares(staker, strategy));
+    }
+
+    function queueWithdrawal(IStrategy strategy, uint256 sharesToWithdraw) public {
+        // Initialize/populate strategy and share arrays
+        IStrategy[] memory strategyArray = new IStrategy[](1);
+        strategyArray[0] = strategy;
+        uint256[] memory shareAmounts = new uint256[](1);
+        shareAmounts[0] = sharesToWithdraw;
+
+        // Create params array
+        IDelegationManager.QueuedWithdrawalParams[] memory params = new IDelegationManager.QueuedWithdrawalParams[](1);
+        params[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategyArray,
+            shares: shareAmounts,
+            withdrawer: address(this)
+        });
+        _queueWithdrawal(params);
+    }
+
+    function queueWithdrawal(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) public {}
+
+    function _queueWithdrawal(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) public {
+        globalRefs.delegationManager().queueWithdrawals(queueWithdrawalParams);
+
+        //TODO: checks
+
+        // Update queuedWithdrawals array
+        for(uint256 i = 0; i < queueWithdrawalParams.length; i++) {
+            IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
+                staker: staker,
+                delegatedTo: globalRefs.delegationManager().delegatedTo(staker),
+                withdrawer: queueWithdrawalParams[i].withdrawer,
+                nonce: globalRefs.delegationManager().stakerNonce(staker) - queueWithdrawalParams.length - i,
+                startBlock: uint32(block.number),
+                strategies: queueWithdrawalParams[i].strategies,
+                shares: queueWithdrawalParams[i].shares
+            });
+            queuedWithdrawals.push(withdrawal);
+        }
+    }
+
+    function completeQueuedWithdrawal() public {
+        
+    } 
+
+    function _dealTokenToStaker(IERC20 token, uint256 amount) internal {
+        StdCheats.deal(address(token), staker, amount);
+    }
 }

--- a/src/test/integration/Staker.sol
+++ b/src/test/integration/Staker.sol
@@ -75,14 +75,14 @@ contract Staker is Test {
         assertEq(_getStakerSharesForStrategy(strategy), stakerSharesBefore + shares, "staker shares not updated correctly");
         assertEq(_getOperatorSharesForStrategy(strategy), operatorSharesBefore + shares, "operator shares not updated correctly");
         if (stakerSharesBefore == 0) {
-            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore + 1, "strategy not added to staker's strategy list");
+            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore + 1, "strategy not added to stakers strategy list");
             assertEq(
                 address(globalRefs.strategyManager().stakerStrategyList(staker, stakerStrategyListLengthBefore)),
                 address(strategy),
-                "strategy not added to staker's strategy list"
+                "strategy not added to stakers strategy list"
             );        
         } else {
-            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore, "staker's strategy list length changed");
+            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore, "stakers strategy list length changed");
         }
     }
 

--- a/src/test/integration/Staker.sol
+++ b/src/test/integration/Staker.sol
@@ -15,6 +15,11 @@ contract Staker is Test {
     // Local Storage
     IDelegationManager.Withdrawal[] public queuedWithdrawals;
 
+    // State to help with helper function checks
+    IStrategy[] internal _tempStakerStrategies; // array of strategies without duplicates
+    mapping(IStrategy => bool) internal _tempStrategyRead;
+    mapping(IStrategy => uint256) internal _tempStrategyShares;
+
     // Staker Address
     address staker = address(this);
 
@@ -26,32 +31,63 @@ contract Staker is Test {
         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
         bytes32 emptySalt;
         _delegate(operator, approverSignatureAndExpiry, emptySalt);
+
+        // Assert that salt is not spent
+        assertFalse(globalRefs.delegationManager().delegationApproverSaltIsSpent(
+            globalRefs.delegationManager().delegationApprover(address(operator)),
+            emptySalt
+        ), "salt somehow spent too early");
     }
 
     function _delegate(Operator operator, ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry, bytes32 approverSalt) internal {
-        //TODO: get operator shares before and operator shares after and compare
+        // Save pre-delegation state of operator 
+        (IStrategy[] memory stakerStrategies, uint256[] memory stakerShares) = globalRefs.delegationManager().getDelegatableShares(staker);
+        uint256[] memory operatorSharesBefore = new uint256[](stakerShares.length);
+        for (uint256 i = 0; i < stakerShares.length; i++) {
+            operatorSharesBefore[i] = globalRefs.delegationManager().operatorShares(address(operator), stakerStrategies[i]);
+        }
+
+        // Delegate to operator
         globalRefs.delegationManager().delegateTo(address(operator), approverSignatureAndExpiry, approverSalt);
 
         // Checks
         assertEq(globalRefs.delegationManager().delegatedTo(staker), address(operator), "staker delegated to the wrong address");
+        for(uint256 i = 0; i < stakerShares.length; i++) {
+            assertEq(globalRefs.delegationManager().operatorShares(address(operator), stakerStrategies[i]), operatorSharesBefore[i] + stakerShares[i], "operator shares not updated correctly");
+        }
         
         // Update operator's delegatedStaker array
         operator.addDelegatedStaker(address(this));
     }
 
-    function delegateWithSig() public {}
+    function depositIntoStrategy(IStrategy strategy, IERC20 token, uint256 amount) public returns (uint256 shares){
+        // Save pre-deposit state
+        uint256 stakerSharesBefore = _getStakerSharesForStrategy(strategy);
+        uint256 operatorSharesBefore = _getOperatorSharesForStrategy(strategy);
+        uint256 stakerStrategyListLengthBefore = globalRefs.strategyManager().stakerStrategyListLength(staker);
 
-    function depositIntoStrategy(IStrategy strategy, IERC20 token, uint256 amount) public {
+        // Deposit into strategy
         _dealTokenToStaker(token, amount);
         token.approve(address(globalRefs.strategyManager()), amount);
+        shares = globalRefs.strategyManager().depositIntoStrategy(strategy, token, amount);
 
-        uint256 shares = globalRefs.strategyManager().depositIntoStrategy(strategy, token, amount);
-
-        // TODO: checks
+        // Checks
+        assertEq(_getStakerSharesForStrategy(strategy), stakerSharesBefore + shares, "staker shares not updated correctly");
+        assertEq(_getOperatorSharesForStrategy(strategy), operatorSharesBefore + shares, "operator shares not updated correctly");
+        if (stakerSharesBefore == 0) {
+            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore + 1, "strategy not added to staker's strategy list");
+            assertEq(
+                address(globalRefs.strategyManager().stakerStrategyList(staker, stakerStrategyListLengthBefore)),
+                address(strategy),
+                "strategy not added to staker's strategy list"
+            );        
+        } else {
+            assertEq(globalRefs.strategyManager().stakerStrategyListLength(staker), stakerStrategyListLengthBefore, "staker's strategy list length changed");
+        }
     }
 
     function queueFullWithdrawal(IStrategy strategy) public {
-        queueWithdrawal(strategy, globalRefs.strategyManager().stakerStrategyShares(staker, strategy));
+        queueWithdrawal(strategy, _getStakerSharesForStrategy(strategy));
     }
 
     function queueWithdrawal(IStrategy strategy, uint256 sharesToWithdraw) public {
@@ -71,31 +107,138 @@ contract Staker is Test {
         _queueWithdrawal(params);
     }
 
-    function queueWithdrawal(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) public {}
+    function _queueWithdrawal(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) internal {
+        // Save pre-withdrawal state
+        (uint256[] memory stakerSharesBefore, uint256[] memory operatorSharesBefore) = _setPreQueuedWithdrawalState(queueWithdrawalParams);
 
-    function _queueWithdrawal(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) public {
-        globalRefs.delegationManager().queueWithdrawals(queueWithdrawalParams);
+        // Queue withdrawal
+        bytes32[] memory withdrawalRoots = globalRefs.delegationManager().queueWithdrawals(queueWithdrawalParams);
 
-        //TODO: checks
+        // Checks
+        assertEq(withdrawalRoots.length, queueWithdrawalParams.length, "withdrawal roots length mismatch");
+        for (uint256 i = 0; i < withdrawalRoots.length; i++) {
+            assertTrue(globalRefs.delegationManager().pendingWithdrawals(withdrawalRoots[i]), "withdrawal not pending");
+        }
+        assertEq(globalRefs.delegationManager().cumulativeWithdrawalsQueued(staker), queuedWithdrawals.length + queueWithdrawalParams.length, "cumulative withdrawals queued not updated correctly");
+        uint256 stakerSharesAfter;
+        uint256 operatorSharesAfter;
+        for(uint256 i = 0; i < _tempStakerStrategies.length; i++) {
+            stakerSharesAfter = _getStakerSharesForStrategy(_tempStakerStrategies[i]);
+            operatorSharesAfter = _getOperatorSharesForStrategy(_tempStakerStrategies[i]);
+            assertEq(stakerSharesAfter, stakerSharesBefore[i] - _tempStrategyShares[_tempStakerStrategies[i]], "staker shares not updated correctly");
+            assertEq(operatorSharesAfter, operatorSharesBefore[i] - _tempStrategyShares[_tempStakerStrategies[i]], "operator shares not updated correctly");
+        }
 
         // Update queuedWithdrawals array
+        uint256 nonce;
         for(uint256 i = 0; i < queueWithdrawalParams.length; i++) {
+            // Calculate nonce. Params.length is always <= cumulativeWithdrawalsQueued
+            if (queueWithdrawalParams.length == globalRefs.delegationManager().cumulativeWithdrawalsQueued(staker)){
+                nonce = i;
+            } else {
+                nonce = globalRefs.delegationManager().stakerNonce(staker) - queueWithdrawalParams.length - i;
+            }
+
             IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
                 staker: staker,
                 delegatedTo: globalRefs.delegationManager().delegatedTo(staker),
                 withdrawer: queueWithdrawalParams[i].withdrawer,
-                nonce: globalRefs.delegationManager().stakerNonce(staker) - queueWithdrawalParams.length - i,
+                nonce: nonce,
                 startBlock: uint32(block.number),
                 strategies: queueWithdrawalParams[i].strategies,
                 shares: queueWithdrawalParams[i].shares
             });
             queuedWithdrawals.push(withdrawal);
         }
+
+        // Clear out temp state
+        _clearTempState();
     }
 
-    function completeQueuedWithdrawal() public {
-        
+    // Completes queued withdrawal as tokens at given index
+    function completeQueuedWithdrawal(uint256 index) public {
+        _completeQueuedWithdrawal(index);
     } 
+
+    // Completes queued withdrawal as tokens
+    function _completeQueuedWithdrawal(uint256 index) internal {
+        // Setup withdrawal struct & store pre-withdrawal state
+        IDelegationManager.Withdrawal memory withdrawal = queuedWithdrawals[index];
+        IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
+        for (uint256 i = 0; i < withdrawal.strategies.length; i++) {
+            tokens[i] = withdrawal.strategies[i].underlyingToken();
+        }
+
+        // Store pre withdrawal state for checks
+        for(uint256 i = 0; i < withdrawal.strategies.length; i++) {
+            if (!_tempStrategyRead[withdrawal.strategies[i]]) {
+                _tempStrategyRead[withdrawal.strategies[i]]= true;
+                _tempStakerStrategies.push(withdrawal.strategies[i]);
+            }
+            _tempStrategyShares[withdrawal.strategies[i]] += withdrawal.shares[i];
+        }
+        uint256[] memory balancesBefore = new uint256[](_tempStakerStrategies.length);
+        uint256[] memory expectedTokensOut = new uint256[](_tempStakerStrategies.length);
+        uint256[] memory totalSharesBefore = new uint256[](_tempStakerStrategies.length);
+        for(uint256 i = 0; i < _tempStakerStrategies.length; i++) {
+            balancesBefore[i] = _tempStakerStrategies[i].underlyingToken().balanceOf(staker);
+            expectedTokensOut[i] = _tempStakerStrategies[i].sharesToUnderlying(_tempStrategyShares[_tempStakerStrategies[i]]);
+            totalSharesBefore[i] = _tempStakerStrategies[i].totalShares();
+        }
+
+        // Complete queued withdrawal
+        globalRefs.delegationManager().completeQueuedWithdrawal(withdrawal, tokens, 0, true);
+
+        // Checks
+        for(uint256 i = 0; i < _tempStakerStrategies.length; i++) {
+            assertEq(_tempStakerStrategies[i].underlyingToken().balanceOf(staker), balancesBefore[i] + expectedTokensOut[i], "incorrect number of tokens received");
+            assertEq(_tempStakerStrategies[i].totalShares(), totalSharesBefore[i] - _tempStrategyShares[_tempStakerStrategies[i]], "total shares not updated correctly");
+        }
+
+        // Clear temp state
+        _clearTempState();
+
+        // Delete ith element from queuedWithdrawals array
+        queuedWithdrawals[index] = queuedWithdrawals[queuedWithdrawals.length - 1];
+        queuedWithdrawals.pop();
+    }
+
+    // Helper Functions
+    function _setPreQueuedWithdrawalState(IDelegationManager.QueuedWithdrawalParams[] memory queueWithdrawalParams) internal returns(uint256[] memory, uint256[] memory) {
+        // There may be duplicate strategies to queue from multiple params, so we aggregate shares to queue for each strategy
+        for (uint256 i = 0; i < queueWithdrawalParams.length; i++) {
+            for (uint256 j = 0; j < queueWithdrawalParams[i].strategies.length; j++) {
+                if (!_tempStrategyRead[queueWithdrawalParams[i].strategies[j]]) {
+                    _tempStrategyRead[queueWithdrawalParams[i].strategies[j]] = true;
+                    _tempStakerStrategies.push(queueWithdrawalParams[i].strategies[j]);
+                }
+                _tempStrategyShares[queueWithdrawalParams[i].strategies[j]] += queueWithdrawalParams[i].shares[j];
+            }
+        }
+        uint256[] memory stakerSharesBefore = new uint256[](_tempStakerStrategies.length);
+        uint256[] memory operatorSharesBefore = new uint256[](_tempStakerStrategies.length);
+        for (uint256 i = 0; i < _tempStakerStrategies.length; i++) {
+            stakerSharesBefore[i] = _getStakerSharesForStrategy(_tempStakerStrategies[i]);
+            operatorSharesBefore[i] = _getOperatorSharesForStrategy(_tempStakerStrategies[i]);
+        }
+        return (stakerSharesBefore, operatorSharesBefore);
+    }
+
+    function _clearTempState() internal {
+        for (uint256 i = 0; i < _tempStakerStrategies.length; i++) {
+            delete _tempStrategyShares[_tempStakerStrategies[i]];
+            delete _tempStrategyRead[_tempStakerStrategies[i]];
+        }
+        delete _tempStakerStrategies;
+    }
+
+    function _getOperatorSharesForStrategy(IStrategy strategy) internal view returns (uint256) {
+        return globalRefs.delegationManager().operatorShares(globalRefs.delegationManager().delegatedTo(staker), strategy);
+    }
+
+    function _getStakerSharesForStrategy(IStrategy strategy) internal view returns (uint256) {
+        return globalRefs.strategyManager().stakerStrategyShares(staker, strategy);
+    }
 
     function _dealTokenToStaker(IERC20 token, uint256 amount) internal {
         StdCheats.deal(address(token), staker, amount);

--- a/src/test/integration/Staker.sol
+++ b/src/test/integration/Staker.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/test/integration/GlobalRefs.sol";
+
+contract Staker {
+    GlobalRefs globalRefs;
+
+    constructor(GlobalRefs _globalRefs) {
+        globalRefs = _globalRefs;
+    }
+
+    function depositIntoStrategy() public {}
+
+    function delegate() public {}
+
+    function queueWithdrawal() public {}
+
+    function completeQueuedWithdrawal() public {} 
+}

--- a/src/test/integration/Staker.sol
+++ b/src/test/integration/Staker.sol
@@ -57,7 +57,7 @@ contract Staker is Test {
         }
         
         // Update operator's delegatedStaker array
-        operator.addDelegatedStaker(address(this));
+        operator.addDelegatedStaker(staker);
     }
 
     function depositIntoStrategy(IStrategy strategy, IERC20 token, uint256 amount) public returns (uint256 shares){
@@ -102,7 +102,7 @@ contract Staker is Test {
         params[0] = IDelegationManager.QueuedWithdrawalParams({
             strategies: strategyArray,
             shares: shareAmounts,
-            withdrawer: address(this)
+            withdrawer: staker
         });
         _queueWithdrawal(params);
     }


### PR DESCRIPTION
PR implements first scenario described in [integration test spreadsheet](https://docs.google.com/spreadsheets/d/1KQvNFDvPrTF6CCKD3v34t3t-sybotUMNaZkzEhPOW9A/edit#gid=0). 

Notes:

- Two user contracts: Staker and operator
- `IntegrationTestRunner` deploys contracts and sets up strategies
- `Scenario` test file should deploy Staker and operator contracts
- `GlobalRefs.sol` contract is used by Staker and operators to reference core protocol contracts
- Each action in the Staker and operator contract does checks after modifying state in the core contracts. Need to think more about the "best" breakdown of checks between user and the scenario contracts. 
