### PR TITLE
fix: update broken links in AVS docs

### DIFF
--- a/docs/experimental/AVS-Guide.md
+++ b/docs/experimental/AVS-Guide.md
@@ -1,5 +1,5 @@
-[middleware-folder-link]: https://github.com/Layr-Labs/eigenlayer-contracts/tree/master/src/contracts/middleware
-[middleware-guide-link]: https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/AVS-Guide.md#quick-start-guide-to-build-avs-contracts
+[middleware-folder-link]: https://github.com/Layr-Labs/eigenlayer-middleware/tree/master/src
+[middleware-guide-link]: https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/experimental/AVS-Guide.md#quick-start-guide-to-build-avs-contracts
 # Purpose
 This document aims to describe and summarize how actively validated services (AVSs) building on EigenLayer interact with the core EigenLayer protocol. Currently, this doc explains how AVS developers can use the current** APIs for: 
 - enabling operators to opt-in to the AVS,
@@ -72,7 +72,7 @@ EigenLayer is a dynamic system where stakers and operators are constantly adjust
 Let us illustrate the usage of this facility with an example: A staker has delegated to an operator, who has opted-in to serving an AVS. Whenever the staker withdraws some or all of its stake from EigenLayer, this withdrawal affects all the AVSs uniformly that the staker's delegated operator is participating in. The series of steps for withdrawing stake is as follows:
  - The staker queues their withdrawal request with EigenLayer. The staker can place this request by calling  `StrategyManager.queueWithdrawal(..)`.
  - The operator, noticing an upcoming change in their delegated stake, notifies the AVS about this change. To do this, the operator triggers the AVS to call the `ServiceManager.recordStakeUpdate(..)` which in turn accesses `Slasher.recordStakeUpdate(..)`.  On successful execution of this call, the event `MiddlewareTimesAdded(..)` is emitted.
-- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/EigenLayer-withdrawal-flow.md) for more details
+- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/outdated/EigenLayer-withdrawal-flow.md) for more details
 
 The following figure illustrates the above flow: 
 ![Stake update](../images/staker_withdrawing.png)


### PR DESCRIPTION
Hello,
I've found several broken links in AVS documentation. This PR fixes them.