### PR TITLE
capella-to-deneb with governance switch

### DIFF
--- a/script/Test.s.sol
+++ b/script/Test.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import "../src/contracts/interfaces/IETHPOSDeposit.sol";
+import "../src/contracts/interfaces/IBeaconChainOracle.sol";
+
+import "../src/contracts/core/StrategyManager.sol";
+import "../src/contracts/core/Slasher.sol";
+import "../src/contracts/core/DelegationManager.sol";
+
+import "../src/contracts/strategies/StrategyBaseTVLLimits.sol";
+
+import "../src/contracts/pods/EigenPod.sol";
+import "../src/contracts/pods/EigenPodManager.sol";
+import "../src/contracts/pods/DelayedWithdrawalRouter.sol";
+
+import "../src/contracts/permissions/PauserRegistry.sol";
+
+import "../src/test/mocks/EmptyContract.sol";
+import "../src/test/mocks/ETHDepositMock.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+
+contract EigenPodDeployer is Script, Test {
+
+
+    IEigenPodManager public epm = IEigenPodManager(address(0x33e42d539abFe9b387B27b0e467374Bbb76cf925));
+    function run() external {
+        address hello = epm.createPod();
+        emit log_named_address("THIS IS THE DEPLOYED ADDRESS", hello);
+    }
+
+
+}

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -105,6 +105,10 @@ interface IEigenPodManager is IPausable {
     /// @notice Returns the maximum number of EigenPods that can be created
     function maxPods() external view returns (uint256);
 
+    function isDeneb() external view returns (bool);
+
+    function setIsDeneb() external;
+
     /**
      * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.
      * @dev The share amount can become negative. This is necessary to accommodate the fact that a pod owner's virtual beacon chain ETH shares can

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -105,9 +105,9 @@ interface IEigenPodManager is IPausable {
     /// @notice Returns the maximum number of EigenPods that can be created
     function maxPods() external view returns (uint256);
 
-    function denebForkTimestamp() external view returns (bool);
+    function denebForkTimestamp() external view returns (uint64);
 
-    function setDenebForkTimestamp() external;
+    function setDenebForkTimestamp(uint64 timestamp) external;
 
     /**
      * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -105,9 +105,9 @@ interface IEigenPodManager is IPausable {
     /// @notice Returns the maximum number of EigenPods that can be created
     function maxPods() external view returns (uint256);
 
-    function isDeneb() external view returns (bool);
+    function denebForkTimestamp() external view returns (bool);
 
-    function setIsDeneb() external;
+    function setDenebForkTimestamp() external;
 
     /**
      * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -213,7 +213,7 @@ library BeaconChainProofs {
         bytes32 beaconStateRoot,
         bytes32[] calldata withdrawalFields,
         WithdrawalProof calldata withdrawalProof,
-        bool denebForkTimestamp
+        uint64 denebForkTimestamp
     ) internal view {
         require(
             withdrawalFields.length == 2 ** WITHDRAWAL_FIELD_TREE_HEIGHT,

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -234,7 +234,7 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawal: historicalSummaryIndex is too large"
         );
 
-        if(block.timestamp >= denebForkTimestamp){
+        if(block.timestamp <= denebForkTimestamp){
             require(
                 withdrawalProof.withdrawalProof.length ==
                     32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA + WITHDRAWALS_TREE_HEIGHT + 1),

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -213,7 +213,7 @@ library BeaconChainProofs {
         bytes32 beaconStateRoot,
         bytes32[] calldata withdrawalFields,
         WithdrawalProof calldata withdrawalProof,
-        bool isDeneb
+        bool denebForkTimestamp
     ) internal view {
         require(
             withdrawalFields.length == 2 ** WITHDRAWAL_FIELD_TREE_HEIGHT,
@@ -234,7 +234,7 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawal: historicalSummaryIndex is too large"
         );
 
-        if(!isDeneb){
+        if(block.timestamp >= denebForkTimestamp){
             require(
                 withdrawalProof.withdrawalProof.length ==
                     32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA + WITHDRAWALS_TREE_HEIGHT + 1),
@@ -258,7 +258,7 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawal: slotProof has incorrect length"
         );
 
-        if(!isDeneb){
+        if(block.timestamp >= denebForkTimestamp){
             require(
             withdrawalProof.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA),
             "BeaconChainProofs.verifyWithdrawal: timestampProof has incorrect length"

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -258,7 +258,7 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawal: slotProof has incorrect length"
         );
 
-        if(block.timestamp >= denebForkTimestamp){
+        if(block.timestamp <= denebForkTimestamp){
             require(
             withdrawalProof.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA),
             "BeaconChainProofs.verifyWithdrawal: timestampProof has incorrect length"

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -27,7 +27,8 @@ library BeaconChainProofs {
     uint256 internal constant VALIDATOR_FIELD_TREE_HEIGHT = 3;
 
     uint256 internal constant NUM_EXECUTION_PAYLOAD_HEADER_FIELDS = 15;
-    uint256 internal constant EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT = 4;
+    uint256 internal constant EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA = 4;
+    uint256 internal constant EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB = 5;
 
     uint256 internal constant NUM_EXECUTION_PAYLOAD_FIELDS = 15;
     uint256 internal constant EXECUTION_PAYLOAD_FIELD_TREE_HEIGHT = 4;
@@ -211,7 +212,8 @@ library BeaconChainProofs {
     function verifyWithdrawal(
         bytes32 beaconStateRoot,
         bytes32[] calldata withdrawalFields,
-        WithdrawalProof calldata withdrawalProof
+        WithdrawalProof calldata withdrawalProof,
+        bool isDeneb
     ) internal view {
         require(
             withdrawalFields.length == 2 ** WITHDRAWAL_FIELD_TREE_HEIGHT,
@@ -232,11 +234,20 @@ library BeaconChainProofs {
             "BeaconChainProofs.verifyWithdrawal: historicalSummaryIndex is too large"
         );
 
-        require(
-            withdrawalProof.withdrawalProof.length ==
-                32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT + WITHDRAWALS_TREE_HEIGHT + 1),
-            "BeaconChainProofs.verifyWithdrawal: withdrawalProof has incorrect length"
-        );
+        if(!isDeneb){
+            require(
+                withdrawalProof.withdrawalProof.length ==
+                    32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA + WITHDRAWALS_TREE_HEIGHT + 1),
+                "BeaconChainProofs.verifyWithdrawal: withdrawalProof has incorrect length"
+            );
+        } else {
+            require(
+                withdrawalProof.withdrawalProof.length ==
+                    32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB + WITHDRAWALS_TREE_HEIGHT + 1),
+                "BeaconChainProofs.verifyWithdrawal: withdrawalProof has incorrect length"
+            );
+        }
+
         require(
             withdrawalProof.executionPayloadProof.length ==
                 32 * (BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT + BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT),
@@ -246,10 +257,18 @@ library BeaconChainProofs {
             withdrawalProof.slotProof.length == 32 * (BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT),
             "BeaconChainProofs.verifyWithdrawal: slotProof has incorrect length"
         );
-        require(
-            withdrawalProof.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT),
+
+        if(!isDeneb){
+            require(
+            withdrawalProof.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA),
             "BeaconChainProofs.verifyWithdrawal: timestampProof has incorrect length"
         );
+        } else {
+            require(
+                withdrawalProof.timestampProof.length == 32 * (EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB),
+                "BeaconChainProofs.verifyWithdrawal: timestampProof has incorrect length"
+            );
+        }
 
         require(
             withdrawalProof.historicalSummaryBlockRootProof.length ==

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -608,7 +608,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             beaconStateRoot: beaconStateRoot, 
             withdrawalFields: withdrawalFields, 
             withdrawalProof: withdrawalProof,
-            denebTimestamp: eigenPodManager.denebTimestamp()
+            denebForkTimestamp: eigenPodManager.denebForkTimestamp()
         });
 
         uint40 validatorIndex = withdrawalFields.getValidatorIndex();

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -607,7 +607,8 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         BeaconChainProofs.verifyWithdrawal({
             beaconStateRoot: beaconStateRoot, 
             withdrawalFields: withdrawalFields, 
-            withdrawalProof: withdrawalProof
+            withdrawalProof: withdrawalProof,
+            isDeneb: eigenPodManager.isDeneb()
         });
 
         uint40 validatorIndex = withdrawalFields.getValidatorIndex();

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -608,7 +608,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             beaconStateRoot: beaconStateRoot, 
             withdrawalFields: withdrawalFields, 
             withdrawalProof: withdrawalProof,
-            isDeneb: eigenPodManager.isDeneb()
+            denebTimestamp: eigenPodManager.denebTimestamp()
         });
 
         uint40 validatorIndex = withdrawalFields.getValidatorIndex();

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -233,6 +233,14 @@ contract EigenPodManager is
         _updateBeaconChainOracle(newBeaconChainOracle);
     }
 
+    /**
+    * @notice Sets the isDeneb flag to true
+    * @dev Callable only by the owner of this contract (i.e. governance)
+    */
+    function setIsDeneb() external onlyOwner {
+        isDeneb = true;
+    }
+
     // INTERNAL FUNCTIONS
 
     function _deployPod() internal onlyWhenNotPaused(PAUSED_NEW_EIGENPODS) returns (IEigenPod) {

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -234,11 +234,11 @@ contract EigenPodManager is
     }
 
     /**
-    * @notice Sets the isDeneb flag to true
+    * @notice Sets the denebTimestamp
     * @dev Callable only by the owner of this contract (i.e. governance)
     */
-    function setIsDeneb() external onlyOwner {
-        isDeneb = true;
+    function setDenebForkTimestamp(uint64 timestamp) external onlyOwner {
+        denebForkTimestamp = timestamp;
     }
 
     // INTERNAL FUNCTIONS

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -64,7 +64,7 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      */
     mapping(address => int256) public podOwnerShares;
 
-    bool public isDeneb;
+    uint64 public denebForkTimestamp;
 
     constructor(
         IETHPOSDeposit _ethPOS,

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -85,5 +85,5 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[45] private __gap;
+    uint256[44] private __gap;
 }

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -64,6 +64,8 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      */
     mapping(address => int256) public podOwnerShares;
 
+    bool public isDeneb;
+
     constructor(
         IETHPOSDeposit _ethPOS,
         IBeacon _eigenPodBeacon,

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1774,7 +1774,7 @@ contract Relayer is Test {
         bytes32[] calldata withdrawalFields,
         BeaconChainProofs.WithdrawalProof calldata proofs
     ) public view {
-        BeaconChainProofs.verifyWithdrawal(beaconStateRoot, withdrawalFields, proofs, false);
+        BeaconChainProofs.verifyWithdrawal(beaconStateRoot, withdrawalFields, proofs, type(uint64).max);
     }
 }
 

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1774,7 +1774,7 @@ contract Relayer is Test {
         bytes32[] calldata withdrawalFields,
         BeaconChainProofs.WithdrawalProof calldata proofs
     ) public view {
-        BeaconChainProofs.verifyWithdrawal(beaconStateRoot, withdrawalFields, proofs);
+        BeaconChainProofs.verifyWithdrawal(beaconStateRoot, withdrawalFields, proofs, false);
     }
 }
 

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -694,8 +694,12 @@ contract BeaconChainMock is Test {
         (BeaconChainProofs.VALIDATOR_TREE_HEIGHT + 1) + BeaconChainProofs.BEACON_STATE_FIELD_TREE_HEIGHT
     );
 
-    uint immutable WITHDRAWAL_PROOF_LEN = 32 * (
-        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT + 
+    uint immutable WITHDRAWAL_PROOF_LEN_CAPELLA = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA + 
+        BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1
+    );
+    uint immutable WITHDRAWAL_PROOF_LEN_DENEB = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB + 
         BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1
     );
     uint immutable EXECPAYLOAD_PROOF_LEN = 32 * (
@@ -705,8 +709,11 @@ contract BeaconChainMock is Test {
     uint immutable SLOT_PROOF_LEN = 32 * (
         BeaconChainProofs.BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT
     );
-    uint immutable TIMESTAMP_PROOF_LEN = 32 * (
-        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT
+    uint immutable TIMESTAMP_PROOF_LEN_CAPELLA = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA
+    );
+    uint immutable TIMESTAMP_PROOF_LEN_DENEB = 32 * (
+        BeaconChainProofs.EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB
     );
     uint immutable HISTSUMMARY_PROOF_LEN = 32 * (
         BeaconChainProofs.BEACON_STATE_FIELD_TREE_HEIGHT +
@@ -725,10 +732,10 @@ contract BeaconChainMock is Test {
         uint64 oracleTimestamp
     ) internal view returns (BeaconChainProofs.WithdrawalProof memory) {
         return BeaconChainProofs.WithdrawalProof({
-            withdrawalProof: new bytes(WITHDRAWAL_PROOF_LEN),
+            withdrawalProof: new bytes(WITHDRAWAL_PROOF_LEN_CAPELLA),
             slotProof: new bytes(SLOT_PROOF_LEN),
             executionPayloadProof: new bytes(EXECPAYLOAD_PROOF_LEN),
-            timestampProof: new bytes(TIMESTAMP_PROOF_LEN),
+            timestampProof: new bytes(TIMESTAMP_PROOF_LEN_CAPELLA),
             historicalSummaryBlockRootProof: new bytes(HISTSUMMARY_PROOF_LEN),
             blockRootIndex: 0,
             historicalSummaryIndex: 0,

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -87,7 +87,7 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
     function maxPods() external view returns (uint256) {}
 
 
-     function isDeneb() external view returns (bool){}
+     function denebForkTimestamp() external view returns (uint64){}
 
-    function setIsDeneb() external{}
+    function setDenebForkTimestamp(uint64 timestamp) external{}
 }

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -85,4 +85,9 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
     function numPods() external view returns (uint256) {}
 
     function maxPods() external view returns (uint256) {}
+
+
+     function isDeneb() external view returns (bool){}
+
+    function setIsDeneb() external{}
 }


### PR DESCRIPTION
Changes EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT from 4 to 5 with a governance switch.  This would be for M2-mainnet assuming that we deploy prior to deneb hard fork on mainnet