### PR TITLE
Operator AVS Mapping Support

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -443,7 +443,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     }
 
     /**
-     * @notice External function called by AVSs to register an operator with the AVS.
+     * @notice Called by AVSs to register an operator with the AVS.
      * @param operator The address of the operator to register.
      * @param signatureWithSaltAndExpiry The signature, salt, and expiry of the operator's signature.
      */
@@ -476,7 +476,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     }
 
     /**
-     * @notice External function called by AVSs to deregister an operator with the AVS.
+     * @notice Called by AVSs to deregister an operator with the AVS.
      * @param operator The address of the operator to deregister.
      */
     function deregisterOperatorFromAVS(address operator) external {
@@ -486,6 +486,14 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         registeredWithAVS[msg.sender][operator] = false;
 
         emit OperatorRegistrationStatusUpdated(operator, msg.sender, OperatorRegistrationStatus.DEREGISTERED);
+    }
+
+    /**
+     * @notice Called by an AVS to emit an `OperatorMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {
+        emit AVSMetadataURIUpdated(msg.sender, metadataURI);
     }
 
     /*******************************************************************************

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -475,6 +475,19 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         emit OperatorRegistrationStatusUpdated(operator, msg.sender, OperatorRegistrationStatus.REGISTERED);
     }
 
+    /**
+     * @notice External function called by AVSs to deregister an operator with the AVS.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external {
+        require(registeredWithAVS[msg.sender][operator], "DelegationManager.deregisterOperatorFromAVS: operator not registered");
+
+        // deregister operator
+        registeredWithAVS[msg.sender][operator] = false;
+
+        emit OperatorRegistrationStatusUpdated(operator, msg.sender, OperatorRegistrationStatus.DEREGISTERED);
+    }
+
     /*******************************************************************************
                             INTERNAL FUNCTIONS
     *******************************************************************************/

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -25,6 +25,10 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     bytes32 public constant DELEGATION_APPROVAL_TYPEHASH =
         keccak256("DelegationApproval(address staker,address operator,bytes32 salt,uint256 expiry)");
 
+    /// @notice The EIP-712 typehash for the `Registration` struct used by the contract
+    bytes32 public constant OPERATOR_AVS_REGISTRATION_TYPEHASH =
+        keccak256("OperatorAVSRegistration(address operator,address delegationApprover,uint256 withdrawalDelayBlocks)");
+
     /**
      * @notice Original EIP-712 Domain separator for this contract.
      * @dev The domain separator may change in the event of a fork that modifies the ChainID.
@@ -92,6 +96,14 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @notice the address of the StakeRegistry contract to call for stake updates when operator shares are changed
     IStakeRegistryStub public stakeRegistry;
 
+    /// @notice Mapping: AVS => operator => whether or not the operator is currently registered with the AVS
+    mapping(address => mapping(address => bool)) public registeredWithAVS;
+
+    /// @notice Mapping: operator => 32-byte salt => whether or not the salt has already been used by the operator.
+    /// @dev Salt is used in the `registerOperatorWithAVS` function.
+    mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
+
+    /// @notice Mapping: operator => 
     constructor(IStrategyManager _strategyManager, ISlasher _slasher, IEigenPodManager _eigenPodManager) {
         strategyManager = _strategyManager;
         eigenPodManager = _eigenPodManager;
@@ -103,5 +115,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[40] private __gap;
+    uint256[38] private __gap;
 }

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -104,6 +104,12 @@ interface IDelegationManager is ISignatureUtils {
         address withdrawer;
     }
 
+    /// @notice Enum representing the status of an operator's registration with the AVS
+    enum OperatorRegistrationStatus {
+        DEREGISTERED,
+        REGISTERED
+    }
+
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, OperatorDetails operatorDetails);
 
@@ -146,6 +152,9 @@ interface IDelegationManager is ISignatureUtils {
 
     /// @notice Emitted when the `withdrawalDelayBlocks` variable is modified from `previousValue` to `newValue`.
     event WithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue);
+
+    /// @notice Emitted when an operator's registration status for an AVS is updated
+    event OperatorRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorRegistrationStatus status);
 
     /**
      * @notice Registers the caller as an operator in EigenLayer.

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -105,11 +105,15 @@ contract DelegationManagerMock is IDelegationManager, Test {
 
     function calculateApproverDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/) external pure returns (bytes32 approverDigestHash) {}
 
+    function calculateOperatorRegistrationDigestHash(address operator, address avs, bytes32 salt, uint256 expiry) external view returns (bytes32) {}
+
     function DOMAIN_TYPEHASH() external view returns (bytes32) {}
 
     function STAKER_DELEGATION_TYPEHASH() external view returns (bytes32) {}
 
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32) {}
+
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32) {}
 
     function domainSeparator() external view returns (bytes32) {}
 
@@ -117,7 +121,17 @@ contract DelegationManagerMock is IDelegationManager, Test {
 
     function calculateWithdrawalRoot(Withdrawal memory withdrawal) external pure returns (bytes32) {}
 
-   function queueWithdrawals(
+    function registerOperatorWithAVS(address operator, ISignatureUtils.SignatureWithSaltAndExpiry memory signatureWithSaltAndExpiry) external {}
+
+    function deregisterOperatorFromAVS(address operator) external {}
+
+    function updateAVSMetadataURI(string calldata metadataURI) external {}
+
+    function registeredWithAVS(address operator, address avs) external view returns (bool) {}
+
+    function operatorSaltIsSpent(address avs, bytes32 salt) external view returns (bool) {}
+
+    function queueWithdrawals(
         QueuedWithdrawalParams[] calldata queuedWithdrawalParams
     ) external returns (bytes32[] memory) {}
 


### PR DESCRIPTION
This WIP PR adds support in the DM to register an operator under a specific AVS. The expectation is that an AVS's registry coordinator will call the `registerOperatorWithAVS` and `deregisterOperatorFromAVS` functions to register and deregister an operator. AVSs can also use the `updateAVSMetadataURI` function to update a URI link. Full design doc is linked [here](https://docs.google.com/document/d/18iGFx7srXSlEt89E4nYLhWxm80R15kpG27cedAgxkTo/edit). 