### PR TITLE
feat: enable AVS update metadata uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ broadcast
 
 # Deployment tools
 /data
+.idea/
 
 # Certora Outputs
 .certora_internal/

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -140,6 +140,14 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     }
 
     /**
+     * @notice Called by an avs to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an avs
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {
+        emit AVSMetadataURIUpdated(msg.sender, metadataURI);
+    }
+
+    /**
      * @notice Caller delegates their stake to an operator.
      * @param operator The account (`msg.sender`) is delegating its assets to for use in serving applications built on EigenLayer.
      * @param approverSignatureAndExpiry Verifies the operator approves of this delegation

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -116,6 +116,12 @@ interface IDelegationManager is ISignatureUtils {
      */
     event OperatorMetadataURIUpdated(address indexed operator, string metadataURI);
 
+    /**
+     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
+     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     */
+    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
+
     /// @notice Emitted whenever an operator's shares are increased for a given strategy. Note that shares is the delta in the operator's shares.
     event OperatorSharesIncreased(address indexed operator, address staker, IStrategy strategy, uint256 shares);
 
@@ -173,8 +179,16 @@ interface IDelegationManager is ISignatureUtils {
     /**
      * @notice Called by an operator to emit an `OperatorMetadataURIUpdated` event indicating the information has updated.
      * @param metadataURI The URI for metadata associated with an operator
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `OperatorMetadataURIUpdated` event
      */
     function updateOperatorMetadataURI(string calldata metadataURI) external;
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external;
 
     /**
      * @notice Caller delegates their stake to an operator.

--- a/src/test/events/IDelegationManagerEvents.sol
+++ b/src/test/events/IDelegationManagerEvents.sol
@@ -20,6 +20,12 @@ interface IDelegationManagerEvents {
      */
     event OperatorMetadataURIUpdated(address indexed operator, string metadataURI);
 
+    /**
+     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
+     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     */
+    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
+
     /// @notice Emitted whenever an operator's shares are increased for a given strategy
     event OperatorSharesIncreased(address indexed operator, address staker, IStrategy strategy, uint256 shares);
 

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -28,6 +28,8 @@ contract DelegationManagerMock is IDelegationManager, Test {
     
     function updateOperatorMetadataURI(string calldata /*metadataURI*/) external pure {}
 
+    function updateAVSMetadataURI(string calldata /*metadataURI*/) external pure {}
+
     function delegateTo(address operator, SignatureWithExpiry memory /*approverSignatureAndExpiry*/, bytes32 /*approverSalt*/) external {
         delegatedTo[msg.sender] = operator;
     }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -42,6 +42,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     // reused in various tests. in storage to help handle stack-too-deep errors
     address defaultStaker = cheats.addr(uint256(123_456_789));
     address defaultOperator = address(this);
+    address defaultAVS = address(this);
 
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
@@ -579,6 +580,15 @@ contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerU
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit OperatorMetadataURIUpdated(defaultOperator, metadataURI);
         delegationManager.updateOperatorMetadataURI(metadataURI);
+    }
+
+    // @notice Tests that an avs who calls `updateAVSMetadataURI` will correctly see an `AVSMetadataURIUpdated` event emitted with their input
+    function testFuzz_UpdateAVSMetadataURI(string memory metadataURI) public {
+        // call `updateAVSMetadataURI` and check for event
+        cheats.prank(defaultAVS);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit AVSMetadataURIUpdated(defaultAVS, metadataURI);
+        delegationManager.updateAVSMetadataURI(metadataURI);
     }
 }
 


### PR DESCRIPTION
enable AVS to update their metadata uri by adding `function updateAVSMetadataURI` and `event AVSMetadataURIUpdated`

borrowed many from Yash's draft, and further polished

i'm not sure what unit tests to add, as there seems not much to test. If there is any, can you advise?