### PR TITLE
fix: update ISSUE templates links

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ User stories are often expressed in a simple sentence, structured as follows: 'A
 
 **Actions**
 - [ ] An action item list describing the work to be done
-- [ ] Link to all of the related tasks needed to complete the feature. See the [tasks](https://github.com/Layr-Labs/docs/blob/949bd6b4ddd0ef08880c6775c2d9a6222e2e7eb3/.github/ISSUE_TEMPLATE/task.md) template.
+- [ ] Link to all of the related tasks needed to complete the feature. See the [tasks](https://github.com/Layr-Labs/eigenlayer-contracts/tree/master/.github/ISSUE_TEMPLATE/task.md) template.
 - [ ] Include everything in the definition of done e.g. unit tests and documentation
 
 **Acceptance criteria**

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -7,7 +7,7 @@ labels: task
 ---
 
 ## Description
-Add a summary and description. Link to any parent [feature requests](https://github.com/Layr-Labs/docs/blob/c78dbcd9a4b229e367f11725ee6758271a65bad3/.github/ISSUE_TEMPLATE/feature_request.md) or [bug reports](https://github.com/Layr-Labs/docs/blob/c78dbcd9a4b229e367f11725ee6758271a65bad3/.github/ISSUE_TEMPLATE/bug_report.md). 
+Add a summary and description. Link to any parent [feature requests](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/.github/ISSUE_TEMPLATE/feature_request.md) or [bug reports](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/.github/ISSUE_TEMPLATE/bug_report.md). 
 
 ### Action Items
 - [ ] An action item list describing the work to be done


### PR DESCRIPTION
Hello,
I've found several broken links in ISSUE templates, this PR fixes them. 

Another issue to fix is to update part of the issue where project should be assigned (the link is also not working). To my knowledge, no LayerZero projects are publicly accessible. 