### PR TITLE
fix: update docs and ensure important state changing methods are pausable

### DIFF
--- a/docs/core/EigenPodManager.md
+++ b/docs/core/EigenPodManager.md
@@ -77,7 +77,7 @@ To complete the deposit process, the Staker needs to prove that the validator's 
 #### `EigenPodManager.createPod`
 
 ```solidity
-function createPod() external returns (address)
+function createPod() external onlyWhenNotPaused(PAUSED_NEW_EIGENPODS) returns (address)
 ```
 
 Allows a Staker to deploy an `EigenPod` instance, if they have not done so already.
@@ -110,6 +110,7 @@ function stake(
 ) 
     external 
     payable
+    onlyWhenNotPaused(PAUSED_NEW_EIGENPODS)
 ```
 
 Allows a Staker to deposit 32 ETH into the beacon chain deposit contract, providing the credentials for the Staker's beacon chain validator. The `EigenPod.stake` method is called, which automatically calculates the correct withdrawal credentials for the pod and passes these to the deposit contract along with the 32 ETH.
@@ -119,7 +120,7 @@ Allows a Staker to deposit 32 ETH into the beacon chain deposit contract, provid
 * See [`EigenPod.stake`](#eigenpodstake)
 
 *Requirements*:
-* If deploying an `EigenPod`, pause status MUST NOT be set: `PAUSED_NEW_EIGENPODS`
+* Pause status MUST NOT be set: `PAUSED_NEW_EIGENPODS`
 * See [`EigenPod.stake`](#eigenpodstake)
 
 ##### `EigenPod.stake`
@@ -690,6 +691,7 @@ function withdrawNonBeaconChainETHBalanceWei(
 ) 
     external 
     onlyEigenPodOwner
+    onlyWhenNotPaused(PAUSED_NON_PROOF_WITHDRAWALS)
 ```
 
 Allows the Pod Owner to withdraw ETH accidentally sent to the contract's `receive` function.
@@ -703,6 +705,7 @@ Withdrawals from this function are sent via the `DelayedWithdrawalRouter`, and c
 * Sends `amountToWithdraw` wei to [`DelayedWithdrawalRouter.createDelayedWithdrawal`](#delayedwithdrawalroutercreatedelayedwithdrawal)
 
 *Requirements:*
+* Pause status MUST NOT be set: `PAUSED_NON_PROOF_WITHDRAWALS`
 * Caller MUST be the Pod Owner
 * `amountToWithdraw` MUST NOT be greater than the amount sent to the contract's `receive` function
 * See [`DelayedWithdrawalRouter.createDelayedWithdrawal`](#delayedwithdrawalroutercreatedelayedwithdrawal)
@@ -717,6 +720,7 @@ function recoverTokens(
 ) 
     external 
     onlyEigenPodOwner
+    onlyWhenNotPaused(PAUSED_NON_PROOF_WITHDRAWALS)
 ```
 
 Allows the Pod Owner to rescue ERC20 tokens accidentally sent to the `EigenPod`.
@@ -725,5 +729,6 @@ Allows the Pod Owner to rescue ERC20 tokens accidentally sent to the `EigenPod`.
 * Calls `transfer` on each of the ERC20's in `tokenList`, sending the corresponding `amountsToWithdraw` to the `recipient`
 
 *Requirements:*
+* Pause status MUST NOT be set: `PAUSED_NON_PROOF_WITHDRAWALS`
 * `tokenList` and `amountsToWithdraw` MUST have equal lengths
 * Caller MUST be the Pod Owner

--- a/docs/core/EigenPodManager.md
+++ b/docs/core/EigenPodManager.md
@@ -77,7 +77,7 @@ To complete the deposit process, the Staker needs to prove that the validator's 
 #### `EigenPodManager.createPod`
 
 ```solidity
-function createPod() external
+function createPod() external returns (address)
 ```
 
 Allows a Staker to deploy an `EigenPod` instance, if they have not done so already.

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -348,7 +348,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     function withdrawNonBeaconChainETHBalanceWei(
         address recipient,
         uint256 amountToWithdraw
-    ) external onlyEigenPodOwner {
+    ) external onlyEigenPodOwner onlyWhenNotPaused(PAUSED_NON_PROOF_WITHDRAWALS) {
         require(
             amountToWithdraw <= nonBeaconChainETHBalanceWei,
             "EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei"
@@ -363,7 +363,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         IERC20[] memory tokenList,
         uint256[] memory amountsToWithdraw,
         address recipient
-    ) external onlyEigenPodOwner {
+    ) external onlyEigenPodOwner onlyWhenNotPaused(PAUSED_NON_PROOF_WITHDRAWALS) {
         require(
             tokenList.length == amountsToWithdraw.length,
             "EigenPod.recoverTokens: tokenList and amountsToWithdraw must be same length"

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -72,7 +72,7 @@ contract EigenPodManager is
      * @dev Function will revert if the `msg.sender` already has an EigenPod.
      * @dev Returns EigenPod address 
      */
-    function createPod() external returns (address) {
+    function createPod() external onlyWhenNotPaused(PAUSED_NEW_EIGENPODS) returns (address) {
         require(!hasPod(msg.sender), "EigenPodManager.createPod: Sender already has a pod");
         // deploy a pod if the sender doesn't have one already
         IEigenPod pod = _deployPod();
@@ -87,7 +87,11 @@ contract EigenPodManager is
      * @param signature The validator's signature of the deposit data.
      * @param depositDataRoot The root/hash of the deposit data for the validator's deposit.
      */
-    function stake(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable {
+    function stake(
+        bytes calldata pubkey, 
+        bytes calldata signature, 
+        bytes32 depositDataRoot
+    ) external payable onlyWhenNotPaused(PAUSED_NEW_EIGENPODS) {
         IEigenPod pod = ownerToPod[msg.sender];
         if (address(pod) == address(0)) {
             //deploy a pod if the sender doesn't have one already
@@ -235,7 +239,7 @@ contract EigenPodManager is
 
     // INTERNAL FUNCTIONS
 
-    function _deployPod() internal onlyWhenNotPaused(PAUSED_NEW_EIGENPODS) returns (IEigenPod) {
+    function _deployPod() internal returns (IEigenPod) {
         // check that the limit of EigenPods has not been hit, and increment the EigenPod count
         require(numPods + 1 <= maxPods, "EigenPodManager._deployPod: pod limit reached");
         ++numPods;

--- a/src/contracts/pods/EigenPodPausingConstants.sol
+++ b/src/contracts/pods/EigenPodPausingConstants.sol
@@ -21,4 +21,6 @@ abstract contract EigenPodPausingConstants {
     uint8 internal constant PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE = 3;
     /// @notice Index for flag that pauses the `verifyBeaconChainFullWithdrawal` function *of the EigenPods* when set. see EigenPod code for details.
     uint8 internal constant PAUSED_EIGENPODS_VERIFY_WITHDRAWAL = 4;
+    /// @notice Pausability for EigenPod's "accidental transfer" withdrawal methods
+    uint8 internal constant PAUSED_NON_PROOF_WITHDRAWALS = 5;
 }


### PR DESCRIPTION
Docs:
* Updates EPM docs with `verifyBalanceUpdates` and `createPod` method signature change
* Adds docs for #363 

Changes:
* EPM.createPod and EPM.stake now pause at the top level. Previously, stake could be called during a pause if the pod owner had a pod deployed already
* EP.recoverTokens and EP.withdrawNonBeaconChainETHBalanceWei now have a pause flag