### PR TITLE
support native eth in integration tests

### DIFF
--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -453,7 +453,7 @@ library BeaconChainProofs {
     /**
      * @dev Retrieves a validator's pubkey hash
      */
-     function getPubkeyHash(bytes32[] memory validatorFields) internal pure returns (bytes32) {
+    function getPubkeyHash(bytes32[] memory validatorFields) internal pure returns (bytes32) {
         return 
             validatorFields[VALIDATOR_PUBKEY_INDEX];
     }
@@ -466,7 +466,7 @@ library BeaconChainProofs {
     /**
      * @dev Retrieves a validator's effective balance (in gwei)
      */
-     function getEffectiveBalanceGwei(bytes32[] memory validatorFields) internal pure returns (uint64) {
+    function getEffectiveBalanceGwei(bytes32[] memory validatorFields) internal pure returns (uint64) {
         return 
             Endian.fromLittleEndianUint64(validatorFields[VALIDATOR_BALANCE_INDEX]);
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -22,7 +22,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
     function _newRandomStaker() internal returns (User, IStrategy[] memory, uint[] memory) {
         (User staker, IStrategy[] memory strategies, uint[] memory tokenBalances) = _randUser();
         
-        assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newStaker: failed to award token balances");
+        assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newRandomStaker: failed to award token balances");
 
         return (staker, strategies, tokenBalances);
     }
@@ -33,9 +33,9 @@ abstract contract IntegrationBase is IntegrationDeployer {
         operator.registerAsOperator();
         operator.depositIntoEigenlayer(strategies, tokenBalances);
 
-        assert_Snap_AddedStakerShares(operator, strategies, tokenBalances, "_newOperator: failed to add delegatable shares");
-        assert_Snap_AddedOperatorShares(operator, strategies, tokenBalances, "_newOperator: failed to award shares to operator");
-        assertTrue(delegationManager.isOperator(address(operator)), "_newOperator: operator should be registered");
+        assert_Snap_AddedStakerShares(operator, strategies, tokenBalances, "_newRandomOperator: failed to add delegatable shares");
+        assert_Snap_AddedOperatorShares(operator, strategies, tokenBalances, "_newRandomOperator: failed to award shares to operator");
+        assertTrue(delegationManager.isOperator(address(operator)), "_newRandomOperator: operator should be registered");
 
         return (operator, strategies, tokenBalances);
     }
@@ -88,9 +88,13 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
             uint actualShares;
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO
-                // actualShares = eigenPodManager.podOwnerShares(address(user));
-                revert("unimplemented");
+                // TODO - is this the right way to handle this?
+                int shares = eigenPodManager.podOwnerShares(address(user));
+                if (shares < 0) {
+                    revert("assert_HasExpectedShares: negative shares");
+                }
+
+                actualShares = uint(shares);
             } else {
                 actualShares = strategyManager.stakerStrategyShares(address(user), strat);
             }
@@ -251,9 +255,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
             uint tokenBalance = tokenBalances[i];
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO - need to calculate this
-                // expectedShares[i] = eigenPodManager.underlyingToShares(tokenBalance);
-                revert("_calculateExpectedShares: unimplemented for native eth");
+                expectedShares[i] = tokenBalances[i];
             } else {
                 expectedShares[i] = strat.underlyingToShares(tokenBalance);
             }
@@ -271,9 +273,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
             IStrategy strat = strategies[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO - need to calculate this
-                // expectedTokens[i] = eigenPodManager.underlyingToShares(tokenBalance);
-                revert("_calculateExpectedShares: unimplemented for native eth");
+                expectedTokens[i] = shares[i];
             } else {
                 expectedTokens[i] = strat.sharesToUnderlying(shares[i]);
             }
@@ -323,8 +323,13 @@ abstract contract IntegrationBase is IntegrationDeployer {
             IStrategy strat = strategies[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // curShares[i] = eigenPodManager.podOwnerShares(address(staker));
-                revert("TODO: unimplemented");
+                // TODO - is this the right way to handle this?
+                int shares = eigenPodManager.podOwnerShares(address(staker));
+                if (shares < 0) {
+                    revert("_getStakerShares: negative shares");
+                }
+
+                curShares[i] = uint(shares);
             } else {
                 curShares[i] = strategyManager.stakerStrategyShares(address(staker), strat);
             }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -88,7 +88,9 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
             uint actualShares;
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO - is this the right way to handle this?
+                // This method should only be used for tests that handle positive
+                // balances. Negative balances are an edge case that require
+                // the own tests and helper methods.
                 int shares = eigenPodManager.podOwnerShares(address(user));
                 if (shares < 0) {
                     revert("assert_HasExpectedShares: negative shares");
@@ -323,7 +325,9 @@ abstract contract IntegrationBase is IntegrationDeployer {
             IStrategy strat = strategies[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO - is this the right way to handle this?
+                // This method should only be used for tests that handle positive
+                // balances. Negative balances are an edge case that require
+                // the own tests and helper methods.
                 int shares = eigenPodManager.podOwnerShares(address(staker));
                 if (shares < 0) {
                     revert("_getStakerShares: negative shares");
@@ -354,7 +358,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
         uint[] memory balances = new uint[](tokens.length);
 
         for (uint i = 0; i < tokens.length; i++) {
-            if (address(tokens[i]) == address(0)) {
+            if (tokens[i] == NATIVE_ETH) {
                 balances[i] = address(staker).balance;
             } else {
                 balances[i] = tokens[i].balanceOf(address(staker));

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -354,7 +354,11 @@ abstract contract IntegrationBase is IntegrationDeployer {
         uint[] memory balances = new uint[](tokens.length);
 
         for (uint i = 0; i < tokens.length; i++) {
-            balances[i] = tokens[i].balanceOf(address(staker));
+            if (address(tokens[i]) == address(0)) {
+                balances[i] = address(staker).balance;
+            } else {
+                balances[i] = tokens[i].balanceOf(address(staker));
+            }
         }
 
         return balances;

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -77,7 +77,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
 
     IStrategy constant BEACONCHAIN_ETH_STRAT = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
     IERC20 constant NATIVE_ETH = IERC20(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
-    
+
     uint constant MIN_BALANCE = 1e6;
     uint constant MAX_BALANCE = 5e6;
 
@@ -301,8 +301,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         emit log_named_uint("_configRand: set random seed to: ", _randomSeed);
         random = keccak256(abi.encodePacked(_randomSeed));
 
-        emit log_named_uint("_configRand: allowed asset types: ", _assetTypes);
-
         // Convert flag bitmaps to bytes of set bits for easy use with _randUint
         assetTypes = _bitmapToBytes(_assetTypes);
         userTypes = _bitmapToBytes(_userTypes);
@@ -392,8 +390,8 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             strategies = new IStrategy[](1);
             tokenBalances = new uint[](1);
 
-            // Award the user 32 ETH
-            uint amount = 32 ether;
+            // Award the user with a random multiple of 32 ETH
+            uint amount = 32 ether * _randUint({ min: 1, max: 3 });
             cheats.deal(address(user), amount);
 
             strategies[0] = BEACONCHAIN_ETH_STRAT;

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -74,7 +74,10 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
     // Constants
     uint64 constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
     uint64 constant GOERLI_GENESIS_TIME = 1616508000;
+
     IStrategy constant BEACONCHAIN_ETH_STRAT = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+    IERC20 constant NATIVE_ETH = IERC20(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+    
     uint constant MIN_BALANCE = 1e6;
     uint constant MAX_BALANCE = 5e6;
 

--- a/src/test/integration/README.md
+++ b/src/test/integration/README.md
@@ -93,5 +93,4 @@ function testFuzz_deposit_delegate_EXAMPLE(uint24 _random) public {
 ### What needs to be done?
 
 * Suggest or PR cleanup if you have ideas. Currently, the `IntegrationDeployer` contract is pretty messy.
-* Currently, the only supported assetTypes are `NO_ASSETS` and `HOLDS_LST`. There are flags for `HOLDS_ETH` and `HOLDS_MIXED`, but we need to implement `EigenPod` proof generation/usage before they can be used.
 * Coordinate in Slack to pick out some user flows to write tests for!

--- a/src/test/integration/README.md
+++ b/src/test/integration/README.md
@@ -16,7 +16,7 @@ Looking at the current tests is a good place to start.
 
 During the test, the config passed into `_configRand` will randomly generate only the values you configure:
 * `assetTypes` affect the assets granted to Users when they are first created. You can use this to ensure your flows and assertions work when users are holding only LSTs, native ETH, or some combination.
-* `userTypes` affect the actual `User` contract being deployed. The `DEFAULT` flag deploys the base `User` contract, while `SIGNED_METHODS` deploys a version that derives from the same contract, but overrides some methods to use "functionWithSignature" variants.
+* `userTypes` affect the actual `User` contract being deployed. The `DEFAULT` flag deploys the base `User` contract, while `ALT_METHODS` deploys a version that derives from the same contract, but overrides some methods to use "functionWithSignature" and other variants.
 
 Here's an example:
 
@@ -27,7 +27,7 @@ function testFuzz_deposit_delegate_EXAMPLE(uint24 _random) public {
     _configRand({
         _randomSeed: _random,
         _assetTypes: HOLDS_LST,
-        _userTypes: DEFAULT | SIGNED_METHODS
+        _userTypes: DEFAULT | ALT_METHODS
     });
 
     // Because of the `assetTypes` flags above, this will create two Users for our test,

--- a/src/test/integration/TimeMachine.t.sol
+++ b/src/test/integration/TimeMachine.t.sol
@@ -10,6 +10,8 @@ contract TimeMachine is Test {
     bool pastExists = false;
     uint lastSnapshot;
 
+    uint64 public proofGenStartTime;
+
     function createSnapshot() public returns (uint) {
         uint snapshot = cheats.snapshot();
         lastSnapshot = snapshot;
@@ -29,5 +31,15 @@ contract TimeMachine is Test {
 
     function warpToPresent(uint curState) public {
         cheats.revertTo(curState);
+    }
+
+    /// @dev Sets the timestamp we use for proof gen to now,
+    /// then sets block timestamp to now + secondsAgo.
+    ///
+    /// This means we can create mock proofs using an oracle time
+    /// of `proofGenStartTime`.
+    function setProofGenStartTime(uint secondsAgo) public {
+        proofGenStartTime = uint64(block.timestamp);
+        cheats.warp(block.timestamp + secondsAgo);
     }
 }

--- a/src/test/integration/User.t.sol
+++ b/src/test/integration/User.t.sol
@@ -63,6 +63,8 @@ contract User is Test {
         _;
     }
 
+    receive() external payable {}
+
     /**
      * DelegationManager methods:
      */
@@ -171,7 +173,10 @@ contract User is Test {
 
                 // If we're withdrawing as tokens, we need to process a withdrawal proof first
                 if (receiveAsTokens) {
-                    WithdrawalProofs memory proofs = beaconChain.exitValidator(validatorIndex);
+                    emit log("exiting validator and processing withdrawals...");
+                    BeaconWithdrawal memory proofs = beaconChain.exitValidator(validatorIndex, address(pod));
+
+                    uint64 withdrawableBefore = pod.withdrawableRestakedExecutionLayerGwei();
 
                     pod.verifyAndProcessWithdrawals({
                         oracleTimestamp: proofs.oracleTimestamp,
@@ -181,6 +186,11 @@ contract User is Test {
                         validatorFields: proofs.validatorFields,
                         withdrawalFields: proofs.withdrawalFields
                     });
+
+                    uint64 withdrawableAfter = pod.withdrawableRestakedExecutionLayerGwei();
+
+                    emit log_named_uint("pod withdrawable before: ", withdrawableBefore);
+                    emit log_named_uint("pod withdrawable after: ", withdrawableAfter);
                 }
             } else {
                 tokens[i] = strat.underlyingToken();

--- a/src/test/integration/User.t.sol
+++ b/src/test/integration/User.t.sol
@@ -174,7 +174,7 @@ contract User is Test {
                 // If we're withdrawing as tokens, we need to process a withdrawal proof first
                 if (receiveAsTokens) {
                     emit log("exiting validator and processing withdrawals...");
-                    BeaconWithdrawal memory proofs = beaconChain.exitValidator(validatorIndex, address(pod));
+                    BeaconWithdrawal memory proofs = beaconChain.exitValidator(validatorIndex);
 
                     uint64 withdrawableBefore = pod.withdrawableRestakedExecutionLayerGwei();
 

--- a/src/test/integration/User.t.sol
+++ b/src/test/integration/User.t.sol
@@ -219,8 +219,8 @@ contract User is Test {
     }
 }
 
-/// @notice A user contract that implements 1271 signatures
-contract User_SignedMethods is User {
+/// @notice A user contract that calls nonstandard methods (like xBySignature methods)
+contract User_AltMethods is User {
 
     mapping(bytes32 => bool) public signedHashes;
 

--- a/src/test/integration/User.t.sol
+++ b/src/test/integration/User.t.sol
@@ -44,8 +44,6 @@ contract User is Test {
     IERC20 constant NATIVE_ETH = IERC20(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
     uint constant GWEI_TO_WEI = 1e9;
 
-    
-
     constructor() {
         IUserDeployer deployer = IUserDeployer(msg.sender);
 
@@ -169,7 +167,7 @@ contract User is Test {
             IStrategy strat = withdrawal.strategies[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                tokens[i] = IERC20(address(0));
+                tokens[i] = NATIVE_ETH;
 
                 // If we're withdrawing as tokens, we need to process a withdrawal proof first
                 if (receiveAsTokens) {

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -115,7 +115,7 @@ contract BeaconChainMock is Test {
 
         // Update state - set validator balance to zero and send balance to withdrawal destination
         validators[validatorIndex].effectiveBalanceGwei = 0;
-        cheats.deal(destination, amountToWithdraw);
+        cheats.deal(destination, destination.balance + amountToWithdraw);
 
         return withdrawal;
     }

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "forge-std/Test.sol";
+
+import "src/contracts/libraries/BeaconChainProofs.sol";
+import "src/contracts/libraries/Merkle.sol";
+
+import "src/test/integration/TimeMachine.t.sol";
+import "src/test/integration/mocks/BeaconChainOracleMock.t.sol";
+
+struct CredentialsProofs {
+    uint64 oracleTimestamp;
+    BeaconChainProofs.StateRootProof stateRootProof;
+    uint40[] validatorIndices;
+    bytes[] validatorFieldsProofs;
+    bytes32[][] validatorFields;
+}
+
+struct WithdrawalProofs {
+    uint64 oracleTimestamp;
+    BeaconChainProofs.StateRootProof stateRootProof;
+    BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
+    bytes[] validatorFieldsProofs;
+    bytes32[][] validatorFields;
+    bytes32[][] withdrawalFields;
+}
+
+contract BeaconChainMock {
+
+    struct Validator {
+        bytes32 pubkeyHash;
+        uint40 validatorIndex;
+        bytes withdrawalCreds;
+        uint64 effectiveBalanceGwei;
+    }
+    
+    uint40 nextIndex = 0;
+    uint64 nextTimestamp;
+    
+    // Sequential list of created Validators
+    // Validator[] validators;
+    // mapping(uint40 => Validator) validators;
+
+    mapping(uint40 => Validator) validators;
+
+    BeaconChainOracleMock oracle;
+
+    uint constant GWEI_TO_WEI = 1e9;
+    uint immutable BLOCKROOT_PROOF_LEN = 32 * BeaconChainProofs.BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT;
+    uint immutable FIELDS_PROOF_LEN = 
+        32 * (
+            (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1) + BeaconChainProofs.BEACON_STATE_FIELD_TREE_HEIGHT
+        );
+    
+    constructor(TimeMachine timeMachine, BeaconChainOracleMock beaconChainOracle) {
+        nextTimestamp = timeMachine.proofGenStartTime();
+        oracle = beaconChainOracle;
+    }
+    
+    /**
+     * @dev Processes a deposit for a new validator and returns the
+     * information needed to prove withdrawal credentials.
+     * 
+     * For now, this returns empty proofs that will pass in the oracle,
+     * but in the future this should use FFI to return a valid proof.
+     */
+    function newValidator( 
+        uint balanceWei, 
+        bytes memory withdrawalCreds
+    ) public returns (uint40, CredentialsProofs memory) {
+
+        // Create unique index for new validator
+        uint40 validatorIndex = nextIndex;
+        nextIndex++;
+
+        // Create new validator and record in state
+        Validator memory validator = Validator({
+            pubkeyHash: keccak256(abi.encodePacked(validatorIndex)),
+            validatorIndex: validatorIndex,
+            withdrawalCreds: withdrawalCreds,
+            effectiveBalanceGwei: uint64(balanceWei / GWEI_TO_WEI)
+        });
+        validators[validatorIndex] = validator;
+
+        return (validator.validatorIndex, _genCredentialsProof(validator));
+    }
+
+    function exitValidator(uint40 validatorIndex) public returns (WithdrawalProofs memory) {
+        Validator memory validator = validators[validatorIndex];
+
+        validators[validatorIndex].effectiveBalanceGwei = 0;
+
+        return (_genExitProof(validator));
+    }
+
+    function _genCredentialsProof(Validator memory validator) internal returns (CredentialsProofs memory) {
+        CredentialsProofs memory proof;
+
+        proof.validatorIndices = new uint40[](1);
+        proof.validatorIndices[0] = validator.validatorIndex;
+
+        // Create validatorFields for the new validator
+        proof.validatorFields = new bytes32[][](1);
+        proof.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
+        proof.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
+        proof.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWAL_CREDENTIALS_INDEX] = 
+            bytes32(validator.withdrawalCreds);
+        proof.validatorFields[0][BeaconChainProofs.VALIDATOR_BALANCE_INDEX] = 
+            _toLittleEndianUint64(validator.effectiveBalanceGwei);
+
+        // Calculate beaconStateRoot using validator index and an empty proof:
+        proof.validatorFieldsProofs = new bytes[](1);
+        proof.validatorFieldsProofs[0] = new bytes(FIELDS_PROOF_LEN);
+        bytes32 validatorRoot = Merkle.merkleizeSha256(proof.validatorFields[0]);
+        uint index = 
+            (BeaconChainProofs.VALIDATOR_TREE_ROOT_INDEX << (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1)) | 
+            uint(validator.validatorIndex);
+
+        bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
+            proof: proof.validatorFieldsProofs[0],
+            leaf: validatorRoot,
+            index: index
+        });
+
+        // Calculate blockRoot using beaconStateRoot and an empty proof:
+        bytes memory blockRootProof = new bytes(BLOCKROOT_PROOF_LEN);
+        bytes32 blockRoot = Merkle.processInclusionProofSha256({
+            proof: blockRootProof,
+            leaf: beaconStateRoot,
+            index: BeaconChainProofs.STATE_ROOT_INDEX
+        });
+
+        proof.stateRootProof = BeaconChainProofs.StateRootProof({
+            beaconStateRoot: beaconStateRoot,
+            proof: blockRootProof
+        });
+
+        // Send the block root to the oracle and increment timestamp:
+        proof.oracleTimestamp = uint64(nextTimestamp);
+        oracle.setBlockRoot(nextTimestamp, blockRoot);
+        nextTimestamp++;
+        
+        return proof;
+    }
+
+    function _genExitProof(Validator memory validator) internal returns (WithdrawalProofs memory) {
+        revert("exitValidator: unimplemented");
+        WithdrawalProofs memory proof;
+        // uint64 withdrawalEpoch = uint64(block.timestamp);
+
+        // // withdrawalFields and proof of withdrawalFields
+        // proof.withdrawalFields = new bytes32[][](1);
+        // proof.withdrawalFields[0] = new bytes32[](2 ** BeaconChainProofs.WITHDRAWAL_FIELD_TREE_HEIGHT);
+        // proof.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_INDEX_INDEX] =
+        //     uint40(_toLittleEndianUint64(validator.validatorIndex));
+        // proof.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX] =
+        //     _toLittleEndianUint64(validator.effectiveBalanceGwei);
+
+        // BeaconChainProofs.WithdrawalProof memory withdrawalProof;
+
+        // // validatorFields and proof of validatorFields
+        // proof.validatorFields = new bytes32[][](1);
+        // proof.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
+        // proof.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
+        // proof.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX] = 
+        //     _toLittleEndianUint64(withdrawalEpoch);
+
+        // // Calculate blockRoot using beaconStateRoot and an empty proof:
+        // bytes memory blockRootProof = new bytes(BLOCKROOT_PROOF_LEN);
+        // bytes32 blockRoot = Merkle.processInclusionProofSha256({
+        //     proof: blockRootProof,
+        //     leaf: beaconStateRoot,
+        //     index: BeaconChainProofs.STATE_ROOT_INDEX
+        // });
+
+        // proof.stateRootProof = BeaconChainProofs.StateRootProof({
+        //     beaconStateRoot: beaconStateRoot,
+        //     proof: blockRootProof
+        // });
+
+
+        // // Send the block root to the oracle and increment timestamp:
+        // proof.oracleTimestamp = uint64(nextTimestamp);
+        // oracle.setBlockRoot(nextTimestamp, blockRoot);
+        // nextTimestamp++;
+        
+        return proof;
+    }
+
+    /// @dev Opposite of Endian.fromLittleEndianUint64
+    function _toLittleEndianUint64(uint64 num) internal pure returns (bytes32) {
+        uint256 lenum;
+    
+        // Rearrange the bytes from big-endian to little-endian format
+        lenum |= uint256((num & 0xFF) << 56);
+        lenum |= uint256((num & 0xFF00) << 40);
+        lenum |= uint256((num & 0xFF0000) << 24);
+        lenum |= uint256((num & 0xFF000000) << 8);
+        lenum |= uint256((num & 0xFF00000000) >> 8);
+        lenum |= uint256((num & 0xFF0000000000) >> 24);
+        lenum |= uint256((num & 0xFF000000000000) >> 40);
+        lenum |= uint256((num & 0xFF00000000000000) >> 56);
+
+        // Shift the little-endian bytes to the end of the bytes32 value
+        return bytes32(lenum << 192);
+    }
+}

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -17,7 +17,7 @@ struct CredentialsProofs {
     bytes32[][] validatorFields;
 }
 
-struct WithdrawalProofs {
+struct BeaconWithdrawal {
     uint64 oracleTimestamp;
     BeaconChainProofs.StateRootProof stateRootProof;
     BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
@@ -26,7 +26,9 @@ struct WithdrawalProofs {
     bytes32[][] withdrawalFields;
 }
 
-contract BeaconChainMock {
+contract BeaconChainMock is Test {
+
+    Vm cheats = Vm(HEVM_ADDRESS);
 
     struct Validator {
         bytes32 pubkeyHash;
@@ -35,7 +37,8 @@ contract BeaconChainMock {
         uint64 effectiveBalanceGwei;
     }
     
-    uint40 nextIndex = 0;
+    uint40 nextValidatorIndex = 0;
+    uint64 constant WITHDRAWAL_INDEX = 0;
     uint64 nextTimestamp;
     
     // Sequential list of created Validators
@@ -48,7 +51,7 @@ contract BeaconChainMock {
 
     uint constant GWEI_TO_WEI = 1e9;
     uint immutable BLOCKROOT_PROOF_LEN = 32 * BeaconChainProofs.BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT;
-    uint immutable FIELDS_PROOF_LEN = 
+    uint immutable VAL_FIELDS_PROOF_LEN = 
         32 * (
             (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1) + BeaconChainProofs.BEACON_STATE_FIELD_TREE_HEIGHT
         );
@@ -71,8 +74,8 @@ contract BeaconChainMock {
     ) public returns (uint40, CredentialsProofs memory) {
 
         // Create unique index for new validator
-        uint40 validatorIndex = nextIndex;
-        nextIndex++;
+        uint40 validatorIndex = nextValidatorIndex;
+        nextValidatorIndex++;
 
         // Create new validator and record in state
         Validator memory validator = Validator({
@@ -86,12 +89,18 @@ contract BeaconChainMock {
         return (validator.validatorIndex, _genCredentialsProof(validator));
     }
 
-    function exitValidator(uint40 validatorIndex) public returns (WithdrawalProofs memory) {
+    function exitValidator(uint40 validatorIndex, address pod) public returns (BeaconWithdrawal memory) {
         Validator memory validator = validators[validatorIndex];
 
-        validators[validatorIndex].effectiveBalanceGwei = 0;
+        uint amountToWithdraw = validators[validatorIndex].effectiveBalanceGwei * GWEI_TO_WEI;
 
-        return (_genExitProof(validator));
+        BeaconWithdrawal memory withdrawal = _genExitProof(validator);
+
+        // Update state - set validator balance to zero and send balance to pod
+        validators[validatorIndex].effectiveBalanceGwei = 0;
+        cheats.deal(pod, amountToWithdraw);
+
+        return withdrawal;
     }
 
     function _genCredentialsProof(Validator memory validator) internal returns (CredentialsProofs memory) {
@@ -111,11 +120,9 @@ contract BeaconChainMock {
 
         // Calculate beaconStateRoot using validator index and an empty proof:
         proof.validatorFieldsProofs = new bytes[](1);
-        proof.validatorFieldsProofs[0] = new bytes(FIELDS_PROOF_LEN);
+        proof.validatorFieldsProofs[0] = new bytes(VAL_FIELDS_PROOF_LEN);
         bytes32 validatorRoot = Merkle.merkleizeSha256(proof.validatorFields[0]);
-        uint index = 
-            (BeaconChainProofs.VALIDATOR_TREE_ROOT_INDEX << (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1)) | 
-            uint(validator.validatorIndex);
+        uint index = _calcValProofIndex(validator.validatorIndex);
 
         bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
             proof: proof.validatorFieldsProofs[0],
@@ -144,48 +151,413 @@ contract BeaconChainMock {
         return proof;
     }
 
-    function _genExitProof(Validator memory validator) internal returns (WithdrawalProofs memory) {
-        revert("exitValidator: unimplemented");
-        WithdrawalProofs memory proof;
-        // uint64 withdrawalEpoch = uint64(block.timestamp);
+    uint immutable EXECPAYLOAD_INDEX = 
+        (BeaconChainProofs.BODY_ROOT_INDEX << BeaconChainProofs.BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT) |
+        BeaconChainProofs.EXECUTION_PAYLOAD_INDEX;
 
-        // // withdrawalFields and proof of withdrawalFields
-        // proof.withdrawalFields = new bytes32[][](1);
-        // proof.withdrawalFields[0] = new bytes32[](2 ** BeaconChainProofs.WITHDRAWAL_FIELD_TREE_HEIGHT);
-        // proof.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_INDEX_INDEX] =
-        //     uint40(_toLittleEndianUint64(validator.validatorIndex));
-        // proof.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX] =
-        //     _toLittleEndianUint64(validator.effectiveBalanceGwei);
+    uint immutable WITHDRAWAL_PROOF_LEN = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT + 
+        BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1
+    );
+    uint immutable EXECPAYLOAD_PROOF_LEN = 32 * (
+        BeaconChainProofs.BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT + 
+        BeaconChainProofs.BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT
+    );
+    uint immutable SLOT_PROOF_LEN = 32 * (
+        BeaconChainProofs.BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT
+    );
+    uint immutable TIMESTAMP_PROOF_LEN = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT
+    );
+    uint immutable HISTSUMMARY_PROOF_LEN = 32 * (
+        BeaconChainProofs.BEACON_STATE_FIELD_TREE_HEIGHT +
+        BeaconChainProofs.HISTORICAL_SUMMARIES_TREE_HEIGHT +
+        BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 2
+    );
 
-        // BeaconChainProofs.WithdrawalProof memory withdrawalProof;
+    function _initWithdrawalProof(
+        uint64 withdrawalEpoch, 
+        uint64 withdrawalIndex,
+        uint64 oracleTimestamp
+    ) internal view returns (BeaconChainProofs.WithdrawalProof memory) {
+        return BeaconChainProofs.WithdrawalProof({
+            withdrawalProof: new bytes(WITHDRAWAL_PROOF_LEN),
+            slotProof: new bytes(SLOT_PROOF_LEN),
+            executionPayloadProof: new bytes(EXECPAYLOAD_PROOF_LEN),
+            timestampProof: new bytes(TIMESTAMP_PROOF_LEN),
+            historicalSummaryBlockRootProof: new bytes(HISTSUMMARY_PROOF_LEN),
+            blockRootIndex: 0,
+            historicalSummaryIndex: 0,
+            withdrawalIndex: withdrawalIndex,
+            blockRoot: bytes32(0),
+            slotRoot: _toLittleEndianUint64(withdrawalEpoch * BeaconChainProofs.SLOTS_PER_EPOCH),
+            timestampRoot: _toLittleEndianUint64(oracleTimestamp),
+            executionPayloadRoot: bytes32(0)
+        });
+    }
+    
+    function _genExitProof(Validator memory validator) internal returns (BeaconWithdrawal memory) {
+        // revert("exitValidator: unimplemented");
+        BeaconWithdrawal memory withdrawal;
+        uint64 withdrawalEpoch = uint64(block.timestamp);
 
-        // // validatorFields and proof of validatorFields
-        // proof.validatorFields = new bytes32[][](1);
-        // proof.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
-        // proof.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
-        // proof.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX] = 
-        //     _toLittleEndianUint64(withdrawalEpoch);
+        withdrawal.oracleTimestamp = uint64(nextTimestamp);
+        nextTimestamp++;
 
-        // // Calculate blockRoot using beaconStateRoot and an empty proof:
-        // bytes memory blockRootProof = new bytes(BLOCKROOT_PROOF_LEN);
-        // bytes32 blockRoot = Merkle.processInclusionProofSha256({
-        //     proof: blockRootProof,
-        //     leaf: beaconStateRoot,
-        //     index: BeaconChainProofs.STATE_ROOT_INDEX
-        // });
+        BeaconChainProofs.WithdrawalProof memory withdrawalProof = _initWithdrawalProof({
+            withdrawalEpoch: withdrawalEpoch,
+            withdrawalIndex: WITHDRAWAL_INDEX,
+            oracleTimestamp: withdrawal.oracleTimestamp
+        });
 
-        // proof.stateRootProof = BeaconChainProofs.StateRootProof({
-        //     beaconStateRoot: beaconStateRoot,
-        //     proof: blockRootProof
-        // });
+        // withdrawalFields 
+        withdrawal.withdrawalFields = new bytes32[][](1);
+        withdrawal.withdrawalFields[0] = new bytes32[](2 ** BeaconChainProofs.WITHDRAWAL_FIELD_TREE_HEIGHT);
+        withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_INDEX_INDEX] =
+            _toLittleEndianUint64(validator.validatorIndex);
+        withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX] =
+            _toLittleEndianUint64(validator.effectiveBalanceGwei);
 
+        {
+            /**
+             * Generate root and proofs:
+             * execPayloadRoot
+             * - timestampRoot
+             * - withdrawalFieldsRoot
+             */
+            (
+                bytes32 execPayloadRoot,
+                bytes memory timestampProof,
+                bytes memory withdrawalFieldsProof
+            ) = _genExecPayloadProofs({ 
+                withdrawalIndex: withdrawalProof.withdrawalIndex,
+                withdrawalRoot: Merkle.merkleizeSha256(withdrawal.withdrawalFields[0]),
+                timestampRoot: withdrawalProof.timestampRoot
+            });
 
-        // // Send the block root to the oracle and increment timestamp:
-        // proof.oracleTimestamp = uint64(nextTimestamp);
-        // oracle.setBlockRoot(nextTimestamp, blockRoot);
-        // nextTimestamp++;
+            withdrawalProof.executionPayloadRoot = execPayloadRoot;
+
+            withdrawalProof.timestampProof = timestampProof;
+            withdrawalProof.withdrawalProof = withdrawalFieldsProof;
+        }
+
+        {
+            /**
+             * Generate root and proofs:
+             * blockRoot
+             * - slotRoot
+             * - execPayloadRoot
+             */
+            (
+                bytes32 blockRoot,
+                bytes memory slotRootProof,
+                bytes memory execPayloadProof
+            ) = _genBlockRootProofs({ 
+                slotRoot: withdrawalProof.slotRoot, 
+                execPayloadRoot: withdrawalProof.executionPayloadRoot 
+            });
+
+            withdrawalProof.blockRoot = blockRoot;
+
+            withdrawalProof.slotProof = slotRootProof;
+            withdrawalProof.executionPayloadProof = execPayloadProof;
+        }
+
+        // validatorFields
+        withdrawal.validatorFields = new bytes32[][](1);
+        withdrawal.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
+        withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
+        withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX] = 
+            _toLittleEndianUint64(withdrawalEpoch);
+
+        {
+            /**
+             * Generate root and proofs:
+             * beaconStateRoot
+             * - blockRoot
+             * - validatorFieldsRoot
+             */
+            (
+                bytes32 beaconStateRoot,
+                bytes memory validatorFieldsProof,
+                bytes memory blockRootProof
+            ) = _genBeaconStateRootProofs({ 
+                validatorIndex: validator.validatorIndex,
+                validatorRoot: Merkle.merkleizeSha256(withdrawal.validatorFields[0]), 
+                withdrawalProof: withdrawalProof
+            });
+    
+            withdrawal.stateRootProof.beaconStateRoot = beaconStateRoot;
+
+            withdrawal.validatorFieldsProofs = new bytes[](1);
+            withdrawal.validatorFieldsProofs[0] = validatorFieldsProof;
+
+            withdrawalProof.historicalSummaryBlockRootProof = blockRootProof;
+        }
+
+        withdrawal.withdrawalProofs = new BeaconChainProofs.WithdrawalProof[](1);
+        withdrawal.withdrawalProofs[0] = withdrawalProof;
+
+        // Calculate blockRoot using beaconStateRoot and an empty proof:
+        withdrawal.stateRootProof.proof = new bytes(BLOCKROOT_PROOF_LEN);
+        bytes32 beaconBlockRoot = Merkle.processInclusionProofSha256({
+            proof: withdrawal.stateRootProof.proof,
+            leaf: withdrawal.stateRootProof.beaconStateRoot,
+            index: BeaconChainProofs.STATE_ROOT_INDEX
+        });
+
+        // Send the block root to the oracle
+        oracle.setBlockRoot(withdrawal.oracleTimestamp, beaconBlockRoot);
+        return withdrawal;
+    }
+
+    function _genExecPayloadProofs(
+        uint64 withdrawalIndex,
+        bytes32 withdrawalRoot,
+        bytes32 timestampRoot
+    ) internal view returns (bytes32, bytes memory, bytes memory) {
+
+        uint withdrawalProofIndex = 
+            (BeaconChainProofs.WITHDRAWALS_INDEX << (BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1)) |
+            uint(withdrawalIndex);
+
+        (bytes memory timestampProof, bytes memory withdrawalFieldsProof) = _calcConvergentProofs({
+            shortProof: new bytes(TIMESTAMP_PROOF_LEN),
+            shortIndex: BeaconChainProofs.TIMESTAMP_INDEX,
+            shortLeaf: timestampRoot,
+            longProof: new bytes(WITHDRAWAL_PROOF_LEN),
+            longIndex: withdrawalProofIndex,
+            longLeaf: withdrawalRoot
+        });
+
+        // Use generated proofs to calculate tree root and verify both proofs
+        // result in the same root:
+        bytes32 execPayloadRoot = Merkle.processInclusionProofSha256({
+            proof: timestampProof,
+            leaf: timestampRoot,
+            index: BeaconChainProofs.TIMESTAMP_INDEX
+        });
+
+        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+            proof: withdrawalFieldsProof,
+            leaf: withdrawalRoot,
+            index: withdrawalProofIndex
+        });
+
+        require(execPayloadRoot == expectedRoot, "_genBlockRootProofs: mismatched roots");
         
-        return proof;
+        return (execPayloadRoot, timestampProof, withdrawalFieldsProof);
+    }
+
+    uint immutable HIST_SUMMARIES_PROOF_INDEX = BeaconChainProofs.HISTORICAL_SUMMARIES_INDEX << (
+        BeaconChainProofs.HISTORICAL_SUMMARIES_TREE_HEIGHT + 1 +
+        BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 1
+    );
+
+    function _genBlockRootProofs(
+        bytes32 slotRoot, 
+        bytes32 execPayloadRoot
+    ) internal view returns (bytes32, bytes memory, bytes memory) {
+
+        uint slotRootIndex = BeaconChainProofs.SLOT_INDEX;
+        uint execPayloadIndex = 
+            (BeaconChainProofs.BODY_ROOT_INDEX << BeaconChainProofs.BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT) |
+            BeaconChainProofs.EXECUTION_PAYLOAD_INDEX;
+
+        (bytes memory slotProof, bytes memory execPayloadProof) = _calcConvergentProofs({
+            shortProof: new bytes(SLOT_PROOF_LEN),
+            shortIndex: slotRootIndex,
+            shortLeaf: slotRoot,
+            longProof: new bytes(EXECPAYLOAD_PROOF_LEN),
+            longIndex: execPayloadIndex,
+            longLeaf: execPayloadRoot
+        });
+
+        // Use generated proofs to calculate tree root and verify both proofs
+        // result in the same root:
+        bytes32 blockRoot = Merkle.processInclusionProofSha256({
+            proof: slotProof,
+            leaf: slotRoot,
+            index: slotRootIndex
+        });
+
+        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+            proof: execPayloadProof,
+            leaf: execPayloadRoot,
+            index: execPayloadIndex
+        });
+
+        require(blockRoot == expectedRoot, "_genBlockRootProofs: mismatched roots");
+        
+        return (blockRoot, slotProof, execPayloadProof);
+    }
+
+    function _genBeaconStateRootProofs(
+        uint40 validatorIndex, 
+        bytes32 validatorRoot,
+        BeaconChainProofs.WithdrawalProof memory withdrawalProof
+    ) internal view returns (bytes32, bytes memory, bytes memory) {
+        uint blockHeaderIndex = _calcBlockHeaderIndex(withdrawalProof);
+        uint validatorProofIndex = _calcValProofIndex(validatorIndex);
+
+        (bytes memory blockRootProof, bytes memory validatorFieldsProof) = _calcConvergentProofs({
+            shortProof: new bytes(HISTSUMMARY_PROOF_LEN),
+            shortIndex: blockHeaderIndex,
+            shortLeaf: withdrawalProof.blockRoot,
+            longProof: new bytes(VAL_FIELDS_PROOF_LEN),
+            longIndex: validatorProofIndex,
+            longLeaf: validatorRoot
+        });
+
+        bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
+            proof: blockRootProof,
+            leaf: withdrawalProof.blockRoot,
+            index: blockHeaderIndex
+        });
+
+        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+            proof: validatorFieldsProof,
+            leaf: validatorRoot,
+            index: validatorProofIndex
+        });
+
+        require(beaconStateRoot == expectedRoot, "_genBeaconStateRootProofs: mismatched roots");
+        
+        return (beaconStateRoot, validatorFieldsProof, blockRootProof);
+    }
+
+    // Returns true if a and b are sibling indices in the same sub-tree.
+    //
+    // i.e this returns true if these indices represent two child nodes in
+    // sequential positions:
+    // [A, B] or [B, A]
+    function _areSiblings(uint a, uint b) internal pure returns (bool) {
+        return 
+            (a % 2 == 0 && b == a + 1) || (b % 2 == 0 && a == b + 1);
+    }
+
+    function _calcConvergentProofs(
+        bytes memory shortProof,
+        uint shortIndex,
+        bytes32 shortLeaf,
+        bytes memory longProof,
+        uint longIndex,
+        bytes32 longLeaf
+    ) internal view returns (bytes memory, bytes memory) {
+        bytes32[1] memory curShortHash = [shortLeaf];
+        bytes32[1] memory curLongHash = [longLeaf];
+
+        // Calculate root of long subtree
+        uint longProofOffset = longProof.length - shortProof.length;
+        for (uint i = 32; i <= longProofOffset; i += 32) {
+            if (longIndex % 2 == 0) {
+                assembly {
+                    mstore(0x00, mload(curLongHash))
+                    mstore(0x20, mload(add(longProof, i)))
+                }
+            } else {
+                assembly {
+                    mstore(0x00, mload(add(longProof, i)))
+                    mstore(0x20, mload(curLongHash))
+                }
+            }
+
+            // Compute hash and divide index
+            assembly {
+                if iszero(staticcall(sub(gas(), 2000), 2, 0x00, 0x40, curLongHash, 0x20)) {
+                    revert(0, 0)
+                }
+                longIndex := div(longIndex, 2)
+            }
+        }
+
+        // 
+        {
+            // Now that we've calculated the validatorFields sub-tree, merklize both trees simultaneously.
+            // When we reach two leaf indices s.t. A is even and B == A + 1, we know we have found the point
+            // where the two sub-trees converge.
+            uint longProof_i = 32 + longProofOffset;
+            uint shortProof_i = 32;
+            bool foundConvergence;
+            for (; longProof_i <= longProof.length; ) {
+                if (_areSiblings(longIndex, shortIndex)) {
+                    foundConvergence = true;
+                    assembly {
+                        mstore(add(longProof, longProof_i), mload(curShortHash))
+                        mstore(add(shortProof, shortProof_i), mload(curLongHash))
+                    }
+
+                    break;
+                }
+                
+                // Compute next hash for longProof
+                {
+                    if (longIndex % 2 == 0) {
+                        assembly {
+                            mstore(0x00, mload(curLongHash))
+                            mstore(0x20, mload(add(longProof, longProof_i)))
+                        }
+                    } else {
+                        assembly {
+                            mstore(0x00, mload(add(longProof, longProof_i)))
+                            mstore(0x20, mload(curLongHash))
+                        }
+                    }
+                    
+                    // Compute hash and divide index
+                    assembly {
+                        if iszero(staticcall(sub(gas(), 2000), 2, 0x00, 0x40, curLongHash, 0x20)) {
+                            revert(0, 0)
+                        }
+                        longIndex := div(longIndex, 2)
+                    }
+                }
+                
+                // Compute next hash for shortProof
+                {
+                    if (shortIndex % 2 == 0) {
+                        assembly {
+                            mstore(0x00, mload(curShortHash))
+                            mstore(0x20, mload(add(shortProof, shortProof_i)))
+                        }
+                    } else {
+                        assembly {
+                            mstore(0x00, mload(add(shortProof, shortProof_i)))
+                            mstore(0x20, mload(curShortHash))
+                        }
+                    }
+
+                    // Compute hash and divide index
+                    assembly {
+                        if iszero(staticcall(sub(gas(), 2000), 2, 0x00, 0x40, curShortHash, 0x20)) {
+                            revert(0, 0)
+                        }
+                        shortIndex := div(shortIndex, 2)
+                    }
+                }
+
+                longProof_i += 32;
+                shortProof_i += 32;
+            }
+
+            require(foundConvergence, "proofs did not converge!");
+        }
+
+        return (shortProof, longProof);
+    }
+
+    function _calcBlockHeaderIndex(BeaconChainProofs.WithdrawalProof memory withdrawalProof) internal view returns (uint) {
+        return 
+            HIST_SUMMARIES_PROOF_INDEX |
+            (uint(withdrawalProof.historicalSummaryIndex) << (BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 1)) |
+            (BeaconChainProofs.BLOCK_SUMMARY_ROOT_INDEX << BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT) |
+            uint(withdrawalProof.blockRootIndex);
+    }
+
+    function _calcValProofIndex(uint40 validatorIndex) internal pure returns (uint) {
+        return 
+            (BeaconChainProofs.VALIDATOR_TREE_ROOT_INDEX << (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1)) | 
+            uint(validatorIndex);
     }
 
     /// @dev Opposite of Endian.fromLittleEndianUint64

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -68,6 +68,15 @@ contract BeaconChainMock is Test {
         uint balanceWei, 
         bytes memory withdrawalCreds
     ) public returns (uint40, CredentialsProofs memory) {
+        // These checks mimic the checks made in the beacon chain deposit contract
+        //
+        // We sanity-check them here because this contract sorta acts like the 
+        // deposit contract and this ensures we only create validators that could
+        // exist IRL
+        require(balanceWei >= 1 ether, "BeaconChainMock.newValidator: deposit value too low");
+        require(balanceWei % 1 gwei == 0, "BeaconChainMock.newValidator: value not multiple of gwei");
+        uint depositAmount = balanceWei / GWEI_TO_WEI;
+        require(depositAmount <= type(uint64).max, "BeaconChainMock.newValidator: deposit value too high");
 
         // Create unique index for new validator
         uint40 validatorIndex = nextValidatorIndex;
@@ -78,7 +87,7 @@ contract BeaconChainMock is Test {
             pubkeyHash: keccak256(abi.encodePacked(validatorIndex)),
             validatorIndex: validatorIndex,
             withdrawalCreds: withdrawalCreds,
-            effectiveBalanceGwei: uint64(balanceWei / GWEI_TO_WEI)
+            effectiveBalanceGwei: uint64(depositAmount)
         });
         validators[validatorIndex] = validator;
 

--- a/src/test/integration/mocks/BeaconChainOracleMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainOracleMock.t.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "src/contracts/interfaces/IBeaconChainOracle.sol";
+
+contract BeaconChainOracleMock is IBeaconChainOracle {
+
+    mapping(uint64 => bytes32) blockRoots;
+
+    function timestampToBlockRoot(uint timestamp) public view returns (bytes32) {
+        return blockRoots[uint64(timestamp)];
+    }
+
+    function setBlockRoot(uint64 timestamp, bytes32 blockRoot) public {
+        blockRoots[timestamp] = blockRoot;
+    }
+}

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -15,8 +15,8 @@ contract Deposit_Delegate_Queue_Complete is IntegrationBase {
         // When new Users are created, they will choose a random configuration from these params: 
         _configRand({
             _randomSeed: _random,
-            _assetTypes: HOLDS_LST | HOLDS_ETH,
-            _userTypes: DEFAULT | SIGNED_METHODS
+            _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -104,8 +104,8 @@ contract Deposit_Delegate_Queue_Complete is IntegrationBase {
         // When new Users are created, they will choose a random configuration from these params: 
         _configRand({
             _randomSeed: _random,
-            _assetTypes: HOLDS_LST | HOLDS_ETH,
-            _userTypes: DEFAULT | SIGNED_METHODS
+            _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -104,7 +104,7 @@ contract Deposit_Delegate_Queue_Complete is IntegrationBase {
         // When new Users are created, they will choose a random configuration from these params: 
         _configRand({
             _randomSeed: _random,
-            _assetTypes: HOLDS_LST,
+            _assetTypes: HOLDS_LST | HOLDS_ETH,
             _userTypes: DEFAULT | SIGNED_METHODS
         });
 

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -15,7 +15,7 @@ contract Deposit_Delegate_Queue_Complete is IntegrationBase {
         // When new Users are created, they will choose a random configuration from these params: 
         _configRand({
             _randomSeed: _random,
-            _assetTypes: HOLDS_LST,
+            _assetTypes: HOLDS_LST | HOLDS_ETH,
             _userTypes: DEFAULT | SIGNED_METHODS
         });
 


### PR DESCRIPTION
- fixes some error messages to display the correct function name
- added `BeaconChainMock`, a mock interface to the beacon chain which generates proofs for pod validators
- full support for native eth stakers using the `HOLDS_ETH` and `HOLDS_ALL` flags to generate users with one or more validators-worth of restaked eth. 
- eth granted to users is now a random multiple of 32 ether. users that are granted more than 1 validator-worth will create multiple validators in the same pod.