### PR TITLE
Feat: add event for beacon chain balance update

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -630,7 +630,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
                         });
                     }
                 } else {
-                    strategyManager.addShares(msg.sender, withdrawal.strategies[i], withdrawal.shares[i]);
+                    strategyManager.addShares(msg.sender, tokens[i], withdrawal.strategies[i], withdrawal.shares[i]);
                     // Similar to `isDelegated` logic
                     if (currentOperator != address(0)) {
                         _increaseOperatorShares({

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -178,10 +178,11 @@ contract StrategyManager is
     /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
     function addShares(
         address staker,
+        IERC20 token,
         IStrategy strategy,
         uint256 shares
     ) external onlyDelegationManager {
-        _addShares(staker, strategy, shares);
+        _addShares(staker, token, strategy, shares);
     }
 
     /// @notice Used by the DelegationManager to convert withdrawn shares to tokens and send them to a recipient
@@ -283,13 +284,14 @@ contract StrategyManager is
     /**
      * @notice This function adds `shares` for a given `strategy` to the `staker` and runs through the necessary update logic.
      * @param staker The address to add shares to
+     * @param token The token that is being deposited (used for indexing)
      * @param strategy The Strategy in which the `staker` is receiving shares
      * @param shares The amount of shares to grant to the `staker`
      * @dev In particular, this function calls `delegation.increaseDelegatedShares(staker, strategy, shares)` to ensure that all
      * delegated shares are tracked, increases the stored share amount in `stakerStrategyShares[staker][strategy]`, and adds `strategy`
      * to the `staker`'s list of strategies, if it is not in the list already.
      */
-    function _addShares(address staker, IStrategy strategy, uint256 shares) internal {
+    function _addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) internal {
         // sanity checks on inputs
         require(staker != address(0), "StrategyManager._addShares: staker cannot be zero address");
         require(shares != 0, "StrategyManager._addShares: shares should not be zero!");
@@ -331,7 +333,7 @@ contract StrategyManager is
         shares = strategy.deposit(token, amount);
 
         // add the returned shares to the staker's existing shares for this strategy
-        _addShares(staker, strategy, shares);
+        _addShares(staker, token, strategy, shares);
 
         // Increase shares delegated to operator, if needed
         delegation.increaseDelegatedShares(staker, strategy, shares);

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -305,6 +305,8 @@ contract StrategyManager is
 
         // add the returned shares to their existing shares for this strategy
         stakerStrategyShares[staker][strategy] += shares;
+
+        emit Deposit(staker, token, strategy, shares);
     }
 
     /**
@@ -334,7 +336,6 @@ contract StrategyManager is
         // Increase shares delegated to operator, if needed
         delegation.increaseDelegatedShares(staker, strategy, shares);
 
-        emit Deposit(staker, token, strategy, shares);
         return shares;
     }
 

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -29,6 +29,9 @@ interface IEigenPodManager is IPausable {
     /// @notice Emitted when `maxPods` value is updated from `previousValue` to `newValue`
     event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
 
+    /// @notice Emitted when the balance of an EigenPod is updated
+    event PodBalanceUpdated(address indexed podOwner, int256 sharesDelta);
+
     /// @notice Emitted when a withdrawal of beacon chain ETH is completed
     event BeaconChainETHWithdrawalCompleted(
         address indexed podOwner,

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -30,7 +30,7 @@ interface IEigenPodManager is IPausable {
     event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
 
     /// @notice Emitted when the balance of an EigenPod is updated
-    event PodBalanceUpdated(address indexed podOwner, int256 sharesDelta);
+    event PodSharesUpdated(address indexed podOwner, int256 sharesDelta);
 
     /// @notice Emitted when a withdrawal of beacon chain ETH is completed
     event BeaconChainETHWithdrawalCompleted(

--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -82,7 +82,7 @@ interface IStrategyManager {
     function removeShares(address staker, IStrategy strategy, uint256 shares) external;
 
     /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
-    function addShares(address staker, IStrategy strategy, uint256 shares) external;
+    function addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) external;
     
     /// @notice Used by the DelegationManager to convert withdrawn shares to tokens and send them to a recipient
     function withdrawSharesAsTokens(address recipient, IStrategy strategy, uint256 shares, IERC20 token) external;

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -211,11 +211,11 @@ contract EigenPodManager is
             if (shares > currentShareDeficit) {
                 podOwnerShares[podOwner] = 0;
                 shares -= currentShareDeficit;
-                emit PodSharesUpdated(podOwner, currentShareDeficit);
+                emit PodSharesUpdated(podOwner, int256(currentShareDeficit));
             // otherwise get rid of as much deficit as possible, and return early, since there is nothing left over to forward on
             } else {
                 podOwnerShares[podOwner] += int256(shares);
-                emit PodSharesUpdated(podOwner, shares);
+                emit PodSharesUpdated(podOwner, int256(shares));
                 return;
             }
         }

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -211,9 +211,11 @@ contract EigenPodManager is
             if (shares > currentShareDeficit) {
                 podOwnerShares[podOwner] = 0;
                 shares -= currentShareDeficit;
+                emit PodSharesUpdated(podOwner, currentShareDeficit);
             // otherwise get rid of as much deficit as possible, and return early, since there is nothing left over to forward on
             } else {
                 podOwnerShares[podOwner] += int256(shares);
+                emit PodSharesUpdated(podOwner, shares);
                 return;
             }
         }

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -140,7 +140,7 @@ contract EigenPodManager is
                 });
             }
         }
-        emit PodBalanceUpdated(podOwner, sharesDelta);
+        emit PodSharesUpdated(podOwner, sharesDelta);
     }
 
     /**
@@ -180,6 +180,8 @@ contract EigenPodManager is
         int256 currentPodOwnerShares = podOwnerShares[podOwner];
         int256 updatedPodOwnerShares = currentPodOwnerShares + int256(shares);
         podOwnerShares[podOwner] = updatedPodOwnerShares;
+
+        emit PodSharesUpdated(podOwner, int256(shares));
 
         return uint256(_calculateChangeInDelegatableShares({sharesBefore: currentPodOwnerShares, sharesAfter: updatedPodOwnerShares}));
     }

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -140,6 +140,7 @@ contract EigenPodManager is
                 });
             }
         }
+        emit PodBalanceUpdated(podOwner, sharesDelta);
     }
 
     /**
@@ -214,7 +215,6 @@ contract EigenPodManager is
                 return;
             }
         }
-
         // Actually withdraw to the destination
         ownerToPod[podOwner].withdrawRestakedBeaconChainETH(destination, shares);
     }

--- a/src/test/events/IEigenPodManagerEvents.sol
+++ b/src/test/events/IEigenPodManagerEvents.sol
@@ -10,4 +10,7 @@ interface IEigenPodManagerEvents {
 
     /// @notice Emitted when `maxPods` value is updated from `previousValue` to `newValue`
     event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
+
+    /// @notice Emitted when the balance of an EigenPod is updated
+    event PodBalanceUpdated(address indexed podOwner, int256 sharesDelta);
 }

--- a/src/test/events/IEigenPodManagerEvents.sol
+++ b/src/test/events/IEigenPodManagerEvents.sol
@@ -12,5 +12,5 @@ interface IEigenPodManagerEvents {
     event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
 
     /// @notice Emitted when the balance of an EigenPod is updated
-    event PodBalanceUpdated(address indexed podOwner, int256 sharesDelta);
+    event PodSharesUpdated(address indexed podOwner, int256 sharesDelta);
 }

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -168,10 +168,11 @@ contract DelegationManagerMock is IDelegationManager, Test {
     function addShares(
         IStrategyManager strategyManager,
         address staker,
+        IERC20 token,
         IStrategy strategy,
         uint256 shares
     ) external {
-        strategyManager.addShares(staker, strategy, shares);
+        strategyManager.addShares(staker, token, strategy, shares);
     }
 
     function removeShares(

--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -100,7 +100,7 @@ contract StrategyManagerMock is
 
     function removeShares(address staker, IStrategy strategy, uint256 shares) external {}
 
-    function addShares(address staker, IStrategy strategy, uint256 shares) external {}
+    function addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) external {}
     
     function withdrawSharesAsTokens(address recipient, IStrategy strategy, uint256 shares, IERC20 token) external {}
 

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -495,7 +495,7 @@ contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodMa
 
         // Update balance
         cheats.expectEmit(true, true, true, true);
-        emit PodBalanceUpdated(defaultStaker, scaledSharesDelta);
+        emit PodSharesUpdated(defaultStaker, scaledSharesDelta);
         cheats.prank(address(defaultPod));
         eigenPodManager.recordBeaconChainETHBalanceUpdate(defaultStaker, scaledSharesDelta);
 

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -462,7 +462,7 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
     }
 }
 
-contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodManagerUnitTests {
+contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodManagerUnitTests, IEigenPodManagerEvents {
 
     function testFuzz_recordBalanceUpdate_revert_notPod(address invalidCaller) public filterFuzzedAddressInputs(invalidCaller) deployPodForStaker(defaultStaker) {
         cheats.assume(invalidCaller != address(defaultPod));
@@ -494,6 +494,8 @@ contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodMa
         _initializePodWithShares(defaultStaker, scaledSharesBefore);
 
         // Update balance
+        cheats.expectEmit(true, true, true, true);
+        emit PodBalanceUpdated(defaultStaker, scaledSharesDelta);
         cheats.prank(address(defaultPod));
         eigenPodManager.recordBeaconChainETHBalanceUpdate(defaultStaker, scaledSharesDelta);
 

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -992,18 +992,18 @@ contract StrategyManagerUnitTests_addShares is StrategyManagerUnitTests {
     function test_Revert_DelegationManagerModifier() external {
         DelegationManagerMock invalidDelegationManager = new DelegationManagerMock();
         cheats.expectRevert("StrategyManager.onlyDelegationManager: not the DelegationManager");
-        invalidDelegationManager.addShares(strategyManager, address(this), dummyStrat, 1);
+        invalidDelegationManager.addShares(strategyManager, address(this), dummyToken, dummyStrat, 1);
     }
 
     function testFuzz_Revert_StakerZeroAddress(uint256 amount) external {
         cheats.expectRevert("StrategyManager._addShares: staker cannot be zero address");
-        delegationManagerMock.addShares(strategyManager, address(0), dummyStrat, amount);
+        delegationManagerMock.addShares(strategyManager, address(0), dummyToken, dummyStrat, amount);
     }
 
     function testFuzz_Revert_ZeroShares(address staker) external filterFuzzedAddressInputs(staker) {
         cheats.assume(staker != address(0));
         cheats.expectRevert("StrategyManager._addShares: shares should not be zero!");
-        delegationManagerMock.addShares(strategyManager, staker, dummyStrat, 0);
+        delegationManagerMock.addShares(strategyManager, staker, dummyToken, dummyStrat, 0);
     }
 
     function testFuzz_AppendsStakerStrategyList(
@@ -1016,7 +1016,7 @@ contract StrategyManagerUnitTests_addShares is StrategyManagerUnitTests {
         assertEq(sharesBefore, 0, "Staker has already deposited into this strategy");
         assertFalse(_isDepositedStrategy(staker, dummyStrat), "strategy should not be deposited");
 
-        delegationManagerMock.addShares(strategyManager, staker, dummyStrat, amount);
+        delegationManagerMock.addShares(strategyManager, staker, dummyToken, dummyStrat, amount);
         uint256 stakerStrategyListLengthAfter = strategyManager.stakerStrategyListLength(staker);
         uint256 sharesAfter = strategyManager.stakerStrategyShares(staker, dummyStrat);
         assertEq(
@@ -1041,7 +1041,7 @@ contract StrategyManagerUnitTests_addShares is StrategyManagerUnitTests {
         assertEq(sharesBefore, initialAmount, "Staker has not deposited amount into strategy");
         assertTrue(_isDepositedStrategy(staker, strategy), "strategy should be deposited");
 
-        delegationManagerMock.addShares(strategyManager, staker, dummyStrat, sharesAmount);
+        delegationManagerMock.addShares(strategyManager, staker, dummyToken, dummyStrat, sharesAmount);
         uint256 stakerStrategyListLengthAfter = strategyManager.stakerStrategyListLength(staker);
         uint256 sharesAfter = strategyManager.stakerStrategyShares(staker, dummyStrat);
         assertEq(
@@ -1091,7 +1091,7 @@ contract StrategyManagerUnitTests_addShares is StrategyManagerUnitTests {
 
         cheats.prank(staker);
         cheats.expectRevert("StrategyManager._addShares: deposit would exceed MAX_STAKER_STRATEGY_LIST_LENGTH");
-        delegationManagerMock.addShares(strategyManager, staker, strategy, amount);
+        delegationManagerMock.addShares(strategyManager, staker, dummyToken, strategy, amount);
 
         cheats.expectRevert("StrategyManager._addShares: deposit would exceed MAX_STAKER_STRATEGY_LIST_LENGTH");
         strategyManager.depositIntoStrategy(strategy, token, amount);


### PR DESCRIPTION
We need to handle the following indexing cases for LST & Native ETH
- podSharesUpdate on balance updates/proving WC
- podSharesUpdate on withdrawing as tokens
- podSharesUpdate on withdrawing as shares
- Deposit event when withdrawing as shares

This is needed for monitoring + will be useful for external parties to properly index shares

Companion doc: https://docs.google.com/document/d/1vjT_i9V1bAclJSS62YpCLAo3KDP2IsHVWCYjdMcfV5w/edit#heading=h.958kgw1yie6h