### PR TITLE
Adding withdrawalDelayBlocks to DelegationManager interface

### DIFF
--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -370,6 +370,14 @@ interface IDelegationManager is ISignatureUtils {
     function delegationApproverSaltIsSpent(address _delegationApprover, bytes32 salt) external view returns (bool);
 
     /**
+     * @notice Minimum delay enforced by this contract for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
+     * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
+     * @dev Note that the withdrawal delay is not enforced on withdrawals of 'beaconChainETH', as the EigenPods have their own separate delay mechanic
+     * and we want to avoid stacking multiple enforced delays onto a single withdrawal.
+     */
+    function withdrawalDelayBlocks() external view returns (uint256);
+
+    /**
      * @notice Calculates the digestHash for a `staker` to sign to delegate to an `operator`
      * @param staker The signing staker
      * @param operator The operator who is being delegated to

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -76,6 +76,10 @@ contract DelegationManagerMock is IDelegationManager, Test {
         return 0;
     }
 
+    function withdrawalDelayBlocks() external pure returns (uint256) {
+        return 0;
+    }
+
     function isDelegated(address staker) external view returns (bool) {
         return (delegatedTo[staker] != address(0));
     }


### PR DESCRIPTION
Small addition to the interface as we are reading this off of the middleware sigchecker.
Here is where we are reading this from the middleware repo.
https://github.com/Layr-Labs/eigenlayer-middleware/commit/e4f39f61b962319578e8d8e4c0ef4582084833c7