### PR TITLE
fix: update forge CI to include contract size checks

### DIFF
--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -37,8 +37,11 @@ jobs:
       with:
         version: nightly
 
-    - name: Install forge dependencies
-      run: forge install
+    - name: Run Forge build
+      run: |
+        forge --version
+        forge build --sizes
+      id: build
 
     - name: Run forge test for the file
       run: forge test --match-path src/test/${{ matrix.file }} --no-match-contract FFI


### PR DESCRIPTION
Setting the forge testing workflows to be consistent between middleware and core contracts 
https://github.com/Layr-Labs/eigenlayer-middleware/blob/m2-mainnet/.github/workflows/tests.yml#L34

This job failed due to the DelegationManager being 1KB over the contract size limit but wasn't caught in the original PR 
Failed Job in middleware:
https://github.com/Layr-Labs/eigenlayer-middleware/actions/runs/7642681323/job/20823350026
Original PR that passed:
https://github.com/Layr-Labs/eigenlayer-contracts/pull/392