### PR TITLE
added read functions for eigenpods

### DIFF
--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -138,11 +138,19 @@ interface IEigenPod {
     /// @notice Returns the validatorInfo struct for the provided pubkeyHash
     function validatorPubkeyHashToInfo(bytes32 validatorPubkeyHash) external view returns (ValidatorInfo memory);
 
+    /// @notice Returns the validatorInfo struct for the provided pubkey
+    function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory);
+
+
     ///@notice mapping that tracks proven withdrawals
     function provenWithdrawal(bytes32 validatorPubkeyHash, uint64 slot) external view returns (bool);
 
-    /// @notice This returns the status of a given validator
+    /// @notice This returns the status of a given validator pubkey hash
     function validatorStatus(bytes32 pubkeyHash) external view returns (VALIDATOR_STATUS);
+
+    /// @notice This returns the status of a given validator pubkey
+    function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS);
+
 
     /**
      * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -141,7 +141,6 @@ interface IEigenPod {
     /// @notice Returns the validatorInfo struct for the provided pubkey
     function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory);
 
-
     ///@notice mapping that tracks proven withdrawals
     function provenWithdrawal(bytes32 validatorPubkeyHash, uint64 slot) external view returns (bool);
 
@@ -150,7 +149,6 @@ interface IEigenPod {
 
     /// @notice This returns the status of a given validator pubkey
     function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS);
-
 
     /**
      * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -792,11 +792,12 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return _validatorPubkeyHashToInfo[pubkeyHash].status;
     }
 
-    ///@notice Returns the validatorInfo for a given validatorPubkey
+    /// @notice Returns the validatorInfo for a given validatorPubkey
     function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
         return _validatorPubkeyHashToInfo[_calculateValidatorPubkeyHash(validatorPubkey)];
     }
 
+    /// @notice Returns the validator status for a given validatorPubkey
     function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS) {
         require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
         bytes32 validatorPubkeyHash = _calculateValidatorPubkeyHash(validatorPubkey);

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -756,6 +756,16 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(this));
     }
 
+    function _validatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
+         bytes memory paddedPubkey = new bytes(data.length + 16);
+
+        // Copy original data to the new array
+        for (uint i = 0; i < validatorPubkey.length; i++) {
+            paddedPubkey[i] = validatorPubkey[i];
+        }
+        return sha256(paddedData);
+    }
+
     /**
      * Calculates delta between two share amounts and returns as an int256
      */
@@ -784,6 +794,17 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     function validatorStatus(bytes32 pubkeyHash) external view returns (VALIDATOR_STATUS) {
         return _validatorPubkeyHashToInfo[pubkeyHash].status;
+    }
+
+    function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
+        require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
+
+        return _validatorPubkeyHash[_validatorPubkeyHash(validatorPubkey)]
+    }
+
+    function validatorStatus(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
+        require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
+        return _validatorPubkeyHashToInfo[_validatorPubkeyHash(validatorPubkey)].status;
     }
 
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -756,6 +756,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(this));
     }
 
+    ///@notice Calculates the pubkey hash of a validator's pubkey as per SSZ spec
     function _calculateValidatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
         require(validatorPubkey.length == 48, "EigenPod._calculateValidatorPubkeyHash must be a 48-byte BLS public key");
         return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
@@ -791,6 +792,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return _validatorPubkeyHashToInfo[pubkeyHash].status;
     }
 
+    ///@notice Returns the validatorInfo for a given validatorPubkey
     function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
         return _validatorPubkeyHashToInfo[_calculateValidatorPubkeyHash(validatorPubkey)];
     }

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -756,14 +756,14 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(this));
     }
 
-    function _validatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
-         bytes memory paddedPubkey = new bytes(data.length + 16);
+    function _calculateValidatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
+         bytes memory paddedPubkey = new bytes(validatorPubkey.length + 16);
 
         // Copy original data to the new array
         for (uint i = 0; i < validatorPubkey.length; i++) {
             paddedPubkey[i] = validatorPubkey[i];
         }
-        return sha256(paddedData);
+        return sha256(paddedPubkey);
     }
 
     /**
@@ -799,12 +799,13 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
         require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
 
-        return _validatorPubkeyHash[_validatorPubkeyHash(validatorPubkey)]
+        return _validatorPubkeyHashToInfo[_calculateValidatorPubkeyHash(validatorPubkey)];
     }
 
-    function validatorStatus(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
+    function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS) {
         require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
-        return _validatorPubkeyHashToInfo[_validatorPubkeyHash(validatorPubkey)].status;
+        bytes32 validatorPubkeyHash = _calculateValidatorPubkeyHash(validatorPubkey);
+        return _validatorPubkeyHashToInfo[validatorPubkeyHash].status;
     }
 
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -757,12 +757,9 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     }
 
     function _calculateValidatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
-         bytes memory paddedPubkey = new bytes(validatorPubkey.length + 16);
-
-        // Copy original data to the new array
-        for (uint i = 0; i < validatorPubkey.length; i++) {
-            paddedPubkey[i] = validatorPubkey[i];
-        }
+        require(validatorPubkey.length == 48, "EigenPod._calculateValidatorPubkeyHash must be a 48-byte BLS public key");
+        bytes16 zeroPadding = bytes16(0);
+        bytes memory paddedPubkey = abi.encodePacked(validatorPubkey, zeroPadding);
         return sha256(paddedPubkey);
     }
 
@@ -797,8 +794,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     }
 
     function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory) {
-        require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
-
         return _validatorPubkeyHashToInfo[_calculateValidatorPubkeyHash(validatorPubkey)];
     }
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -758,9 +758,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     function _calculateValidatorPubkeyHash(bytes memory validatorPubkey) internal view returns(bytes32){
         require(validatorPubkey.length == 48, "EigenPod._calculateValidatorPubkeyHash must be a 48-byte BLS public key");
-        bytes16 zeroPadding = bytes16(0);
-        bytes memory paddedPubkey = abi.encodePacked(validatorPubkey, zeroPadding);
-        return sha256(paddedPubkey);
+        return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
     }
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -799,7 +799,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
 
     /// @notice Returns the validator status for a given validatorPubkey
     function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS) {
-        require(validatorPubkey.length == 48, "EigenPod.validatorPubkeyHashToInfo must be a 48-byte BLS public key");
         bytes32 validatorPubkeyHash = _calculateValidatorPubkeyHash(validatorPubkey);
         return _validatorPubkeyHashToInfo[validatorPubkeyHash].status;
     }

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1380,6 +1380,18 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
+    function test_validatorPubkeyToInfo() external {
+        bytes memory pubkey = hex"93a0dd04ccddf3f1b419fdebf99481a2182c17d67cf14d32d6e50fc4bf8effc8db4a04b7c2f3a5975c1b9b74e2841888";
+
+        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+        _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
+        IEigenPod pod = eigenPodManager.getPod(podOwner);
+
+        IEigenPod.ValidatorInfo memory info = pod.validatorPubkeyToInfo(pubkey);
+
+
+    }
+
     /* TODO: reimplement similar tests
     function testQueueBeaconChainETHWithdrawalWithoutProvingFullWithdrawal() external {
         // ./solidityProofGen  -newBalance=32000115173 "ValidatorFieldsProof" 302913 true "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "withdrawal_credential_proof_302913.json"

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1387,9 +1387,26 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
         IEigenPod pod = eigenPodManager.getPod(podOwner);
 
-        IEigenPod.ValidatorInfo memory info = pod.validatorPubkeyToInfo(pubkey);
+        IEigenPod.ValidatorInfo memory info1 = pod.validatorPubkeyToInfo(pubkey);
+        IEigenPod.ValidatorInfo memory info2 = pod.validatorPubkeyHashToInfo(getValidatorPubkeyHash());
 
+        require(info1.validatorIndex == info2.validatorIndex, "validatorIndex does not match");
+        require(info1.restakedBalanceGwei == info2.restakedBalanceGwei, "restakedBalanceGwei does not match");
+        require(info1.mostRecentBalanceUpdateTimestamp == info2.mostRecentBalanceUpdateTimestamp, "mostRecentBalanceUpdateTimestamp does not match");
+        require(info1.status == info2.status, "status does not match");
+    }
 
+    function test_validatorStatus() external {
+        bytes memory pubkey = hex"93a0dd04ccddf3f1b419fdebf99481a2182c17d67cf14d32d6e50fc4bf8effc8db4a04b7c2f3a5975c1b9b74e2841888";
+
+        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+        _testDeployAndVerifyNewEigenPod(podOwner, signature, depositDataRoot);
+        IEigenPod pod = eigenPodManager.getPod(podOwner);
+
+        IEigenPod.VALIDATOR_STATUS status1 = pod.validatorStatus(pubkey);
+        IEigenPod.VALIDATOR_STATUS status2 = pod.validatorStatus(getValidatorPubkeyHash());
+
+        require(status1 == status2, "status does not match");
     }
 
     /* TODO: reimplement similar tests

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1391,6 +1391,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         IEigenPod.ValidatorInfo memory info2 = pod.validatorPubkeyHashToInfo(getValidatorPubkeyHash());
 
         require(info1.validatorIndex == info2.validatorIndex, "validatorIndex does not match");
+        require(info1.restakedBalanceGwei > 0, "restakedBalanceGwei is 0");
         require(info1.restakedBalanceGwei == info2.restakedBalanceGwei, "restakedBalanceGwei does not match");
         require(info1.mostRecentBalanceUpdateTimestamp == info2.mostRecentBalanceUpdateTimestamp, "mostRecentBalanceUpdateTimestamp does not match");
         require(info1.status == info2.status, "status does not match");

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -87,4 +87,7 @@ contract EigenPodMock is IEigenPod, Test {
 
     /// @notice called by owner of a pod to remove any ERC20s deposited in the pod
     function recoverTokens(IERC20[] memory tokenList, uint256[] memory amountsToWithdraw, address recipient) external {}
+
+    function validatorStatus(bytes calldata pubkey) external view returns (VALIDATOR_STATUS){}
+    function validatorPubkeyToInfo(bytes calldata validatorPubkey) external view returns (ValidatorInfo memory){}
 }


### PR DESCRIPTION
Making this PR based on requests to access these functions.  Since the pubkey hash is not simply sha256(pubkey) but rather sha256(pubkey + bytes(16)), adding these would make it easier for users to call these functions with data they have on hand. Specifically, Figment requested this.


Note:  maybe worht just deleting the other functions that take in the pubkey hash if we dont use them actively for the FE?