### PR TITLE
Feat: Remove set withdrawal delay

### DIFF
--- a/script/middleware/DeployOpenEigenLayer.s.sol
+++ b/script/middleware/DeployOpenEigenLayer.s.sol
@@ -139,7 +139,7 @@ contract DeployOpenEigenLayer is Script, Test {
         eigenLayerProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(delegation))),
             address(delegationImplementation),
-            abi.encodeWithSelector(DelegationManager.initialize.selector, executorMultisig, eigenLayerPauserReg, 0)
+            abi.encodeWithSelector(DelegationManager.initialize.selector, executorMultisig, eigenLayerPauserReg, 0, 0 /* withdrawalDelayBlocks */)
         );
         eigenLayerProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(strategyManager))),

--- a/script/milestone/M2Deploy.s.sol
+++ b/script/milestone/M2Deploy.s.sol
@@ -326,7 +326,7 @@ contract M2Deploy is Script, Test {
         );
 
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
-        DelegationManager(address(delegation)).initialize(address(this), PauserRegistry(address(this)), 0);
+        DelegationManager(address(delegation)).initialize(address(this), PauserRegistry(address(this)), 0, 0);
 
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
         EigenPodManager(address(eigenPodManager)).initialize(

--- a/script/testing/M2_Deploy_From_Scratch.s.sol
+++ b/script/testing/M2_Deploy_From_Scratch.s.sol
@@ -82,6 +82,7 @@ contract Deployer_M2 is Script, Test {
     uint256 STRATEGY_MANAGER_INIT_PAUSED_STATUS;
     uint256 SLASHER_INIT_PAUSED_STATUS;
     uint256 DELEGATION_INIT_PAUSED_STATUS;
+    uint256 DELEGATION_WITHDRAWAL_DELAY_BLOCKS;
     uint256 EIGENPOD_MANAGER_INIT_PAUSED_STATUS;
     uint256 EIGENPOD_MANAGER_MAX_PODS;
     uint256 DELAYED_WITHDRAWAL_ROUTER_INIT_PAUSED_STATUS;
@@ -103,6 +104,7 @@ contract Deployer_M2 is Script, Test {
         STRATEGY_MANAGER_INIT_PAUSED_STATUS = stdJson.readUint(config_data, ".strategyManager.init_paused_status");
         SLASHER_INIT_PAUSED_STATUS = stdJson.readUint(config_data, ".slasher.init_paused_status");
         DELEGATION_INIT_PAUSED_STATUS = stdJson.readUint(config_data, ".delegation.init_paused_status");
+        DELEGATION_WITHDRAWAL_DELAY_BLOCKS = stdJson.readUint(config_data, ".delegation.init_withdrawal_delay_blocks");
         EIGENPOD_MANAGER_MAX_PODS = stdJson.readUint(config_data, ".eigenPodManager.max_pods");
         EIGENPOD_MANAGER_INIT_PAUSED_STATUS = stdJson.readUint(config_data, ".eigenPodManager.init_paused_status");
         DELAYED_WITHDRAWAL_ROUTER_INIT_PAUSED_STATUS = stdJson.readUint(
@@ -208,7 +210,8 @@ contract Deployer_M2 is Script, Test {
                 DelegationManager.initialize.selector,
                 executorMultisig,
                 eigenLayerPauserReg,
-                DELEGATION_INIT_PAUSED_STATUS
+                DELEGATION_INIT_PAUSED_STATUS,
+                DELEGATION_WITHDRAWAL_DELAY_BLOCKS
             )
         );
         eigenLayerProxyAdmin.upgradeAndCall(

--- a/script/testing/M2_deploy_from_scratch.mainnet.config.json
+++ b/script/testing/M2_deploy_from_scratch.mainnet.config.json
@@ -53,7 +53,8 @@
           },
      "delegation":
           {
-               "init_paused_status": 0
+               "init_paused_status": 0,
+               "init_withdrawal_delay_blocks": 50400
           },
      "ethPOSDepositAddress": "0x00000000219ab540356cBB839Cbe05303d7705Fa"
  }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -758,6 +758,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             _withdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS,
             "DelegationManager._initializeWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
         );
+        emit WithdrawalDelayBlocksSet(withdrawalDelayBlocks, _withdrawalDelayBlocks);
         withdrawalDelayBlocks = _withdrawalDelayBlocks;
     }
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -65,15 +65,18 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
     /**
      * @dev Initializes the addresses of the initial owner, pauser registry, and paused status.
+     * withdrawalDelayBlocks is set only once here
      */
     function initialize(
         address initialOwner,
         IPauserRegistry _pauserRegistry,
-        uint256 initialPausedStatus
+        uint256 initialPausedStatus,
+        uint256 _withdrawalDelayBlocks
     ) external initializer {
         _initializePauser(_pauserRegistry, initialPausedStatus);
         _DOMAIN_SEPARATOR = _calculateDomainSeparator();
         _transferOwnership(initialOwner);
+        _initializeWithdrawalDelayBlocks(_withdrawalDelayBlocks);
     }
 
     /*******************************************************************************
@@ -208,19 +211,6 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         // go through the internal delegation flow, checking the `approverSignatureAndExpiry` if applicable
         _delegate(staker, operator, approverSignatureAndExpiry, approverSalt);
-    }
-
-    /**
-     * @notice Owner-only function for modifying the value of the `withdrawalDelayBlocks` variable.
-     * @param newWithdrawalDelayBlocks new value of `withdrawalDelayBlocks`.
-     */
-    function setWithdrawalDelayBlocks(uint256 newWithdrawalDelayBlocks) external onlyOwner {
-        require(
-            newWithdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS,
-            "DelegationManager.setWithdrawalDelayBlocks: newWithdrawalDelayBlocks too high"
-        );
-        emit WithdrawalDelayBlocksSet(withdrawalDelayBlocks, newWithdrawalDelayBlocks);
-        withdrawalDelayBlocks = newWithdrawalDelayBlocks;
     }
 
     /**
@@ -761,6 +751,14 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         } else {
             strategyManager.withdrawSharesAsTokens(withdrawer, strategy, shares, token);
         }
+    }
+
+    function _initializeWithdrawalDelayBlocks(uint256 _withdrawalDelayBlocks) internal {
+        require(
+            _withdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS,
+            "DelegationManager._initializeWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
+        );
+        withdrawalDelayBlocks = _withdrawalDelayBlocks;
     }
 
     /*******************************************************************************

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -333,7 +333,7 @@ contract DelegationTests is EigenLayerTestHelper {
     ///         cannot be intitialized multiple times
     function testCannotInitMultipleTimesDelegation() public cannotReinit {
         //delegation has already been initialized in the Deployer test contract
-        delegation.initialize(address(this), eigenLayerPauserReg, 0);
+        delegation.initialize(address(this), eigenLayerPauserReg, 0, initializedWithdrawalDelayBlocks);
     }
 
     /// @notice This function tests to ensure that a you can't register as a delegate multiple times
@@ -370,7 +370,7 @@ contract DelegationTests is EigenLayerTestHelper {
         //delegation has already been initialized in the Deployer test contract
         vm.prank(_attacker);
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
-        delegation.initialize(_attacker, eigenLayerPauserReg, 0);
+        delegation.initialize(_attacker, eigenLayerPauserReg, 0, initializedWithdrawalDelayBlocks);
     }
 
     /// @notice This function tests that the earningsReceiver cannot be set to address(0)

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -500,7 +500,8 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
                 DelegationManager.initialize.selector,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
-                0/*initialPausedStatus*/
+                0 /*initialPausedStatus*/,
+                initializedWithdrawalDelayBlocks
             )
         );
         eigenLayerProxyAdmin.upgradeAndCall(

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -73,6 +73,7 @@ contract EigenLayerDeployer is Operators {
     uint256 public constant eigenTotalSupply = 1000e18;
     uint256 nonce = 69;
     uint256 public gasLimit = 750000;
+    uint256 initializedWithdrawalDelayBlocks = 0;
     uint32 PARTIAL_WITHDRAWAL_FRAUD_PROOF_PERIOD_BLOCKS = 7 days / 12 seconds;
     uint256 REQUIRED_BALANCE_WEI = 32 ether;
     uint64 MAX_PARTIAL_WTIHDRAWAL_AMOUNT_GWEI = 1 ether / 1e9;
@@ -268,7 +269,8 @@ contract EigenLayerDeployer is Operators {
                 DelegationManager.initialize.selector,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
-                0 /*initialPausedStatus*/
+                0 /*initialPausedStatus*/,
+                initializedWithdrawalDelayBlocks
             )
         );
         eigenLayerProxyAdmin.upgradeAndCall(

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -204,7 +204,8 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
                 DelegationManager.initialize.selector,
                 initialOwner,
                 pauserReg,
-                0 /*initialPausedStatus*/
+                0 /*initialPausedStatus*/,
+                WITHDRAWAL_DELAY_BLOCKS
             )
         );
         eigenLayerProxyAdmin.upgradeAndCall(

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -189,6 +189,7 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
         DelayedWithdrawalRouter delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
 
         // Third, upgrade the proxy contracts to point to the implementations
+        uint256 withdrawalDelayBlocks = 7 days / 12 seconds;
         // DelegationManager
         eigenLayerProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(delegationManager))),
@@ -197,7 +198,8 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
                 DelegationManager.initialize.selector,
                 eigenLayerReputedMultisig, // initialOwner
                 pauserRegistry,
-                0 // initialPausedStatus
+                0 /* initialPausedStatus */,
+                withdrawalDelayBlocks
             )
         );
         // StrategyManager
@@ -237,7 +239,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             )
         );
         // Delayed Withdrawal Router
-        uint256 withdrawalDelayBlocks = 7 days / 12 seconds;
         eigenLayerProxyAdmin.upgradeAndCall(
             TransparentUpgradeableProxy(payable(address(delayedWithdrawalRouter))),
             address(delayedWithdrawalRouterImplementation),

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -43,7 +43,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     address defaultStaker = cheats.addr(uint256(123_456_789));
     address defaultOperator = address(this);
 
-    uint256 initializedWithdrawalDelayBlocks = 0;
+    uint256 initializedWithdrawalDelayBlocks = 50400;
 
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 


### PR DESCRIPTION
Description:
Removes the ability to modify `delegation.withdrawDelayBlocks()` and only settable in `initialize` as the BLSSignatureChecker in middleware depends on this withdrawal window and modifying `withdrawDelayBlocks` could make previous invalid signatures valid. Since we don't have plans on modifying this value the plan is to just remove the setter entirely.

Changes:
- `Delegation.initialize` and `Delegation._initializeWithdrawalDelayBlocks`
- Fixed all scripts and compile errors
- added a regression test for initializing <= MAX_WITHDRAWAL_DELAY_BLOCKS