### PR TITLE
chore: migrate to certora prover v5

### DIFF
--- a/.github/workflows/certora-prover.yml
+++ b/.github/workflows/certora-prover.yml
@@ -43,7 +43,7 @@ jobs:
           distribution: temurin
           java-version: '17'
       - name: Install certora
-        run: pip install certora-cli==4.13.1
+        run: pip install certora-cli
       - name: Install solc
         run: |
           wget https://github.com/ethereum/solidity/releases/download/v0.8.12/solc-static-linux

--- a/certora/scripts/core/verifyDelegationManager.sh
+++ b/certora/scripts/core/verifyDelegationManager.sh
@@ -13,6 +13,7 @@ certoraRun certora/harnesses/DelegationManagerHarness.sol \
     --optimistic_loop \
     --prover_args '-optimisticFallback true' \
     --optimistic_hashing \
+    --parametric_contracts DelegationManagerHarness \
     $RULE \
     --loop_iter 2 \
     --packages @openzeppelin=lib/openzeppelin-contracts @openzeppelin-upgrades=lib/openzeppelin-contracts-upgradeable \

--- a/certora/scripts/core/verifyStrategyManager.sh
+++ b/certora/scripts/core/verifyStrategyManager.sh
@@ -14,6 +14,7 @@ certoraRun certora/harnesses/StrategyManagerHarness.sol \
     --optimistic_loop \
     --prover_args '-optimisticFallback true' \
     --optimistic_hashing \
+    --parametric_contracts StrategyManagerHarness \
     $RULE \
     --loop_iter 2 \
     --packages @openzeppelin=lib/openzeppelin-contracts @openzeppelin-upgrades=lib/openzeppelin-contracts-upgradeable \

--- a/certora/scripts/libraries/verifyStructuredLinkedList.sh
+++ b/certora/scripts/libraries/verifyStructuredLinkedList.sh
@@ -9,6 +9,7 @@ certoraRun certora/harnesses/StructuredLinkedListHarness.sol \
     --verify StructuredLinkedListHarness:certora/specs/libraries/StructuredLinkedList.spec \
     --optimistic_loop \
     --prover_args '-optimisticFallback true' \
+    --parametric_contracts StructuredLinkedListHarness \
     $RULE \
     --rule_sanity \
     --loop_iter 3 \

--- a/certora/scripts/pods/verifyEigenPodManager.sh
+++ b/certora/scripts/pods/verifyEigenPodManager.sh
@@ -12,6 +12,7 @@ certoraRun certora/harnesses/EigenPodManagerHarness.sol \
     --optimistic_loop \
     --prover_args '-optimisticFallback true' \
     --optimistic_hashing \
+    --parametric_contracts EigenPodManagerHarness \
     $RULE \
     --loop_iter 3 \
     --packages @openzeppelin=lib/openzeppelin-contracts @openzeppelin-upgrades=lib/openzeppelin-contracts-upgradeable \

--- a/certora/scripts/strategies/verifyStrategyBase.sh
+++ b/certora/scripts/strategies/verifyStrategyBase.sh
@@ -16,5 +16,6 @@ certoraRun certora/munged/strategies/StrategyBase.sol \
     --loop_iter 3 \
     --packages @openzeppelin=lib/openzeppelin-contracts @openzeppelin-upgrades=lib/openzeppelin-contracts-upgradeable \
     --link StrategyBase:strategyManager=StrategyManager \
+    --parametric_contracts StrategyBase \
     $RULE \
     --msg "StrategyBase $1 $2" \


### PR DESCRIPTION
- switch from fixed v4.13.1 to floating / latest version

- implement minimal changes that (hopefully) make existing specs work with v5


This is a minimal PR to migrate from v4.13.1 to v5 _without breaking our specs_.
We will need to do more work to actually take full advantage of the new features in v5.