### PR TITLE
Test: Add back missing withdrawal tests to DelegationUnit.t.sol

### DIFF
--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -27,8 +27,8 @@ contract StrategyManagerMock is
     ISlasher public slasher;
     address public strategyWhitelister;
 
-    IStrategy[] public strategiesToReturn;
-    uint256[] public sharesToReturn;
+    mapping(address => IStrategy[]) public strategiesToReturn;
+    mapping(address => uint256[]) public sharesToReturn;
 
     /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated. only increments (doesn't decrement)
     mapping(address => uint256) public cumulativeWithdrawalsQueued;
@@ -67,21 +67,22 @@ contract StrategyManagerMock is
 
     /**
      * @notice mocks the return value of getDeposits
+     * @param staker staker whose deposits are being mocked
      * @param _strategiesToReturn strategies to return in getDeposits
      * @param _sharesToReturn shares to return in getDeposits
      */
-    function setDeposits(IStrategy[] calldata _strategiesToReturn, uint256[] calldata _sharesToReturn) external {
+    function setDeposits(address staker, IStrategy[] calldata _strategiesToReturn, uint256[] calldata _sharesToReturn) external {
         require(_strategiesToReturn.length == _sharesToReturn.length, "StrategyManagerMock: length mismatch");
-        strategiesToReturn = _strategiesToReturn;
-        sharesToReturn = _sharesToReturn;
+        strategiesToReturn[staker] = _strategiesToReturn;
+        sharesToReturn[staker] = _sharesToReturn;
     }
 
     /**
-     * @notice Get all details on the depositor's deposits and corresponding shares
-     * @return (depositor's strategies, shares in these strategies)
+     * @notice Get all details on the staker's deposits and corresponding shares
+     * @return (staker's strategies, shares in these strategies)
      */
-    function getDeposits(address /*depositor*/) external view returns (IStrategy[] memory, uint256[] memory) {
-        return (strategiesToReturn, sharesToReturn);
+    function getDeposits(address staker) external view returns (IStrategy[] memory, uint256[] memory) {
+        return (strategiesToReturn[staker], sharesToReturn[staker]);
     }
 
     /// @notice Returns the array of strategies in which `staker` has nonzero shares

--- a/src/test/tree/DelegationManagerUnit.tree
+++ b/src/test/tree/DelegationManagerUnit.tree
@@ -178,13 +178,6 @@
 │   └── given that the staker is delegated
 │       ├── it should increase the operator's share for the staker and its associated strategy
 │       └── it should push an operator stake update
-├── when setWithdrawalDelayBlocks is called
-│   ├── given not called by owner
-│   │   └── it should revert
-│   ├── given new delay is > MAX_WITHDRAWAL_DELAY_BLOCKS
-│   │   └── it should revert
-│   └── given called by owner and new delay is <= MAX_WITHDRAWAL_DELAY_BLOCKS
-│       └── it should set the new delay and emit event
 └── when setStakeRegistry is called
     ├── given not called by owner
     │   └── it should revert

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -332,7 +332,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         return withdrawalAmounts;
     }
 
-    function _setUpQueueWithdrawalsStructSingleStrat(
+    function _setUpQueueWithdrawalsSingleStrat(
         address staker,
         address withdrawer,
         IStrategy strategy,
@@ -368,7 +368,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
     }
 
-    function _setUpQueueWithdrawalsStruct(
+    function _setUpQueueWithdrawals(
         address staker,
         address withdrawer,
         IStrategy[] memory strategies,
@@ -419,7 +419,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
             IDelegationManager.Withdrawal memory withdrawal,
             bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsStructSingleStrat({
+        ) = _setUpQueueWithdrawalsSingleStrat({
             staker: staker,
             withdrawer: withdrawer,
             strategy: strategies[0],
@@ -456,7 +456,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
             IDelegationManager.Withdrawal memory withdrawal,
             bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsStruct({
+        ) = _setUpQueueWithdrawals({
             staker: staker,
             withdrawer: withdrawer,
             strategies: strategies,
@@ -2740,7 +2740,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
     function test_Revert_WhenEnterQueueWithdrawalsPaused() public {
         cheats.prank(pauser);
         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
-        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsStructSingleStrat({
+        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
             withdrawer: defaultStaker,
             strategy: strategyMock,
@@ -2769,7 +2769,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
     }
 
     function test_Revert_WhenZeroAddressWithdrawer() public {
-        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsStructSingleStrat({
+        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
             withdrawer: address(0),
             strategy: strategyMock,
@@ -2820,7 +2820,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
             IDelegationManager.Withdrawal memory withdrawal,
             bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsStructSingleStrat({
+        ) = _setUpQueueWithdrawalsSingleStrat({
             staker: staker,
             withdrawer: staker,
             strategy: strategies[0],
@@ -2866,7 +2866,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
             IDelegationManager.Withdrawal memory withdrawal,
             bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsStruct({
+        ) = _setUpQueueWithdrawals({
             staker: staker,
             withdrawer: staker,
             strategies: strategies,


### PR DESCRIPTION
Added some missing unit tests for `queueWithdrawals` and `completeQueuedWithdrawal`

Changes:
- Removed `setWithdrawalDelayBlocks` from tree file as it is now removed and withdrawalDelayBlocks is only initialized on each upgrade
- Added helpers `_deployAndDepositIntoStrategies`, `_setUpQueueWithdrawals`, `_setUpCompleteQueuedWithdrawal`, `_fuzzWithdrawalAmounts` for easier setup of fuzzing and testing