### PR TITLE
refactor: decouple AVS<>Operator mapping from DelegationManager

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgrades/contracts/access/OwnableUpgradeable.sol";
+import "@openzeppelin-upgrades/contracts/security/ReentrancyGuardUpgradeable.sol";
+import "../permissions/Pausable.sol";
+import "../libraries/EIP1271SignatureUtils.sol";
+import "./AVSDirectoryStorage.sol";
+
+contract AVSDirectory is
+    Initializable,
+    OwnableUpgradeable,
+    Pausable,
+    AVSDirectoryStorage,
+    ReentrancyGuardUpgradeable
+{
+    // @dev Index for flag that pauses operator register/deregister to avs when set.
+    uint8 internal constant PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS = 0;
+
+    // @dev Chain ID at the time of contract deployment
+    uint256 internal immutable ORIGINAL_CHAIN_ID;
+
+    /*******************************************************************************
+                            INITIALIZING FUNCTIONS
+    *******************************************************************************/
+
+    /**
+     * @dev Initializes the immutable addresses of the strategy mananger, delegationManager, slasher, 
+     * and eigenpodManager contracts
+     */
+    constructor(
+        IDelegationManager _delegation,
+        IStrategyManager _strategyManager,
+        ISlasher _slasher,
+        IEigenPodManager _eigenPodManager
+    ) AVSDirectoryStorage(_delegation, _strategyManager, _slasher, _eigenPodManager) {
+        _disableInitializers();
+        ORIGINAL_CHAIN_ID = block.chainid;
+    }
+
+    /**
+     * @dev Initializes the addresses of the initial owner, pauser registry, and paused status.
+     * minWithdrawalDelayBlocks is set only once here
+     */
+    function initialize(
+        address initialOwner,
+        IPauserRegistry _pauserRegistry,
+        uint256 initialPausedStatus
+    ) external initializer {
+        _initializePauser(_pauserRegistry, initialPausedStatus);
+        _DOMAIN_SEPARATOR = _calculateDomainSeparator();
+        _transferOwnership(initialOwner);
+    }
+
+    /*******************************************************************************
+                            EXTERNAL FUNCTIONS 
+    *******************************************************************************/
+
+
+    /**
+     * @notice Called by the AVS's service manager contract to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+
+        require(
+            operatorSignature.expiry >= block.timestamp,
+            "AVSDirectory.registerOperatorToAVS: operator signature expired"
+        );
+        require(
+            avsOperatorStatus[msg.sender][operator] != OperatorAVSRegistrationStatus.REGISTERED,
+            "AVSDirectory.registerOperatorToAVS: operator already registered"
+        );
+        require(
+            !operatorSaltIsSpent[operator][operatorSignature.salt],
+            "AVSDirectory.registerOperatorToAVS: salt already spent"
+        );
+        require(
+            delegation.isOperator(operator),
+            "AVSDirectory.registerOperatorToAVS: operator not registered to EigenLayer yet");
+
+        // Calculate the digest hash
+        bytes32 operatorRegistrationDigestHash = calculateOperatorAVSRegistrationDigestHash({
+            operator: operator,
+            avs: msg.sender,
+            salt: operatorSignature.salt,
+            expiry: operatorSignature.expiry
+        });
+
+        // Check that the signature is valid
+        EIP1271SignatureUtils.checkSignature_EIP1271(
+            operator,
+            operatorRegistrationDigestHash,
+            operatorSignature.signature
+        );
+
+        // Set the operator as registered
+        avsOperatorStatus[msg.sender][operator] = OperatorAVSRegistrationStatus.REGISTERED;
+
+        // Mark the salt as spent
+        operatorSaltIsSpent[operator][operatorSignature.salt] = true;
+
+        emit OperatorAVSRegistrationStatusUpdated(operator, msg.sender, OperatorAVSRegistrationStatus.REGISTERED);
+    }
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+        require(
+            avsOperatorStatus[msg.sender][operator] == OperatorAVSRegistrationStatus.REGISTERED,
+            "AVSDirectory.deregisterOperatorFromAVS: operator not registered"
+        );
+
+        // Set the operator as deregistered
+        avsOperatorStatus[msg.sender][operator] = OperatorAVSRegistrationStatus.UNREGISTERED;
+
+        emit OperatorAVSRegistrationStatusUpdated(operator, msg.sender, OperatorAVSRegistrationStatus.UNREGISTERED);
+    }
+
+    /**
+     * @notice Called by an avs to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an avs
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external {
+        emit AVSMetadataURIUpdated(msg.sender, metadataURI);
+    }
+
+    /*******************************************************************************
+                            VIEW FUNCTIONS
+    *******************************************************************************/
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The address of the service manager contract for the AVS that the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) public view returns (bytes32) {
+        // calculate the struct hash
+        bytes32 structHash = keccak256(
+            abi.encode(OPERATOR_AVS_REGISTRATION_TYPEHASH, operator, avs, salt, expiry)
+        );
+        // calculate the digest hash
+        bytes32 digestHash = keccak256(
+            abi.encodePacked("\x19\x01", domainSeparator(), structHash)
+        );
+        return digestHash;
+    }
+
+    /**
+     * @notice Getter function for the current EIP-712 domain separator for this contract.
+     * @dev The domain separator will change in the event of a fork that changes the ChainID.
+     */
+    function domainSeparator() public view returns (bytes32) {
+        if (block.chainid == ORIGINAL_CHAIN_ID) {
+            return _DOMAIN_SEPARATOR;
+        } else {
+            return _calculateDomainSeparator();
+        }
+    }
+
+    // @notice Internal function for calculating the current domain separator of this contract
+    function _calculateDomainSeparator() internal view returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes("EigenLayer")), block.chainid, address(this)));
+    }
+}

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -29,12 +29,7 @@ contract AVSDirectory is
      * @dev Initializes the immutable addresses of the strategy mananger, delegationManager, slasher, 
      * and eigenpodManager contracts
      */
-    constructor(
-        IDelegationManager _delegation,
-        IStrategyManager _strategyManager,
-        ISlasher _slasher,
-        IEigenPodManager _eigenPodManager
-    ) AVSDirectoryStorage(_delegation, _strategyManager, _slasher, _eigenPodManager) {
+    constructor(IDelegationManager _delegation) AVSDirectoryStorage(_delegation) {
         _disableInitializers();
         ORIGINAL_CHAIN_ID = block.chainid;
     }

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -18,15 +18,6 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
 
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegation;
-    
-    /// @notice The StrategyManager contract for EigenLayer
-    IStrategyManager public immutable strategyManager;
-
-    /// @notice The Slasher contract for EigenLayer
-    ISlasher public immutable slasher;
-
-    /// @notice The EigenPodManager contract for EigenLayer
-    IEigenPodManager public immutable eigenPodManager;
 
     /**
      * @notice Original EIP-712 Domain separator for this contract.
@@ -42,16 +33,8 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @dev Salt is used in the `registerOperatorToAVS` function.
     mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
 
-    constructor(
-        IDelegationManager _delegation,
-        IStrategyManager _strategyManager,
-        ISlasher _slasher,
-        IEigenPodManager _eigenPodManager
-    ) {
+    constructor(IDelegationManager _delegation) {
         delegation = _delegation;
-        strategyManager = _strategyManager;
-        slasher = _slasher;
-        eigenPodManager = _eigenPodManager;
     }
 
     /**

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
+
+import "../interfaces/IAVSDirectory.sol";
+import "../interfaces/IStrategyManager.sol";
+import "../interfaces/IDelegationManager.sol";
+import "../interfaces/ISlasher.sol";
+import "../interfaces/IEigenPodManager.sol";
+
+abstract contract AVSDirectoryStorage is IAVSDirectory {
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The EIP-712 typehash for the `Registration` struct used by the contract
+    bytes32 public constant OPERATOR_AVS_REGISTRATION_TYPEHASH =
+        keccak256("OperatorAVSRegistration(address operator,address avs,bytes32 salt,uint256 expiry)");
+
+    /// @notice The DelegationManager contract for EigenLayer
+    IDelegationManager public immutable delegation;
+    
+    /// @notice The StrategyManager contract for EigenLayer
+    IStrategyManager public immutable strategyManager;
+
+    /// @notice The Slasher contract for EigenLayer
+    ISlasher public immutable slasher;
+
+    /// @notice The EigenPodManager contract for EigenLayer
+    IEigenPodManager public immutable eigenPodManager;
+
+    /**
+     * @notice Original EIP-712 Domain separator for this contract.
+     * @dev The domain separator may change in the event of a fork that modifies the ChainID.
+     * Use the getter function `domainSeparator` to get the current domain separator for this contract.
+     */
+    bytes32 internal _DOMAIN_SEPARATOR;
+    
+    /// @notice Mapping: AVS => operator => enum of operator status to the AVS
+    mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
+
+    /// @notice Mapping: operator => 32-byte salt => whether or not the salt has already been used by the operator.
+    /// @dev Salt is used in the `registerOperatorToAVS` function.
+    mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
+
+    constructor(
+        IDelegationManager _delegation,
+        IStrategyManager _strategyManager,
+        ISlasher _slasher,
+        IEigenPodManager _eigenPodManager
+    ) {
+        delegation = _delegation;
+        strategyManager = _strategyManager;
+        slasher = _slasher;
+        eigenPodManager = _eigenPodManager;
+    }
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[47] private __gap;
+}

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -100,7 +100,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     ) external {
         require(
             _operatorDetails[msg.sender].earningsReceiver == address(0),
-            "registerAsOperator: operator has already registered"
+            "DelegationManager.registerAsOperator: operator has already registered"
         );
         _setOperatorDetails(msg.sender, registeringOperatorDetails);
         SignatureWithExpiry memory emptySignatureAndExpiry;
@@ -119,7 +119,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
      * @dev This function will revert if the caller attempts to set their `earningsReceiver` to address(0).
      */
     function modifyOperatorDetails(OperatorDetails calldata newOperatorDetails) external {
-        require(isOperator(msg.sender), "modifyOperatorDetails: caller must be an operator");
+        require(isOperator(msg.sender), "DelegationManager.modifyOperatorDetails: caller must be an operator");
         _setOperatorDetails(msg.sender, newOperatorDetails);
     }
 
@@ -128,7 +128,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
      * @param metadataURI The URI for metadata associated with an operator
      */
     function updateOperatorMetadataURI(string calldata metadataURI) external {
-        require(isOperator(msg.sender), "updateOperatorMetadataURI: caller must be an operator");
+        require(isOperator(msg.sender), "DelegationManager.updateOperatorMetadataURI: caller must be an operator");
         emit OperatorMetadataURIUpdated(msg.sender, metadataURI);
     }
 
@@ -181,7 +181,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         // check the signature expiry
         require(
             stakerSignatureAndExpiry.expiry >= block.timestamp,
-            "delegateToBySignature: staker signature expired"
+            "DelegationManager.delegateToBySignature: staker signature expired"
         );
 
         // calculate the digest hash, then increment `staker`'s nonce
@@ -209,15 +209,15 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
      * both the staker and operator, and places the shares and strategies in the withdrawal queue
      */
     function undelegate(address staker) external onlyWhenNotPaused(PAUSED_ENTER_WITHDRAWAL_QUEUE) returns (bytes32[] memory withdrawalRoots) {
-        require(isDelegated(staker), "undelegate: staker must be delegated to undelegate");
-        require(!isOperator(staker), "undelegate: operators cannot be undelegated");
-        require(staker != address(0), "undelegate: cannot undelegate zero address");
+        require(isDelegated(staker), "DelegationManager.undelegate: staker must be delegated to undelegate");
+        require(!isOperator(staker), "DelegationManager.undelegate: operators cannot be undelegated");
+        require(staker != address(0), "DelegationManager.undelegate: cannot undelegate zero address");
         address operator = delegatedTo[staker];
         require(
             msg.sender == staker ||
                 msg.sender == operator ||
                 msg.sender == _operatorDetails[operator].delegationApprover,
-            "undelegate: caller cannot undelegate staker"
+            "DelegationManager.undelegate: caller cannot undelegate staker"
         );
 
         // Gather strategies and shares to remove from staker/operator during undelegation
@@ -271,8 +271,8 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         address operator = delegatedTo[msg.sender];
 
         for (uint256 i = 0; i < queuedWithdrawalParams.length; i++) {
-            require(queuedWithdrawalParams[i].strategies.length == queuedWithdrawalParams[i].shares.length, "queueWithdrawal: input length mismatch");
-            require(queuedWithdrawalParams[i].withdrawer != address(0), "queueWithdrawal: must provide valid withdrawal address");
+            require(queuedWithdrawalParams[i].strategies.length == queuedWithdrawalParams[i].shares.length, "DelegationManager.queueWithdrawal: input length mismatch");
+            require(queuedWithdrawalParams[i].withdrawer != address(0), "DelegationManager.queueWithdrawal: must provide valid withdrawal address");
 
             // Remove shares from staker's strategies and place strategies/shares in queue.
             // If the staker is delegated to an operator, the operator's delegated shares are also reduced
@@ -358,7 +358,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
                 // create the new storage
                 bytes32 newRoot = calculateWithdrawalRoot(migratedWithdrawal);
                 // safety check to ensure that root doesn't exist already -- this should *never* be hit
-                require(!pendingWithdrawals[newRoot], "migrateQueuedWithdrawals: withdrawal already exists");
+                require(!pendingWithdrawals[newRoot], "DelegationManager.migrateQueuedWithdrawals: withdrawal already exists");
                 pendingWithdrawals[newRoot] = true;
 
                 emit WithdrawalQueued(newRoot, migratedWithdrawal);
@@ -451,15 +451,15 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     function _setOperatorDetails(address operator, OperatorDetails calldata newOperatorDetails) internal {
         require(
             newOperatorDetails.earningsReceiver != address(0),
-            "_setOperatorDetails: cannot set `earningsReceiver` to zero address"
+            "DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address"
         );
         require(
             newOperatorDetails.stakerOptOutWindowBlocks <= MAX_STAKER_OPT_OUT_WINDOW_BLOCKS,
-            "_setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
+            "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
         );
         require(
             newOperatorDetails.stakerOptOutWindowBlocks >= _operatorDetails[operator].stakerOptOutWindowBlocks,
-            "_setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased"
+            "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased"
         );
         _operatorDetails[operator] = newOperatorDetails;
         emit OperatorDetailsModified(msg.sender, newOperatorDetails);
@@ -482,8 +482,8 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
     ) internal onlyWhenNotPaused(PAUSED_NEW_DELEGATION) {
-        require(!isDelegated(staker), "_delegate: staker is already actively delegated");
-        require(isOperator(operator), "_delegate: operator is not registered in EigenLayer");
+        require(!isDelegated(staker), "DelegationManager._delegate: staker is already actively delegated");
+        require(isOperator(operator), "DelegationManager._delegate: operator is not registered in EigenLayer");
 
         // fetch the operator's `delegationApprover` address and store it in memory in case we need to use it multiple times
         address _delegationApprover = _operatorDetails[operator].delegationApprover;
@@ -496,12 +496,12 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             // check the signature expiry
             require(
                 approverSignatureAndExpiry.expiry >= block.timestamp,
-                "_delegate: approver signature expired"
+                "DelegationManager._delegate: approver signature expired"
             );
             // check that the salt hasn't been used previously, then mark the salt as spent
             require(
                 !delegationApproverSaltIsSpent[_delegationApprover][approverSalt],
-                "_delegate: approverSalt already spent"
+                "DelegationManager._delegate: approverSalt already spent"
             );
             delegationApproverSaltIsSpent[_delegationApprover][approverSalt] = true;
 
@@ -555,23 +555,23 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         require(
             pendingWithdrawals[withdrawalRoot], 
-            "_completeQueuedWithdrawal: action is not in queue"
+            "DelegationManager._completeQueuedWithdrawal: action is not in queue"
         );
 
         require(
             withdrawal.startBlock + minWithdrawalDelayBlocks <= block.number, 
-            "_completeQueuedWithdrawal: minWithdrawalDelayBlocks period has not yet passed"
+            "DelegationManager._completeQueuedWithdrawal: minWithdrawalDelayBlocks period has not yet passed"
         );
 
         require(
             msg.sender == withdrawal.withdrawer, 
-            "_completeQueuedWithdrawal: only withdrawer can complete action"
+            "DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action"
         );
 
         if (receiveAsTokens) {
             require(
                 tokens.length == withdrawal.strategies.length, 
-                "_completeQueuedWithdrawal: input length mismatch"
+                "DelegationManager._completeQueuedWithdrawal: input length mismatch"
             );
         }
 
@@ -584,7 +584,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             for (uint256 i = 0; i < withdrawal.strategies.length; ) {
                 require(
                     withdrawal.startBlock + strategyWithdrawalDelayBlocks[withdrawal.strategies[i]] <= block.number,
-                    "_completeQueuedWithdrawal: withdrawalDelayBlocks period has not yet passed for this strategy"
+                    "DelegationManager._completeQueuedWithdrawal: withdrawalDelayBlocks period has not yet passed for this strategy"
                 );
 
                 _withdrawSharesAsTokens({
@@ -602,7 +602,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             for (uint256 i = 0; i < withdrawal.strategies.length; ) {
                 require(
                     withdrawal.startBlock + strategyWithdrawalDelayBlocks[withdrawal.strategies[i]] <= block.number, 
-                    "_completeQueuedWithdrawal: withdrawalDelayBlocks period has not yet passed for this strategy"
+                    "DelegationManager._completeQueuedWithdrawal: withdrawalDelayBlocks period has not yet passed for this strategy"
                 );
 
                 /** When awarding podOwnerShares in EigenPodManager, we need to be sure to only give them back to the original podOwner.
@@ -674,8 +674,8 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         IStrategy[] memory strategies, 
         uint256[] memory shares
     ) internal returns (bytes32) {
-        require(staker != address(0), "_removeSharesAndQueueWithdrawal: staker cannot be zero address");
-        require(strategies.length != 0, "_removeSharesAndQueueWithdrawal: strategies cannot be empty");
+        require(staker != address(0), "DelegationManager._removeSharesAndQueueWithdrawal: staker cannot be zero address");
+        require(strategies.length != 0, "DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
     
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
@@ -702,7 +702,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             } else {
                 require(
                     staker == withdrawer || !strategyManager.thirdPartyTransfersForbidden(strategies[i]),
-                    "_removeSharesAndQueueWithdrawal: withdrawer must be same address as staker if thirdPartyTransfersForbidden are set"
+                    "DelegationManager._removeSharesAndQueueWithdrawal: withdrawer must be same address as staker if thirdPartyTransfersForbidden are set"
                 );
                 // this call will revert if `shares[i]` exceeds the Staker's current shares in `strategies[i]`
                 strategyManager.removeShares(staker, strategies[i], shares[i]);
@@ -753,7 +753,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     function _initializeMinWithdrawalDelayBlocks(uint256 _minWithdrawalDelayBlocks) internal {
         require(
             _minWithdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS,
-            "_initializeMinWithdrawalDelayBlocks: _minWithdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
+            "DelegationManager._initializeMinWithdrawalDelayBlocks: _minWithdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
         );
         emit MinWithdrawalDelayBlocksSet(minWithdrawalDelayBlocks, _minWithdrawalDelayBlocks);
         minWithdrawalDelayBlocks = _minWithdrawalDelayBlocks;
@@ -769,7 +769,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
     ) internal {
         require(
             _strategies.length == _withdrawalDelayBlocks.length,
-            "_setStrategyWithdrawalDelayBlocks: input length mismatch"
+            "DelegationManager._setStrategyWithdrawalDelayBlocks: input length mismatch"
         );
         uint256 numStrats = _strategies.length;
         for (uint256 i = 0; i < numStrats; ++i) {
@@ -778,7 +778,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
             uint256 newStrategyWithdrawalDelayBlocks = _withdrawalDelayBlocks[i];
             require(
                 newStrategyWithdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS,
-                "_setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
+                "DelegationManager._setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
             );
 
             // set the new withdrawal delay blocks

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -25,10 +25,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     bytes32 public constant DELEGATION_APPROVAL_TYPEHASH =
         keccak256("DelegationApproval(address staker,address operator,bytes32 salt,uint256 expiry)");
 
-    /// @notice The EIP-712 typehash for the `Registration` struct used by the contract
-    bytes32 public constant OPERATOR_AVS_REGISTRATION_TYPEHASH =
-        keccak256("OperatorAVSRegistration(address operator,address avs,bytes32 salt,uint256 expiry)");
-
     /**
      * @notice Original EIP-712 Domain separator for this contract.
      * @dev The domain separator may change in the event of a fork that modifies the ChainID.
@@ -99,13 +95,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// See conversation here: https://github.com/Layr-Labs/eigenlayer-contracts/pull/365/files#r1417525270
     address private __deprecated_stakeRegistry;
 
-    /// @notice Mapping: AVS => operator => enum of operator status to the AVS
-    mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
-
-    /// @notice Mapping: operator => 32-byte salt => whether or not the salt has already been used by the operator.
-    /// @dev Salt is used in the `registerOperatorToAVS` function.
-    mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
-
     /**
      * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
      * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
@@ -123,5 +112,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[37] private __gap;
+    uint256[39] private __gap;
 }

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.5.0;
+
+import "./ISignatureUtils.sol";
+
+interface IAVSDirectory is ISignatureUtils {
+    /// @notice Enum representing the status of an operator's registration with an AVS
+    enum OperatorAVSRegistrationStatus {
+        UNREGISTERED,       // Operator not registered to AVS
+        REGISTERED          // Operator registered to AVS
+    }
+
+    /**
+     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
+     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     */
+    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
+
+    /// @notice Emitted when an operator's registration status for an AVS is updated
+    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
+
+    /**
+     * @notice Called by an avs to register an operator with the avs.
+     * @param operator The address of the operator to register.
+     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     */
+    function registerOperatorToAVS(
+        address operator,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external;
+
+    /**
+     * @notice Called by an avs to deregister an operator with the avs.
+     * @param operator The address of the operator to deregister.
+     */
+    function deregisterOperatorFromAVS(address operator) external;
+
+    /**
+     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an AVS
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external;
+
+    /**
+     * @notice Returns whether or not the salt has already been used by the operator.
+     * @dev Salts is used in the `registerOperatorToAVS` function.
+     */
+    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool);
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
+     * @param operator The account registering as an operator
+     * @param avs The AVS the operator is registering to
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid
+     */
+    function calculateOperatorAVSRegistrationDigestHash(
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32);
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32);
+}

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -100,12 +100,6 @@ interface IDelegationManager is ISignatureUtils {
         address withdrawer;
     }
 
-    /// @notice Enum representing the status of an operator's registration with an AVS
-    enum OperatorAVSRegistrationStatus {
-        UNREGISTERED,       // Operator not registered to AVS
-        REGISTERED          // Operator registered to AVS
-    }
-
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, OperatorDetails operatorDetails);
 
@@ -117,15 +111,6 @@ interface IDelegationManager is ISignatureUtils {
      * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
      */
     event OperatorMetadataURIUpdated(address indexed operator, string metadataURI);
-
-    /**
-     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
-     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
-     */
-    event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
-
-    /// @notice Emitted when an operator's registration status for an AVS is updated
-    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
 
     /// @notice Emitted whenever an operator's shares are increased for a given strategy. Note that shares is the delta in the operator's shares.
     event OperatorSharesIncreased(address indexed operator, address staker, IStrategy strategy, uint256 shares);
@@ -190,13 +175,6 @@ interface IDelegationManager is ISignatureUtils {
      * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `OperatorMetadataURIUpdated` event
      */
     function updateOperatorMetadataURI(string calldata metadataURI) external;
-
-    /**
-     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
-     * @param metadataURI The URI for metadata associated with an AVS
-     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
-     */
-    function updateAVSMetadataURI(string calldata metadataURI) external;
 
     /**
      * @notice Caller delegates their stake to an operator.
@@ -333,42 +311,6 @@ interface IDelegationManager is ISignatureUtils {
     ) external;
 
     /**
-     * @notice Called by an avs to register an operator with the avs.
-     * @param operator The address of the operator to register.
-     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
-     */
-    function registerOperatorToAVS(
-        address operator,
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
-    ) external;
-
-    /**
-     * @notice Called by an avs to deregister an operator with the avs.
-     * @param operator The address of the operator to deregister.
-     */
-    function deregisterOperatorFromAVS(address operator) external;
-
-    /**
-     * @notice Returns whether or not the salt has already been used by the operator.
-     * @dev Salts is used in the `registerOperatorToAVS` function.
-     */
-    function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool);
-
-    /**
-     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
-     * @param operator The account registering as an operator
-     * @param avs The AVS the operator is registering to
-     * @param salt A unique and single use value associated with the approver signature.
-     * @param expiry Time after which the approver's signature becomes invalid
-     */
-    function calculateOperatorAVSRegistrationDigestHash(
-        address operator,
-        address avs,
-        bytes32 salt,
-        uint256 expiry
-    ) external view returns (bytes32);
-
-    /**
      * @notice returns the address of the operator that `staker` is delegated to.
      * @notice Mapping: staker => operator whom the staker is currently delegated to.
      * @dev Note that returning address(0) indicates that the staker is not actively delegated to any operator.
@@ -495,9 +437,6 @@ interface IDelegationManager is ISignatureUtils {
 
     /// @notice The EIP-712 typehash for the DelegationApproval struct used by the contract
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32);
-
-    /// @notice The EIP-712 typehash for the Registration struct used by the contract
-    function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32);
 
     /**
      * @notice Getter function for the current EIP-712 domain separator for this contract.

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -1,0 +1,104 @@
+// contract DelegationManagerUnitTests_operatorAVSRegisterationStatus is DelegationManagerUnitTests {
+//     // @notice Tests that an avs who calls `updateAVSMetadataURI` will correctly see an `AVSMetadataURIUpdated` event emitted with their input
+//     function testFuzz_UpdateAVSMetadataURI(string memory metadataURI) public {
+//         // call `updateAVSMetadataURI` and check for event
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         cheats.prank(defaultAVS);
+//         emit AVSMetadataURIUpdated(defaultAVS, metadataURI);
+//         delegationManager.updateAVSMetadataURI(metadataURI);
+//     }
+
+//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
+//     function testFuzz_registerOperatorToAVS(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorAVSRegistrationStatusUpdated(operator, defaultAVS, OperatorAVSRegistrationStatus.REGISTERED);
+
+//         uint256 expiry = type(uint256).max;
+
+//         cheats.prank(defaultAVS);
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
+//     function testFuzz_revert_whenOperatorNotRegisteredToEigenLayerYet(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+
+//         cheats.prank(defaultAVS);
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator not registered to EigenLayer yet");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when the signature is not from the operator
+//     function testFuzz_revert_whenSignatureAddressIsNotOperator(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+//         cheats.prank(operator);
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when the signature expiry already expires
+//     function testFuzz_revert_whenExpiryHasExpired(bytes32 salt, uint256 expiry, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         cheats.assume(operatorSignature.expiry < block.timestamp);
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator signature expired");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when it's already registered to the avs
+//     function testFuzz_revert_whenOperatorAlreadyRegisteredToAVS(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.startPrank(defaultAVS);
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator already registered");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//         cheats.stopPrank();
+//     }
+// }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1,3236 +1,3236 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity =0.8.12;
+// // SPDX-License-Identifier: BUSL-1.1
+// pragma solidity =0.8.12;
 
-import "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
-import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+// import "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
+// import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
-import "src/contracts/core/DelegationManager.sol";
-import "src/contracts/strategies/StrategyBase.sol";
+// import "src/contracts/core/DelegationManager.sol";
+// import "src/contracts/strategies/StrategyBase.sol";
 
-import "src/test/events/IDelegationManagerEvents.sol";
-import "src/test/utils/EigenLayerUnitTestSetup.sol";
+// import "src/test/events/IDelegationManagerEvents.sol";
+// import "src/test/utils/EigenLayerUnitTestSetup.sol";
 
-/**
- * @notice Unit testing of the DelegationManager contract. Withdrawals are tightly coupled
- * with EigenPodManager and StrategyManager and are part of integration tests.
- * Contracts tested: DelegationManager
- * Contracts not mocked: StrategyBase, PauserRegistry
- */
-contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManagerEvents {
-    // Contract under test
-    DelegationManager delegationManager;
-    DelegationManager delegationManagerImplementation;
+// /**
+//  * @notice Unit testing of the DelegationManager contract. Withdrawals are tightly coupled
+//  * with EigenPodManager and StrategyManager and are part of integration tests.
+//  * Contracts tested: DelegationManager
+//  * Contracts not mocked: StrategyBase, PauserRegistry
+//  */
+// contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManagerEvents {
+//     // Contract under test
+//     DelegationManager delegationManager;
+//     DelegationManager delegationManagerImplementation;
 
-    // Mocks
-    StrategyBase strategyImplementation;
-    StrategyBase strategyMock;
-    IERC20 mockToken;
-    uint256 mockTokenInitialSupply = 10e50;
+//     // Mocks
+//     StrategyBase strategyImplementation;
+//     StrategyBase strategyMock;
+//     IERC20 mockToken;
+//     uint256 mockTokenInitialSupply = 10e50;
 
-    // Delegation signer
-    uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
-    uint256 stakerPrivateKey = uint256(123_456_789);
+//     // Delegation signer
+//     uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+//     uint256 stakerPrivateKey = uint256(123_456_789);
 
-    // empty string reused across many tests
-    string emptyStringForMetadataURI;
+//     // empty string reused across many tests
+//     string emptyStringForMetadataURI;
 
-    // "empty" / zero salt, reused across many tests
-    bytes32 emptySalt;
+//     // "empty" / zero salt, reused across many tests
+//     bytes32 emptySalt;
 
-    // reused in various tests. in storage to help handle stack-too-deep errors
-    address defaultStaker = cheats.addr(uint256(123_456_789));
-    address defaultOperator = address(this);
-    address defaultAVS = address(this);
+//     // reused in various tests. in storage to help handle stack-too-deep errors
+//     address defaultStaker = cheats.addr(uint256(123_456_789));
+//     address defaultOperator = address(this);
+//     address defaultAVS = address(this);
 
-    uint256 minWithdrawalDelayBlocks = 216000;
-    IStrategy[] public initializeStrategiesToSetDelayBlocks;
-    uint256[] public initializeWithdrawalDelayBlocks;
+//     uint256 minWithdrawalDelayBlocks = 216000;
+//     IStrategy[] public initializeStrategiesToSetDelayBlocks;
+//     uint256[] public initializeWithdrawalDelayBlocks;
 
-    IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+//     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
-    // Index for flag that pauses new delegations when set.
-    uint8 internal constant PAUSED_NEW_DELEGATION = 0;
+//     // Index for flag that pauses new delegations when set.
+//     uint8 internal constant PAUSED_NEW_DELEGATION = 0;
 
-    // Index for flag that pauses queuing new withdrawals when set.
-    uint8 internal constant PAUSED_ENTER_WITHDRAWAL_QUEUE = 1;
+//     // Index for flag that pauses queuing new withdrawals when set.
+//     uint8 internal constant PAUSED_ENTER_WITHDRAWAL_QUEUE = 1;
 
-    // Index for flag that pauses completing existing withdrawals when set.
-    uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
+//     // Index for flag that pauses completing existing withdrawals when set.
+//     uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
 
-    // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
-    uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = 216000;
+//     // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
+//     uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = 216000;
 
-    /// @notice mappings used to handle duplicate entries in fuzzed address array input
-    mapping(address => uint256) public totalSharesForStrategyInArray;
-    mapping(IStrategy => uint256) public delegatedSharesBefore;
+//     /// @notice mappings used to handle duplicate entries in fuzzed address array input
+//     mapping(address => uint256) public totalSharesForStrategyInArray;
+//     mapping(IStrategy => uint256) public delegatedSharesBefore;
 
-    function setUp() public virtual override {
-        // Setup
-        EigenLayerUnitTestSetup.setUp();
+//     function setUp() public virtual override {
+//         // Setup
+//         EigenLayerUnitTestSetup.setUp();
 
-        // Deploy DelegationManager implmentation and proxy
-        initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
-        initializeWithdrawalDelayBlocks = new uint256[](0);
-        delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
-        delegationManager = DelegationManager(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(delegationManagerImplementation),
-                    address(eigenLayerProxyAdmin),
-                    abi.encodeWithSelector(
-                        DelegationManager.initialize.selector,
-                        address(this),
-                        pauserRegistry,
-                        0, // 0 is initialPausedStatus
-                        minWithdrawalDelayBlocks,
-                        initializeStrategiesToSetDelayBlocks,
-                        initializeWithdrawalDelayBlocks
-                    )
-                )
-            )
-        );
+//         // Deploy DelegationManager implmentation and proxy
+//         initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
+//         initializeWithdrawalDelayBlocks = new uint256[](0);
+//         delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
+//         delegationManager = DelegationManager(
+//             address(
+//                 new TransparentUpgradeableProxy(
+//                     address(delegationManagerImplementation),
+//                     address(eigenLayerProxyAdmin),
+//                     abi.encodeWithSelector(
+//                         DelegationManager.initialize.selector,
+//                         address(this),
+//                         pauserRegistry,
+//                         0, // 0 is initialPausedStatus
+//                         minWithdrawalDelayBlocks,
+//                         initializeStrategiesToSetDelayBlocks,
+//                         initializeWithdrawalDelayBlocks
+//                     )
+//                 )
+//             )
+//         );
 
-        // Deploy mock token and strategy
-        mockToken = new ERC20PresetFixedSupply("Mock Token", "MOCK", mockTokenInitialSupply, address(this));
-        strategyImplementation = new StrategyBase(strategyManagerMock);
-        strategyMock = StrategyBase(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(strategyImplementation),
-                    address(eigenLayerProxyAdmin),
-                    abi.encodeWithSelector(StrategyBase.initialize.selector, mockToken, pauserRegistry)
-                )
-            )
-        );
+//         // Deploy mock token and strategy
+//         mockToken = new ERC20PresetFixedSupply("Mock Token", "MOCK", mockTokenInitialSupply, address(this));
+//         strategyImplementation = new StrategyBase(strategyManagerMock);
+//         strategyMock = StrategyBase(
+//             address(
+//                 new TransparentUpgradeableProxy(
+//                     address(strategyImplementation),
+//                     address(eigenLayerProxyAdmin),
+//                     abi.encodeWithSelector(StrategyBase.initialize.selector, mockToken, pauserRegistry)
+//                 )
+//             )
+//         );
 
-        // Exclude delegation manager from fuzzed tests
-        addressIsExcludedFromFuzzedInputs[address(delegationManager)] = true;
-    }
+//         // Exclude delegation manager from fuzzed tests
+//         addressIsExcludedFromFuzzedInputs[address(delegationManager)] = true;
+//     }
 
-    /**
-     * INTERNAL / HELPER FUNCTIONS
-     */
+//     /**
+//      * INTERNAL / HELPER FUNCTIONS
+//      */
 
-    /**
-     * @notice internal function to deploy mock tokens and strategies and have the staker deposit into them. 
-     * Since we are mocking the strategyManager we call strategyManagerMock.setDeposits so that when
-     * DelegationManager calls getDeposits, we can have these share amounts returned.
-     */
-    function _deployAndDepositIntoStrategies(
-        address staker,
-        uint256[] memory sharesAmounts
-    ) internal returns (IStrategy[] memory) {
-        uint256 numStrats = sharesAmounts.length;
-        IStrategy[] memory strategies = new IStrategy[](numStrats);
-        for (uint8 i = 0; i < numStrats; i++) {
-            ERC20PresetFixedSupply token = new ERC20PresetFixedSupply(
-                string(abi.encodePacked("Mock Token ", i)),
-                string(abi.encodePacked("MOCK", i)),
-                mockTokenInitialSupply,
-                address(this)
-            );
-            strategies[i] = StrategyBase(
-                address(
-                    new TransparentUpgradeableProxy(
-                        address(strategyImplementation),
-                        address(eigenLayerProxyAdmin),
-                        abi.encodeWithSelector(StrategyBase.initialize.selector, token, pauserRegistry)
-                    )
-                )
-            );
-        }
-        strategyManagerMock.setDeposits(staker, strategies, sharesAmounts);
-        return strategies;
-    }
+//     /**
+//      * @notice internal function to deploy mock tokens and strategies and have the staker deposit into them. 
+//      * Since we are mocking the strategyManager we call strategyManagerMock.setDeposits so that when
+//      * DelegationManager calls getDeposits, we can have these share amounts returned.
+//      */
+//     function _deployAndDepositIntoStrategies(
+//         address staker,
+//         uint256[] memory sharesAmounts
+//     ) internal returns (IStrategy[] memory) {
+//         uint256 numStrats = sharesAmounts.length;
+//         IStrategy[] memory strategies = new IStrategy[](numStrats);
+//         for (uint8 i = 0; i < numStrats; i++) {
+//             ERC20PresetFixedSupply token = new ERC20PresetFixedSupply(
+//                 string(abi.encodePacked("Mock Token ", i)),
+//                 string(abi.encodePacked("MOCK", i)),
+//                 mockTokenInitialSupply,
+//                 address(this)
+//             );
+//             strategies[i] = StrategyBase(
+//                 address(
+//                     new TransparentUpgradeableProxy(
+//                         address(strategyImplementation),
+//                         address(eigenLayerProxyAdmin),
+//                         abi.encodeWithSelector(StrategyBase.initialize.selector, token, pauserRegistry)
+//                     )
+//                 )
+//             );
+//         }
+//         strategyManagerMock.setDeposits(staker, strategies, sharesAmounts);
+//         return strategies;
+//     }
 
-    /**
-     * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
-     * the `staker` to delegate to `operator`, with the specified `salt`, and expiring at `expiry`.
-     */
-    function _getApproverSignature(
-        uint256 _delegationSignerPrivateKey,
-        address staker,
-        address operator,
-        bytes32 salt,
-        uint256 expiry
-    ) internal view returns (ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) {
-        approverSignatureAndExpiry.expiry = expiry;
-        {
-            bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
-                staker,
-                operator,
-                delegationManager.delegationApprover(operator),
-                salt,
-                expiry
-            );
-            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_delegationSignerPrivateKey, digestHash);
-            approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-        }
-        return approverSignatureAndExpiry;
-    }
+//     /**
+//      * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
+//      * the `staker` to delegate to `operator`, with the specified `salt`, and expiring at `expiry`.
+//      */
+//     function _getApproverSignature(
+//         uint256 _delegationSignerPrivateKey,
+//         address staker,
+//         address operator,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) internal view returns (ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) {
+//         approverSignatureAndExpiry.expiry = expiry;
+//         {
+//             bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
+//                 staker,
+//                 operator,
+//                 delegationManager.delegationApprover(operator),
+//                 salt,
+//                 expiry
+//             );
+//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_delegationSignerPrivateKey, digestHash);
+//             approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+//         }
+//         return approverSignatureAndExpiry;
+//     }
 
-    /**
-     * @notice internal function for calculating a signature from the staker corresponding to `_stakerPrivateKey`, delegating them to
-     * the `operator`, and expiring at `expiry`.
-     */
-    function _getStakerSignature(
-        uint256 _stakerPrivateKey,
-        address operator,
-        uint256 expiry
-    ) internal view returns (ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry) {
-        address staker = cheats.addr(stakerPrivateKey);
-        stakerSignatureAndExpiry.expiry = expiry;
-        {
-            bytes32 digestHash = delegationManager.calculateCurrentStakerDelegationDigestHash(staker, operator, expiry);
-            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
-            stakerSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-        }
-        return stakerSignatureAndExpiry;
-    }
+//     /**
+//      * @notice internal function for calculating a signature from the staker corresponding to `_stakerPrivateKey`, delegating them to
+//      * the `operator`, and expiring at `expiry`.
+//      */
+//     function _getStakerSignature(
+//         uint256 _stakerPrivateKey,
+//         address operator,
+//         uint256 expiry
+//     ) internal view returns (ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry) {
+//         address staker = cheats.addr(stakerPrivateKey);
+//         stakerSignatureAndExpiry.expiry = expiry;
+//         {
+//             bytes32 digestHash = delegationManager.calculateCurrentStakerDelegationDigestHash(staker, operator, expiry);
+//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
+//             stakerSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+//         }
+//         return stakerSignatureAndExpiry;
+//     }
 
-    /**
-     * @notice internal function for calculating a signature from the operator corresponding to `_operatorPrivateKey`, delegating them to
-     * the `operator`, and expiring at `expiry`.
-     */
-    function _getOperatorSignature(
-        uint256 _operatorPrivateKey,
-        address operator,
-        address avs,
-        bytes32 salt,
-        uint256 expiry
-    ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) {
-        operatorSignature.expiry = expiry;
-        operatorSignature.salt = salt;
-        {
-            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
-            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
-            operatorSignature.signature = abi.encodePacked(r, s, v);
-        }
-        return operatorSignature;
-    }
+//     /**
+//      * @notice internal function for calculating a signature from the operator corresponding to `_operatorPrivateKey`, delegating them to
+//      * the `operator`, and expiring at `expiry`.
+//      */
+//     function _getOperatorSignature(
+//         uint256 _operatorPrivateKey,
+//         address operator,
+//         address avs,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) {
+//         operatorSignature.expiry = expiry;
+//         operatorSignature.salt = salt;
+//         {
+//             bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
+//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
+//             operatorSignature.signature = abi.encodePacked(r, s, v);
+//         }
+//         return operatorSignature;
+//     }
 
 
-    // @notice Assumes operator does not have a delegation approver & staker != approver
-    function _delegateToOperatorWhoAcceptsAllStakers(address staker, address operator) internal {
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        cheats.prank(staker);
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
-    }
+//     // @notice Assumes operator does not have a delegation approver & staker != approver
+//     function _delegateToOperatorWhoAcceptsAllStakers(address staker, address operator) internal {
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         cheats.prank(staker);
+//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
+//     }
 
-    function _delegateToOperatorWhoRequiresSig(address staker, address operator, bytes32 salt) internal {
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            operator,
-            salt,
-            expiry
-        );
-        cheats.prank(staker);
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
-    }
+//     function _delegateToOperatorWhoRequiresSig(address staker, address operator, bytes32 salt) internal {
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             operator,
+//             salt,
+//             expiry
+//         );
+//         cheats.prank(staker);
+//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
+//     }
 
-    function _delegateToOperatorWhoRequiresSig(address staker, address operator) internal {
-        _delegateToOperatorWhoRequiresSig(staker, operator, emptySalt);
-    }
+//     function _delegateToOperatorWhoRequiresSig(address staker, address operator) internal {
+//         _delegateToOperatorWhoRequiresSig(staker, operator, emptySalt);
+//     }
 
-    function _delegateToBySignatureOperatorWhoAcceptsAllStakers(
-        address staker,
-        address caller,
-        address operator,
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
-        bytes32 salt
-    ) internal {
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        cheats.prank(caller);
-        delegationManager.delegateToBySignature(
-            staker,
-            operator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            salt
-        );
-    }
+//     function _delegateToBySignatureOperatorWhoAcceptsAllStakers(
+//         address staker,
+//         address caller,
+//         address operator,
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
+//         bytes32 salt
+//     ) internal {
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         cheats.prank(caller);
+//         delegationManager.delegateToBySignature(
+//             staker,
+//             operator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             salt
+//         );
+//     }
 
-    function _delegateToBySignatureOperatorWhoRequiresSig(
-        address staker,
-        address caller,
-        address operator,
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
-        bytes32 salt
-    ) internal {
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            operator,
-            salt,
-            expiry
-        );
-        cheats.prank(caller);
-        delegationManager.delegateToBySignature(
-            staker,
-            operator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            salt
-        );
-    }
+//     function _delegateToBySignatureOperatorWhoRequiresSig(
+//         address staker,
+//         address caller,
+//         address operator,
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
+//         bytes32 salt
+//     ) internal {
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             operator,
+//             salt,
+//             expiry
+//         );
+//         cheats.prank(caller);
+//         delegationManager.delegateToBySignature(
+//             staker,
+//             operator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             salt
+//         );
+//     }
 
-    function _registerOperatorWithBaseDetails(address operator) internal {
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
-            delegationApprover: address(0),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
-    }
+//     function _registerOperatorWithBaseDetails(address operator) internal {
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: operator,
+//             delegationApprover: address(0),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+//     }
 
-    function _registerOperatorWithDelegationApprover(address operator) internal {
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
-            delegationApprover: cheats.addr(delegationSignerPrivateKey),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
-    }
+//     function _registerOperatorWithDelegationApprover(address operator) internal {
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: operator,
+//             delegationApprover: cheats.addr(delegationSignerPrivateKey),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+//     }
 
-    function _registerOperatorWith1271DelegationApprover(address operator) internal returns (ERC1271WalletMock) {
-        address delegationSigner = cheats.addr(delegationSignerPrivateKey);
-        /**
-         * deploy a ERC1271WalletMock contract with the `delegationSigner` address as the owner,
-         * so that we can create valid signatures from the `delegationSigner` for the contract to check when called
-         */
-        ERC1271WalletMock wallet = new ERC1271WalletMock(delegationSigner);
+//     function _registerOperatorWith1271DelegationApprover(address operator) internal returns (ERC1271WalletMock) {
+//         address delegationSigner = cheats.addr(delegationSignerPrivateKey);
+//         /**
+//          * deploy a ERC1271WalletMock contract with the `delegationSigner` address as the owner,
+//          * so that we can create valid signatures from the `delegationSigner` for the contract to check when called
+//          */
+//         ERC1271WalletMock wallet = new ERC1271WalletMock(delegationSigner);
 
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: operator,
-            delegationApprover: address(wallet),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: operator,
+//             delegationApprover: address(wallet),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-        return wallet;
-    }
+//         return wallet;
+//     }
 
-    function _registerOperator(
-        address operator,
-        IDelegationManager.OperatorDetails memory operatorDetails,
-        string memory metadataURI
-    ) internal filterFuzzedAddressInputs(operator) {
-        _filterOperatorDetails(operator, operatorDetails);
-        cheats.prank(operator);
-        delegationManager.registerAsOperator(operatorDetails, metadataURI);
-    }
+//     function _registerOperator(
+//         address operator,
+//         IDelegationManager.OperatorDetails memory operatorDetails,
+//         string memory metadataURI
+//     ) internal filterFuzzedAddressInputs(operator) {
+//         _filterOperatorDetails(operator, operatorDetails);
+//         cheats.prank(operator);
+//         delegationManager.registerAsOperator(operatorDetails, metadataURI);
+//     }
 
-    function _filterOperatorDetails(
-        address operator,
-        IDelegationManager.OperatorDetails memory operatorDetails
-    ) internal view {
-        // filter out zero address since people can't delegate to the zero address and operators are delegated to themselves
-        cheats.assume(operator != address(0));
-        // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
-        cheats.assume(operatorDetails.earningsReceiver != address(0));
-        // filter out disallowed stakerOptOutWindowBlocks values
-        cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
-    }
+//     function _filterOperatorDetails(
+//         address operator,
+//         IDelegationManager.OperatorDetails memory operatorDetails
+//     ) internal view {
+//         // filter out zero address since people can't delegate to the zero address and operators are delegated to themselves
+//         cheats.assume(operator != address(0));
+//         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
+//         cheats.assume(operatorDetails.earningsReceiver != address(0));
+//         // filter out disallowed stakerOptOutWindowBlocks values
+//         cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
+//     }
 
-    /**
-     * @notice Using this helper function to fuzz withdrawalAmounts since fuzzing two dynamic sized arrays of equal lengths
-     * reject too many inputs. 
-     */
-    function _fuzzWithdrawalAmounts(uint256[] memory depositAmounts) internal view returns (uint256[] memory) {
-        uint256[] memory withdrawalAmounts = new uint256[](depositAmounts.length);
-        for (uint256 i = 0; i < depositAmounts.length; i++) {
-            cheats.assume(depositAmounts[i] > 0);
-            // generate withdrawal amount within range s.t withdrawAmount <= depositAmount
-            withdrawalAmounts[i] = bound(
-                uint256(keccak256(abi.encodePacked(depositAmounts[i]))),
-                0,
-                depositAmounts[i]
-            );
-        }
-        return withdrawalAmounts;
-    }
+//     /**
+//      * @notice Using this helper function to fuzz withdrawalAmounts since fuzzing two dynamic sized arrays of equal lengths
+//      * reject too many inputs. 
+//      */
+//     function _fuzzWithdrawalAmounts(uint256[] memory depositAmounts) internal view returns (uint256[] memory) {
+//         uint256[] memory withdrawalAmounts = new uint256[](depositAmounts.length);
+//         for (uint256 i = 0; i < depositAmounts.length; i++) {
+//             cheats.assume(depositAmounts[i] > 0);
+//             // generate withdrawal amount within range s.t withdrawAmount <= depositAmount
+//             withdrawalAmounts[i] = bound(
+//                 uint256(keccak256(abi.encodePacked(depositAmounts[i]))),
+//                 0,
+//                 depositAmounts[i]
+//             );
+//         }
+//         return withdrawalAmounts;
+//     }
 
-    function _setUpQueueWithdrawalsSingleStrat(
-        address staker,
-        address withdrawer,
-        IStrategy strategy,
-        uint256 withdrawalAmount
-    ) internal view returns (
-        IDelegationManager.QueuedWithdrawalParams[] memory,
-        IDelegationManager.Withdrawal memory,
-        bytes32
-    ) {
-        IStrategy[] memory strategyArray = new IStrategy[](1);
-        strategyArray[0] = strategy;
-        uint256[] memory withdrawalAmounts = new uint256[](1);
-        withdrawalAmounts[0] = withdrawalAmount;
+//     function _setUpQueueWithdrawalsSingleStrat(
+//         address staker,
+//         address withdrawer,
+//         IStrategy strategy,
+//         uint256 withdrawalAmount
+//     ) internal view returns (
+//         IDelegationManager.QueuedWithdrawalParams[] memory,
+//         IDelegationManager.Withdrawal memory,
+//         bytes32
+//     ) {
+//         IStrategy[] memory strategyArray = new IStrategy[](1);
+//         strategyArray[0] = strategy;
+//         uint256[] memory withdrawalAmounts = new uint256[](1);
+//         withdrawalAmounts[0] = withdrawalAmount;
 
-        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategyArray,
-            shares: withdrawalAmounts,
-            withdrawer: withdrawer
-        });
+//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+//             strategies: strategyArray,
+//             shares: withdrawalAmounts,
+//             withdrawer: withdrawer
+//         });
 
-        IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
-            staker: staker,
-            delegatedTo: delegationManager.delegatedTo(staker),
-            withdrawer: withdrawer,
-            nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-            startBlock: uint32(block.number),
-            strategies: strategyArray,
-            shares: withdrawalAmounts
-        });
-        bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
+//         IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
+//             staker: staker,
+//             delegatedTo: delegationManager.delegatedTo(staker),
+//             withdrawer: withdrawer,
+//             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
+//             startBlock: uint32(block.number),
+//             strategies: strategyArray,
+//             shares: withdrawalAmounts
+//         });
+//         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
-        return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
-    }
+//         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
+//     }
 
-    function _setUpQueueWithdrawals(
-        address staker,
-        address withdrawer,
-        IStrategy[] memory strategies,
-        uint256[] memory withdrawalAmounts
-    ) internal view returns (
-        IDelegationManager.QueuedWithdrawalParams[] memory,
-        IDelegationManager.Withdrawal memory,
-        bytes32
-    ) {
-        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategies,
-            shares: withdrawalAmounts,
-            withdrawer: withdrawer
-        });
+//     function _setUpQueueWithdrawals(
+//         address staker,
+//         address withdrawer,
+//         IStrategy[] memory strategies,
+//         uint256[] memory withdrawalAmounts
+//     ) internal view returns (
+//         IDelegationManager.QueuedWithdrawalParams[] memory,
+//         IDelegationManager.Withdrawal memory,
+//         bytes32
+//     ) {
+//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+//             strategies: strategies,
+//             shares: withdrawalAmounts,
+//             withdrawer: withdrawer
+//         });
         
-        IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
-            staker: staker,
-            delegatedTo: delegationManager.delegatedTo(staker),
-            withdrawer: withdrawer,
-            nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-            startBlock: uint32(block.number),
-            strategies: strategies,
-            shares: withdrawalAmounts
-        });
-        bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
+//         IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
+//             staker: staker,
+//             delegatedTo: delegationManager.delegatedTo(staker),
+//             withdrawer: withdrawer,
+//             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
+//             startBlock: uint32(block.number),
+//             strategies: strategies,
+//             shares: withdrawalAmounts
+//         });
+//         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
-        return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
-    }
-
-    /**
-     * Deploy and deposit staker into a single strategy, then set up a queued withdrawal for the staker
-     * Assumptions: 
-     * - operator is already a registered operator.
-     * - withdrawalAmount <= depositAmount
-     */
-    function _setUpCompleteQueuedWithdrawalSingleStrat(
-        address staker,
-        address operator,
-        address withdrawer,
-        uint256 depositAmount,
-        uint256 withdrawalAmount
-    ) internal returns (IDelegationManager.Withdrawal memory, IERC20[] memory, bytes32) {
-        uint256[] memory depositAmounts = new uint256[](1);
-        depositAmounts[0] = depositAmount;
-        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-        (
-            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-            IDelegationManager.Withdrawal memory withdrawal,
-            bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsSingleStrat({
-            staker: staker,
-            withdrawer: withdrawer,
-            strategy: strategies[0],
-            withdrawalAmount: withdrawalAmount
-        });
-
-        cheats.prank(staker);
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-        // Set the current deposits to be the depositAmount - withdrawalAmount
-        uint256[] memory currentAmounts = new uint256[](1);
-        currentAmounts[0] = depositAmount - withdrawalAmount;
-        strategyManagerMock.setDeposits(staker, strategies, currentAmounts);
-
-        IERC20[] memory tokens = new IERC20[](1);
-        tokens[0] = strategies[0].underlyingToken();
-        return (withdrawal, tokens, withdrawalRoot);
-    }
-
-    /**
-     * Deploy and deposit staker into strategies, then set up a queued withdrawal for the staker
-     * Assumptions: 
-     * - operator is already a registered operator.
-     * - for each i, withdrawalAmount[i] <= depositAmount[i] (see filterFuzzedDepositWithdrawInputs above)
-     */
-    function _setUpCompleteQueuedWithdrawal(
-        address staker,
-        address operator,
-        address withdrawer,
-        uint256[] memory depositAmounts,
-        uint256[] memory withdrawalAmounts
-    ) internal returns (IDelegationManager.Withdrawal memory, bytes32) {
-        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-        (
-            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-            IDelegationManager.Withdrawal memory withdrawal,
-            bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawals({
-            staker: staker,
-            withdrawer: withdrawer,
-            strategies: strategies,
-            withdrawalAmounts: withdrawalAmounts
-        });
-
-        cheats.prank(staker);
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-        return (withdrawal, withdrawalRoot);
-    }
-}
-
-contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerUnitTests {
-    function test_initialization() public {
-        assertEq(
-            address(delegationManager.strategyManager()),
-            address(strategyManagerMock),
-            "constructor / initializer incorrect, strategyManager set wrong"
-        );
-        assertEq(
-            address(delegationManager.slasher()),
-            address(slasherMock),
-            "constructor / initializer incorrect, slasher set wrong"
-        );
-        assertEq(
-            address(delegationManager.pauserRegistry()),
-            address(pauserRegistry),
-            "constructor / initializer incorrect, pauserRegistry set wrong"
-        );
-        assertEq(delegationManager.owner(), address(this), "constructor / initializer incorrect, owner set wrong");
-        assertEq(delegationManager.paused(), 0, "constructor / initializer incorrect, paused status set wrong");
-    }
-
-    /// @notice Verifies that the DelegationManager cannot be iniitalized multiple times
-    function test_initialize_revert_reinitialization() public {
-        cheats.expectRevert("Initializable: contract is already initialized");
-        delegationManager.initialize(
-            address(this),
-            pauserRegistry,
-            0,
-            0, // minWithdrawalDelayBLocks
-            initializeStrategiesToSetDelayBlocks,
-            initializeWithdrawalDelayBlocks
-        );
-    }
-
-    function testFuzz_initialize_Revert_WhenWithdrawalDelayBlocksTooLarge(
-        uint256[] memory withdrawalDelayBlocks,
-        uint256 invalidStrategyIndex
-    ) public {
-        // set withdrawalDelayBlocks to be too large
-        cheats.assume(withdrawalDelayBlocks.length > 0);
-        uint256 numStrats = withdrawalDelayBlocks.length;
-        IStrategy[] memory strategiesToSetDelayBlocks = new IStrategy[](numStrats);
-        for (uint256 i = 0; i < numStrats; i++) {
-            strategiesToSetDelayBlocks[i] = IStrategy(address(uint160(uint256(keccak256(abi.encode(strategyMock, i))))));
-        }
-
-        // set at least one index to be too large for withdrawalDelayBlocks
-        invalidStrategyIndex = invalidStrategyIndex % numStrats;
-        withdrawalDelayBlocks[invalidStrategyIndex] = MAX_WITHDRAWAL_DELAY_BLOCKS + 1;
-
-        // Deploy DelegationManager implmentation and proxy
-        delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
-        cheats.expectRevert(
-            "DelegationManager._setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
-        );
-        delegationManager = DelegationManager(
-            address(
-                new TransparentUpgradeableProxy(
-                    address(delegationManagerImplementation),
-                    address(eigenLayerProxyAdmin),
-                    abi.encodeWithSelector(
-                        DelegationManager.initialize.selector,
-                        address(this),
-                        pauserRegistry,
-                        0, // 0 is initialPausedStatus
-                        minWithdrawalDelayBlocks,
-                        strategiesToSetDelayBlocks,
-                        withdrawalDelayBlocks
-                    )
-                )
-            )
-        );
-    }
-}
-
-contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerUnitTests {
-    function test_registerAsOperator_revert_paused() public {
-        // set the pausing flag
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.registerAsOperator(
-            IDelegationManager.OperatorDetails({
-                earningsReceiver: defaultOperator,
-                delegationApprover: address(0),
-                stakerOptOutWindowBlocks: 0
-            }),
-            emptyStringForMetadataURI
-        );
-    }
-
-    // @notice Verifies that someone cannot successfully call `DelegationManager.registerAsOperator(operatorDetails)` again after registering for the first time
-    function testFuzz_registerAsOperator_revert_cannotRegisterMultipleTimes(
-        address operator,
-        IDelegationManager.OperatorDetails memory operatorDetails
-    ) public filterFuzzedAddressInputs(operator) {
-        _filterOperatorDetails(operator, operatorDetails);
-
-        // Register once
-        cheats.startPrank(operator);
-        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-
-        // Expect revert when register again
-        cheats.expectRevert("DelegationManager.registerAsOperator: operator has already registered");
-        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice Verifies that an operator cannot register with `earningsReceiver` set to the zero address
-     * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
-     */
-    function testFuzz_registerAsOperator_revert_earningsReceiverZeroAddress() public {
-        IDelegationManager.OperatorDetails memory operatorDetails;
-
-        cheats.prank(defaultOperator);
-        cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
-        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-    }
-
-    /**
-     * @notice Verifies that an operator cannot register with `stakerOptOutWindowBlocks` set larger than `MAX_STAKER_OPT_OUT_WINDOW_BLOCKS`
-     */
-    function testFuzz_registerAsOperator_revert_optOutBlocksTooLarge(
-        IDelegationManager.OperatorDetails memory operatorDetails
-    ) public {
-        // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
-        cheats.assume(operatorDetails.earningsReceiver != address(0));
-        // filter out *allowed* stakerOptOutWindowBlocks values
-        cheats.assume(operatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
-
-        cheats.prank(defaultOperator);
-        cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS");
-        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-    }
-
-    /**
-     * @notice `operator` registers via calling `DelegationManager.registerAsOperator(operatorDetails, metadataURI)`
-     * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
-     * The set parameters should match the desired parameters (correct storage update)
-     * Operator becomes delegated to themselves
-     * Properly emits events – especially the `OperatorRegistered` event, but also `StakerDelegated` & `OperatorDetailsModified` events
-     * Reverts appropriately if operator was already delegated to someone (including themselves, i.e. they were already an operator)
-     * @param operator and @param operatorDetails are fuzzed inputs
-     */
-    function testFuzz_registerAsOperator(
-        address operator,
-        IDelegationManager.OperatorDetails memory operatorDetails,
-        string memory metadataURI
-    ) public filterFuzzedAddressInputs(operator) {
-        _filterOperatorDetails(operator, operatorDetails);
-
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorDetailsModified(operator, operatorDetails);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(operator, operator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorRegistered(operator, operatorDetails);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorMetadataURIUpdated(operator, metadataURI);
-
-        cheats.prank(operator);
-        delegationManager.registerAsOperator(operatorDetails, metadataURI);
-
-        // Storage checks
-        assertEq(
-            operatorDetails.earningsReceiver,
-            delegationManager.earningsReceiver(operator),
-            "earningsReceiver not set correctly"
-        );
-        assertEq(
-            operatorDetails.delegationApprover,
-            delegationManager.delegationApprover(operator),
-            "delegationApprover not set correctly"
-        );
-        assertEq(
-            operatorDetails.stakerOptOutWindowBlocks,
-            delegationManager.stakerOptOutWindowBlocks(operator),
-            "stakerOptOutWindowBlocks not set correctly"
-        );
-        assertEq(delegationManager.delegatedTo(operator), operator, "operator not delegated to self");
-    }
-
-    // @notice Verifies that a staker who is actively delegated to an operator cannot register as an operator (without first undelegating, at least)
-    function testFuzz_registerAsOperator_cannotRegisterWhileDelegated(
-        address staker,
-        IDelegationManager.OperatorDetails memory operatorDetails
-    ) public filterFuzzedAddressInputs(staker) {
-        cheats.assume(staker != defaultOperator);
-        // Staker becomes an operator, so filter against staker's address
-        _filterOperatorDetails(staker, operatorDetails);
-
-        // register *this contract* as an operator
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-
-        // expect revert if attempt to register as operator
-        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice Verifies that an operator cannot modify their `earningsReceiver` address to set it to the zero address
-     * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
-     */
-    function test_modifyOperatorParameters_revert_earningsReceiverZeroAddress() public {
-        // register *this contract* as an operator
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: defaultOperator,
-            delegationApprover: address(0),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-        operatorDetails.earningsReceiver = address(0);
-        cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
-        delegationManager.modifyOperatorDetails(operatorDetails);
-    }
-
-    /**
-     * @notice Tests that an operator can modify their OperatorDetails by calling `DelegationManager.modifyOperatorDetails`
-     * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
-     * The set parameters should match the desired parameters (correct storage update)
-     * Properly emits an `OperatorDetailsModified` event
-     * Reverts appropriately if the caller is not an operator
-     * Reverts if operator tries to decrease their `stakerOptOutWindowBlocks` parameter
-     * @param initialOperatorDetails and @param modifiedOperatorDetails are fuzzed inputs
-     */
-    function testFuzz_modifyOperatorParameters(
-        IDelegationManager.OperatorDetails memory initialOperatorDetails,
-        IDelegationManager.OperatorDetails memory modifiedOperatorDetails
-    ) public {
-        // filter out zero address since people can't set their earningsReceiver address to the zero address (test case verified above)
-        cheats.assume(modifiedOperatorDetails.earningsReceiver != address(0));
-
-        _registerOperator(defaultOperator, initialOperatorDetails, emptyStringForMetadataURI);
-
-        cheats.startPrank(defaultOperator);
-
-        // either it fails for trying to set the stakerOptOutWindowBlocks
-        if (modifiedOperatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS()) {
-            cheats.expectRevert(
-                "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
-            );
-            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-            // or the transition is allowed,
-        } else if (
-            modifiedOperatorDetails.stakerOptOutWindowBlocks >= initialOperatorDetails.stakerOptOutWindowBlocks
-        ) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorDetailsModified(defaultOperator, modifiedOperatorDetails);
-            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-
-            assertEq(
-                modifiedOperatorDetails.earningsReceiver,
-                delegationManager.earningsReceiver(defaultOperator),
-                "earningsReceiver not set correctly"
-            );
-            assertEq(
-                modifiedOperatorDetails.delegationApprover,
-                delegationManager.delegationApprover(defaultOperator),
-                "delegationApprover not set correctly"
-            );
-            assertEq(
-                modifiedOperatorDetails.stakerOptOutWindowBlocks,
-                delegationManager.stakerOptOutWindowBlocks(defaultOperator),
-                "stakerOptOutWindowBlocks not set correctly"
-            );
-            assertEq(delegationManager.delegatedTo(defaultOperator), defaultOperator, "operator not delegated to self");
-            // or else the transition is disallowed
-        } else {
-            cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased");
-            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-        }
-
-        cheats.stopPrank();
-    }
-
-    // @notice Tests that an address which is not an operator cannot successfully call `updateOperatorMetadataURI`.
-    function test_updateOperatorMetadataUri_notRegistered() public {
-        assertFalse(delegationManager.isOperator(defaultOperator), "bad test setup");
-
-        cheats.prank(defaultOperator);
-        cheats.expectRevert("DelegationManager.updateOperatorMetadataURI: caller must be an operator");
-        delegationManager.updateOperatorMetadataURI(emptyStringForMetadataURI);
-    }
-
-    /**
-     * @notice Verifies that a staker cannot call cannot modify their `OperatorDetails` without first registering as an operator
-     * @dev This is an important check to ensure that our definition of 'operator' remains consistent, in particular for preserving the
-     * invariant that 'operators' are always delegated to themselves
-     */
-    function testFuzz_updateOperatorMetadataUri_revert_notOperator(
-        IDelegationManager.OperatorDetails memory operatorDetails
-    ) public {
-        cheats.expectRevert("DelegationManager.modifyOperatorDetails: caller must be an operator");
-        delegationManager.modifyOperatorDetails(operatorDetails);
-    }
-
-    // @notice Tests that an operator who calls `updateOperatorMetadataURI` will correctly see an `OperatorMetadataURIUpdated` event emitted with their input
-    function testFuzz_UpdateOperatorMetadataURI(string memory metadataURI) public {
-        // register *this contract* as an operator
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // call `updateOperatorMetadataURI` and check for event
-        cheats.prank(defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorMetadataURIUpdated(defaultOperator, metadataURI);
-        delegationManager.updateOperatorMetadataURI(metadataURI);
-    }
-}
-
-contract DelegationManagerUnitTests_operatorAVSRegisterationStatus is DelegationManagerUnitTests {
-    // @notice Tests that an avs who calls `updateAVSMetadataURI` will correctly see an `AVSMetadataURIUpdated` event emitted with their input
-    function testFuzz_UpdateAVSMetadataURI(string memory metadataURI) public {
-        // call `updateAVSMetadataURI` and check for event
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        cheats.prank(defaultAVS);
-        emit AVSMetadataURIUpdated(defaultAVS, metadataURI);
-        delegationManager.updateAVSMetadataURI(metadataURI);
-    }
-
-    // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
-    function testFuzz_registerOperatorToAVS(bytes32 salt) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        assertFalse(delegationManager.isOperator(operator), "bad test setup");
-        _registerOperatorWithBaseDetails(operator);
-
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorAVSRegistrationStatusUpdated(operator, defaultAVS, OperatorAVSRegistrationStatus.REGISTERED);
-
-        uint256 expiry = type(uint256).max;
-
-        cheats.prank(defaultAVS);
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-            delegationSignerPrivateKey,
-            operator,
-            defaultAVS,
-            salt,
-            expiry
-        );
-
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-    }
-
-    // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
-    function testFuzz_revert_whenOperatorNotRegisteredToEigenLayerYet(bytes32 salt) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        assertFalse(delegationManager.isOperator(operator), "bad test setup");
-
-        cheats.prank(defaultAVS);
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-            delegationSignerPrivateKey,
-            operator,
-            defaultAVS,
-            salt,
-            expiry
-        );
-
-        cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator not registered to EigenLayer yet");
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-    }
-
-    // @notice Verifies an operator registers fails when the signature is not from the operator
-    function testFuzz_revert_whenSignatureAddressIsNotOperator(bytes32 salt) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        assertFalse(delegationManager.isOperator(operator), "bad test setup");
-        _registerOperatorWithBaseDetails(operator);
-
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-            delegationSignerPrivateKey,
-            operator,
-            defaultAVS,
-            salt,
-            expiry
-        );
-
-        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-        cheats.prank(operator);
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-    }
-
-    // @notice Verifies an operator registers fails when the signature expiry already expires
-    function testFuzz_revert_whenExpiryHasExpired(bytes32 salt, uint256 expiry, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        cheats.assume(operatorSignature.expiry < block.timestamp);
-
-        cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator signature expired");
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-    }
-
-    // @notice Verifies an operator registers fails when it's already registered to the avs
-    function testFuzz_revert_whenOperatorAlreadyRegisteredToAVS(bytes32 salt) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        assertFalse(delegationManager.isOperator(operator), "bad test setup");
-        _registerOperatorWithBaseDetails(operator);
-
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-            delegationSignerPrivateKey,
-            operator,
-            defaultAVS,
-            salt,
-            expiry
-        );
-
-        cheats.startPrank(defaultAVS);
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-
-        cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator already registered");
-        delegationManager.registerOperatorToAVS(operator, operatorSignature);
-        cheats.stopPrank();
-    }
-}
-
-contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
-    function test_Revert_WhenPaused() public {
-        // set the pausing flag
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        cheats.prank(defaultStaker);
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-    }
-
-    /**
-     * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
-     */
-    function testFuzz_Revert_WhenDelegateWhileDelegated(
-        address staker,
-        address operator,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-        bytes32 salt
-    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-        // filter out input since if the staker tries to delegate again after registering as an operator, we will revert earlier than this test is designed to check
-        cheats.assume(staker != operator);
-
-        // delegate from the staker to an operator
-        cheats.assume(operator != address(this));
-        _registerOperatorWithBaseDetails(operator);
-        _delegateToOperatorWhoAcceptsAllStakers(staker, operator);
-
-        // try to delegate again and check that the call reverts
-        cheats.startPrank(staker);
-        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-    }
-
-    // @notice Verifies that `staker` cannot delegate to an unregistered `operator`
-    function testFuzz_Revert_WhenDelegateToUnregisteredOperator(
-        address staker,
-        address operator
-    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-        assertFalse(delegationManager.isOperator(operator), "incorrect test input?");
-
-        // try to delegate and check that the call reverts
-        cheats.startPrank(staker);
-        cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass with any `operatorSignature` input (since it should be unused)
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoAcceptsAllStakers_StrategyManagerShares(
-        address staker,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-        bytes32 salt,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(staker) {
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // Set staker shares in StrategyManager
-        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-        strategiesToReturn[0] = strategyMock;
-        uint256[] memory sharesToReturn = new uint256[](1);
-        sharesToReturn[0] = shares;
-        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-
-        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        // verify that the salt is still marked as unused (since it wasn't checked or used)
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass with any `operatorSignature` input (since it should be unused)
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * OperatorSharesIncreased event should only be emitted if beaconShares is > 0. Since a staker can have negative shares nothing should happen in that case
-     */
-    function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainStrategyShares(
-        address staker,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-        bytes32 salt,
-        int256 beaconShares
-    ) public filterFuzzedAddressInputs(staker) {
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // Set staker shares in BeaconChainStrategy
-        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-        if (beaconShares <= 0) {
-            assertEq(
-                beaconSharesBefore,
-                beaconSharesAfter,
-                "operator beaconchain shares should not have increased with negative shares"
-            );
-        } else {
-            assertEq(
-                beaconSharesBefore + uint256(beaconShares),
-                beaconSharesAfter,
-                "operator beaconchain shares not increased correctly"
-            );
-        }
-        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        // verify that the salt is still marked as unused (since it wasn't checked or used)
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * Similar to tests above but now with staker who has both EigenPod and StrategyManager shares.
-     */
-    function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainAndStrategyManagerShares(
-        address staker,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-        bytes32 salt,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(staker) {
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // Set staker shares in BeaconChainStrategy and StrategyMananger
-        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-        strategiesToReturn[0] = strategyMock;
-        uint256[] memory sharesToReturn = new uint256[](1);
-        sharesToReturn[0] = shares;
-        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-        if (beaconShares <= 0) {
-            assertEq(
-                beaconSharesBefore,
-                beaconSharesAfter,
-                "operator beaconchain shares should not have increased with negative shares"
-            );
-        } else {
-            assertEq(
-                beaconSharesBefore + uint256(beaconShares),
-                beaconSharesAfter,
-                "operator beaconchain shares not increased correctly"
-            );
-        }
-        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        // verify that the salt is still marked as unused (since it wasn't checked or used)
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-    }
-
-    /**
-     * @notice `staker` delegates to a operator who does not require any signature verification similar to test above.
-     * In this scenario, staker doesn't have any delegatable shares and operator shares should not increase. Staker
-     * should still be correctly delegated to the operator after the call.
-     */
-    function testFuzz_OperatorWhoAcceptsAllStakers_ZeroDelegatableShares(
-        address staker,
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-        bytes32 salt
-    ) public filterFuzzedAddressInputs(staker) {
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-
-        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        // verify that the salt is still marked as unused (since it wasn't checked or used)
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-    }
-
-    /**
-     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an invalid expiry on purpose and checking that reversion occurs
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_ExpiredDelegationApproverSignature(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // roll to a very late timestamp
-        cheats.roll(type(uint256).max / 2);
-        // filter to only *invalid* `expiry` values
-        cheats.assume(expiry < block.timestamp);
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but undelegating after delegating and trying the same approveSignature
-     * and checking that reversion occurs with the same salt
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_PreviouslyUsedSalt(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        // staker also must not be the delegationApprover so that signature verification process takes place
-        cheats.assume(staker != defaultOperator);
-        cheats.assume(staker != delegationApprover);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, undelegate, and then try to delegate again with same approversalt
-        // to check that call reverts
-        cheats.startPrank(staker);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        assertTrue(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent not spent?"
-        );
-        delegationManager.undelegate(staker);
-        cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an incorrect signature on purpose and checking that reversion occurs
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_WithBadSignature(
-        address staker,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // calculate the signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        approverSignatureAndExpiry.expiry = expiry;
-        {
-            bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
-                staker,
-                defaultOperator,
-                delegationManager.delegationApprover(defaultOperator),
-                emptySalt,
-                expiry
-            );
-            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(delegationSignerPrivateKey, digestHash);
-            // mess up the signature by flipping v's parity
-            v = (v == 27 ? 28 : 27);
-            approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-        }
-
-        // try to delegate from the `staker` to the operator, and check reversion
-        cheats.startPrank(staker);
-        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoRequiresECDSASignature(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-        if (staker == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Operator shares should increase by the amount of shares delegated
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoRequiresECDSASignature_StrategyManagerShares(
-        address staker,
-        bytes32 salt,
-        uint256 expiry,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // Set staker shares in StrategyManager
-        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-        strategiesToReturn[0] = strategyMock;
-        uint256[] memory sharesToReturn = new uint256[](1);
-        sharesToReturn[0] = shares;
-        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-        if (staker == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Operator beaconShares should increase by the amount of shares delegated if beaconShares > 0
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainStrategyShares(
-        address staker,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // Set staker shares in BeaconChainStrategy
-        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-        if (beaconShares <= 0) {
-            assertEq(
-                beaconSharesBefore,
-                beaconSharesAfter,
-                "operator beaconchain shares should not have increased with negative shares"
-            );
-        } else {
-            assertEq(
-                beaconSharesBefore + uint256(beaconShares),
-                beaconSharesAfter,
-                "operator beaconchain shares not increased correctly"
-            );
-        }
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-        if (staker == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-     * via the `staker` calling `DelegationManager.delegateTo`
-     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Operator beaconshares should increase by the amount of beaconShares delegated if beaconShares > 0
-     * Operator strategy manager shares should icnrease by amount of shares
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainAndStrategyManagerShares(
-        address staker,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // Set staker shares in BeaconChainStrategy and StrategyMananger
-        {
-            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-            strategiesToReturn[0] = strategyMock;
-            uint256[] memory sharesToReturn = new uint256[](1);
-            sharesToReturn[0] = shares;
-            strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-            eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-        }
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-        if (beaconShares <= 0) {
-            assertEq(
-                beaconSharesBefore,
-                beaconSharesAfter,
-                "operator beaconchain shares should not have increased with negative shares"
-            );
-        } else {
-            assertEq(
-                beaconSharesBefore + uint256(beaconShares),
-                beaconSharesAfter,
-                "operator beaconchain shares not increased correctly"
-            );
-        }
-        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-        if (staker == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-    }
-
-    /**
-     * @notice delegateTo test with operator's delegationApprover address set to a contract address
-     * and check that reversion occurs when the signature is expired
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_ExpiredDelegationApproverSignature(
-        address staker,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // roll to a very late timestamp
-        cheats.roll(type(uint256).max / 2);
-        // filter to only *invalid* `expiry` values
-        cheats.assume(expiry < block.timestamp);
-
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // create the signature struct
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        approverSignatureAndExpiry.expiry = expiry;
-
-        // try to delegate from the `staker` to the operator, and check reversion
-        cheats.startPrank(staker);
-        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice delegateTo test with operator's delegationApprover address set to a contract address
-     * and check that reversion occurs when the signature approverSalt is already used.
-     * Performed by delegating to operator, undelegating, and trying to reuse the same signature
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_PreviouslyUsedSalt(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        ERC1271WalletMock wallet = _registerOperatorWith1271DelegationApprover(defaultOperator);
-        cheats.assume(staker != address(wallet) && staker != defaultOperator);
-
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        delegationManager.undelegate(staker);
-        // Reusing same signature should revert with salt already being used
-        cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice delegateTo test with operator's delegationApprover address set to a contract address that
-     * is non compliant with EIP1271
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_NonCompliantWallet(
-        address staker,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        // deploy a ERC1271MaliciousMock contract that will return an incorrect value when called
-        ERC1271MaliciousMock wallet = new ERC1271MaliciousMock();
-
-        // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
-        // then we don't even trigger the signature verification call, so we won't get a revert as expected
-        cheats.assume(staker != address(wallet));
-
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: defaultOperator,
-            delegationApprover: address(wallet),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-        // create the signature struct
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        approverSignatureAndExpiry.expiry = expiry;
-
-        // try to delegate from the `staker` to the operator, and check reversion
-        cheats.startPrank(staker);
-        // because the ERC1271MaliciousMock contract returns the wrong amount of data, we get a low-level "EvmError: Revert" message here rather than the error message bubbling up
-        cheats.expectRevert();
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice delegateTo test with operator's delegationApprover address set to a contract address that
-     * returns a value other than the EIP1271 "magic bytes" and checking that reversion occurs appropriately
-     */
-    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_IsValidSignatureFails(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        // deploy a ERC1271WalletMock contract that will return an incorrect value when called
-        // owner is the 0 address
-        ERC1271WalletMock wallet = new ERC1271WalletMock(address(1));
-
-        // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
-        // then we don't even trigger the signature verification call, so we won't get a revert as expected
-        cheats.assume(staker != address(wallet));
-
-        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-            earningsReceiver: defaultOperator,
-            delegationApprover: address(wallet),
-            stakerOptOutWindowBlocks: 0
-        });
-        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-        // calculate the delegationSigner's but this is not the correct signature from the wallet contract
-        // since the wallet owner is address(1)
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // try to delegate from the `staker` to the operator, and check reversion
-        cheats.startPrank(staker);
-        // Signature should fail as the wallet will not return EIP1271_MAGICVALUE
-        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice `staker` delegates to an operator who requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
-     * set to a nonzero and code-containing address) via the `staker` calling `DelegationManager.delegateTo`
-     * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
-     * OR if called by the operator or their delegationApprover themselves
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_OperatorWhoRequiresEIP1271Signature(
-        address staker,
-        bytes32 salt,
-        uint256 expiry
-    ) public filterFuzzedAddressInputs(staker) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-
-        // register *this contract* as an operator
-        // filter inputs, since this will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        _registerOperatorWith1271DelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            staker,
-            defaultOperator,
-            salt,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator
-        cheats.startPrank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(staker, defaultOperator);
-        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-        cheats.stopPrank();
-
-        assertTrue(delegationManager.isDelegated(staker), "staker not delegated correctly");
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-        // check that the nonce incremented appropriately
-        if (staker == defaultOperator || staker == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-    }
-}
-
-contract DelegationManagerUnitTests_delegateToBySignature is DelegationManagerUnitTests {
-    function test_revert_paused() public {
-        // set the pausing flag
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.delegateToBySignature(
-            defaultStaker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-    }
-
-    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's signature has expired
-    function testFuzz_Revert_WhenStakerSignatureExpired(
-        address staker,
-        address operator,
-        uint256 expiry,
-        bytes memory signature
-    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-        cheats.assume(expiry < block.timestamp);
-        cheats.expectRevert("DelegationManager.delegateToBySignature: staker signature expired");
-        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = ISignatureUtils.SignatureWithExpiry({
-            signature: signature,
-            expiry: expiry
-        });
-        delegationManager.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, emptySalt);
-    }
-
-    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's ECDSA signature verification fails
-    function test_Revert_EOAStaker_WhenStakerSignatureVerificationFails() public {
-        address invalidStaker = address(1000);
-        address caller = address(2000);
-        uint256 expiry = type(uint256).max;
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        // Should revert from invalid signature as staker is not set as the address of signer
-        cheats.startPrank(caller);
-        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-        // use an empty approver signature input since none is needed / the input is unchecked
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateToBySignature(
-            invalidStaker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-        cheats.stopPrank();
-    }
-
-    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's contract signature verification fails
-    function test_Revert_ERC1271Staker_WhenStakerSignatureVerficationFails() public {
-        address staker = address(new ERC1271WalletMock(address(1)));
-        address caller = address(2000);
-        uint256 expiry = type(uint256).max;
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        // Should revert from invalid signature as staker is not set as the address of signer
-        cheats.startPrank(caller);
-        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
-        // use an empty approver signature input since none is needed / the input is unchecked
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateToBySignature(
-            staker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-        cheats.stopPrank();
-    }
-
-    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts when the staker is already delegated
-    function test_Revert_Staker_WhenAlreadyDelegated() public {
-        address staker = cheats.addr(stakerPrivateKey);
-        address caller = address(2000);
-        uint256 expiry = type(uint256).max;
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        // Should revert as `staker` has already delegated to `operator`
-        cheats.startPrank(caller);
-        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-        // use an empty approver signature input since none is needed / the input is unchecked
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateToBySignature(
-            staker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-        cheats.stopPrank();
-    }
-
-    /// @notice Checks that `delegateToBySignature` reverts when operator is not registered after successful staker signature verification
-    function test_Revert_EOAStaker_OperatorNotRegistered() public {
-        address staker = cheats.addr(stakerPrivateKey);
-        address caller = address(2000);
-        uint256 expiry = type(uint256).max;
-
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        // Should revert as `operator` is not registered
-        cheats.startPrank(caller);
-        cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
-        // use an empty approver signature input since none is needed / the input is unchecked
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-        delegationManager.delegateToBySignature(
-            staker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice Checks that `DelegationManager.delegateToBySignature` reverts if the delegationApprover's signature has expired
-     * after successful staker signature verification
-     */
-    function testFuzz_Revert_WhenDelegationApproverSignatureExpired(
-        address caller,
-        uint256 stakerExpiry,
-        uint256 delegationApproverExpiry
-    ) public filterFuzzedAddressInputs(caller) {
-        // filter to only valid `stakerExpiry` values
-        cheats.assume(stakerExpiry >= block.timestamp);
-        // roll to a very late timestamp
-        cheats.roll(type(uint256).max / 2);
-        // filter to only *invalid* `delegationApproverExpiry` values
-        cheats.assume(delegationApproverExpiry < block.timestamp);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // calculate the delegationSigner's signature
-        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-            delegationSignerPrivateKey,
-            defaultStaker,
-            defaultOperator,
-            emptySalt,
-            delegationApproverExpiry
-        );
-
-        // calculate the staker signature
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            stakerExpiry
-        );
-
-        // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
-        cheats.startPrank(caller);
-        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-        delegationManager.delegateToBySignature(
-            defaultStaker,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            approverSignatureAndExpiry,
-            emptySalt
-        );
-        cheats.stopPrank();
-    }
-
-    /**
-     * @notice `staker` becomes delegated to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-     * via the `caller` calling `DelegationManager.delegateToBySignature`
-     * The function should pass with any `operatorSignature` input (since it should be unused)
-     * The function should pass only with a valid `stakerSignatureAndExpiry` input
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * BeaconChainStrategy and StrategyManager operator shares should increase for operator
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(
-        address caller,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        cheats.assume(expiry >= block.timestamp);
-        cheats.assume(shares > 0);
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                emptySalt
-            ),
-            "salt somehow spent too early?"
-        );
-        {
-            // Set staker shares in BeaconChainStrategy and StrategyMananger
-            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-            strategiesToReturn[0] = strategyMock;
-            uint256[] memory sharesToReturn = new uint256[](1);
-            sharesToReturn[0] = shares;
-            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-        }
-
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-        // fetch the staker's current nonce
-        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-        // calculate the staker signature
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(defaultStaker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        _delegateToBySignatureOperatorWhoAcceptsAllStakers(
-            defaultStaker,
-            caller,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            emptySalt
-        );
-
-        // Check operator shares increases
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-        if (beaconShares <= 0) {
-            assertEq(
-                beaconSharesBefore,
-                beaconSharesAfter,
-                "operator beaconchain shares should not have increased with negative shares"
-            );
-        } else {
-            assertEq(
-                beaconSharesBefore + uint256(beaconShares),
-                beaconSharesAfter,
-                "operator beaconchain shares not increased correctly"
-            );
-        }
-        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        // check all the delegation status changes
-        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-        assertEq(
-            delegationManager.delegatedTo(defaultStaker),
-            defaultOperator,
-            "staker delegated to the wrong address"
-        );
-        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-        // check that the staker nonce incremented appropriately
-        assertEq(
-            delegationManager.stakerNonce(defaultStaker),
-            currentStakerNonce + 1,
-            "staker nonce did not increment"
-        );
-        // verify that the salt is still marked as unused (since it wasn't checked or used)
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                emptySalt
-            ),
-            "salt somehow spent too incorrectly?"
-        );
-    }
-
-    /**
-     * @notice `staker` becomes delegated to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-     * via the `caller` calling `DelegationManager.delegateToBySignature`
-     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-     * AND with a valid `stakerSignatureAndExpiry` input
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * BeaconChainStrategy and StrategyManager operator shares should increase for operator
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(
-        address caller,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        // filter to only valid `expiry` values
-        cheats.assume(expiry >= block.timestamp);
-        cheats.assume(shares > 0);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        {
-            // Set staker shares in BeaconChainStrategy and StrategyMananger
-            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-            strategiesToReturn[0] = strategyMock;
-            uint256[] memory sharesToReturn = new uint256[](1);
-            sharesToReturn[0] = shares;
-            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-        }
-
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-        // fetch the staker's current nonce
-        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-        // calculate the staker signature
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(defaultStaker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        _delegateToBySignatureOperatorWhoRequiresSig(
-            defaultStaker,
-            caller,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            salt
-        );
-        {
-            // Check operator shares increases
-            uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-            uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-            if (beaconShares <= 0) {
-                assertEq(
-                    beaconSharesBefore,
-                    beaconSharesAfter,
-                    "operator beaconchain shares should not have increased with negative shares"
-                );
-            } else {
-                assertEq(
-                    beaconSharesBefore + uint256(beaconShares),
-                    beaconSharesAfter,
-                    "operator beaconchain shares not increased correctly"
-                );
-            }
-            assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        }
-        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-        assertEq(
-            delegationManager.delegatedTo(defaultStaker),
-            defaultOperator,
-            "staker delegated to the wrong address"
-        );
-        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-
-        // check that the delegationApprover nonce incremented appropriately
-        if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-
-        // check that the staker nonce incremented appropriately
-        assertEq(
-            delegationManager.stakerNonce(defaultStaker),
-            currentStakerNonce + 1,
-            "staker nonce did not increment"
-        );
-    }
-
-    /**
-     * @notice `staker` becomes delegated to an operatorwho requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
-     * set to a nonzero and code-containing address) via the `caller` calling `DelegationManager.delegateToBySignature`
-     * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
-     * OR if called by the operator or their delegationApprover themselves
-     * AND with a valid `stakerSignatureAndExpiry` input
-     * Properly emits a `StakerDelegated` event
-     * Staker is correctly delegated after the call (i.e. correct storage update)
-     * Reverts if the staker is already delegated (to the operator or to anyone else)
-     * Reverts if the ‘operator’ is not actually registered as an operator
-     */
-    function testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(
-        address caller,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        cheats.assume(expiry >= block.timestamp);
-        cheats.assume(shares > 0);
-
-        _registerOperatorWith1271DelegationApprover(defaultOperator);
-
-        // verify that the salt hasn't been used before
-        assertFalse(
-            delegationManager.delegationApproverSaltIsSpent(
-                delegationManager.delegationApprover(defaultOperator),
-                salt
-            ),
-            "salt somehow spent too early?"
-        );
-        {
-            // Set staker shares in BeaconChainStrategy and StrategyMananger
-            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-            strategiesToReturn[0] = strategyMock;
-            uint256[] memory sharesToReturn = new uint256[](1);
-            sharesToReturn[0] = shares;
-            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-        }
-
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-        // fetch the staker's current nonce
-        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-        // calculate the staker signature
-        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-            stakerPrivateKey,
-            defaultOperator,
-            expiry
-        );
-
-        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerDelegated(defaultStaker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-        if (beaconShares > 0) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-        }
-        _delegateToBySignatureOperatorWhoRequiresSig(
-            defaultStaker,
-            caller,
-            defaultOperator,
-            stakerSignatureAndExpiry,
-            salt
-        );
-
-        {
-            // Check operator shares increases
-            uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-            uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-            if (beaconShares <= 0) {
-                assertEq(
-                    beaconSharesBefore,
-                    beaconSharesAfter,
-                    "operator beaconchain shares should not have increased with negative shares"
-                );
-            } else {
-                assertEq(
-                    beaconSharesBefore + uint256(beaconShares),
-                    beaconSharesAfter,
-                    "operator beaconchain shares not increased correctly"
-                );
-            }
-            assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-        }
-        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-        assertEq(
-            delegationManager.delegatedTo(defaultStaker),
-            defaultOperator,
-            "staker delegated to the wrong address"
-        );
-        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-
-        // check that the delegationApprover nonce incremented appropriately
-        if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
-            // verify that the salt is still marked as unused (since it wasn't checked or used)
-            assertFalse(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent too incorrectly?"
-            );
-        } else {
-            // verify that the salt is marked as used
-            assertTrue(
-                delegationManager.delegationApproverSaltIsSpent(
-                    delegationManager.delegationApprover(defaultOperator),
-                    salt
-                ),
-                "salt somehow spent not spent?"
-            );
-        }
-
-        // check that the staker nonce incremented appropriately
-        assertEq(
-            delegationManager.stakerNonce(defaultStaker),
-            currentStakerNonce + 1,
-            "staker nonce did not increment"
-        );
-    }
-
-    /**
-     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-     * Generates valid signatures from the staker to delegate to operator `defaultOperator`
-     */
-    function testFuzz_ERC1271Staker_OperatorWhoAcceptsAllStakers(
-        address caller,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-        testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(caller, expiry, beaconShares, shares);
-    }
-
-    /**
-     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-     * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
-     * a delegationApprover address set to a nonzero EOA
-     */
-    function testFuzz_ERC1271Staker_OperatorWhoRequiresECDSASignature(
-        address caller,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        // Call same test but with the staker address being a ERC1271WalletMock
-        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-        testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(caller, salt, expiry, beaconShares, shares);
-    }
-
-    /**
-     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-     * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
-     * a delegationApprover address set to a nonzero ERC1271 compliant contract
-     */
-    function testFuzz_ERC1271Staker_OperatorWhoRequiresEIP1271Signature(
-        address caller,
-        bytes32 salt,
-        uint256 expiry,
-        int256 beaconShares,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(caller) {
-        // Call same test but with the staker address being a ERC1271WalletMock
-        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-        testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(caller, salt, expiry, beaconShares, shares);
-    }
-}
-
-contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTests {
-    // @notice Verifies that `DelegationManager.increaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
-    function testFuzz_increaseDelegatedShares_revert_invalidCaller(
-        address invalidCaller,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(invalidCaller) {
-        cheats.assume(invalidCaller != address(strategyManagerMock));
-        cheats.assume(invalidCaller != address(eigenPodManagerMock));
-        cheats.assume(invalidCaller != address(eigenLayerProxyAdmin));
-
-        cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
-        delegationManager.increaseDelegatedShares(invalidCaller, strategyMock, shares);
-    }
-
-    // @notice Verifies that there is no change in shares if the staker is not delegated
-    function testFuzz_increaseDelegatedShares_noop(address staker) public {
-        cheats.assume(staker != defaultOperator);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        assertFalse(delegationManager.isDelegated(staker), "bad test setup");
-
-        cheats.prank(address(strategyManagerMock));
-        delegationManager.increaseDelegatedShares(staker, strategyMock, 1);
-        assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.increaseDelegatedShares` properly increases the delegated `shares` that the operator
-     * who the `staker` is delegated to has in the strategy
-     * @dev Checks that there is no change if the staker is not delegated
-     */
-    function testFuzz_increaseDelegatedShares(
-        address staker,
-        uint256 shares,
-        bool delegateFromStakerToOperator
-    ) public {
-        // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
-        cheats.assume(staker != defaultOperator);
-
-        // Register operator
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
-        if (delegateFromStakerToOperator) {
-            _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        }
-
-        uint256 _delegatedSharesBefore = delegationManager.operatorShares(
-            delegationManager.delegatedTo(staker),
-            strategyMock
-        );
-
-        if (delegationManager.isDelegated(staker)) {
-            cheats.expectEmit(true, true, true, true, address(delegationManager));
-            emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-        }
-
-        cheats.prank(address(strategyManagerMock));
-        delegationManager.increaseDelegatedShares(staker, strategyMock, shares);
-
-        uint256 delegatedSharesAfter = delegationManager.operatorShares(
-            delegationManager.delegatedTo(staker),
-            strategyMock
-        );
-
-        if (delegationManager.isDelegated(staker)) {
-            assertEq(
-                delegatedSharesAfter,
-                _delegatedSharesBefore + shares,
-                "delegated shares did not increment correctly"
-            );
-        } else {
-            assertEq(delegatedSharesAfter, _delegatedSharesBefore, "delegated shares incremented incorrectly");
-            assertEq(_delegatedSharesBefore, 0, "nonzero shares delegated to zero address!");
-        }
-    }
-
-    // @notice Verifies that `DelegationManager.decreaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
-    function testFuzz_decreaseDelegatedShares_revert_invalidCaller(
-        address invalidCaller,
-        uint256 shares
-    ) public filterFuzzedAddressInputs(invalidCaller) {
-        cheats.assume(invalidCaller != address(strategyManagerMock));
-        cheats.assume(invalidCaller != address(eigenPodManagerMock));
-
-        cheats.startPrank(invalidCaller);
-        cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
-        delegationManager.decreaseDelegatedShares(invalidCaller, strategyMock, shares);
-    }
-
-    // @notice Verifies that there is no change in shares if the staker is not delegated
-    function testFuzz_decreaseDelegatedShares_noop(address staker) public {
-        cheats.assume(staker != defaultOperator);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        assertFalse(delegationManager.isDelegated(staker), "bad test setup");
-
-        cheats.prank(address(strategyManagerMock));
-        delegationManager.decreaseDelegatedShares(staker, strategyMock, 1);
-        assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.decreaseDelegatedShares` properly decreases the delegated `shares` that the operator
-     * who the `staker` is delegated to has in the strategies
-     * @dev Checks that there is no change if the staker is not delegated
-     */
-    function testFuzz_decreaseDelegatedShares(
-        address staker,
-        IStrategy[] memory strategies,
-        uint128 shares,
-        bool delegateFromStakerToOperator
-    ) public filterFuzzedAddressInputs(staker) {
-        // sanity-filtering on fuzzed input length & staker
-        cheats.assume(strategies.length <= 32);
-        cheats.assume(staker != defaultOperator);
-
-        // Register operator
-        _registerOperatorWithBaseDetails(defaultOperator);
-
-        // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
-        if (delegateFromStakerToOperator) {
-            _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        }
-
-        uint256[] memory sharesInputArray = new uint256[](strategies.length);
-
-        address delegatedTo = delegationManager.delegatedTo(staker);
-
-        // for each strategy in `strategies`, increase delegated shares by `shares`
-        // noop if the staker is not delegated
-        cheats.startPrank(address(strategyManagerMock));
-        for (uint256 i = 0; i < strategies.length; ++i) {
-            delegationManager.increaseDelegatedShares(staker, strategies[i], shares);
-            // store delegated shares in a mapping
-            delegatedSharesBefore[strategies[i]] = delegationManager.operatorShares(delegatedTo, strategies[i]);
-            // also construct an array which we'll use in another loop
-            sharesInputArray[i] = shares;
-            totalSharesForStrategyInArray[address(strategies[i])] += sharesInputArray[i];
-        }
-        cheats.stopPrank();
-
-        bool isDelegated = delegationManager.isDelegated(staker);
-
-        // for each strategy in `strategies`, decrease delegated shares by `shares`
-        {
-            cheats.startPrank(address(strategyManagerMock));
-            address operatorToDecreaseSharesOf = delegationManager.delegatedTo(staker);
-            if (isDelegated) {
-                for (uint256 i = 0; i < strategies.length; ++i) {
-                    cheats.expectEmit(true, true, true, true, address(delegationManager));
-                    emit OperatorSharesDecreased(
-                        operatorToDecreaseSharesOf,
-                        staker,
-                        strategies[i],
-                        sharesInputArray[i]
-                    );
-                    delegationManager.decreaseDelegatedShares(staker, strategies[i], sharesInputArray[i]);
-                }
-            }
-            cheats.stopPrank();
-        }
-
-        // check shares after call to `decreaseDelegatedShares`
-        for (uint256 i = 0; i < strategies.length; ++i) {
-            uint256 delegatedSharesAfter = delegationManager.operatorShares(delegatedTo, strategies[i]);
-
-            if (isDelegated) {
-                assertEq(
-                    delegatedSharesAfter + totalSharesForStrategyInArray[address(strategies[i])],
-                    delegatedSharesBefore[strategies[i]],
-                    "delegated shares did not decrement correctly"
-                );
-                assertEq(delegatedSharesAfter, 0, "nonzero shares delegated to");
-            } else {
-                assertEq(
-                    delegatedSharesAfter,
-                    delegatedSharesBefore[strategies[i]],
-                    "delegated shares decremented incorrectly"
-                );
-                assertEq(delegatedSharesBefore[strategies[i]], 0, "nonzero shares delegated to zero address!");
-            }
-        }
-    }
-}
-
-contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
-    // @notice Verifies that undelegating is not possible when the "undelegation paused" switch is flipped
-    function test_undelegate_revert_paused(address staker) public filterFuzzedAddressInputs(staker) {
-        // set the pausing flag
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
-
-        cheats.prank(staker);
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.undelegate(staker);
-    }
-
-    function testFuzz_undelegate_revert_notDelgated(
-        address undelegatedStaker
-    ) public filterFuzzedAddressInputs(undelegatedStaker) {
-        cheats.assume(undelegatedStaker != defaultOperator);
-        assertFalse(delegationManager.isDelegated(undelegatedStaker), "bad test setup");
-
-        cheats.prank(undelegatedStaker);
-        cheats.expectRevert("DelegationManager.undelegate: staker must be delegated to undelegate");
-        delegationManager.undelegate(undelegatedStaker);
-    }
-
-    // @notice Verifies that an operator cannot undelegate from themself (this should always be forbidden)
-    function testFuzz_undelegate_revert_stakerIsOperator(address operator) public filterFuzzedAddressInputs(operator) {
-        _registerOperatorWithBaseDetails(operator);
-
-        cheats.prank(operator);
-        cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
-        delegationManager.undelegate(operator);
-    }
-
-    /**
-     * @notice verifies that `DelegationManager.undelegate` reverts if trying to undelegate an operator from themselves
-     * @param callFromOperatorOrApprover -- calls from the operator if 'false' and the 'approver' if true
-     */
-    function testFuzz_undelegate_operatorCannotForceUndelegateThemself(
-        address delegationApprover,
-        bool callFromOperatorOrApprover
-    ) public {
-        // register *this contract* as an operator with the default `delegationApprover`
-        _registerOperatorWithDelegationApprover(defaultOperator);
-
-        address caller;
-        if (callFromOperatorOrApprover) {
-            caller = delegationApprover;
-        } else {
-            caller = defaultOperator;
-        }
-
-        // try to call the `undelegate` function and check for reversion
-        cheats.prank(caller);
-        cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
-        delegationManager.undelegate(defaultOperator);
-    }
-
-    //TODO: verify that this check is even needed
-    function test_undelegate_revert_zeroAddress() public {
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(address(0), defaultOperator);
-
-        cheats.prank(address(0));
-        cheats.expectRevert("DelegationManager.undelegate: cannot undelegate zero address");
-        delegationManager.undelegate(address(0));
-    }
-
-    /**
-     * @notice Verifies that the `undelegate` function has proper access controls (can only be called by the operator who the `staker` has delegated
-     * to or the operator's `delegationApprover`), or the staker themselves
-     */
-    function testFuzz_undelegate_revert_invalidCaller(
-        address invalidCaller
-    ) public filterFuzzedAddressInputs(invalidCaller) {
-        address staker = address(0x123);
-        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-        // filter out addresses that are actually allowed to call the function
-        cheats.assume(invalidCaller != staker);
-        cheats.assume(invalidCaller != defaultOperator);
-        cheats.assume(invalidCaller != delegationApprover);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-        _delegateToOperatorWhoRequiresSig(staker, defaultOperator);
-
-        cheats.prank(invalidCaller);
-        cheats.expectRevert("DelegationManager.undelegate: caller cannot undelegate staker");
-        delegationManager.undelegate(staker);
-    }
-
-    /**
-     * Staker is undelegated from an operator, via a call to `undelegate`, properly originating from the staker's address.
-     * Reverts if the staker is themselves an operator (i.e. they are delegated to themselves)
-     * Does nothing if the staker is already undelegated
-     * Properly undelegates the staker, i.e. the staker becomes “delegated to” the zero address, and `isDelegated(staker)` returns ‘false’
-     * Emits a `StakerUndelegated` event
-     */
-    function testFuzz_undelegate_noDelegateableShares(address staker) public filterFuzzedAddressInputs(staker) {
-        // register *this contract* as an operator and delegate from the `staker` to them
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerUndelegated(staker, delegationManager.delegatedTo(staker));
-        cheats.prank(staker);
-        bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
-
-        assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
-        assertEq(
-            delegationManager.delegatedTo(staker),
-            address(0),
-            "undelegated staker should be delegated to zero address"
-        );
-        assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
-    }
-
-    /**
-     * @notice Verifies that the `undelegate` function allows for a force undelegation
-     */
-    function testFuzz_undelegate_forceUndelegation_noDelegateableShares(
-        address staker,
-        bytes32 salt,
-        bool callFromOperatorOrApprover
-    ) public filterFuzzedAddressInputs(staker) {
-        cheats.assume(staker != defaultOperator);
-        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-
-        _registerOperatorWithDelegationApprover(defaultOperator);
-        _delegateToOperatorWhoRequiresSig(staker, defaultOperator, salt);
-
-        address caller;
-        if (callFromOperatorOrApprover) {
-            caller = delegationApprover;
-        } else {
-            caller = defaultOperator;
-        }
-
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerForceUndelegated(staker, defaultOperator);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit StakerUndelegated(staker, defaultOperator);
-        cheats.prank(caller);
-        bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
-
-        assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
-        assertEq(
-            delegationManager.delegatedTo(staker),
-            address(0),
-            "undelegated staker should be delegated to zero address"
-        );
-        assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
-    }
-}
-
-contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTests {
-    function test_Revert_WhenEnterQueueWithdrawalsPaused() public {
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
-        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
-            staker: defaultStaker,
-            withdrawer: defaultStaker,
-            strategy: strategyMock,
-            withdrawalAmount: 100
-        });
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-    }
-
-    function test_Revert_WhenQueueWithdrawalParamsLengthMismatch() public {
-        IStrategy[] memory strategyArray = new IStrategy[](1);
-        strategyArray[0] = strategyMock;
-        uint256[] memory shareAmounts = new uint256[](2);
-        shareAmounts[0] = 100;
-        shareAmounts[1] = 100;
-
-        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategyArray,
-            shares: shareAmounts,
-            withdrawer: defaultStaker
-        });
-
-        cheats.expectRevert("DelegationManager.queueWithdrawal: input length mismatch");
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-    }
-
-    function test_Revert_WhenZeroAddressWithdrawer() public {
-        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
-            staker: defaultStaker,
-            withdrawer: address(0),
-            strategy: strategyMock,
-            withdrawalAmount: 100
-        });
-        cheats.expectRevert("DelegationManager.queueWithdrawal: must provide valid withdrawal address");
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-    }
-
-    function test_Revert_WhenEmptyStrategiesArray() public {
-        IStrategy[] memory strategyArray = new IStrategy[](0);
-        uint256[] memory shareAmounts = new uint256[](0);
-        address withdrawer = defaultOperator;
-
-        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-            strategies: strategyArray,
-            shares: shareAmounts,
-            withdrawer: withdrawer
-        });
-
-        cheats.expectRevert("DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
-     * from the `strategy` for the `sharesAmount`. 
-     * - Asserts that staker is delegated to the operator
-     * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
-     * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
-     * - Checks that event was emitted with correct withdrawalRoot and withdrawal
-     */
-    function testFuzz_queueWithdrawal_SingleStrat(
-        address staker,
-        uint256 depositAmount,
-        uint256 withdrawalAmount
-    ) public filterFuzzedAddressInputs(staker) {
-        cheats.assume(staker != defaultOperator);
-        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-        uint256[] memory sharesAmounts = new uint256[](1);
-        sharesAmounts[0] = depositAmount;
-        // sharesAmounts is single element so returns single strategy
-        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, sharesAmounts);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        (
-            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-            IDelegationManager.Withdrawal memory withdrawal,
-            bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawalsSingleStrat({
-            staker: staker,
-            withdrawer: staker,
-            strategy: strategies[0],
-            withdrawalAmount: withdrawalAmount
-        });
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
-        uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
-        uint256 delegatedSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[0]);
-
-        // queueWithdrawals
-        cheats.prank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit WithdrawalQueued(withdrawalRoot, withdrawal);
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-        uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
-        uint256 delegatedSharesAfter = delegationManager.operatorShares(defaultOperator, strategies[0]);
-        assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
-        assertEq(delegatedSharesBefore - withdrawalAmount, delegatedSharesAfter, "delegated shares not decreased correctly");
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
-     * with multiple strategies and sharesAmounts. Depending on length sharesAmounts, deploys corresponding number of strategies
-     * and deposits sharesAmounts into each strategy for the staker and delegates to operator.
-     * For each strategy, withdrawAmount <= depositAmount
-     * - Asserts that staker is delegated to the operator
-     * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
-     * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
-     * - Checks that event was emitted with correct withdrawalRoot and withdrawal
-     */
-    function testFuzz_queueWithdrawal_MultipleStrats(
-        address staker,
-        uint256[] memory depositAmounts
-    ) public filterFuzzedAddressInputs(staker){
-        cheats.assume(depositAmounts.length > 0 && depositAmounts.length <= 32);
-        uint256[] memory withdrawalAmounts = _fuzzWithdrawalAmounts(depositAmounts);
-
-        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        (
-            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-            IDelegationManager.Withdrawal memory withdrawal,
-            bytes32 withdrawalRoot
-        ) = _setUpQueueWithdrawals({
-            staker: staker,
-            withdrawer: staker,
-            strategies: strategies,
-            withdrawalAmounts: withdrawalAmounts
-        });
-        // Before queueWithdrawal state values
-        uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
-        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
-        uint256[] memory delegatedSharesBefore = new uint256[](strategies.length);
-        for (uint256 i = 0; i < strategies.length; i++) {
-            delegatedSharesBefore[i] = delegationManager.operatorShares(defaultOperator, strategies[i]);
-        }
-
-        // queueWithdrawals
-        cheats.prank(staker);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit WithdrawalQueued(withdrawalRoot, withdrawal);
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-        // Post queueWithdrawal state values
-        for (uint256 i = 0; i < strategies.length; i++) {
-            assertEq(
-                delegatedSharesBefore[i] - withdrawalAmounts[i], // Shares before - withdrawal amount
-                delegationManager.operatorShares(defaultOperator, strategies[i]), // Shares after
-                "delegated shares not decreased correctly"
-            );
-        }
-        uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
-        assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
-    }
-}
-
-contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManagerUnitTests {
-    function test_Revert_WhenExitWithdrawalQueuePaused() public {
-        cheats.prank(pauser);
-        delegationManager.pause(2 ** PAUSED_EXIT_WITHDRAWAL_QUEUE);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (
-            IDelegationManager.Withdrawal memory withdrawal,
-            IERC20[] memory tokens,
-            /* bytes32 withdrawalRoot */
-        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: defaultStaker,
-            operator: defaultOperator,
-            withdrawer: defaultStaker,
-            depositAmount: 100,
-            withdrawalAmount: 100
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-        cheats.expectRevert("Pausable: index is paused");
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-    }
-
-    function test_Revert_WhenInvalidWithdrawalRoot() public {
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (
-            IDelegationManager.Withdrawal memory withdrawal,
-            IERC20[] memory tokens,
-            bytes32 withdrawalRoot
-        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: defaultStaker,
-            operator: defaultOperator,
-            withdrawer: defaultStaker,
-            depositAmount: 100,
-            withdrawalAmount: 100
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.prank(defaultStaker);
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-
-        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: action is not in queue");
-        cheats.prank(defaultStaker);
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-    }
-
-    // TODO: Fix withdrawal delay blocks test
-    // function test_Revert_WhenWithdrawalDelayBlocksNotPassed() public {
-    //     _registerOperatorWithBaseDetails(defaultOperator);
-    //     (
-    //         IDelegationManager.Withdrawal memory withdrawal,
-    //         IERC20[] memory tokens,
-    //         /* bytes32 withdrawalRoot */
-    //     ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-    //         staker: defaultStaker,
-    //         operator: defaultOperator,
-    //         withdrawer: defaultStaker,
-    //         depositAmount: 100,
-    //         withdrawalAmount: 100
-    //     });
-    //     _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-    //     cheats.expectRevert("DelegationManager.completeQueuedAction: withdrawalDelayBlocks period has not yet passed");
-    //     delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-    // }
-
-    function test_Revert_WhenNotCalledByWithdrawer() public {
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (
-            IDelegationManager.Withdrawal memory withdrawal,
-            IERC20[] memory tokens,
-            bytes32 withdrawalRoot
-        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: defaultStaker,
-            operator: defaultOperator,
-            withdrawer: defaultStaker,
-            depositAmount: 100,
-            withdrawalAmount: 100
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action");
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-    }
-
-    function test_Revert_WhenTokensArrayLengthMismatch() public {
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (IDelegationManager.Withdrawal memory withdrawal, , ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: defaultStaker,
-            operator: defaultOperator,
-            withdrawer: defaultStaker,
-            depositAmount: 100,
-            withdrawalAmount: 100
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-        IERC20[] memory tokens = new IERC20[](0);
-        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: input length mismatch");
-        cheats.prank(defaultStaker);
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
-     * for a single strategy. Withdraws as tokens so there are no operator shares increase.
-     * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
-     * - Asserts operatorShares is unchanged after `completeQueuedWithdrawal`
-     * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
-     */
-    function test_completeQueuedWithdrawal_SingleStratWithdrawAsTokens(
-        address staker,
-        address withdrawer,
-        uint256 depositAmount,
-        uint256 withdrawalAmount
-    ) public filterFuzzedAddressInputs(staker) {
-        cheats.assume(staker != defaultOperator);
-        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (
-            IDelegationManager.Withdrawal memory withdrawal,
-            IERC20[] memory tokens,
-            bytes32 withdrawalRoot
-        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: staker,
-            operator: defaultOperator,
-            withdrawer: withdrawer,
-            depositAmount: depositAmount,
-            withdrawalAmount: withdrawalAmount
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-
-        // completeQueuedWithdrawal
-        cheats.prank(withdrawer);
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit WithdrawalCompleted(withdrawalRoot);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
-
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-        assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
-        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-    }
-
-    /**
-     * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
-     * for a single strategy. Withdraws as shares so if the withdrawer is delegated, operator shares increase. In the test case, this only
-     * happens if staker and withdrawer are fuzzed the same address (i.e. staker == withdrawer)
-     * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
-     * - Asserts if staker == withdrawer, operatorShares increase, otherwise operatorShares are unchanged
-     * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
-     */
-    function test_completeQueuedWithdrawal_SingleStratWithdrawAsShares(
-        address staker,
-        address withdrawer,
-        uint256 depositAmount,
-        uint256 withdrawalAmount
-    ) public filterFuzzedAddressInputs(staker) {
-        cheats.assume(staker != defaultOperator);
-        cheats.assume(withdrawer != defaultOperator);
-        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-        _registerOperatorWithBaseDetails(defaultOperator);
-        (
-            IDelegationManager.Withdrawal memory withdrawal,
-            IERC20[] memory tokens,
-            bytes32 withdrawalRoot
-        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-            staker: staker,
-            operator: defaultOperator,
-            withdrawer: withdrawer,
-            depositAmount: depositAmount,
-            withdrawalAmount: withdrawalAmount
-        });
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-
-        // completeQueuedWithdrawal
-        cheats.prank(withdrawer);
-        cheats.roll(block.number + minWithdrawalDelayBlocks);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit WithdrawalCompleted(withdrawalRoot);
-        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-        if (staker == withdrawer) {
-            // Since staker is delegated, operatorShares get incremented
-            assertEq(operatorSharesAfter, operatorSharesBefore + withdrawalAmount, "operator shares not increased correctly");
-        } else {
-            // Since withdrawer is not the staker and isn't delegated, staker's oeprator shares are unchanged
-            assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
-        }
-        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-    }
-}
+//         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
+//     }
+
+//     /**
+//      * Deploy and deposit staker into a single strategy, then set up a queued withdrawal for the staker
+//      * Assumptions: 
+//      * - operator is already a registered operator.
+//      * - withdrawalAmount <= depositAmount
+//      */
+//     function _setUpCompleteQueuedWithdrawalSingleStrat(
+//         address staker,
+//         address operator,
+//         address withdrawer,
+//         uint256 depositAmount,
+//         uint256 withdrawalAmount
+//     ) internal returns (IDelegationManager.Withdrawal memory, IERC20[] memory, bytes32) {
+//         uint256[] memory depositAmounts = new uint256[](1);
+//         depositAmounts[0] = depositAmount;
+//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+//         (
+//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             bytes32 withdrawalRoot
+//         ) = _setUpQueueWithdrawalsSingleStrat({
+//             staker: staker,
+//             withdrawer: withdrawer,
+//             strategy: strategies[0],
+//             withdrawalAmount: withdrawalAmount
+//         });
+
+//         cheats.prank(staker);
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+//         // Set the current deposits to be the depositAmount - withdrawalAmount
+//         uint256[] memory currentAmounts = new uint256[](1);
+//         currentAmounts[0] = depositAmount - withdrawalAmount;
+//         strategyManagerMock.setDeposits(staker, strategies, currentAmounts);
+
+//         IERC20[] memory tokens = new IERC20[](1);
+//         tokens[0] = strategies[0].underlyingToken();
+//         return (withdrawal, tokens, withdrawalRoot);
+//     }
+
+//     /**
+//      * Deploy and deposit staker into strategies, then set up a queued withdrawal for the staker
+//      * Assumptions: 
+//      * - operator is already a registered operator.
+//      * - for each i, withdrawalAmount[i] <= depositAmount[i] (see filterFuzzedDepositWithdrawInputs above)
+//      */
+//     function _setUpCompleteQueuedWithdrawal(
+//         address staker,
+//         address operator,
+//         address withdrawer,
+//         uint256[] memory depositAmounts,
+//         uint256[] memory withdrawalAmounts
+//     ) internal returns (IDelegationManager.Withdrawal memory, bytes32) {
+//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+//         (
+//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             bytes32 withdrawalRoot
+//         ) = _setUpQueueWithdrawals({
+//             staker: staker,
+//             withdrawer: withdrawer,
+//             strategies: strategies,
+//             withdrawalAmounts: withdrawalAmounts
+//         });
+
+//         cheats.prank(staker);
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+//         return (withdrawal, withdrawalRoot);
+//     }
+// }
+
+// contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerUnitTests {
+//     function test_initialization() public {
+//         assertEq(
+//             address(delegationManager.strategyManager()),
+//             address(strategyManagerMock),
+//             "constructor / initializer incorrect, strategyManager set wrong"
+//         );
+//         assertEq(
+//             address(delegationManager.slasher()),
+//             address(slasherMock),
+//             "constructor / initializer incorrect, slasher set wrong"
+//         );
+//         assertEq(
+//             address(delegationManager.pauserRegistry()),
+//             address(pauserRegistry),
+//             "constructor / initializer incorrect, pauserRegistry set wrong"
+//         );
+//         assertEq(delegationManager.owner(), address(this), "constructor / initializer incorrect, owner set wrong");
+//         assertEq(delegationManager.paused(), 0, "constructor / initializer incorrect, paused status set wrong");
+//     }
+
+//     /// @notice Verifies that the DelegationManager cannot be iniitalized multiple times
+//     function test_initialize_revert_reinitialization() public {
+//         cheats.expectRevert("Initializable: contract is already initialized");
+//         delegationManager.initialize(
+//             address(this),
+//             pauserRegistry,
+//             0,
+//             0, // minWithdrawalDelayBLocks
+//             initializeStrategiesToSetDelayBlocks,
+//             initializeWithdrawalDelayBlocks
+//         );
+//     }
+
+//     function testFuzz_initialize_Revert_WhenWithdrawalDelayBlocksTooLarge(
+//         uint256[] memory withdrawalDelayBlocks,
+//         uint256 invalidStrategyIndex
+//     ) public {
+//         // set withdrawalDelayBlocks to be too large
+//         cheats.assume(withdrawalDelayBlocks.length > 0);
+//         uint256 numStrats = withdrawalDelayBlocks.length;
+//         IStrategy[] memory strategiesToSetDelayBlocks = new IStrategy[](numStrats);
+//         for (uint256 i = 0; i < numStrats; i++) {
+//             strategiesToSetDelayBlocks[i] = IStrategy(address(uint160(uint256(keccak256(abi.encode(strategyMock, i))))));
+//         }
+
+//         // set at least one index to be too large for withdrawalDelayBlocks
+//         invalidStrategyIndex = invalidStrategyIndex % numStrats;
+//         withdrawalDelayBlocks[invalidStrategyIndex] = MAX_WITHDRAWAL_DELAY_BLOCKS + 1;
+
+//         // Deploy DelegationManager implmentation and proxy
+//         delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
+//         cheats.expectRevert(
+//             "DelegationManager._setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
+//         );
+//         delegationManager = DelegationManager(
+//             address(
+//                 new TransparentUpgradeableProxy(
+//                     address(delegationManagerImplementation),
+//                     address(eigenLayerProxyAdmin),
+//                     abi.encodeWithSelector(
+//                         DelegationManager.initialize.selector,
+//                         address(this),
+//                         pauserRegistry,
+//                         0, // 0 is initialPausedStatus
+//                         minWithdrawalDelayBlocks,
+//                         strategiesToSetDelayBlocks,
+//                         withdrawalDelayBlocks
+//                     )
+//                 )
+//             )
+//         );
+//     }
+// }
+
+// contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerUnitTests {
+//     function test_registerAsOperator_revert_paused() public {
+//         // set the pausing flag
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.registerAsOperator(
+//             IDelegationManager.OperatorDetails({
+//                 earningsReceiver: defaultOperator,
+//                 delegationApprover: address(0),
+//                 stakerOptOutWindowBlocks: 0
+//             }),
+//             emptyStringForMetadataURI
+//         );
+//     }
+
+//     // @notice Verifies that someone cannot successfully call `DelegationManager.registerAsOperator(operatorDetails)` again after registering for the first time
+//     function testFuzz_registerAsOperator_revert_cannotRegisterMultipleTimes(
+//         address operator,
+//         IDelegationManager.OperatorDetails memory operatorDetails
+//     ) public filterFuzzedAddressInputs(operator) {
+//         _filterOperatorDetails(operator, operatorDetails);
+
+//         // Register once
+//         cheats.startPrank(operator);
+//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+
+//         // Expect revert when register again
+//         cheats.expectRevert("DelegationManager.registerAsOperator: operator has already registered");
+//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice Verifies that an operator cannot register with `earningsReceiver` set to the zero address
+//      * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
+//      */
+//     function testFuzz_registerAsOperator_revert_earningsReceiverZeroAddress() public {
+//         IDelegationManager.OperatorDetails memory operatorDetails;
+
+//         cheats.prank(defaultOperator);
+//         cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
+//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+//     }
+
+//     /**
+//      * @notice Verifies that an operator cannot register with `stakerOptOutWindowBlocks` set larger than `MAX_STAKER_OPT_OUT_WINDOW_BLOCKS`
+//      */
+//     function testFuzz_registerAsOperator_revert_optOutBlocksTooLarge(
+//         IDelegationManager.OperatorDetails memory operatorDetails
+//     ) public {
+//         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
+//         cheats.assume(operatorDetails.earningsReceiver != address(0));
+//         // filter out *allowed* stakerOptOutWindowBlocks values
+//         cheats.assume(operatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
+
+//         cheats.prank(defaultOperator);
+//         cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS");
+//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+//     }
+
+//     /**
+//      * @notice `operator` registers via calling `DelegationManager.registerAsOperator(operatorDetails, metadataURI)`
+//      * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
+//      * The set parameters should match the desired parameters (correct storage update)
+//      * Operator becomes delegated to themselves
+//      * Properly emits events – especially the `OperatorRegistered` event, but also `StakerDelegated` & `OperatorDetailsModified` events
+//      * Reverts appropriately if operator was already delegated to someone (including themselves, i.e. they were already an operator)
+//      * @param operator and @param operatorDetails are fuzzed inputs
+//      */
+//     function testFuzz_registerAsOperator(
+//         address operator,
+//         IDelegationManager.OperatorDetails memory operatorDetails,
+//         string memory metadataURI
+//     ) public filterFuzzedAddressInputs(operator) {
+//         _filterOperatorDetails(operator, operatorDetails);
+
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorDetailsModified(operator, operatorDetails);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(operator, operator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorRegistered(operator, operatorDetails);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorMetadataURIUpdated(operator, metadataURI);
+
+//         cheats.prank(operator);
+//         delegationManager.registerAsOperator(operatorDetails, metadataURI);
+
+//         // Storage checks
+//         assertEq(
+//             operatorDetails.earningsReceiver,
+//             delegationManager.earningsReceiver(operator),
+//             "earningsReceiver not set correctly"
+//         );
+//         assertEq(
+//             operatorDetails.delegationApprover,
+//             delegationManager.delegationApprover(operator),
+//             "delegationApprover not set correctly"
+//         );
+//         assertEq(
+//             operatorDetails.stakerOptOutWindowBlocks,
+//             delegationManager.stakerOptOutWindowBlocks(operator),
+//             "stakerOptOutWindowBlocks not set correctly"
+//         );
+//         assertEq(delegationManager.delegatedTo(operator), operator, "operator not delegated to self");
+//     }
+
+//     // @notice Verifies that a staker who is actively delegated to an operator cannot register as an operator (without first undelegating, at least)
+//     function testFuzz_registerAsOperator_cannotRegisterWhileDelegated(
+//         address staker,
+//         IDelegationManager.OperatorDetails memory operatorDetails
+//     ) public filterFuzzedAddressInputs(staker) {
+//         cheats.assume(staker != defaultOperator);
+//         // Staker becomes an operator, so filter against staker's address
+//         _filterOperatorDetails(staker, operatorDetails);
+
+//         // register *this contract* as an operator
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+
+//         // expect revert if attempt to register as operator
+//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice Verifies that an operator cannot modify their `earningsReceiver` address to set it to the zero address
+//      * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
+//      */
+//     function test_modifyOperatorParameters_revert_earningsReceiverZeroAddress() public {
+//         // register *this contract* as an operator
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: defaultOperator,
+//             delegationApprover: address(0),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+//         operatorDetails.earningsReceiver = address(0);
+//         cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
+//         delegationManager.modifyOperatorDetails(operatorDetails);
+//     }
+
+//     /**
+//      * @notice Tests that an operator can modify their OperatorDetails by calling `DelegationManager.modifyOperatorDetails`
+//      * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
+//      * The set parameters should match the desired parameters (correct storage update)
+//      * Properly emits an `OperatorDetailsModified` event
+//      * Reverts appropriately if the caller is not an operator
+//      * Reverts if operator tries to decrease their `stakerOptOutWindowBlocks` parameter
+//      * @param initialOperatorDetails and @param modifiedOperatorDetails are fuzzed inputs
+//      */
+//     function testFuzz_modifyOperatorParameters(
+//         IDelegationManager.OperatorDetails memory initialOperatorDetails,
+//         IDelegationManager.OperatorDetails memory modifiedOperatorDetails
+//     ) public {
+//         // filter out zero address since people can't set their earningsReceiver address to the zero address (test case verified above)
+//         cheats.assume(modifiedOperatorDetails.earningsReceiver != address(0));
+
+//         _registerOperator(defaultOperator, initialOperatorDetails, emptyStringForMetadataURI);
+
+//         cheats.startPrank(defaultOperator);
+
+//         // either it fails for trying to set the stakerOptOutWindowBlocks
+//         if (modifiedOperatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS()) {
+//             cheats.expectRevert(
+//                 "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
+//             );
+//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+//             // or the transition is allowed,
+//         } else if (
+//             modifiedOperatorDetails.stakerOptOutWindowBlocks >= initialOperatorDetails.stakerOptOutWindowBlocks
+//         ) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorDetailsModified(defaultOperator, modifiedOperatorDetails);
+//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+
+//             assertEq(
+//                 modifiedOperatorDetails.earningsReceiver,
+//                 delegationManager.earningsReceiver(defaultOperator),
+//                 "earningsReceiver not set correctly"
+//             );
+//             assertEq(
+//                 modifiedOperatorDetails.delegationApprover,
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 "delegationApprover not set correctly"
+//             );
+//             assertEq(
+//                 modifiedOperatorDetails.stakerOptOutWindowBlocks,
+//                 delegationManager.stakerOptOutWindowBlocks(defaultOperator),
+//                 "stakerOptOutWindowBlocks not set correctly"
+//             );
+//             assertEq(delegationManager.delegatedTo(defaultOperator), defaultOperator, "operator not delegated to self");
+//             // or else the transition is disallowed
+//         } else {
+//             cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased");
+//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+//         }
+
+//         cheats.stopPrank();
+//     }
+
+//     // @notice Tests that an address which is not an operator cannot successfully call `updateOperatorMetadataURI`.
+//     function test_updateOperatorMetadataUri_notRegistered() public {
+//         assertFalse(delegationManager.isOperator(defaultOperator), "bad test setup");
+
+//         cheats.prank(defaultOperator);
+//         cheats.expectRevert("DelegationManager.updateOperatorMetadataURI: caller must be an operator");
+//         delegationManager.updateOperatorMetadataURI(emptyStringForMetadataURI);
+//     }
+
+//     /**
+//      * @notice Verifies that a staker cannot call cannot modify their `OperatorDetails` without first registering as an operator
+//      * @dev This is an important check to ensure that our definition of 'operator' remains consistent, in particular for preserving the
+//      * invariant that 'operators' are always delegated to themselves
+//      */
+//     function testFuzz_updateOperatorMetadataUri_revert_notOperator(
+//         IDelegationManager.OperatorDetails memory operatorDetails
+//     ) public {
+//         cheats.expectRevert("DelegationManager.modifyOperatorDetails: caller must be an operator");
+//         delegationManager.modifyOperatorDetails(operatorDetails);
+//     }
+
+//     // @notice Tests that an operator who calls `updateOperatorMetadataURI` will correctly see an `OperatorMetadataURIUpdated` event emitted with their input
+//     function testFuzz_UpdateOperatorMetadataURI(string memory metadataURI) public {
+//         // register *this contract* as an operator
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // call `updateOperatorMetadataURI` and check for event
+//         cheats.prank(defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorMetadataURIUpdated(defaultOperator, metadataURI);
+//         delegationManager.updateOperatorMetadataURI(metadataURI);
+//     }
+// }
+
+// contract DelegationManagerUnitTests_operatorAVSRegisterationStatus is DelegationManagerUnitTests {
+//     // @notice Tests that an avs who calls `updateAVSMetadataURI` will correctly see an `AVSMetadataURIUpdated` event emitted with their input
+//     function testFuzz_UpdateAVSMetadataURI(string memory metadataURI) public {
+//         // call `updateAVSMetadataURI` and check for event
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         cheats.prank(defaultAVS);
+//         emit AVSMetadataURIUpdated(defaultAVS, metadataURI);
+//         delegationManager.updateAVSMetadataURI(metadataURI);
+//     }
+
+//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
+//     function testFuzz_registerOperatorToAVS(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorAVSRegistrationStatusUpdated(operator, defaultAVS, OperatorAVSRegistrationStatus.REGISTERED);
+
+//         uint256 expiry = type(uint256).max;
+
+//         cheats.prank(defaultAVS);
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
+//     function testFuzz_revert_whenOperatorNotRegisteredToEigenLayerYet(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+
+//         cheats.prank(defaultAVS);
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator not registered to EigenLayer yet");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when the signature is not from the operator
+//     function testFuzz_revert_whenSignatureAddressIsNotOperator(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+//         cheats.prank(operator);
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when the signature expiry already expires
+//     function testFuzz_revert_whenExpiryHasExpired(bytes32 salt, uint256 expiry, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         cheats.assume(operatorSignature.expiry < block.timestamp);
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator signature expired");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//     }
+
+//     // @notice Verifies an operator registers fails when it's already registered to the avs
+//     function testFuzz_revert_whenOperatorAlreadyRegisteredToAVS(bytes32 salt) public {
+//         address operator = cheats.addr(delegationSignerPrivateKey);
+//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
+//         _registerOperatorWithBaseDetails(operator);
+
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
+//             delegationSignerPrivateKey,
+//             operator,
+//             defaultAVS,
+//             salt,
+//             expiry
+//         );
+
+//         cheats.startPrank(defaultAVS);
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+
+//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator already registered");
+//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
+//         cheats.stopPrank();
+//     }
+// }
+
+// contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
+//     function test_Revert_WhenPaused() public {
+//         // set the pausing flag
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         cheats.prank(defaultStaker);
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+//     }
+
+//     /**
+//      * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
+//      */
+//     function testFuzz_Revert_WhenDelegateWhileDelegated(
+//         address staker,
+//         address operator,
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+//         bytes32 salt
+//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+//         // filter out input since if the staker tries to delegate again after registering as an operator, we will revert earlier than this test is designed to check
+//         cheats.assume(staker != operator);
+
+//         // delegate from the staker to an operator
+//         cheats.assume(operator != address(this));
+//         _registerOperatorWithBaseDetails(operator);
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, operator);
+
+//         // try to delegate again and check that the call reverts
+//         cheats.startPrank(staker);
+//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//     }
+
+//     // @notice Verifies that `staker` cannot delegate to an unregistered `operator`
+//     function testFuzz_Revert_WhenDelegateToUnregisteredOperator(
+//         address staker,
+//         address operator
+//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+//         assertFalse(delegationManager.isOperator(operator), "incorrect test input?");
+
+//         // try to delegate and check that the call reverts
+//         cheats.startPrank(staker);
+//         cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass with any `operatorSignature` input (since it should be unused)
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoAcceptsAllStakers_StrategyManagerShares(
+//         address staker,
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+//         bytes32 salt,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // Set staker shares in StrategyManager
+//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//         strategiesToReturn[0] = strategyMock;
+//         uint256[] memory sharesToReturn = new uint256[](1);
+//         sharesToReturn[0] = shares;
+//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+
+//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         // verify that the salt is still marked as unused (since it wasn't checked or used)
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass with any `operatorSignature` input (since it should be unused)
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * OperatorSharesIncreased event should only be emitted if beaconShares is > 0. Since a staker can have negative shares nothing should happen in that case
+//      */
+//     function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainStrategyShares(
+//         address staker,
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+//         bytes32 salt,
+//         int256 beaconShares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // Set staker shares in BeaconChainStrategy
+//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//         if (beaconShares <= 0) {
+//             assertEq(
+//                 beaconSharesBefore,
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares should not have increased with negative shares"
+//             );
+//         } else {
+//             assertEq(
+//                 beaconSharesBefore + uint256(beaconShares),
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares not increased correctly"
+//             );
+//         }
+//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         // verify that the salt is still marked as unused (since it wasn't checked or used)
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * Similar to tests above but now with staker who has both EigenPod and StrategyManager shares.
+//      */
+//     function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainAndStrategyManagerShares(
+//         address staker,
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+//         bytes32 salt,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // Set staker shares in BeaconChainStrategy and StrategyMananger
+//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//         strategiesToReturn[0] = strategyMock;
+//         uint256[] memory sharesToReturn = new uint256[](1);
+//         sharesToReturn[0] = shares;
+//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//         if (beaconShares <= 0) {
+//             assertEq(
+//                 beaconSharesBefore,
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares should not have increased with negative shares"
+//             );
+//         } else {
+//             assertEq(
+//                 beaconSharesBefore + uint256(beaconShares),
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares not increased correctly"
+//             );
+//         }
+//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         // verify that the salt is still marked as unused (since it wasn't checked or used)
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//     }
+
+//     /**
+//      * @notice `staker` delegates to a operator who does not require any signature verification similar to test above.
+//      * In this scenario, staker doesn't have any delegatable shares and operator shares should not increase. Staker
+//      * should still be correctly delegated to the operator after the call.
+//      */
+//     function testFuzz_OperatorWhoAcceptsAllStakers_ZeroDelegatableShares(
+//         address staker,
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+//         bytes32 salt
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+
+//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         // verify that the salt is still marked as unused (since it wasn't checked or used)
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//     }
+
+//     /**
+//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an invalid expiry on purpose and checking that reversion occurs
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_ExpiredDelegationApproverSignature(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // roll to a very late timestamp
+//         cheats.roll(type(uint256).max / 2);
+//         // filter to only *invalid* `expiry` values
+//         cheats.assume(expiry < block.timestamp);
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but undelegating after delegating and trying the same approveSignature
+//      * and checking that reversion occurs with the same salt
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_PreviouslyUsedSalt(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         // staker also must not be the delegationApprover so that signature verification process takes place
+//         cheats.assume(staker != defaultOperator);
+//         cheats.assume(staker != delegationApprover);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, undelegate, and then try to delegate again with same approversalt
+//         // to check that call reverts
+//         cheats.startPrank(staker);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         assertTrue(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent not spent?"
+//         );
+//         delegationManager.undelegate(staker);
+//         cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an incorrect signature on purpose and checking that reversion occurs
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_WithBadSignature(
+//         address staker,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // calculate the signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         approverSignatureAndExpiry.expiry = expiry;
+//         {
+//             bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
+//                 staker,
+//                 defaultOperator,
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 emptySalt,
+//                 expiry
+//             );
+//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(delegationSignerPrivateKey, digestHash);
+//             // mess up the signature by flipping v's parity
+//             v = (v == 27 ? 28 : 27);
+//             approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+//         }
+
+//         // try to delegate from the `staker` to the operator, and check reversion
+//         cheats.startPrank(staker);
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoRequiresECDSASignature(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Operator shares should increase by the amount of shares delegated
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoRequiresECDSASignature_StrategyManagerShares(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // Set staker shares in StrategyManager
+//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//         strategiesToReturn[0] = strategyMock;
+//         uint256[] memory sharesToReturn = new uint256[](1);
+//         sharesToReturn[0] = shares;
+//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Operator beaconShares should increase by the amount of shares delegated if beaconShares > 0
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainStrategyShares(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // Set staker shares in BeaconChainStrategy
+//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//         if (beaconShares <= 0) {
+//             assertEq(
+//                 beaconSharesBefore,
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares should not have increased with negative shares"
+//             );
+//         } else {
+//             assertEq(
+//                 beaconSharesBefore + uint256(beaconShares),
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares not increased correctly"
+//             );
+//         }
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+//      * via the `staker` calling `DelegationManager.delegateTo`
+//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Operator beaconshares should increase by the amount of beaconShares delegated if beaconShares > 0
+//      * Operator strategy manager shares should icnrease by amount of shares
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainAndStrategyManagerShares(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // Set staker shares in BeaconChainStrategy and StrategyMananger
+//         {
+//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//             strategiesToReturn[0] = strategyMock;
+//             uint256[] memory sharesToReturn = new uint256[](1);
+//             sharesToReturn[0] = shares;
+//             strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+//             eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+//         }
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//         if (beaconShares <= 0) {
+//             assertEq(
+//                 beaconSharesBefore,
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares should not have increased with negative shares"
+//             );
+//         } else {
+//             assertEq(
+//                 beaconSharesBefore + uint256(beaconShares),
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares not increased correctly"
+//             );
+//         }
+//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+//     }
+
+//     /**
+//      * @notice delegateTo test with operator's delegationApprover address set to a contract address
+//      * and check that reversion occurs when the signature is expired
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_ExpiredDelegationApproverSignature(
+//         address staker,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // roll to a very late timestamp
+//         cheats.roll(type(uint256).max / 2);
+//         // filter to only *invalid* `expiry` values
+//         cheats.assume(expiry < block.timestamp);
+
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // create the signature struct
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         approverSignatureAndExpiry.expiry = expiry;
+
+//         // try to delegate from the `staker` to the operator, and check reversion
+//         cheats.startPrank(staker);
+//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice delegateTo test with operator's delegationApprover address set to a contract address
+//      * and check that reversion occurs when the signature approverSalt is already used.
+//      * Performed by delegating to operator, undelegating, and trying to reuse the same signature
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_PreviouslyUsedSalt(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         ERC1271WalletMock wallet = _registerOperatorWith1271DelegationApprover(defaultOperator);
+//         cheats.assume(staker != address(wallet) && staker != defaultOperator);
+
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         delegationManager.undelegate(staker);
+//         // Reusing same signature should revert with salt already being used
+//         cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice delegateTo test with operator's delegationApprover address set to a contract address that
+//      * is non compliant with EIP1271
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_NonCompliantWallet(
+//         address staker,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         // deploy a ERC1271MaliciousMock contract that will return an incorrect value when called
+//         ERC1271MaliciousMock wallet = new ERC1271MaliciousMock();
+
+//         // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
+//         // then we don't even trigger the signature verification call, so we won't get a revert as expected
+//         cheats.assume(staker != address(wallet));
+
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: defaultOperator,
+//             delegationApprover: address(wallet),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+//         // create the signature struct
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         approverSignatureAndExpiry.expiry = expiry;
+
+//         // try to delegate from the `staker` to the operator, and check reversion
+//         cheats.startPrank(staker);
+//         // because the ERC1271MaliciousMock contract returns the wrong amount of data, we get a low-level "EvmError: Revert" message here rather than the error message bubbling up
+//         cheats.expectRevert();
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice delegateTo test with operator's delegationApprover address set to a contract address that
+//      * returns a value other than the EIP1271 "magic bytes" and checking that reversion occurs appropriately
+//      */
+//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_IsValidSignatureFails(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         // deploy a ERC1271WalletMock contract that will return an incorrect value when called
+//         // owner is the 0 address
+//         ERC1271WalletMock wallet = new ERC1271WalletMock(address(1));
+
+//         // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
+//         // then we don't even trigger the signature verification call, so we won't get a revert as expected
+//         cheats.assume(staker != address(wallet));
+
+//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+//             earningsReceiver: defaultOperator,
+//             delegationApprover: address(wallet),
+//             stakerOptOutWindowBlocks: 0
+//         });
+//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+//         // calculate the delegationSigner's but this is not the correct signature from the wallet contract
+//         // since the wallet owner is address(1)
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // try to delegate from the `staker` to the operator, and check reversion
+//         cheats.startPrank(staker);
+//         // Signature should fail as the wallet will not return EIP1271_MAGICVALUE
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice `staker` delegates to an operator who requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
+//      * set to a nonzero and code-containing address) via the `staker` calling `DelegationManager.delegateTo`
+//      * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
+//      * OR if called by the operator or their delegationApprover themselves
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_OperatorWhoRequiresEIP1271Signature(
+//         address staker,
+//         bytes32 salt,
+//         uint256 expiry
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+
+//         // register *this contract* as an operator
+//         // filter inputs, since this will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         _registerOperatorWith1271DelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             staker,
+//             defaultOperator,
+//             salt,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator
+//         cheats.startPrank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(staker, defaultOperator);
+//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+//         cheats.stopPrank();
+
+//         assertTrue(delegationManager.isDelegated(staker), "staker not delegated correctly");
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+//         // check that the nonce incremented appropriately
+//         if (staker == defaultOperator || staker == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+//     }
+// }
+
+// contract DelegationManagerUnitTests_delegateToBySignature is DelegationManagerUnitTests {
+//     function test_revert_paused() public {
+//         // set the pausing flag
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+//         uint256 expiry = type(uint256).max;
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.delegateToBySignature(
+//             defaultStaker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//     }
+
+//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's signature has expired
+//     function testFuzz_Revert_WhenStakerSignatureExpired(
+//         address staker,
+//         address operator,
+//         uint256 expiry,
+//         bytes memory signature
+//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+//         cheats.assume(expiry < block.timestamp);
+//         cheats.expectRevert("DelegationManager.delegateToBySignature: staker signature expired");
+//         ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = ISignatureUtils.SignatureWithExpiry({
+//             signature: signature,
+//             expiry: expiry
+//         });
+//         delegationManager.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, emptySalt);
+//     }
+
+//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's ECDSA signature verification fails
+//     function test_Revert_EOAStaker_WhenStakerSignatureVerificationFails() public {
+//         address invalidStaker = address(1000);
+//         address caller = address(2000);
+//         uint256 expiry = type(uint256).max;
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         // Should revert from invalid signature as staker is not set as the address of signer
+//         cheats.startPrank(caller);
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+//         // use an empty approver signature input since none is needed / the input is unchecked
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateToBySignature(
+//             invalidStaker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//         cheats.stopPrank();
+//     }
+
+//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's contract signature verification fails
+//     function test_Revert_ERC1271Staker_WhenStakerSignatureVerficationFails() public {
+//         address staker = address(new ERC1271WalletMock(address(1)));
+//         address caller = address(2000);
+//         uint256 expiry = type(uint256).max;
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         // Should revert from invalid signature as staker is not set as the address of signer
+//         cheats.startPrank(caller);
+//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
+//         // use an empty approver signature input since none is needed / the input is unchecked
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateToBySignature(
+//             staker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//         cheats.stopPrank();
+//     }
+
+//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts when the staker is already delegated
+//     function test_Revert_Staker_WhenAlreadyDelegated() public {
+//         address staker = cheats.addr(stakerPrivateKey);
+//         address caller = address(2000);
+//         uint256 expiry = type(uint256).max;
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         // Should revert as `staker` has already delegated to `operator`
+//         cheats.startPrank(caller);
+//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+//         // use an empty approver signature input since none is needed / the input is unchecked
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateToBySignature(
+//             staker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//         cheats.stopPrank();
+//     }
+
+//     /// @notice Checks that `delegateToBySignature` reverts when operator is not registered after successful staker signature verification
+//     function test_Revert_EOAStaker_OperatorNotRegistered() public {
+//         address staker = cheats.addr(stakerPrivateKey);
+//         address caller = address(2000);
+//         uint256 expiry = type(uint256).max;
+
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         // Should revert as `operator` is not registered
+//         cheats.startPrank(caller);
+//         cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
+//         // use an empty approver signature input since none is needed / the input is unchecked
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+//         delegationManager.delegateToBySignature(
+//             staker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice Checks that `DelegationManager.delegateToBySignature` reverts if the delegationApprover's signature has expired
+//      * after successful staker signature verification
+//      */
+//     function testFuzz_Revert_WhenDelegationApproverSignatureExpired(
+//         address caller,
+//         uint256 stakerExpiry,
+//         uint256 delegationApproverExpiry
+//     ) public filterFuzzedAddressInputs(caller) {
+//         // filter to only valid `stakerExpiry` values
+//         cheats.assume(stakerExpiry >= block.timestamp);
+//         // roll to a very late timestamp
+//         cheats.roll(type(uint256).max / 2);
+//         // filter to only *invalid* `delegationApproverExpiry` values
+//         cheats.assume(delegationApproverExpiry < block.timestamp);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // calculate the delegationSigner's signature
+//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+//             delegationSignerPrivateKey,
+//             defaultStaker,
+//             defaultOperator,
+//             emptySalt,
+//             delegationApproverExpiry
+//         );
+
+//         // calculate the staker signature
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             stakerExpiry
+//         );
+
+//         // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
+//         cheats.startPrank(caller);
+//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+//         delegationManager.delegateToBySignature(
+//             defaultStaker,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             approverSignatureAndExpiry,
+//             emptySalt
+//         );
+//         cheats.stopPrank();
+//     }
+
+//     /**
+//      * @notice `staker` becomes delegated to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+//      * via the `caller` calling `DelegationManager.delegateToBySignature`
+//      * The function should pass with any `operatorSignature` input (since it should be unused)
+//      * The function should pass only with a valid `stakerSignatureAndExpiry` input
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * BeaconChainStrategy and StrategyManager operator shares should increase for operator
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(
+//         address caller,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         cheats.assume(expiry >= block.timestamp);
+//         cheats.assume(shares > 0);
+
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 emptySalt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         {
+//             // Set staker shares in BeaconChainStrategy and StrategyMananger
+//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//             strategiesToReturn[0] = strategyMock;
+//             uint256[] memory sharesToReturn = new uint256[](1);
+//             sharesToReturn[0] = shares;
+//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+//         }
+
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+//         // fetch the staker's current nonce
+//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+//         // calculate the staker signature
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(defaultStaker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         _delegateToBySignatureOperatorWhoAcceptsAllStakers(
+//             defaultStaker,
+//             caller,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             emptySalt
+//         );
+
+//         // Check operator shares increases
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//         if (beaconShares <= 0) {
+//             assertEq(
+//                 beaconSharesBefore,
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares should not have increased with negative shares"
+//             );
+//         } else {
+//             assertEq(
+//                 beaconSharesBefore + uint256(beaconShares),
+//                 beaconSharesAfter,
+//                 "operator beaconchain shares not increased correctly"
+//             );
+//         }
+//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         // check all the delegation status changes
+//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+//         assertEq(
+//             delegationManager.delegatedTo(defaultStaker),
+//             defaultOperator,
+//             "staker delegated to the wrong address"
+//         );
+//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+//         // check that the staker nonce incremented appropriately
+//         assertEq(
+//             delegationManager.stakerNonce(defaultStaker),
+//             currentStakerNonce + 1,
+//             "staker nonce did not increment"
+//         );
+//         // verify that the salt is still marked as unused (since it wasn't checked or used)
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 emptySalt
+//             ),
+//             "salt somehow spent too incorrectly?"
+//         );
+//     }
+
+//     /**
+//      * @notice `staker` becomes delegated to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+//      * via the `caller` calling `DelegationManager.delegateToBySignature`
+//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+//      * AND with a valid `stakerSignatureAndExpiry` input
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * BeaconChainStrategy and StrategyManager operator shares should increase for operator
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(
+//         address caller,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         // filter to only valid `expiry` values
+//         cheats.assume(expiry >= block.timestamp);
+//         cheats.assume(shares > 0);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         {
+//             // Set staker shares in BeaconChainStrategy and StrategyMananger
+//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//             strategiesToReturn[0] = strategyMock;
+//             uint256[] memory sharesToReturn = new uint256[](1);
+//             sharesToReturn[0] = shares;
+//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+//         }
+
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+//         // fetch the staker's current nonce
+//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+//         // calculate the staker signature
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(defaultStaker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         _delegateToBySignatureOperatorWhoRequiresSig(
+//             defaultStaker,
+//             caller,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             salt
+//         );
+//         {
+//             // Check operator shares increases
+//             uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//             uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//             if (beaconShares <= 0) {
+//                 assertEq(
+//                     beaconSharesBefore,
+//                     beaconSharesAfter,
+//                     "operator beaconchain shares should not have increased with negative shares"
+//                 );
+//             } else {
+//                 assertEq(
+//                     beaconSharesBefore + uint256(beaconShares),
+//                     beaconSharesAfter,
+//                     "operator beaconchain shares not increased correctly"
+//                 );
+//             }
+//             assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         }
+//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+//         assertEq(
+//             delegationManager.delegatedTo(defaultStaker),
+//             defaultOperator,
+//             "staker delegated to the wrong address"
+//         );
+//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+
+//         // check that the delegationApprover nonce incremented appropriately
+//         if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+
+//         // check that the staker nonce incremented appropriately
+//         assertEq(
+//             delegationManager.stakerNonce(defaultStaker),
+//             currentStakerNonce + 1,
+//             "staker nonce did not increment"
+//         );
+//     }
+
+//     /**
+//      * @notice `staker` becomes delegated to an operatorwho requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
+//      * set to a nonzero and code-containing address) via the `caller` calling `DelegationManager.delegateToBySignature`
+//      * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
+//      * OR if called by the operator or their delegationApprover themselves
+//      * AND with a valid `stakerSignatureAndExpiry` input
+//      * Properly emits a `StakerDelegated` event
+//      * Staker is correctly delegated after the call (i.e. correct storage update)
+//      * Reverts if the staker is already delegated (to the operator or to anyone else)
+//      * Reverts if the ‘operator’ is not actually registered as an operator
+//      */
+//     function testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(
+//         address caller,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         cheats.assume(expiry >= block.timestamp);
+//         cheats.assume(shares > 0);
+
+//         _registerOperatorWith1271DelegationApprover(defaultOperator);
+
+//         // verify that the salt hasn't been used before
+//         assertFalse(
+//             delegationManager.delegationApproverSaltIsSpent(
+//                 delegationManager.delegationApprover(defaultOperator),
+//                 salt
+//             ),
+//             "salt somehow spent too early?"
+//         );
+//         {
+//             // Set staker shares in BeaconChainStrategy and StrategyMananger
+//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+//             strategiesToReturn[0] = strategyMock;
+//             uint256[] memory sharesToReturn = new uint256[](1);
+//             sharesToReturn[0] = shares;
+//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+//         }
+
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+//         // fetch the staker's current nonce
+//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+//         // calculate the staker signature
+//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+//             stakerPrivateKey,
+//             defaultOperator,
+//             expiry
+//         );
+
+//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerDelegated(defaultStaker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+//         if (beaconShares > 0) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+//         }
+//         _delegateToBySignatureOperatorWhoRequiresSig(
+//             defaultStaker,
+//             caller,
+//             defaultOperator,
+//             stakerSignatureAndExpiry,
+//             salt
+//         );
+
+//         {
+//             // Check operator shares increases
+//             uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+//             uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+//             if (beaconShares <= 0) {
+//                 assertEq(
+//                     beaconSharesBefore,
+//                     beaconSharesAfter,
+//                     "operator beaconchain shares should not have increased with negative shares"
+//                 );
+//             } else {
+//                 assertEq(
+//                     beaconSharesBefore + uint256(beaconShares),
+//                     beaconSharesAfter,
+//                     "operator beaconchain shares not increased correctly"
+//                 );
+//             }
+//             assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+//         }
+//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+//         assertEq(
+//             delegationManager.delegatedTo(defaultStaker),
+//             defaultOperator,
+//             "staker delegated to the wrong address"
+//         );
+//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+
+//         // check that the delegationApprover nonce incremented appropriately
+//         if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
+//             // verify that the salt is still marked as unused (since it wasn't checked or used)
+//             assertFalse(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent too incorrectly?"
+//             );
+//         } else {
+//             // verify that the salt is marked as used
+//             assertTrue(
+//                 delegationManager.delegationApproverSaltIsSpent(
+//                     delegationManager.delegationApprover(defaultOperator),
+//                     salt
+//                 ),
+//                 "salt somehow spent not spent?"
+//             );
+//         }
+
+//         // check that the staker nonce incremented appropriately
+//         assertEq(
+//             delegationManager.stakerNonce(defaultStaker),
+//             currentStakerNonce + 1,
+//             "staker nonce did not increment"
+//         );
+//     }
+
+//     /**
+//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+//      * Generates valid signatures from the staker to delegate to operator `defaultOperator`
+//      */
+//     function testFuzz_ERC1271Staker_OperatorWhoAcceptsAllStakers(
+//         address caller,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+//         testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(caller, expiry, beaconShares, shares);
+//     }
+
+//     /**
+//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+//      * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
+//      * a delegationApprover address set to a nonzero EOA
+//      */
+//     function testFuzz_ERC1271Staker_OperatorWhoRequiresECDSASignature(
+//         address caller,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         // Call same test but with the staker address being a ERC1271WalletMock
+//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+//         testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(caller, salt, expiry, beaconShares, shares);
+//     }
+
+//     /**
+//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+//      * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
+//      * a delegationApprover address set to a nonzero ERC1271 compliant contract
+//      */
+//     function testFuzz_ERC1271Staker_OperatorWhoRequiresEIP1271Signature(
+//         address caller,
+//         bytes32 salt,
+//         uint256 expiry,
+//         int256 beaconShares,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(caller) {
+//         // Call same test but with the staker address being a ERC1271WalletMock
+//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+//         testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(caller, salt, expiry, beaconShares, shares);
+//     }
+// }
+
+// contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTests {
+//     // @notice Verifies that `DelegationManager.increaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
+//     function testFuzz_increaseDelegatedShares_revert_invalidCaller(
+//         address invalidCaller,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(invalidCaller) {
+//         cheats.assume(invalidCaller != address(strategyManagerMock));
+//         cheats.assume(invalidCaller != address(eigenPodManagerMock));
+//         cheats.assume(invalidCaller != address(eigenLayerProxyAdmin));
+
+//         cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
+//         delegationManager.increaseDelegatedShares(invalidCaller, strategyMock, shares);
+//     }
+
+//     // @notice Verifies that there is no change in shares if the staker is not delegated
+//     function testFuzz_increaseDelegatedShares_noop(address staker) public {
+//         cheats.assume(staker != defaultOperator);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         assertFalse(delegationManager.isDelegated(staker), "bad test setup");
+
+//         cheats.prank(address(strategyManagerMock));
+//         delegationManager.increaseDelegatedShares(staker, strategyMock, 1);
+//         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.increaseDelegatedShares` properly increases the delegated `shares` that the operator
+//      * who the `staker` is delegated to has in the strategy
+//      * @dev Checks that there is no change if the staker is not delegated
+//      */
+//     function testFuzz_increaseDelegatedShares(
+//         address staker,
+//         uint256 shares,
+//         bool delegateFromStakerToOperator
+//     ) public {
+//         // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
+//         cheats.assume(staker != defaultOperator);
+
+//         // Register operator
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
+//         if (delegateFromStakerToOperator) {
+//             _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         }
+
+//         uint256 _delegatedSharesBefore = delegationManager.operatorShares(
+//             delegationManager.delegatedTo(staker),
+//             strategyMock
+//         );
+
+//         if (delegationManager.isDelegated(staker)) {
+//             cheats.expectEmit(true, true, true, true, address(delegationManager));
+//             emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+//         }
+
+//         cheats.prank(address(strategyManagerMock));
+//         delegationManager.increaseDelegatedShares(staker, strategyMock, shares);
+
+//         uint256 delegatedSharesAfter = delegationManager.operatorShares(
+//             delegationManager.delegatedTo(staker),
+//             strategyMock
+//         );
+
+//         if (delegationManager.isDelegated(staker)) {
+//             assertEq(
+//                 delegatedSharesAfter,
+//                 _delegatedSharesBefore + shares,
+//                 "delegated shares did not increment correctly"
+//             );
+//         } else {
+//             assertEq(delegatedSharesAfter, _delegatedSharesBefore, "delegated shares incremented incorrectly");
+//             assertEq(_delegatedSharesBefore, 0, "nonzero shares delegated to zero address!");
+//         }
+//     }
+
+//     // @notice Verifies that `DelegationManager.decreaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
+//     function testFuzz_decreaseDelegatedShares_revert_invalidCaller(
+//         address invalidCaller,
+//         uint256 shares
+//     ) public filterFuzzedAddressInputs(invalidCaller) {
+//         cheats.assume(invalidCaller != address(strategyManagerMock));
+//         cheats.assume(invalidCaller != address(eigenPodManagerMock));
+
+//         cheats.startPrank(invalidCaller);
+//         cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
+//         delegationManager.decreaseDelegatedShares(invalidCaller, strategyMock, shares);
+//     }
+
+//     // @notice Verifies that there is no change in shares if the staker is not delegated
+//     function testFuzz_decreaseDelegatedShares_noop(address staker) public {
+//         cheats.assume(staker != defaultOperator);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         assertFalse(delegationManager.isDelegated(staker), "bad test setup");
+
+//         cheats.prank(address(strategyManagerMock));
+//         delegationManager.decreaseDelegatedShares(staker, strategyMock, 1);
+//         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.decreaseDelegatedShares` properly decreases the delegated `shares` that the operator
+//      * who the `staker` is delegated to has in the strategies
+//      * @dev Checks that there is no change if the staker is not delegated
+//      */
+//     function testFuzz_decreaseDelegatedShares(
+//         address staker,
+//         IStrategy[] memory strategies,
+//         uint128 shares,
+//         bool delegateFromStakerToOperator
+//     ) public filterFuzzedAddressInputs(staker) {
+//         // sanity-filtering on fuzzed input length & staker
+//         cheats.assume(strategies.length <= 32);
+//         cheats.assume(staker != defaultOperator);
+
+//         // Register operator
+//         _registerOperatorWithBaseDetails(defaultOperator);
+
+//         // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
+//         if (delegateFromStakerToOperator) {
+//             _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         }
+
+//         uint256[] memory sharesInputArray = new uint256[](strategies.length);
+
+//         address delegatedTo = delegationManager.delegatedTo(staker);
+
+//         // for each strategy in `strategies`, increase delegated shares by `shares`
+//         // noop if the staker is not delegated
+//         cheats.startPrank(address(strategyManagerMock));
+//         for (uint256 i = 0; i < strategies.length; ++i) {
+//             delegationManager.increaseDelegatedShares(staker, strategies[i], shares);
+//             // store delegated shares in a mapping
+//             delegatedSharesBefore[strategies[i]] = delegationManager.operatorShares(delegatedTo, strategies[i]);
+//             // also construct an array which we'll use in another loop
+//             sharesInputArray[i] = shares;
+//             totalSharesForStrategyInArray[address(strategies[i])] += sharesInputArray[i];
+//         }
+//         cheats.stopPrank();
+
+//         bool isDelegated = delegationManager.isDelegated(staker);
+
+//         // for each strategy in `strategies`, decrease delegated shares by `shares`
+//         {
+//             cheats.startPrank(address(strategyManagerMock));
+//             address operatorToDecreaseSharesOf = delegationManager.delegatedTo(staker);
+//             if (isDelegated) {
+//                 for (uint256 i = 0; i < strategies.length; ++i) {
+//                     cheats.expectEmit(true, true, true, true, address(delegationManager));
+//                     emit OperatorSharesDecreased(
+//                         operatorToDecreaseSharesOf,
+//                         staker,
+//                         strategies[i],
+//                         sharesInputArray[i]
+//                     );
+//                     delegationManager.decreaseDelegatedShares(staker, strategies[i], sharesInputArray[i]);
+//                 }
+//             }
+//             cheats.stopPrank();
+//         }
+
+//         // check shares after call to `decreaseDelegatedShares`
+//         for (uint256 i = 0; i < strategies.length; ++i) {
+//             uint256 delegatedSharesAfter = delegationManager.operatorShares(delegatedTo, strategies[i]);
+
+//             if (isDelegated) {
+//                 assertEq(
+//                     delegatedSharesAfter + totalSharesForStrategyInArray[address(strategies[i])],
+//                     delegatedSharesBefore[strategies[i]],
+//                     "delegated shares did not decrement correctly"
+//                 );
+//                 assertEq(delegatedSharesAfter, 0, "nonzero shares delegated to");
+//             } else {
+//                 assertEq(
+//                     delegatedSharesAfter,
+//                     delegatedSharesBefore[strategies[i]],
+//                     "delegated shares decremented incorrectly"
+//                 );
+//                 assertEq(delegatedSharesBefore[strategies[i]], 0, "nonzero shares delegated to zero address!");
+//             }
+//         }
+//     }
+// }
+
+// contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
+//     // @notice Verifies that undelegating is not possible when the "undelegation paused" switch is flipped
+//     function test_undelegate_revert_paused(address staker) public filterFuzzedAddressInputs(staker) {
+//         // set the pausing flag
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
+
+//         cheats.prank(staker);
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.undelegate(staker);
+//     }
+
+//     function testFuzz_undelegate_revert_notDelgated(
+//         address undelegatedStaker
+//     ) public filterFuzzedAddressInputs(undelegatedStaker) {
+//         cheats.assume(undelegatedStaker != defaultOperator);
+//         assertFalse(delegationManager.isDelegated(undelegatedStaker), "bad test setup");
+
+//         cheats.prank(undelegatedStaker);
+//         cheats.expectRevert("DelegationManager.undelegate: staker must be delegated to undelegate");
+//         delegationManager.undelegate(undelegatedStaker);
+//     }
+
+//     // @notice Verifies that an operator cannot undelegate from themself (this should always be forbidden)
+//     function testFuzz_undelegate_revert_stakerIsOperator(address operator) public filterFuzzedAddressInputs(operator) {
+//         _registerOperatorWithBaseDetails(operator);
+
+//         cheats.prank(operator);
+//         cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
+//         delegationManager.undelegate(operator);
+//     }
+
+//     /**
+//      * @notice verifies that `DelegationManager.undelegate` reverts if trying to undelegate an operator from themselves
+//      * @param callFromOperatorOrApprover -- calls from the operator if 'false' and the 'approver' if true
+//      */
+//     function testFuzz_undelegate_operatorCannotForceUndelegateThemself(
+//         address delegationApprover,
+//         bool callFromOperatorOrApprover
+//     ) public {
+//         // register *this contract* as an operator with the default `delegationApprover`
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+
+//         address caller;
+//         if (callFromOperatorOrApprover) {
+//             caller = delegationApprover;
+//         } else {
+//             caller = defaultOperator;
+//         }
+
+//         // try to call the `undelegate` function and check for reversion
+//         cheats.prank(caller);
+//         cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
+//         delegationManager.undelegate(defaultOperator);
+//     }
+
+//     //TODO: verify that this check is even needed
+//     function test_undelegate_revert_zeroAddress() public {
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         _delegateToOperatorWhoAcceptsAllStakers(address(0), defaultOperator);
+
+//         cheats.prank(address(0));
+//         cheats.expectRevert("DelegationManager.undelegate: cannot undelegate zero address");
+//         delegationManager.undelegate(address(0));
+//     }
+
+//     /**
+//      * @notice Verifies that the `undelegate` function has proper access controls (can only be called by the operator who the `staker` has delegated
+//      * to or the operator's `delegationApprover`), or the staker themselves
+//      */
+//     function testFuzz_undelegate_revert_invalidCaller(
+//         address invalidCaller
+//     ) public filterFuzzedAddressInputs(invalidCaller) {
+//         address staker = address(0x123);
+//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+//         // filter out addresses that are actually allowed to call the function
+//         cheats.assume(invalidCaller != staker);
+//         cheats.assume(invalidCaller != defaultOperator);
+//         cheats.assume(invalidCaller != delegationApprover);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+//         _delegateToOperatorWhoRequiresSig(staker, defaultOperator);
+
+//         cheats.prank(invalidCaller);
+//         cheats.expectRevert("DelegationManager.undelegate: caller cannot undelegate staker");
+//         delegationManager.undelegate(staker);
+//     }
+
+//     /**
+//      * Staker is undelegated from an operator, via a call to `undelegate`, properly originating from the staker's address.
+//      * Reverts if the staker is themselves an operator (i.e. they are delegated to themselves)
+//      * Does nothing if the staker is already undelegated
+//      * Properly undelegates the staker, i.e. the staker becomes “delegated to” the zero address, and `isDelegated(staker)` returns ‘false’
+//      * Emits a `StakerUndelegated` event
+//      */
+//     function testFuzz_undelegate_noDelegateableShares(address staker) public filterFuzzedAddressInputs(staker) {
+//         // register *this contract* as an operator and delegate from the `staker` to them
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerUndelegated(staker, delegationManager.delegatedTo(staker));
+//         cheats.prank(staker);
+//         bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
+
+//         assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
+//         assertEq(
+//             delegationManager.delegatedTo(staker),
+//             address(0),
+//             "undelegated staker should be delegated to zero address"
+//         );
+//         assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
+//     }
+
+//     /**
+//      * @notice Verifies that the `undelegate` function allows for a force undelegation
+//      */
+//     function testFuzz_undelegate_forceUndelegation_noDelegateableShares(
+//         address staker,
+//         bytes32 salt,
+//         bool callFromOperatorOrApprover
+//     ) public filterFuzzedAddressInputs(staker) {
+//         cheats.assume(staker != defaultOperator);
+//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+
+//         _registerOperatorWithDelegationApprover(defaultOperator);
+//         _delegateToOperatorWhoRequiresSig(staker, defaultOperator, salt);
+
+//         address caller;
+//         if (callFromOperatorOrApprover) {
+//             caller = delegationApprover;
+//         } else {
+//             caller = defaultOperator;
+//         }
+
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerForceUndelegated(staker, defaultOperator);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit StakerUndelegated(staker, defaultOperator);
+//         cheats.prank(caller);
+//         bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
+
+//         assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
+//         assertEq(
+//             delegationManager.delegatedTo(staker),
+//             address(0),
+//             "undelegated staker should be delegated to zero address"
+//         );
+//         assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
+//     }
+// }
+
+// contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTests {
+//     function test_Revert_WhenEnterQueueWithdrawalsPaused() public {
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
+//         (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
+//             staker: defaultStaker,
+//             withdrawer: defaultStaker,
+//             strategy: strategyMock,
+//             withdrawalAmount: 100
+//         });
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+//     }
+
+//     function test_Revert_WhenQueueWithdrawalParamsLengthMismatch() public {
+//         IStrategy[] memory strategyArray = new IStrategy[](1);
+//         strategyArray[0] = strategyMock;
+//         uint256[] memory shareAmounts = new uint256[](2);
+//         shareAmounts[0] = 100;
+//         shareAmounts[1] = 100;
+
+//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+//             strategies: strategyArray,
+//             shares: shareAmounts,
+//             withdrawer: defaultStaker
+//         });
+
+//         cheats.expectRevert("DelegationManager.queueWithdrawal: input length mismatch");
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+//     }
+
+//     function test_Revert_WhenZeroAddressWithdrawer() public {
+//         (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
+//             staker: defaultStaker,
+//             withdrawer: address(0),
+//             strategy: strategyMock,
+//             withdrawalAmount: 100
+//         });
+//         cheats.expectRevert("DelegationManager.queueWithdrawal: must provide valid withdrawal address");
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+//     }
+
+//     function test_Revert_WhenEmptyStrategiesArray() public {
+//         IStrategy[] memory strategyArray = new IStrategy[](0);
+//         uint256[] memory shareAmounts = new uint256[](0);
+//         address withdrawer = defaultOperator;
+
+//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+//             strategies: strategyArray,
+//             shares: shareAmounts,
+//             withdrawer: withdrawer
+//         });
+
+//         cheats.expectRevert("DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
+//      * from the `strategy` for the `sharesAmount`. 
+//      * - Asserts that staker is delegated to the operator
+//      * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
+//      * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
+//      * - Checks that event was emitted with correct withdrawalRoot and withdrawal
+//      */
+//     function testFuzz_queueWithdrawal_SingleStrat(
+//         address staker,
+//         uint256 depositAmount,
+//         uint256 withdrawalAmount
+//     ) public filterFuzzedAddressInputs(staker) {
+//         cheats.assume(staker != defaultOperator);
+//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+//         uint256[] memory sharesAmounts = new uint256[](1);
+//         sharesAmounts[0] = depositAmount;
+//         // sharesAmounts is single element so returns single strategy
+//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, sharesAmounts);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         (
+//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             bytes32 withdrawalRoot
+//         ) = _setUpQueueWithdrawalsSingleStrat({
+//             staker: staker,
+//             withdrawer: staker,
+//             strategy: strategies[0],
+//             withdrawalAmount: withdrawalAmount
+//         });
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
+//         uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
+//         uint256 delegatedSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[0]);
+
+//         // queueWithdrawals
+//         cheats.prank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit WithdrawalQueued(withdrawalRoot, withdrawal);
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+//         uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
+//         uint256 delegatedSharesAfter = delegationManager.operatorShares(defaultOperator, strategies[0]);
+//         assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
+//         assertEq(delegatedSharesBefore - withdrawalAmount, delegatedSharesAfter, "delegated shares not decreased correctly");
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
+//      * with multiple strategies and sharesAmounts. Depending on length sharesAmounts, deploys corresponding number of strategies
+//      * and deposits sharesAmounts into each strategy for the staker and delegates to operator.
+//      * For each strategy, withdrawAmount <= depositAmount
+//      * - Asserts that staker is delegated to the operator
+//      * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
+//      * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
+//      * - Checks that event was emitted with correct withdrawalRoot and withdrawal
+//      */
+//     function testFuzz_queueWithdrawal_MultipleStrats(
+//         address staker,
+//         uint256[] memory depositAmounts
+//     ) public filterFuzzedAddressInputs(staker){
+//         cheats.assume(depositAmounts.length > 0 && depositAmounts.length <= 32);
+//         uint256[] memory withdrawalAmounts = _fuzzWithdrawalAmounts(depositAmounts);
+
+//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         (
+//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             bytes32 withdrawalRoot
+//         ) = _setUpQueueWithdrawals({
+//             staker: staker,
+//             withdrawer: staker,
+//             strategies: strategies,
+//             withdrawalAmounts: withdrawalAmounts
+//         });
+//         // Before queueWithdrawal state values
+//         uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
+//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
+//         uint256[] memory delegatedSharesBefore = new uint256[](strategies.length);
+//         for (uint256 i = 0; i < strategies.length; i++) {
+//             delegatedSharesBefore[i] = delegationManager.operatorShares(defaultOperator, strategies[i]);
+//         }
+
+//         // queueWithdrawals
+//         cheats.prank(staker);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit WithdrawalQueued(withdrawalRoot, withdrawal);
+//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+//         // Post queueWithdrawal state values
+//         for (uint256 i = 0; i < strategies.length; i++) {
+//             assertEq(
+//                 delegatedSharesBefore[i] - withdrawalAmounts[i], // Shares before - withdrawal amount
+//                 delegationManager.operatorShares(defaultOperator, strategies[i]), // Shares after
+//                 "delegated shares not decreased correctly"
+//             );
+//         }
+//         uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
+//         assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
+//     }
+// }
+
+// contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManagerUnitTests {
+//     function test_Revert_WhenExitWithdrawalQueuePaused() public {
+//         cheats.prank(pauser);
+//         delegationManager.pause(2 ** PAUSED_EXIT_WITHDRAWAL_QUEUE);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             IERC20[] memory tokens,
+//             /* bytes32 withdrawalRoot */
+//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: defaultStaker,
+//             operator: defaultOperator,
+//             withdrawer: defaultStaker,
+//             depositAmount: 100,
+//             withdrawalAmount: 100
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+//         cheats.expectRevert("Pausable: index is paused");
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+//     }
+
+//     function test_Revert_WhenInvalidWithdrawalRoot() public {
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             IERC20[] memory tokens,
+//             bytes32 withdrawalRoot
+//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: defaultStaker,
+//             operator: defaultOperator,
+//             withdrawer: defaultStaker,
+//             depositAmount: 100,
+//             withdrawalAmount: 100
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+//         cheats.prank(defaultStaker);
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+
+//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: action is not in queue");
+//         cheats.prank(defaultStaker);
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+//     }
+
+//     // TODO: Fix withdrawal delay blocks test
+//     // function test_Revert_WhenWithdrawalDelayBlocksNotPassed() public {
+//     //     _registerOperatorWithBaseDetails(defaultOperator);
+//     //     (
+//     //         IDelegationManager.Withdrawal memory withdrawal,
+//     //         IERC20[] memory tokens,
+//     //         /* bytes32 withdrawalRoot */
+//     //     ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//     //         staker: defaultStaker,
+//     //         operator: defaultOperator,
+//     //         withdrawer: defaultStaker,
+//     //         depositAmount: 100,
+//     //         withdrawalAmount: 100
+//     //     });
+//     //     _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+//     //     cheats.expectRevert("DelegationManager.completeQueuedAction: withdrawalDelayBlocks period has not yet passed");
+//     //     delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+//     // }
+
+//     function test_Revert_WhenNotCalledByWithdrawer() public {
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             IERC20[] memory tokens,
+//             bytes32 withdrawalRoot
+//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: defaultStaker,
+//             operator: defaultOperator,
+//             withdrawer: defaultStaker,
+//             depositAmount: 100,
+//             withdrawalAmount: 100
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action");
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+//     }
+
+//     function test_Revert_WhenTokensArrayLengthMismatch() public {
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (IDelegationManager.Withdrawal memory withdrawal, , ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: defaultStaker,
+//             operator: defaultOperator,
+//             withdrawer: defaultStaker,
+//             depositAmount: 100,
+//             withdrawalAmount: 100
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+//         IERC20[] memory tokens = new IERC20[](0);
+//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: input length mismatch");
+//         cheats.prank(defaultStaker);
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
+//      * for a single strategy. Withdraws as tokens so there are no operator shares increase.
+//      * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
+//      * - Asserts operatorShares is unchanged after `completeQueuedWithdrawal`
+//      * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
+//      */
+//     function test_completeQueuedWithdrawal_SingleStratWithdrawAsTokens(
+//         address staker,
+//         address withdrawer,
+//         uint256 depositAmount,
+//         uint256 withdrawalAmount
+//     ) public filterFuzzedAddressInputs(staker) {
+//         cheats.assume(staker != defaultOperator);
+//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             IERC20[] memory tokens,
+//             bytes32 withdrawalRoot
+//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: staker,
+//             operator: defaultOperator,
+//             withdrawer: withdrawer,
+//             depositAmount: depositAmount,
+//             withdrawalAmount: withdrawalAmount
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+
+//         // completeQueuedWithdrawal
+//         cheats.prank(withdrawer);
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit WithdrawalCompleted(withdrawalRoot);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
+
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+//         assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
+//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+//     }
+
+//     /**
+//      * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
+//      * for a single strategy. Withdraws as shares so if the withdrawer is delegated, operator shares increase. In the test case, this only
+//      * happens if staker and withdrawer are fuzzed the same address (i.e. staker == withdrawer)
+//      * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
+//      * - Asserts if staker == withdrawer, operatorShares increase, otherwise operatorShares are unchanged
+//      * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
+//      */
+//     function test_completeQueuedWithdrawal_SingleStratWithdrawAsShares(
+//         address staker,
+//         address withdrawer,
+//         uint256 depositAmount,
+//         uint256 withdrawalAmount
+//     ) public filterFuzzedAddressInputs(staker) {
+//         cheats.assume(staker != defaultOperator);
+//         cheats.assume(withdrawer != defaultOperator);
+//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+//         _registerOperatorWithBaseDetails(defaultOperator);
+//         (
+//             IDelegationManager.Withdrawal memory withdrawal,
+//             IERC20[] memory tokens,
+//             bytes32 withdrawalRoot
+//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+//             staker: staker,
+//             operator: defaultOperator,
+//             withdrawer: withdrawer,
+//             depositAmount: depositAmount,
+//             withdrawalAmount: withdrawalAmount
+//         });
+//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+
+//         // completeQueuedWithdrawal
+//         cheats.prank(withdrawer);
+//         cheats.roll(block.number + minWithdrawalDelayBlocks);
+//         cheats.expectEmit(true, true, true, true, address(delegationManager));
+//         emit WithdrawalCompleted(withdrawalRoot);
+//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+
+//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+//         if (staker == withdrawer) {
+//             // Since staker is delegated, operatorShares get incremented
+//             assertEq(operatorSharesAfter, operatorSharesBefore + withdrawalAmount, "operator shares not increased correctly");
+//         } else {
+//             // Since withdrawer is not the staker and isn't delegated, staker's oeprator shares are unchanged
+//             assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
+//         }
+//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+//     }
+// }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1,3236 +1,3131 @@
-// // SPDX-License-Identifier: BUSL-1.1
-// pragma solidity =0.8.12;
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.12;
 
-// import "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
-// import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
+import "@openzeppelin/contracts/mocks/ERC1271WalletMock.sol";
+import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 
-// import "src/contracts/core/DelegationManager.sol";
-// import "src/contracts/strategies/StrategyBase.sol";
+import "src/contracts/core/DelegationManager.sol";
+import "src/contracts/strategies/StrategyBase.sol";
 
-// import "src/test/events/IDelegationManagerEvents.sol";
-// import "src/test/utils/EigenLayerUnitTestSetup.sol";
+import "src/test/events/IDelegationManagerEvents.sol";
+import "src/test/utils/EigenLayerUnitTestSetup.sol";
 
-// /**
-//  * @notice Unit testing of the DelegationManager contract. Withdrawals are tightly coupled
-//  * with EigenPodManager and StrategyManager and are part of integration tests.
-//  * Contracts tested: DelegationManager
-//  * Contracts not mocked: StrategyBase, PauserRegistry
-//  */
-// contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManagerEvents {
-//     // Contract under test
-//     DelegationManager delegationManager;
-//     DelegationManager delegationManagerImplementation;
+/**
+ * @notice Unit testing of the DelegationManager contract. Withdrawals are tightly coupled
+ * with EigenPodManager and StrategyManager and are part of integration tests.
+ * Contracts tested: DelegationManager
+ * Contracts not mocked: StrategyBase, PauserRegistry
+ */
+contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManagerEvents {
+    // Contract under test
+    DelegationManager delegationManager;
+    DelegationManager delegationManagerImplementation;
 
-//     // Mocks
-//     StrategyBase strategyImplementation;
-//     StrategyBase strategyMock;
-//     IERC20 mockToken;
-//     uint256 mockTokenInitialSupply = 10e50;
+    // Mocks
+    StrategyBase strategyImplementation;
+    StrategyBase strategyMock;
+    IERC20 mockToken;
+    uint256 mockTokenInitialSupply = 10e50;
 
-//     // Delegation signer
-//     uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
-//     uint256 stakerPrivateKey = uint256(123_456_789);
+    // Delegation signer
+    uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
+    uint256 stakerPrivateKey = uint256(123_456_789);
 
-//     // empty string reused across many tests
-//     string emptyStringForMetadataURI;
+    // empty string reused across many tests
+    string emptyStringForMetadataURI;
 
-//     // "empty" / zero salt, reused across many tests
-//     bytes32 emptySalt;
+    // "empty" / zero salt, reused across many tests
+    bytes32 emptySalt;
 
-//     // reused in various tests. in storage to help handle stack-too-deep errors
-//     address defaultStaker = cheats.addr(uint256(123_456_789));
-//     address defaultOperator = address(this);
-//     address defaultAVS = address(this);
+    // reused in various tests. in storage to help handle stack-too-deep errors
+    address defaultStaker = cheats.addr(uint256(123_456_789));
+    address defaultOperator = address(this);
+    address defaultAVS = address(this);
 
-//     uint256 minWithdrawalDelayBlocks = 216000;
-//     IStrategy[] public initializeStrategiesToSetDelayBlocks;
-//     uint256[] public initializeWithdrawalDelayBlocks;
+    uint256 minWithdrawalDelayBlocks = 216000;
+    IStrategy[] public initializeStrategiesToSetDelayBlocks;
+    uint256[] public initializeWithdrawalDelayBlocks;
 
-//     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+    IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
-//     // Index for flag that pauses new delegations when set.
-//     uint8 internal constant PAUSED_NEW_DELEGATION = 0;
+    // Index for flag that pauses new delegations when set.
+    uint8 internal constant PAUSED_NEW_DELEGATION = 0;
 
-//     // Index for flag that pauses queuing new withdrawals when set.
-//     uint8 internal constant PAUSED_ENTER_WITHDRAWAL_QUEUE = 1;
+    // Index for flag that pauses queuing new withdrawals when set.
+    uint8 internal constant PAUSED_ENTER_WITHDRAWAL_QUEUE = 1;
 
-//     // Index for flag that pauses completing existing withdrawals when set.
-//     uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
+    // Index for flag that pauses completing existing withdrawals when set.
+    uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
 
-//     // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
-//     uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = 216000;
+    // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
+    uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = 216000;
 
-//     /// @notice mappings used to handle duplicate entries in fuzzed address array input
-//     mapping(address => uint256) public totalSharesForStrategyInArray;
-//     mapping(IStrategy => uint256) public delegatedSharesBefore;
+    /// @notice mappings used to handle duplicate entries in fuzzed address array input
+    mapping(address => uint256) public totalSharesForStrategyInArray;
+    mapping(IStrategy => uint256) public delegatedSharesBefore;
 
-//     function setUp() public virtual override {
-//         // Setup
-//         EigenLayerUnitTestSetup.setUp();
+    function setUp() public virtual override {
+        // Setup
+        EigenLayerUnitTestSetup.setUp();
 
-//         // Deploy DelegationManager implmentation and proxy
-//         initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
-//         initializeWithdrawalDelayBlocks = new uint256[](0);
-//         delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
-//         delegationManager = DelegationManager(
-//             address(
-//                 new TransparentUpgradeableProxy(
-//                     address(delegationManagerImplementation),
-//                     address(eigenLayerProxyAdmin),
-//                     abi.encodeWithSelector(
-//                         DelegationManager.initialize.selector,
-//                         address(this),
-//                         pauserRegistry,
-//                         0, // 0 is initialPausedStatus
-//                         minWithdrawalDelayBlocks,
-//                         initializeStrategiesToSetDelayBlocks,
-//                         initializeWithdrawalDelayBlocks
-//                     )
-//                 )
-//             )
-//         );
+        // Deploy DelegationManager implmentation and proxy
+        initializeStrategiesToSetDelayBlocks = new IStrategy[](0);
+        initializeWithdrawalDelayBlocks = new uint256[](0);
+        delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
+        delegationManager = DelegationManager(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(delegationManagerImplementation),
+                    address(eigenLayerProxyAdmin),
+                    abi.encodeWithSelector(
+                        DelegationManager.initialize.selector,
+                        address(this),
+                        pauserRegistry,
+                        0, // 0 is initialPausedStatus
+                        minWithdrawalDelayBlocks,
+                        initializeStrategiesToSetDelayBlocks,
+                        initializeWithdrawalDelayBlocks
+                    )
+                )
+            )
+        );
 
-//         // Deploy mock token and strategy
-//         mockToken = new ERC20PresetFixedSupply("Mock Token", "MOCK", mockTokenInitialSupply, address(this));
-//         strategyImplementation = new StrategyBase(strategyManagerMock);
-//         strategyMock = StrategyBase(
-//             address(
-//                 new TransparentUpgradeableProxy(
-//                     address(strategyImplementation),
-//                     address(eigenLayerProxyAdmin),
-//                     abi.encodeWithSelector(StrategyBase.initialize.selector, mockToken, pauserRegistry)
-//                 )
-//             )
-//         );
+        // Deploy mock token and strategy
+        mockToken = new ERC20PresetFixedSupply("Mock Token", "MOCK", mockTokenInitialSupply, address(this));
+        strategyImplementation = new StrategyBase(strategyManagerMock);
+        strategyMock = StrategyBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(strategyImplementation),
+                    address(eigenLayerProxyAdmin),
+                    abi.encodeWithSelector(StrategyBase.initialize.selector, mockToken, pauserRegistry)
+                )
+            )
+        );
 
-//         // Exclude delegation manager from fuzzed tests
-//         addressIsExcludedFromFuzzedInputs[address(delegationManager)] = true;
-//     }
+        // Exclude delegation manager from fuzzed tests
+        addressIsExcludedFromFuzzedInputs[address(delegationManager)] = true;
+    }
 
-//     /**
-//      * INTERNAL / HELPER FUNCTIONS
-//      */
+    /**
+     * INTERNAL / HELPER FUNCTIONS
+     */
 
-//     /**
-//      * @notice internal function to deploy mock tokens and strategies and have the staker deposit into them. 
-//      * Since we are mocking the strategyManager we call strategyManagerMock.setDeposits so that when
-//      * DelegationManager calls getDeposits, we can have these share amounts returned.
-//      */
-//     function _deployAndDepositIntoStrategies(
-//         address staker,
-//         uint256[] memory sharesAmounts
-//     ) internal returns (IStrategy[] memory) {
-//         uint256 numStrats = sharesAmounts.length;
-//         IStrategy[] memory strategies = new IStrategy[](numStrats);
-//         for (uint8 i = 0; i < numStrats; i++) {
-//             ERC20PresetFixedSupply token = new ERC20PresetFixedSupply(
-//                 string(abi.encodePacked("Mock Token ", i)),
-//                 string(abi.encodePacked("MOCK", i)),
-//                 mockTokenInitialSupply,
-//                 address(this)
-//             );
-//             strategies[i] = StrategyBase(
-//                 address(
-//                     new TransparentUpgradeableProxy(
-//                         address(strategyImplementation),
-//                         address(eigenLayerProxyAdmin),
-//                         abi.encodeWithSelector(StrategyBase.initialize.selector, token, pauserRegistry)
-//                     )
-//                 )
-//             );
-//         }
-//         strategyManagerMock.setDeposits(staker, strategies, sharesAmounts);
-//         return strategies;
-//     }
+    /**
+     * @notice internal function to deploy mock tokens and strategies and have the staker deposit into them. 
+     * Since we are mocking the strategyManager we call strategyManagerMock.setDeposits so that when
+     * DelegationManager calls getDeposits, we can have these share amounts returned.
+     */
+    function _deployAndDepositIntoStrategies(
+        address staker,
+        uint256[] memory sharesAmounts
+    ) internal returns (IStrategy[] memory) {
+        uint256 numStrats = sharesAmounts.length;
+        IStrategy[] memory strategies = new IStrategy[](numStrats);
+        for (uint8 i = 0; i < numStrats; i++) {
+            ERC20PresetFixedSupply token = new ERC20PresetFixedSupply(
+                string(abi.encodePacked("Mock Token ", i)),
+                string(abi.encodePacked("MOCK", i)),
+                mockTokenInitialSupply,
+                address(this)
+            );
+            strategies[i] = StrategyBase(
+                address(
+                    new TransparentUpgradeableProxy(
+                        address(strategyImplementation),
+                        address(eigenLayerProxyAdmin),
+                        abi.encodeWithSelector(StrategyBase.initialize.selector, token, pauserRegistry)
+                    )
+                )
+            );
+        }
+        strategyManagerMock.setDeposits(staker, strategies, sharesAmounts);
+        return strategies;
+    }
 
-//     /**
-//      * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
-//      * the `staker` to delegate to `operator`, with the specified `salt`, and expiring at `expiry`.
-//      */
-//     function _getApproverSignature(
-//         uint256 _delegationSignerPrivateKey,
-//         address staker,
-//         address operator,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) internal view returns (ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) {
-//         approverSignatureAndExpiry.expiry = expiry;
-//         {
-//             bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
-//                 staker,
-//                 operator,
-//                 delegationManager.delegationApprover(operator),
-//                 salt,
-//                 expiry
-//             );
-//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_delegationSignerPrivateKey, digestHash);
-//             approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-//         }
-//         return approverSignatureAndExpiry;
-//     }
+    /**
+     * @notice internal function for calculating a signature from the delegationSigner corresponding to `_delegationSignerPrivateKey`, approving
+     * the `staker` to delegate to `operator`, with the specified `salt`, and expiring at `expiry`.
+     */
+    function _getApproverSignature(
+        uint256 _delegationSignerPrivateKey,
+        address staker,
+        address operator,
+        bytes32 salt,
+        uint256 expiry
+    ) internal view returns (ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry) {
+        approverSignatureAndExpiry.expiry = expiry;
+        {
+            bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
+                staker,
+                operator,
+                delegationManager.delegationApprover(operator),
+                salt,
+                expiry
+            );
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_delegationSignerPrivateKey, digestHash);
+            approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+        }
+        return approverSignatureAndExpiry;
+    }
 
-//     /**
-//      * @notice internal function for calculating a signature from the staker corresponding to `_stakerPrivateKey`, delegating them to
-//      * the `operator`, and expiring at `expiry`.
-//      */
-//     function _getStakerSignature(
-//         uint256 _stakerPrivateKey,
-//         address operator,
-//         uint256 expiry
-//     ) internal view returns (ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry) {
-//         address staker = cheats.addr(stakerPrivateKey);
-//         stakerSignatureAndExpiry.expiry = expiry;
-//         {
-//             bytes32 digestHash = delegationManager.calculateCurrentStakerDelegationDigestHash(staker, operator, expiry);
-//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
-//             stakerSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-//         }
-//         return stakerSignatureAndExpiry;
-//     }
+    /**
+     * @notice internal function for calculating a signature from the staker corresponding to `_stakerPrivateKey`, delegating them to
+     * the `operator`, and expiring at `expiry`.
+     */
+    function _getStakerSignature(
+        uint256 _stakerPrivateKey,
+        address operator,
+        uint256 expiry
+    ) internal view returns (ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry) {
+        address staker = cheats.addr(stakerPrivateKey);
+        stakerSignatureAndExpiry.expiry = expiry;
+        {
+            bytes32 digestHash = delegationManager.calculateCurrentStakerDelegationDigestHash(staker, operator, expiry);
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
+            stakerSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+        }
+        return stakerSignatureAndExpiry;
+    }
 
-//     /**
-//      * @notice internal function for calculating a signature from the operator corresponding to `_operatorPrivateKey`, delegating them to
-//      * the `operator`, and expiring at `expiry`.
-//      */
-//     function _getOperatorSignature(
-//         uint256 _operatorPrivateKey,
-//         address operator,
-//         address avs,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) {
-//         operatorSignature.expiry = expiry;
-//         operatorSignature.salt = salt;
-//         {
-//             bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
-//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
-//             operatorSignature.signature = abi.encodePacked(r, s, v);
-//         }
-//         return operatorSignature;
-//     }
+    /**
+     * @notice internal function for calculating a signature from the operator corresponding to `_operatorPrivateKey`, delegating them to
+     * the `operator`, and expiring at `expiry`.
+     */
+    function _getOperatorSignature(
+        uint256 _operatorPrivateKey,
+        address operator,
+        address avs,
+        bytes32 salt,
+        uint256 expiry
+    ) internal view returns (ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) {
+        operatorSignature.expiry = expiry;
+        operatorSignature.salt = salt;
+        {
+            bytes32 digestHash = delegationManager.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
+            operatorSignature.signature = abi.encodePacked(r, s, v);
+        }
+        return operatorSignature;
+    }
 
 
-//     // @notice Assumes operator does not have a delegation approver & staker != approver
-//     function _delegateToOperatorWhoAcceptsAllStakers(address staker, address operator) internal {
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         cheats.prank(staker);
-//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
-//     }
+    // @notice Assumes operator does not have a delegation approver & staker != approver
+    function _delegateToOperatorWhoAcceptsAllStakers(address staker, address operator) internal {
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        cheats.prank(staker);
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
+    }
 
-//     function _delegateToOperatorWhoRequiresSig(address staker, address operator, bytes32 salt) internal {
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             operator,
-//             salt,
-//             expiry
-//         );
-//         cheats.prank(staker);
-//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
-//     }
+    function _delegateToOperatorWhoRequiresSig(address staker, address operator, bytes32 salt) internal {
+        uint256 expiry = type(uint256).max;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            operator,
+            salt,
+            expiry
+        );
+        cheats.prank(staker);
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
+    }
 
-//     function _delegateToOperatorWhoRequiresSig(address staker, address operator) internal {
-//         _delegateToOperatorWhoRequiresSig(staker, operator, emptySalt);
-//     }
+    function _delegateToOperatorWhoRequiresSig(address staker, address operator) internal {
+        _delegateToOperatorWhoRequiresSig(staker, operator, emptySalt);
+    }
 
-//     function _delegateToBySignatureOperatorWhoAcceptsAllStakers(
-//         address staker,
-//         address caller,
-//         address operator,
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
-//         bytes32 salt
-//     ) internal {
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         cheats.prank(caller);
-//         delegationManager.delegateToBySignature(
-//             staker,
-//             operator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             salt
-//         );
-//     }
+    function _delegateToBySignatureOperatorWhoAcceptsAllStakers(
+        address staker,
+        address caller,
+        address operator,
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
+        bytes32 salt
+    ) internal {
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        cheats.prank(caller);
+        delegationManager.delegateToBySignature(
+            staker,
+            operator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            salt
+        );
+    }
 
-//     function _delegateToBySignatureOperatorWhoRequiresSig(
-//         address staker,
-//         address caller,
-//         address operator,
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
-//         bytes32 salt
-//     ) internal {
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             operator,
-//             salt,
-//             expiry
-//         );
-//         cheats.prank(caller);
-//         delegationManager.delegateToBySignature(
-//             staker,
-//             operator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             salt
-//         );
-//     }
+    function _delegateToBySignatureOperatorWhoRequiresSig(
+        address staker,
+        address caller,
+        address operator,
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry,
+        bytes32 salt
+    ) internal {
+        uint256 expiry = type(uint256).max;
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            operator,
+            salt,
+            expiry
+        );
+        cheats.prank(caller);
+        delegationManager.delegateToBySignature(
+            staker,
+            operator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            salt
+        );
+    }
 
-//     function _registerOperatorWithBaseDetails(address operator) internal {
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: operator,
-//             delegationApprover: address(0),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
-//     }
+    function _registerOperatorWithBaseDetails(address operator) internal {
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: operator,
+            delegationApprover: address(0),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+    }
 
-//     function _registerOperatorWithDelegationApprover(address operator) internal {
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: operator,
-//             delegationApprover: cheats.addr(delegationSignerPrivateKey),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
-//     }
+    function _registerOperatorWithDelegationApprover(address operator) internal {
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: operator,
+            delegationApprover: cheats.addr(delegationSignerPrivateKey),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+    }
 
-//     function _registerOperatorWith1271DelegationApprover(address operator) internal returns (ERC1271WalletMock) {
-//         address delegationSigner = cheats.addr(delegationSignerPrivateKey);
-//         /**
-//          * deploy a ERC1271WalletMock contract with the `delegationSigner` address as the owner,
-//          * so that we can create valid signatures from the `delegationSigner` for the contract to check when called
-//          */
-//         ERC1271WalletMock wallet = new ERC1271WalletMock(delegationSigner);
+    function _registerOperatorWith1271DelegationApprover(address operator) internal returns (ERC1271WalletMock) {
+        address delegationSigner = cheats.addr(delegationSignerPrivateKey);
+        /**
+         * deploy a ERC1271WalletMock contract with the `delegationSigner` address as the owner,
+         * so that we can create valid signatures from the `delegationSigner` for the contract to check when called
+         */
+        ERC1271WalletMock wallet = new ERC1271WalletMock(delegationSigner);
 
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: operator,
-//             delegationApprover: address(wallet),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: operator,
+            delegationApprover: address(wallet),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(operator, operatorDetails, emptyStringForMetadataURI);
 
-//         return wallet;
-//     }
+        return wallet;
+    }
 
-//     function _registerOperator(
-//         address operator,
-//         IDelegationManager.OperatorDetails memory operatorDetails,
-//         string memory metadataURI
-//     ) internal filterFuzzedAddressInputs(operator) {
-//         _filterOperatorDetails(operator, operatorDetails);
-//         cheats.prank(operator);
-//         delegationManager.registerAsOperator(operatorDetails, metadataURI);
-//     }
+    function _registerOperator(
+        address operator,
+        IDelegationManager.OperatorDetails memory operatorDetails,
+        string memory metadataURI
+    ) internal filterFuzzedAddressInputs(operator) {
+        _filterOperatorDetails(operator, operatorDetails);
+        cheats.prank(operator);
+        delegationManager.registerAsOperator(operatorDetails, metadataURI);
+    }
 
-//     function _filterOperatorDetails(
-//         address operator,
-//         IDelegationManager.OperatorDetails memory operatorDetails
-//     ) internal view {
-//         // filter out zero address since people can't delegate to the zero address and operators are delegated to themselves
-//         cheats.assume(operator != address(0));
-//         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
-//         cheats.assume(operatorDetails.earningsReceiver != address(0));
-//         // filter out disallowed stakerOptOutWindowBlocks values
-//         cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
-//     }
+    function _filterOperatorDetails(
+        address operator,
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) internal view {
+        // filter out zero address since people can't delegate to the zero address and operators are delegated to themselves
+        cheats.assume(operator != address(0));
+        // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
+        cheats.assume(operatorDetails.earningsReceiver != address(0));
+        // filter out disallowed stakerOptOutWindowBlocks values
+        cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
+    }
 
-//     /**
-//      * @notice Using this helper function to fuzz withdrawalAmounts since fuzzing two dynamic sized arrays of equal lengths
-//      * reject too many inputs. 
-//      */
-//     function _fuzzWithdrawalAmounts(uint256[] memory depositAmounts) internal view returns (uint256[] memory) {
-//         uint256[] memory withdrawalAmounts = new uint256[](depositAmounts.length);
-//         for (uint256 i = 0; i < depositAmounts.length; i++) {
-//             cheats.assume(depositAmounts[i] > 0);
-//             // generate withdrawal amount within range s.t withdrawAmount <= depositAmount
-//             withdrawalAmounts[i] = bound(
-//                 uint256(keccak256(abi.encodePacked(depositAmounts[i]))),
-//                 0,
-//                 depositAmounts[i]
-//             );
-//         }
-//         return withdrawalAmounts;
-//     }
+    /**
+     * @notice Using this helper function to fuzz withdrawalAmounts since fuzzing two dynamic sized arrays of equal lengths
+     * reject too many inputs. 
+     */
+    function _fuzzWithdrawalAmounts(uint256[] memory depositAmounts) internal view returns (uint256[] memory) {
+        uint256[] memory withdrawalAmounts = new uint256[](depositAmounts.length);
+        for (uint256 i = 0; i < depositAmounts.length; i++) {
+            cheats.assume(depositAmounts[i] > 0);
+            // generate withdrawal amount within range s.t withdrawAmount <= depositAmount
+            withdrawalAmounts[i] = bound(
+                uint256(keccak256(abi.encodePacked(depositAmounts[i]))),
+                0,
+                depositAmounts[i]
+            );
+        }
+        return withdrawalAmounts;
+    }
 
-//     function _setUpQueueWithdrawalsSingleStrat(
-//         address staker,
-//         address withdrawer,
-//         IStrategy strategy,
-//         uint256 withdrawalAmount
-//     ) internal view returns (
-//         IDelegationManager.QueuedWithdrawalParams[] memory,
-//         IDelegationManager.Withdrawal memory,
-//         bytes32
-//     ) {
-//         IStrategy[] memory strategyArray = new IStrategy[](1);
-//         strategyArray[0] = strategy;
-//         uint256[] memory withdrawalAmounts = new uint256[](1);
-//         withdrawalAmounts[0] = withdrawalAmount;
+    function _setUpQueueWithdrawalsSingleStrat(
+        address staker,
+        address withdrawer,
+        IStrategy strategy,
+        uint256 withdrawalAmount
+    ) internal view returns (
+        IDelegationManager.QueuedWithdrawalParams[] memory,
+        IDelegationManager.Withdrawal memory,
+        bytes32
+    ) {
+        IStrategy[] memory strategyArray = new IStrategy[](1);
+        strategyArray[0] = strategy;
+        uint256[] memory withdrawalAmounts = new uint256[](1);
+        withdrawalAmounts[0] = withdrawalAmount;
 
-//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-//             strategies: strategyArray,
-//             shares: withdrawalAmounts,
-//             withdrawer: withdrawer
-//         });
+        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategyArray,
+            shares: withdrawalAmounts,
+            withdrawer: withdrawer
+        });
 
-//         IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
-//             staker: staker,
-//             delegatedTo: delegationManager.delegatedTo(staker),
-//             withdrawer: withdrawer,
-//             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-//             startBlock: uint32(block.number),
-//             strategies: strategyArray,
-//             shares: withdrawalAmounts
-//         });
-//         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
+        IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
+            staker: staker,
+            delegatedTo: delegationManager.delegatedTo(staker),
+            withdrawer: withdrawer,
+            nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
+            startBlock: uint32(block.number),
+            strategies: strategyArray,
+            shares: withdrawalAmounts
+        });
+        bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
-//         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
-//     }
+        return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
+    }
 
-//     function _setUpQueueWithdrawals(
-//         address staker,
-//         address withdrawer,
-//         IStrategy[] memory strategies,
-//         uint256[] memory withdrawalAmounts
-//     ) internal view returns (
-//         IDelegationManager.QueuedWithdrawalParams[] memory,
-//         IDelegationManager.Withdrawal memory,
-//         bytes32
-//     ) {
-//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-//             strategies: strategies,
-//             shares: withdrawalAmounts,
-//             withdrawer: withdrawer
-//         });
+    function _setUpQueueWithdrawals(
+        address staker,
+        address withdrawer,
+        IStrategy[] memory strategies,
+        uint256[] memory withdrawalAmounts
+    ) internal view returns (
+        IDelegationManager.QueuedWithdrawalParams[] memory,
+        IDelegationManager.Withdrawal memory,
+        bytes32
+    ) {
+        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategies,
+            shares: withdrawalAmounts,
+            withdrawer: withdrawer
+        });
         
-//         IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
-//             staker: staker,
-//             delegatedTo: delegationManager.delegatedTo(staker),
-//             withdrawer: withdrawer,
-//             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-//             startBlock: uint32(block.number),
-//             strategies: strategies,
-//             shares: withdrawalAmounts
-//         });
-//         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
+        IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({
+            staker: staker,
+            delegatedTo: delegationManager.delegatedTo(staker),
+            withdrawer: withdrawer,
+            nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
+            startBlock: uint32(block.number),
+            strategies: strategies,
+            shares: withdrawalAmounts
+        });
+        bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
-//         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
-//     }
-
-//     /**
-//      * Deploy and deposit staker into a single strategy, then set up a queued withdrawal for the staker
-//      * Assumptions: 
-//      * - operator is already a registered operator.
-//      * - withdrawalAmount <= depositAmount
-//      */
-//     function _setUpCompleteQueuedWithdrawalSingleStrat(
-//         address staker,
-//         address operator,
-//         address withdrawer,
-//         uint256 depositAmount,
-//         uint256 withdrawalAmount
-//     ) internal returns (IDelegationManager.Withdrawal memory, IERC20[] memory, bytes32) {
-//         uint256[] memory depositAmounts = new uint256[](1);
-//         depositAmounts[0] = depositAmount;
-//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-//         (
-//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             bytes32 withdrawalRoot
-//         ) = _setUpQueueWithdrawalsSingleStrat({
-//             staker: staker,
-//             withdrawer: withdrawer,
-//             strategy: strategies[0],
-//             withdrawalAmount: withdrawalAmount
-//         });
-
-//         cheats.prank(staker);
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-//         // Set the current deposits to be the depositAmount - withdrawalAmount
-//         uint256[] memory currentAmounts = new uint256[](1);
-//         currentAmounts[0] = depositAmount - withdrawalAmount;
-//         strategyManagerMock.setDeposits(staker, strategies, currentAmounts);
-
-//         IERC20[] memory tokens = new IERC20[](1);
-//         tokens[0] = strategies[0].underlyingToken();
-//         return (withdrawal, tokens, withdrawalRoot);
-//     }
-
-//     /**
-//      * Deploy and deposit staker into strategies, then set up a queued withdrawal for the staker
-//      * Assumptions: 
-//      * - operator is already a registered operator.
-//      * - for each i, withdrawalAmount[i] <= depositAmount[i] (see filterFuzzedDepositWithdrawInputs above)
-//      */
-//     function _setUpCompleteQueuedWithdrawal(
-//         address staker,
-//         address operator,
-//         address withdrawer,
-//         uint256[] memory depositAmounts,
-//         uint256[] memory withdrawalAmounts
-//     ) internal returns (IDelegationManager.Withdrawal memory, bytes32) {
-//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-//         (
-//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             bytes32 withdrawalRoot
-//         ) = _setUpQueueWithdrawals({
-//             staker: staker,
-//             withdrawer: withdrawer,
-//             strategies: strategies,
-//             withdrawalAmounts: withdrawalAmounts
-//         });
-
-//         cheats.prank(staker);
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-//         return (withdrawal, withdrawalRoot);
-//     }
-// }
-
-// contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerUnitTests {
-//     function test_initialization() public {
-//         assertEq(
-//             address(delegationManager.strategyManager()),
-//             address(strategyManagerMock),
-//             "constructor / initializer incorrect, strategyManager set wrong"
-//         );
-//         assertEq(
-//             address(delegationManager.slasher()),
-//             address(slasherMock),
-//             "constructor / initializer incorrect, slasher set wrong"
-//         );
-//         assertEq(
-//             address(delegationManager.pauserRegistry()),
-//             address(pauserRegistry),
-//             "constructor / initializer incorrect, pauserRegistry set wrong"
-//         );
-//         assertEq(delegationManager.owner(), address(this), "constructor / initializer incorrect, owner set wrong");
-//         assertEq(delegationManager.paused(), 0, "constructor / initializer incorrect, paused status set wrong");
-//     }
-
-//     /// @notice Verifies that the DelegationManager cannot be iniitalized multiple times
-//     function test_initialize_revert_reinitialization() public {
-//         cheats.expectRevert("Initializable: contract is already initialized");
-//         delegationManager.initialize(
-//             address(this),
-//             pauserRegistry,
-//             0,
-//             0, // minWithdrawalDelayBLocks
-//             initializeStrategiesToSetDelayBlocks,
-//             initializeWithdrawalDelayBlocks
-//         );
-//     }
-
-//     function testFuzz_initialize_Revert_WhenWithdrawalDelayBlocksTooLarge(
-//         uint256[] memory withdrawalDelayBlocks,
-//         uint256 invalidStrategyIndex
-//     ) public {
-//         // set withdrawalDelayBlocks to be too large
-//         cheats.assume(withdrawalDelayBlocks.length > 0);
-//         uint256 numStrats = withdrawalDelayBlocks.length;
-//         IStrategy[] memory strategiesToSetDelayBlocks = new IStrategy[](numStrats);
-//         for (uint256 i = 0; i < numStrats; i++) {
-//             strategiesToSetDelayBlocks[i] = IStrategy(address(uint160(uint256(keccak256(abi.encode(strategyMock, i))))));
-//         }
-
-//         // set at least one index to be too large for withdrawalDelayBlocks
-//         invalidStrategyIndex = invalidStrategyIndex % numStrats;
-//         withdrawalDelayBlocks[invalidStrategyIndex] = MAX_WITHDRAWAL_DELAY_BLOCKS + 1;
-
-//         // Deploy DelegationManager implmentation and proxy
-//         delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
-//         cheats.expectRevert(
-//             "DelegationManager._setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
-//         );
-//         delegationManager = DelegationManager(
-//             address(
-//                 new TransparentUpgradeableProxy(
-//                     address(delegationManagerImplementation),
-//                     address(eigenLayerProxyAdmin),
-//                     abi.encodeWithSelector(
-//                         DelegationManager.initialize.selector,
-//                         address(this),
-//                         pauserRegistry,
-//                         0, // 0 is initialPausedStatus
-//                         minWithdrawalDelayBlocks,
-//                         strategiesToSetDelayBlocks,
-//                         withdrawalDelayBlocks
-//                     )
-//                 )
-//             )
-//         );
-//     }
-// }
-
-// contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerUnitTests {
-//     function test_registerAsOperator_revert_paused() public {
-//         // set the pausing flag
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.registerAsOperator(
-//             IDelegationManager.OperatorDetails({
-//                 earningsReceiver: defaultOperator,
-//                 delegationApprover: address(0),
-//                 stakerOptOutWindowBlocks: 0
-//             }),
-//             emptyStringForMetadataURI
-//         );
-//     }
-
-//     // @notice Verifies that someone cannot successfully call `DelegationManager.registerAsOperator(operatorDetails)` again after registering for the first time
-//     function testFuzz_registerAsOperator_revert_cannotRegisterMultipleTimes(
-//         address operator,
-//         IDelegationManager.OperatorDetails memory operatorDetails
-//     ) public filterFuzzedAddressInputs(operator) {
-//         _filterOperatorDetails(operator, operatorDetails);
-
-//         // Register once
-//         cheats.startPrank(operator);
-//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-
-//         // Expect revert when register again
-//         cheats.expectRevert("DelegationManager.registerAsOperator: operator has already registered");
-//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice Verifies that an operator cannot register with `earningsReceiver` set to the zero address
-//      * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
-//      */
-//     function testFuzz_registerAsOperator_revert_earningsReceiverZeroAddress() public {
-//         IDelegationManager.OperatorDetails memory operatorDetails;
-
-//         cheats.prank(defaultOperator);
-//         cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
-//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-//     }
-
-//     /**
-//      * @notice Verifies that an operator cannot register with `stakerOptOutWindowBlocks` set larger than `MAX_STAKER_OPT_OUT_WINDOW_BLOCKS`
-//      */
-//     function testFuzz_registerAsOperator_revert_optOutBlocksTooLarge(
-//         IDelegationManager.OperatorDetails memory operatorDetails
-//     ) public {
-//         // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
-//         cheats.assume(operatorDetails.earningsReceiver != address(0));
-//         // filter out *allowed* stakerOptOutWindowBlocks values
-//         cheats.assume(operatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
-
-//         cheats.prank(defaultOperator);
-//         cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS");
-//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-//     }
-
-//     /**
-//      * @notice `operator` registers via calling `DelegationManager.registerAsOperator(operatorDetails, metadataURI)`
-//      * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
-//      * The set parameters should match the desired parameters (correct storage update)
-//      * Operator becomes delegated to themselves
-//      * Properly emits events – especially the `OperatorRegistered` event, but also `StakerDelegated` & `OperatorDetailsModified` events
-//      * Reverts appropriately if operator was already delegated to someone (including themselves, i.e. they were already an operator)
-//      * @param operator and @param operatorDetails are fuzzed inputs
-//      */
-//     function testFuzz_registerAsOperator(
-//         address operator,
-//         IDelegationManager.OperatorDetails memory operatorDetails,
-//         string memory metadataURI
-//     ) public filterFuzzedAddressInputs(operator) {
-//         _filterOperatorDetails(operator, operatorDetails);
-
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorDetailsModified(operator, operatorDetails);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(operator, operator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorRegistered(operator, operatorDetails);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorMetadataURIUpdated(operator, metadataURI);
-
-//         cheats.prank(operator);
-//         delegationManager.registerAsOperator(operatorDetails, metadataURI);
-
-//         // Storage checks
-//         assertEq(
-//             operatorDetails.earningsReceiver,
-//             delegationManager.earningsReceiver(operator),
-//             "earningsReceiver not set correctly"
-//         );
-//         assertEq(
-//             operatorDetails.delegationApprover,
-//             delegationManager.delegationApprover(operator),
-//             "delegationApprover not set correctly"
-//         );
-//         assertEq(
-//             operatorDetails.stakerOptOutWindowBlocks,
-//             delegationManager.stakerOptOutWindowBlocks(operator),
-//             "stakerOptOutWindowBlocks not set correctly"
-//         );
-//         assertEq(delegationManager.delegatedTo(operator), operator, "operator not delegated to self");
-//     }
-
-//     // @notice Verifies that a staker who is actively delegated to an operator cannot register as an operator (without first undelegating, at least)
-//     function testFuzz_registerAsOperator_cannotRegisterWhileDelegated(
-//         address staker,
-//         IDelegationManager.OperatorDetails memory operatorDetails
-//     ) public filterFuzzedAddressInputs(staker) {
-//         cheats.assume(staker != defaultOperator);
-//         // Staker becomes an operator, so filter against staker's address
-//         _filterOperatorDetails(staker, operatorDetails);
-
-//         // register *this contract* as an operator
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-
-//         // expect revert if attempt to register as operator
-//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-//         delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
-
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice Verifies that an operator cannot modify their `earningsReceiver` address to set it to the zero address
-//      * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
-//      */
-//     function test_modifyOperatorParameters_revert_earningsReceiverZeroAddress() public {
-//         // register *this contract* as an operator
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: defaultOperator,
-//             delegationApprover: address(0),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-//         operatorDetails.earningsReceiver = address(0);
-//         cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
-//         delegationManager.modifyOperatorDetails(operatorDetails);
-//     }
-
-//     /**
-//      * @notice Tests that an operator can modify their OperatorDetails by calling `DelegationManager.modifyOperatorDetails`
-//      * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
-//      * The set parameters should match the desired parameters (correct storage update)
-//      * Properly emits an `OperatorDetailsModified` event
-//      * Reverts appropriately if the caller is not an operator
-//      * Reverts if operator tries to decrease their `stakerOptOutWindowBlocks` parameter
-//      * @param initialOperatorDetails and @param modifiedOperatorDetails are fuzzed inputs
-//      */
-//     function testFuzz_modifyOperatorParameters(
-//         IDelegationManager.OperatorDetails memory initialOperatorDetails,
-//         IDelegationManager.OperatorDetails memory modifiedOperatorDetails
-//     ) public {
-//         // filter out zero address since people can't set their earningsReceiver address to the zero address (test case verified above)
-//         cheats.assume(modifiedOperatorDetails.earningsReceiver != address(0));
-
-//         _registerOperator(defaultOperator, initialOperatorDetails, emptyStringForMetadataURI);
-
-//         cheats.startPrank(defaultOperator);
-
-//         // either it fails for trying to set the stakerOptOutWindowBlocks
-//         if (modifiedOperatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS()) {
-//             cheats.expectRevert(
-//                 "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
-//             );
-//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-//             // or the transition is allowed,
-//         } else if (
-//             modifiedOperatorDetails.stakerOptOutWindowBlocks >= initialOperatorDetails.stakerOptOutWindowBlocks
-//         ) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorDetailsModified(defaultOperator, modifiedOperatorDetails);
-//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-
-//             assertEq(
-//                 modifiedOperatorDetails.earningsReceiver,
-//                 delegationManager.earningsReceiver(defaultOperator),
-//                 "earningsReceiver not set correctly"
-//             );
-//             assertEq(
-//                 modifiedOperatorDetails.delegationApprover,
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 "delegationApprover not set correctly"
-//             );
-//             assertEq(
-//                 modifiedOperatorDetails.stakerOptOutWindowBlocks,
-//                 delegationManager.stakerOptOutWindowBlocks(defaultOperator),
-//                 "stakerOptOutWindowBlocks not set correctly"
-//             );
-//             assertEq(delegationManager.delegatedTo(defaultOperator), defaultOperator, "operator not delegated to self");
-//             // or else the transition is disallowed
-//         } else {
-//             cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased");
-//             delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
-//         }
-
-//         cheats.stopPrank();
-//     }
-
-//     // @notice Tests that an address which is not an operator cannot successfully call `updateOperatorMetadataURI`.
-//     function test_updateOperatorMetadataUri_notRegistered() public {
-//         assertFalse(delegationManager.isOperator(defaultOperator), "bad test setup");
-
-//         cheats.prank(defaultOperator);
-//         cheats.expectRevert("DelegationManager.updateOperatorMetadataURI: caller must be an operator");
-//         delegationManager.updateOperatorMetadataURI(emptyStringForMetadataURI);
-//     }
-
-//     /**
-//      * @notice Verifies that a staker cannot call cannot modify their `OperatorDetails` without first registering as an operator
-//      * @dev This is an important check to ensure that our definition of 'operator' remains consistent, in particular for preserving the
-//      * invariant that 'operators' are always delegated to themselves
-//      */
-//     function testFuzz_updateOperatorMetadataUri_revert_notOperator(
-//         IDelegationManager.OperatorDetails memory operatorDetails
-//     ) public {
-//         cheats.expectRevert("DelegationManager.modifyOperatorDetails: caller must be an operator");
-//         delegationManager.modifyOperatorDetails(operatorDetails);
-//     }
-
-//     // @notice Tests that an operator who calls `updateOperatorMetadataURI` will correctly see an `OperatorMetadataURIUpdated` event emitted with their input
-//     function testFuzz_UpdateOperatorMetadataURI(string memory metadataURI) public {
-//         // register *this contract* as an operator
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // call `updateOperatorMetadataURI` and check for event
-//         cheats.prank(defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorMetadataURIUpdated(defaultOperator, metadataURI);
-//         delegationManager.updateOperatorMetadataURI(metadataURI);
-//     }
-// }
-
-// contract DelegationManagerUnitTests_operatorAVSRegisterationStatus is DelegationManagerUnitTests {
-//     // @notice Tests that an avs who calls `updateAVSMetadataURI` will correctly see an `AVSMetadataURIUpdated` event emitted with their input
-//     function testFuzz_UpdateAVSMetadataURI(string memory metadataURI) public {
-//         // call `updateAVSMetadataURI` and check for event
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         cheats.prank(defaultAVS);
-//         emit AVSMetadataURIUpdated(defaultAVS, metadataURI);
-//         delegationManager.updateAVSMetadataURI(metadataURI);
-//     }
-
-//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
-//     function testFuzz_registerOperatorToAVS(bytes32 salt) public {
-//         address operator = cheats.addr(delegationSignerPrivateKey);
-//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
-//         _registerOperatorWithBaseDetails(operator);
-
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorAVSRegistrationStatusUpdated(operator, defaultAVS, OperatorAVSRegistrationStatus.REGISTERED);
-
-//         uint256 expiry = type(uint256).max;
-
-//         cheats.prank(defaultAVS);
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-//             delegationSignerPrivateKey,
-//             operator,
-//             defaultAVS,
-//             salt,
-//             expiry
-//         );
-
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-//     }
-
-//     // @notice Verifies an operator registers successfull to avs and see an `OperatorAVSRegistrationStatusUpdated` event emitted
-//     function testFuzz_revert_whenOperatorNotRegisteredToEigenLayerYet(bytes32 salt) public {
-//         address operator = cheats.addr(delegationSignerPrivateKey);
-//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
-
-//         cheats.prank(defaultAVS);
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-//             delegationSignerPrivateKey,
-//             operator,
-//             defaultAVS,
-//             salt,
-//             expiry
-//         );
-
-//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator not registered to EigenLayer yet");
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-//     }
-
-//     // @notice Verifies an operator registers fails when the signature is not from the operator
-//     function testFuzz_revert_whenSignatureAddressIsNotOperator(bytes32 salt) public {
-//         address operator = cheats.addr(delegationSignerPrivateKey);
-//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
-//         _registerOperatorWithBaseDetails(operator);
-
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-//             delegationSignerPrivateKey,
-//             operator,
-//             defaultAVS,
-//             salt,
-//             expiry
-//         );
-
-//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-//         cheats.prank(operator);
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-//     }
-
-//     // @notice Verifies an operator registers fails when the signature expiry already expires
-//     function testFuzz_revert_whenExpiryHasExpired(bytes32 salt, uint256 expiry, ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature) public {
-//         address operator = cheats.addr(delegationSignerPrivateKey);
-//         cheats.assume(operatorSignature.expiry < block.timestamp);
-
-//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator signature expired");
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-//     }
-
-//     // @notice Verifies an operator registers fails when it's already registered to the avs
-//     function testFuzz_revert_whenOperatorAlreadyRegisteredToAVS(bytes32 salt) public {
-//         address operator = cheats.addr(delegationSignerPrivateKey);
-//         assertFalse(delegationManager.isOperator(operator), "bad test setup");
-//         _registerOperatorWithBaseDetails(operator);
-
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature = _getOperatorSignature(
-//             delegationSignerPrivateKey,
-//             operator,
-//             defaultAVS,
-//             salt,
-//             expiry
-//         );
-
-//         cheats.startPrank(defaultAVS);
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-
-//         cheats.expectRevert("DelegationManager.registerOperatorToAVS: operator already registered");
-//         delegationManager.registerOperatorToAVS(operator, operatorSignature);
-//         cheats.stopPrank();
-//     }
-// }
-
-// contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
-//     function test_Revert_WhenPaused() public {
-//         // set the pausing flag
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         cheats.prank(defaultStaker);
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-//     }
-
-//     /**
-//      * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
-//      */
-//     function testFuzz_Revert_WhenDelegateWhileDelegated(
-//         address staker,
-//         address operator,
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-//         bytes32 salt
-//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-//         // filter out input since if the staker tries to delegate again after registering as an operator, we will revert earlier than this test is designed to check
-//         cheats.assume(staker != operator);
-
-//         // delegate from the staker to an operator
-//         cheats.assume(operator != address(this));
-//         _registerOperatorWithBaseDetails(operator);
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, operator);
-
-//         // try to delegate again and check that the call reverts
-//         cheats.startPrank(staker);
-//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//     }
-
-//     // @notice Verifies that `staker` cannot delegate to an unregistered `operator`
-//     function testFuzz_Revert_WhenDelegateToUnregisteredOperator(
-//         address staker,
-//         address operator
-//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-//         assertFalse(delegationManager.isOperator(operator), "incorrect test input?");
-
-//         // try to delegate and check that the call reverts
-//         cheats.startPrank(staker);
-//         cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass with any `operatorSignature` input (since it should be unused)
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoAcceptsAllStakers_StrategyManagerShares(
-//         address staker,
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-//         bytes32 salt,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // Set staker shares in StrategyManager
-//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//         strategiesToReturn[0] = strategyMock;
-//         uint256[] memory sharesToReturn = new uint256[](1);
-//         sharesToReturn[0] = shares;
-//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-
-//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         // verify that the salt is still marked as unused (since it wasn't checked or used)
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass with any `operatorSignature` input (since it should be unused)
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * OperatorSharesIncreased event should only be emitted if beaconShares is > 0. Since a staker can have negative shares nothing should happen in that case
-//      */
-//     function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainStrategyShares(
-//         address staker,
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-//         bytes32 salt,
-//         int256 beaconShares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // Set staker shares in BeaconChainStrategy
-//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//         if (beaconShares <= 0) {
-//             assertEq(
-//                 beaconSharesBefore,
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares should not have increased with negative shares"
-//             );
-//         } else {
-//             assertEq(
-//                 beaconSharesBefore + uint256(beaconShares),
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares not increased correctly"
-//             );
-//         }
-//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         // verify that the salt is still marked as unused (since it wasn't checked or used)
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * Similar to tests above but now with staker who has both EigenPod and StrategyManager shares.
-//      */
-//     function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainAndStrategyManagerShares(
-//         address staker,
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-//         bytes32 salt,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // Set staker shares in BeaconChainStrategy and StrategyMananger
-//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//         strategiesToReturn[0] = strategyMock;
-//         uint256[] memory sharesToReturn = new uint256[](1);
-//         sharesToReturn[0] = shares;
-//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//         if (beaconShares <= 0) {
-//             assertEq(
-//                 beaconSharesBefore,
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares should not have increased with negative shares"
-//             );
-//         } else {
-//             assertEq(
-//                 beaconSharesBefore + uint256(beaconShares),
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares not increased correctly"
-//             );
-//         }
-//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         // verify that the salt is still marked as unused (since it wasn't checked or used)
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//     }
-
-//     /**
-//      * @notice `staker` delegates to a operator who does not require any signature verification similar to test above.
-//      * In this scenario, staker doesn't have any delegatable shares and operator shares should not increase. Staker
-//      * should still be correctly delegated to the operator after the call.
-//      */
-//     function testFuzz_OperatorWhoAcceptsAllStakers_ZeroDelegatableShares(
-//         address staker,
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
-//         bytes32 salt
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-
-//         assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         // verify that the salt is still marked as unused (since it wasn't checked or used)
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//     }
-
-//     /**
-//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an invalid expiry on purpose and checking that reversion occurs
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_ExpiredDelegationApproverSignature(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // roll to a very late timestamp
-//         cheats.roll(type(uint256).max / 2);
-//         // filter to only *invalid* `expiry` values
-//         cheats.assume(expiry < block.timestamp);
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but undelegating after delegating and trying the same approveSignature
-//      * and checking that reversion occurs with the same salt
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_PreviouslyUsedSalt(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         // staker also must not be the delegationApprover so that signature verification process takes place
-//         cheats.assume(staker != defaultOperator);
-//         cheats.assume(staker != delegationApprover);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, undelegate, and then try to delegate again with same approversalt
-//         // to check that call reverts
-//         cheats.startPrank(staker);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         assertTrue(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent not spent?"
-//         );
-//         delegationManager.undelegate(staker);
-//         cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an incorrect signature on purpose and checking that reversion occurs
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_WithBadSignature(
-//         address staker,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // calculate the signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         approverSignatureAndExpiry.expiry = expiry;
-//         {
-//             bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
-//                 staker,
-//                 defaultOperator,
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 emptySalt,
-//                 expiry
-//             );
-//             (uint8 v, bytes32 r, bytes32 s) = cheats.sign(delegationSignerPrivateKey, digestHash);
-//             // mess up the signature by flipping v's parity
-//             v = (v == 27 ? 28 : 27);
-//             approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
-//         }
-
-//         // try to delegate from the `staker` to the operator, and check reversion
-//         cheats.startPrank(staker);
-//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoRequiresECDSASignature(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Operator shares should increase by the amount of shares delegated
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoRequiresECDSASignature_StrategyManagerShares(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // Set staker shares in StrategyManager
-//         IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//         strategiesToReturn[0] = strategyMock;
-//         uint256[] memory sharesToReturn = new uint256[](1);
-//         sharesToReturn[0] = shares;
-//         strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Operator beaconShares should increase by the amount of shares delegated if beaconShares > 0
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainStrategyShares(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // Set staker shares in BeaconChainStrategy
-//         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//         if (beaconShares <= 0) {
-//             assertEq(
-//                 beaconSharesBefore,
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares should not have increased with negative shares"
-//             );
-//         } else {
-//             assertEq(
-//                 beaconSharesBefore + uint256(beaconShares),
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares not increased correctly"
-//             );
-//         }
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-//      * via the `staker` calling `DelegationManager.delegateTo`
-//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Operator beaconshares should increase by the amount of beaconShares delegated if beaconShares > 0
-//      * Operator strategy manager shares should icnrease by amount of shares
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainAndStrategyManagerShares(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // Set staker shares in BeaconChainStrategy and StrategyMananger
-//         {
-//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//             strategiesToReturn[0] = strategyMock;
-//             uint256[] memory sharesToReturn = new uint256[](1);
-//             sharesToReturn[0] = shares;
-//             strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
-//             eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
-//         }
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//         if (beaconShares <= 0) {
-//             assertEq(
-//                 beaconSharesBefore,
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares should not have increased with negative shares"
-//             );
-//         } else {
-//             assertEq(
-//                 beaconSharesBefore + uint256(beaconShares),
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares not increased correctly"
-//             );
-//         }
-//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-//         if (staker == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-//     }
-
-//     /**
-//      * @notice delegateTo test with operator's delegationApprover address set to a contract address
-//      * and check that reversion occurs when the signature is expired
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_ExpiredDelegationApproverSignature(
-//         address staker,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // roll to a very late timestamp
-//         cheats.roll(type(uint256).max / 2);
-//         // filter to only *invalid* `expiry` values
-//         cheats.assume(expiry < block.timestamp);
-
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // create the signature struct
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         approverSignatureAndExpiry.expiry = expiry;
-
-//         // try to delegate from the `staker` to the operator, and check reversion
-//         cheats.startPrank(staker);
-//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice delegateTo test with operator's delegationApprover address set to a contract address
-//      * and check that reversion occurs when the signature approverSalt is already used.
-//      * Performed by delegating to operator, undelegating, and trying to reuse the same signature
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_PreviouslyUsedSalt(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         ERC1271WalletMock wallet = _registerOperatorWith1271DelegationApprover(defaultOperator);
-//         cheats.assume(staker != address(wallet) && staker != defaultOperator);
-
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         delegationManager.undelegate(staker);
-//         // Reusing same signature should revert with salt already being used
-//         cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice delegateTo test with operator's delegationApprover address set to a contract address that
-//      * is non compliant with EIP1271
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_NonCompliantWallet(
-//         address staker,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         // deploy a ERC1271MaliciousMock contract that will return an incorrect value when called
-//         ERC1271MaliciousMock wallet = new ERC1271MaliciousMock();
-
-//         // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
-//         // then we don't even trigger the signature verification call, so we won't get a revert as expected
-//         cheats.assume(staker != address(wallet));
-
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: defaultOperator,
-//             delegationApprover: address(wallet),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-//         // create the signature struct
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         approverSignatureAndExpiry.expiry = expiry;
-
-//         // try to delegate from the `staker` to the operator, and check reversion
-//         cheats.startPrank(staker);
-//         // because the ERC1271MaliciousMock contract returns the wrong amount of data, we get a low-level "EvmError: Revert" message here rather than the error message bubbling up
-//         cheats.expectRevert();
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice delegateTo test with operator's delegationApprover address set to a contract address that
-//      * returns a value other than the EIP1271 "magic bytes" and checking that reversion occurs appropriately
-//      */
-//     function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_IsValidSignatureFails(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         // deploy a ERC1271WalletMock contract that will return an incorrect value when called
-//         // owner is the 0 address
-//         ERC1271WalletMock wallet = new ERC1271WalletMock(address(1));
-
-//         // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
-//         // then we don't even trigger the signature verification call, so we won't get a revert as expected
-//         cheats.assume(staker != address(wallet));
-
-//         IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
-//             earningsReceiver: defaultOperator,
-//             delegationApprover: address(wallet),
-//             stakerOptOutWindowBlocks: 0
-//         });
-//         _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
-
-//         // calculate the delegationSigner's but this is not the correct signature from the wallet contract
-//         // since the wallet owner is address(1)
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // try to delegate from the `staker` to the operator, and check reversion
-//         cheats.startPrank(staker);
-//         // Signature should fail as the wallet will not return EIP1271_MAGICVALUE
-//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice `staker` delegates to an operator who requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
-//      * set to a nonzero and code-containing address) via the `staker` calling `DelegationManager.delegateTo`
-//      * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
-//      * OR if called by the operator or their delegationApprover themselves
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_OperatorWhoRequiresEIP1271Signature(
-//         address staker,
-//         bytes32 salt,
-//         uint256 expiry
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-
-//         // register *this contract* as an operator
-//         // filter inputs, since this will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         _registerOperatorWith1271DelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             staker,
-//             defaultOperator,
-//             salt,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator
-//         cheats.startPrank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(staker, defaultOperator);
-//         delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
-//         cheats.stopPrank();
-
-//         assertTrue(delegationManager.isDelegated(staker), "staker not delegated correctly");
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
-//         assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
-
-//         // check that the nonce incremented appropriately
-//         if (staker == defaultOperator || staker == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-//     }
-// }
-
-// contract DelegationManagerUnitTests_delegateToBySignature is DelegationManagerUnitTests {
-//     function test_revert_paused() public {
-//         // set the pausing flag
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
-
-//         uint256 expiry = type(uint256).max;
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.delegateToBySignature(
-//             defaultStaker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//     }
-
-//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's signature has expired
-//     function testFuzz_Revert_WhenStakerSignatureExpired(
-//         address staker,
-//         address operator,
-//         uint256 expiry,
-//         bytes memory signature
-//     ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
-//         cheats.assume(expiry < block.timestamp);
-//         cheats.expectRevert("DelegationManager.delegateToBySignature: staker signature expired");
-//         ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = ISignatureUtils.SignatureWithExpiry({
-//             signature: signature,
-//             expiry: expiry
-//         });
-//         delegationManager.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, emptySalt);
-//     }
-
-//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's ECDSA signature verification fails
-//     function test_Revert_EOAStaker_WhenStakerSignatureVerificationFails() public {
-//         address invalidStaker = address(1000);
-//         address caller = address(2000);
-//         uint256 expiry = type(uint256).max;
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         // Should revert from invalid signature as staker is not set as the address of signer
-//         cheats.startPrank(caller);
-//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
-//         // use an empty approver signature input since none is needed / the input is unchecked
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateToBySignature(
-//             invalidStaker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//         cheats.stopPrank();
-//     }
-
-//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's contract signature verification fails
-//     function test_Revert_ERC1271Staker_WhenStakerSignatureVerficationFails() public {
-//         address staker = address(new ERC1271WalletMock(address(1)));
-//         address caller = address(2000);
-//         uint256 expiry = type(uint256).max;
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         // Should revert from invalid signature as staker is not set as the address of signer
-//         cheats.startPrank(caller);
-//         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
-//         // use an empty approver signature input since none is needed / the input is unchecked
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateToBySignature(
-//             staker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//         cheats.stopPrank();
-//     }
-
-//     /// @notice Checks that `DelegationManager.delegateToBySignature` reverts when the staker is already delegated
-//     function test_Revert_Staker_WhenAlreadyDelegated() public {
-//         address staker = cheats.addr(stakerPrivateKey);
-//         address caller = address(2000);
-//         uint256 expiry = type(uint256).max;
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         // Should revert as `staker` has already delegated to `operator`
-//         cheats.startPrank(caller);
-//         cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
-//         // use an empty approver signature input since none is needed / the input is unchecked
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateToBySignature(
-//             staker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//         cheats.stopPrank();
-//     }
-
-//     /// @notice Checks that `delegateToBySignature` reverts when operator is not registered after successful staker signature verification
-//     function test_Revert_EOAStaker_OperatorNotRegistered() public {
-//         address staker = cheats.addr(stakerPrivateKey);
-//         address caller = address(2000);
-//         uint256 expiry = type(uint256).max;
-
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         // Should revert as `operator` is not registered
-//         cheats.startPrank(caller);
-//         cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
-//         // use an empty approver signature input since none is needed / the input is unchecked
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
-//         delegationManager.delegateToBySignature(
-//             staker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice Checks that `DelegationManager.delegateToBySignature` reverts if the delegationApprover's signature has expired
-//      * after successful staker signature verification
-//      */
-//     function testFuzz_Revert_WhenDelegationApproverSignatureExpired(
-//         address caller,
-//         uint256 stakerExpiry,
-//         uint256 delegationApproverExpiry
-//     ) public filterFuzzedAddressInputs(caller) {
-//         // filter to only valid `stakerExpiry` values
-//         cheats.assume(stakerExpiry >= block.timestamp);
-//         // roll to a very late timestamp
-//         cheats.roll(type(uint256).max / 2);
-//         // filter to only *invalid* `delegationApproverExpiry` values
-//         cheats.assume(delegationApproverExpiry < block.timestamp);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // calculate the delegationSigner's signature
-//         ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
-//             delegationSignerPrivateKey,
-//             defaultStaker,
-//             defaultOperator,
-//             emptySalt,
-//             delegationApproverExpiry
-//         );
-
-//         // calculate the staker signature
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             stakerExpiry
-//         );
-
-//         // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
-//         cheats.startPrank(caller);
-//         cheats.expectRevert("DelegationManager._delegate: approver signature expired");
-//         delegationManager.delegateToBySignature(
-//             defaultStaker,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             approverSignatureAndExpiry,
-//             emptySalt
-//         );
-//         cheats.stopPrank();
-//     }
-
-//     /**
-//      * @notice `staker` becomes delegated to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
-//      * via the `caller` calling `DelegationManager.delegateToBySignature`
-//      * The function should pass with any `operatorSignature` input (since it should be unused)
-//      * The function should pass only with a valid `stakerSignatureAndExpiry` input
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * BeaconChainStrategy and StrategyManager operator shares should increase for operator
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(
-//         address caller,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         cheats.assume(expiry >= block.timestamp);
-//         cheats.assume(shares > 0);
-
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 emptySalt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         {
-//             // Set staker shares in BeaconChainStrategy and StrategyMananger
-//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//             strategiesToReturn[0] = strategyMock;
-//             uint256[] memory sharesToReturn = new uint256[](1);
-//             sharesToReturn[0] = shares;
-//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-//         }
-
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-//         // fetch the staker's current nonce
-//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-//         // calculate the staker signature
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(defaultStaker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         _delegateToBySignatureOperatorWhoAcceptsAllStakers(
-//             defaultStaker,
-//             caller,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             emptySalt
-//         );
-
-//         // Check operator shares increases
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//         if (beaconShares <= 0) {
-//             assertEq(
-//                 beaconSharesBefore,
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares should not have increased with negative shares"
-//             );
-//         } else {
-//             assertEq(
-//                 beaconSharesBefore + uint256(beaconShares),
-//                 beaconSharesAfter,
-//                 "operator beaconchain shares not increased correctly"
-//             );
-//         }
-//         assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         // check all the delegation status changes
-//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-//         assertEq(
-//             delegationManager.delegatedTo(defaultStaker),
-//             defaultOperator,
-//             "staker delegated to the wrong address"
-//         );
-//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-//         // check that the staker nonce incremented appropriately
-//         assertEq(
-//             delegationManager.stakerNonce(defaultStaker),
-//             currentStakerNonce + 1,
-//             "staker nonce did not increment"
-//         );
-//         // verify that the salt is still marked as unused (since it wasn't checked or used)
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 emptySalt
-//             ),
-//             "salt somehow spent too incorrectly?"
-//         );
-//     }
-
-//     /**
-//      * @notice `staker` becomes delegated to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
-//      * via the `caller` calling `DelegationManager.delegateToBySignature`
-//      * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
-//      * AND with a valid `stakerSignatureAndExpiry` input
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * BeaconChainStrategy and StrategyManager operator shares should increase for operator
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(
-//         address caller,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         // filter to only valid `expiry` values
-//         cheats.assume(expiry >= block.timestamp);
-//         cheats.assume(shares > 0);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         {
-//             // Set staker shares in BeaconChainStrategy and StrategyMananger
-//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//             strategiesToReturn[0] = strategyMock;
-//             uint256[] memory sharesToReturn = new uint256[](1);
-//             sharesToReturn[0] = shares;
-//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-//         }
-
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-//         // fetch the staker's current nonce
-//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-//         // calculate the staker signature
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(defaultStaker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         _delegateToBySignatureOperatorWhoRequiresSig(
-//             defaultStaker,
-//             caller,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             salt
-//         );
-//         {
-//             // Check operator shares increases
-//             uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//             uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//             if (beaconShares <= 0) {
-//                 assertEq(
-//                     beaconSharesBefore,
-//                     beaconSharesAfter,
-//                     "operator beaconchain shares should not have increased with negative shares"
-//                 );
-//             } else {
-//                 assertEq(
-//                     beaconSharesBefore + uint256(beaconShares),
-//                     beaconSharesAfter,
-//                     "operator beaconchain shares not increased correctly"
-//                 );
-//             }
-//             assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         }
-//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-//         assertEq(
-//             delegationManager.delegatedTo(defaultStaker),
-//             defaultOperator,
-//             "staker delegated to the wrong address"
-//         );
-//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-
-//         // check that the delegationApprover nonce incremented appropriately
-//         if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-
-//         // check that the staker nonce incremented appropriately
-//         assertEq(
-//             delegationManager.stakerNonce(defaultStaker),
-//             currentStakerNonce + 1,
-//             "staker nonce did not increment"
-//         );
-//     }
-
-//     /**
-//      * @notice `staker` becomes delegated to an operatorwho requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
-//      * set to a nonzero and code-containing address) via the `caller` calling `DelegationManager.delegateToBySignature`
-//      * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
-//      * OR if called by the operator or their delegationApprover themselves
-//      * AND with a valid `stakerSignatureAndExpiry` input
-//      * Properly emits a `StakerDelegated` event
-//      * Staker is correctly delegated after the call (i.e. correct storage update)
-//      * Reverts if the staker is already delegated (to the operator or to anyone else)
-//      * Reverts if the ‘operator’ is not actually registered as an operator
-//      */
-//     function testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(
-//         address caller,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         cheats.assume(expiry >= block.timestamp);
-//         cheats.assume(shares > 0);
-
-//         _registerOperatorWith1271DelegationApprover(defaultOperator);
-
-//         // verify that the salt hasn't been used before
-//         assertFalse(
-//             delegationManager.delegationApproverSaltIsSpent(
-//                 delegationManager.delegationApprover(defaultOperator),
-//                 salt
-//             ),
-//             "salt somehow spent too early?"
-//         );
-//         {
-//             // Set staker shares in BeaconChainStrategy and StrategyMananger
-//             IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-//             strategiesToReturn[0] = strategyMock;
-//             uint256[] memory sharesToReturn = new uint256[](1);
-//             sharesToReturn[0] = shares;
-//             strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
-//             eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
-//         }
-
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
-//         uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
-//         // fetch the staker's current nonce
-//         uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
-//         // calculate the staker signature
-//         ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
-//             stakerPrivateKey,
-//             defaultOperator,
-//             expiry
-//         );
-
-//         // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerDelegated(defaultStaker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
-//         if (beaconShares > 0) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
-//         }
-//         _delegateToBySignatureOperatorWhoRequiresSig(
-//             defaultStaker,
-//             caller,
-//             defaultOperator,
-//             stakerSignatureAndExpiry,
-//             salt
-//         );
-
-//         {
-//             // Check operator shares increases
-//             uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
-//             uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
-//             if (beaconShares <= 0) {
-//                 assertEq(
-//                     beaconSharesBefore,
-//                     beaconSharesAfter,
-//                     "operator beaconchain shares should not have increased with negative shares"
-//                 );
-//             } else {
-//                 assertEq(
-//                     beaconSharesBefore + uint256(beaconShares),
-//                     beaconSharesAfter,
-//                     "operator beaconchain shares not increased correctly"
-//                 );
-//             }
-//             assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
-//         }
-//         assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
-//         assertEq(
-//             delegationManager.delegatedTo(defaultStaker),
-//             defaultOperator,
-//             "staker delegated to the wrong address"
-//         );
-//         assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
-
-//         // check that the delegationApprover nonce incremented appropriately
-//         if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
-//             // verify that the salt is still marked as unused (since it wasn't checked or used)
-//             assertFalse(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent too incorrectly?"
-//             );
-//         } else {
-//             // verify that the salt is marked as used
-//             assertTrue(
-//                 delegationManager.delegationApproverSaltIsSpent(
-//                     delegationManager.delegationApprover(defaultOperator),
-//                     salt
-//                 ),
-//                 "salt somehow spent not spent?"
-//             );
-//         }
-
-//         // check that the staker nonce incremented appropriately
-//         assertEq(
-//             delegationManager.stakerNonce(defaultStaker),
-//             currentStakerNonce + 1,
-//             "staker nonce did not increment"
-//         );
-//     }
-
-//     /**
-//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-//      * Generates valid signatures from the staker to delegate to operator `defaultOperator`
-//      */
-//     function testFuzz_ERC1271Staker_OperatorWhoAcceptsAllStakers(
-//         address caller,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-//         testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(caller, expiry, beaconShares, shares);
-//     }
-
-//     /**
-//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-//      * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
-//      * a delegationApprover address set to a nonzero EOA
-//      */
-//     function testFuzz_ERC1271Staker_OperatorWhoRequiresECDSASignature(
-//         address caller,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         // Call same test but with the staker address being a ERC1271WalletMock
-//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-//         testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(caller, salt, expiry, beaconShares, shares);
-//     }
-
-//     /**
-//      * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
-//      * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
-//      * a delegationApprover address set to a nonzero ERC1271 compliant contract
-//      */
-//     function testFuzz_ERC1271Staker_OperatorWhoRequiresEIP1271Signature(
-//         address caller,
-//         bytes32 salt,
-//         uint256 expiry,
-//         int256 beaconShares,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(caller) {
-//         // Call same test but with the staker address being a ERC1271WalletMock
-//         defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
-//         testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(caller, salt, expiry, beaconShares, shares);
-//     }
-// }
-
-// contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTests {
-//     // @notice Verifies that `DelegationManager.increaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
-//     function testFuzz_increaseDelegatedShares_revert_invalidCaller(
-//         address invalidCaller,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(invalidCaller) {
-//         cheats.assume(invalidCaller != address(strategyManagerMock));
-//         cheats.assume(invalidCaller != address(eigenPodManagerMock));
-//         cheats.assume(invalidCaller != address(eigenLayerProxyAdmin));
-
-//         cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
-//         delegationManager.increaseDelegatedShares(invalidCaller, strategyMock, shares);
-//     }
-
-//     // @notice Verifies that there is no change in shares if the staker is not delegated
-//     function testFuzz_increaseDelegatedShares_noop(address staker) public {
-//         cheats.assume(staker != defaultOperator);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         assertFalse(delegationManager.isDelegated(staker), "bad test setup");
-
-//         cheats.prank(address(strategyManagerMock));
-//         delegationManager.increaseDelegatedShares(staker, strategyMock, 1);
-//         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.increaseDelegatedShares` properly increases the delegated `shares` that the operator
-//      * who the `staker` is delegated to has in the strategy
-//      * @dev Checks that there is no change if the staker is not delegated
-//      */
-//     function testFuzz_increaseDelegatedShares(
-//         address staker,
-//         uint256 shares,
-//         bool delegateFromStakerToOperator
-//     ) public {
-//         // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
-//         cheats.assume(staker != defaultOperator);
-
-//         // Register operator
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
-//         if (delegateFromStakerToOperator) {
-//             _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         }
-
-//         uint256 _delegatedSharesBefore = delegationManager.operatorShares(
-//             delegationManager.delegatedTo(staker),
-//             strategyMock
-//         );
-
-//         if (delegationManager.isDelegated(staker)) {
-//             cheats.expectEmit(true, true, true, true, address(delegationManager));
-//             emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
-//         }
-
-//         cheats.prank(address(strategyManagerMock));
-//         delegationManager.increaseDelegatedShares(staker, strategyMock, shares);
-
-//         uint256 delegatedSharesAfter = delegationManager.operatorShares(
-//             delegationManager.delegatedTo(staker),
-//             strategyMock
-//         );
-
-//         if (delegationManager.isDelegated(staker)) {
-//             assertEq(
-//                 delegatedSharesAfter,
-//                 _delegatedSharesBefore + shares,
-//                 "delegated shares did not increment correctly"
-//             );
-//         } else {
-//             assertEq(delegatedSharesAfter, _delegatedSharesBefore, "delegated shares incremented incorrectly");
-//             assertEq(_delegatedSharesBefore, 0, "nonzero shares delegated to zero address!");
-//         }
-//     }
-
-//     // @notice Verifies that `DelegationManager.decreaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
-//     function testFuzz_decreaseDelegatedShares_revert_invalidCaller(
-//         address invalidCaller,
-//         uint256 shares
-//     ) public filterFuzzedAddressInputs(invalidCaller) {
-//         cheats.assume(invalidCaller != address(strategyManagerMock));
-//         cheats.assume(invalidCaller != address(eigenPodManagerMock));
-
-//         cheats.startPrank(invalidCaller);
-//         cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
-//         delegationManager.decreaseDelegatedShares(invalidCaller, strategyMock, shares);
-//     }
-
-//     // @notice Verifies that there is no change in shares if the staker is not delegated
-//     function testFuzz_decreaseDelegatedShares_noop(address staker) public {
-//         cheats.assume(staker != defaultOperator);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         assertFalse(delegationManager.isDelegated(staker), "bad test setup");
-
-//         cheats.prank(address(strategyManagerMock));
-//         delegationManager.decreaseDelegatedShares(staker, strategyMock, 1);
-//         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.decreaseDelegatedShares` properly decreases the delegated `shares` that the operator
-//      * who the `staker` is delegated to has in the strategies
-//      * @dev Checks that there is no change if the staker is not delegated
-//      */
-//     function testFuzz_decreaseDelegatedShares(
-//         address staker,
-//         IStrategy[] memory strategies,
-//         uint128 shares,
-//         bool delegateFromStakerToOperator
-//     ) public filterFuzzedAddressInputs(staker) {
-//         // sanity-filtering on fuzzed input length & staker
-//         cheats.assume(strategies.length <= 32);
-//         cheats.assume(staker != defaultOperator);
-
-//         // Register operator
-//         _registerOperatorWithBaseDetails(defaultOperator);
-
-//         // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
-//         if (delegateFromStakerToOperator) {
-//             _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         }
-
-//         uint256[] memory sharesInputArray = new uint256[](strategies.length);
-
-//         address delegatedTo = delegationManager.delegatedTo(staker);
-
-//         // for each strategy in `strategies`, increase delegated shares by `shares`
-//         // noop if the staker is not delegated
-//         cheats.startPrank(address(strategyManagerMock));
-//         for (uint256 i = 0; i < strategies.length; ++i) {
-//             delegationManager.increaseDelegatedShares(staker, strategies[i], shares);
-//             // store delegated shares in a mapping
-//             delegatedSharesBefore[strategies[i]] = delegationManager.operatorShares(delegatedTo, strategies[i]);
-//             // also construct an array which we'll use in another loop
-//             sharesInputArray[i] = shares;
-//             totalSharesForStrategyInArray[address(strategies[i])] += sharesInputArray[i];
-//         }
-//         cheats.stopPrank();
-
-//         bool isDelegated = delegationManager.isDelegated(staker);
-
-//         // for each strategy in `strategies`, decrease delegated shares by `shares`
-//         {
-//             cheats.startPrank(address(strategyManagerMock));
-//             address operatorToDecreaseSharesOf = delegationManager.delegatedTo(staker);
-//             if (isDelegated) {
-//                 for (uint256 i = 0; i < strategies.length; ++i) {
-//                     cheats.expectEmit(true, true, true, true, address(delegationManager));
-//                     emit OperatorSharesDecreased(
-//                         operatorToDecreaseSharesOf,
-//                         staker,
-//                         strategies[i],
-//                         sharesInputArray[i]
-//                     );
-//                     delegationManager.decreaseDelegatedShares(staker, strategies[i], sharesInputArray[i]);
-//                 }
-//             }
-//             cheats.stopPrank();
-//         }
-
-//         // check shares after call to `decreaseDelegatedShares`
-//         for (uint256 i = 0; i < strategies.length; ++i) {
-//             uint256 delegatedSharesAfter = delegationManager.operatorShares(delegatedTo, strategies[i]);
-
-//             if (isDelegated) {
-//                 assertEq(
-//                     delegatedSharesAfter + totalSharesForStrategyInArray[address(strategies[i])],
-//                     delegatedSharesBefore[strategies[i]],
-//                     "delegated shares did not decrement correctly"
-//                 );
-//                 assertEq(delegatedSharesAfter, 0, "nonzero shares delegated to");
-//             } else {
-//                 assertEq(
-//                     delegatedSharesAfter,
-//                     delegatedSharesBefore[strategies[i]],
-//                     "delegated shares decremented incorrectly"
-//                 );
-//                 assertEq(delegatedSharesBefore[strategies[i]], 0, "nonzero shares delegated to zero address!");
-//             }
-//         }
-//     }
-// }
-
-// contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
-//     // @notice Verifies that undelegating is not possible when the "undelegation paused" switch is flipped
-//     function test_undelegate_revert_paused(address staker) public filterFuzzedAddressInputs(staker) {
-//         // set the pausing flag
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
-
-//         cheats.prank(staker);
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.undelegate(staker);
-//     }
-
-//     function testFuzz_undelegate_revert_notDelgated(
-//         address undelegatedStaker
-//     ) public filterFuzzedAddressInputs(undelegatedStaker) {
-//         cheats.assume(undelegatedStaker != defaultOperator);
-//         assertFalse(delegationManager.isDelegated(undelegatedStaker), "bad test setup");
-
-//         cheats.prank(undelegatedStaker);
-//         cheats.expectRevert("DelegationManager.undelegate: staker must be delegated to undelegate");
-//         delegationManager.undelegate(undelegatedStaker);
-//     }
-
-//     // @notice Verifies that an operator cannot undelegate from themself (this should always be forbidden)
-//     function testFuzz_undelegate_revert_stakerIsOperator(address operator) public filterFuzzedAddressInputs(operator) {
-//         _registerOperatorWithBaseDetails(operator);
-
-//         cheats.prank(operator);
-//         cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
-//         delegationManager.undelegate(operator);
-//     }
-
-//     /**
-//      * @notice verifies that `DelegationManager.undelegate` reverts if trying to undelegate an operator from themselves
-//      * @param callFromOperatorOrApprover -- calls from the operator if 'false' and the 'approver' if true
-//      */
-//     function testFuzz_undelegate_operatorCannotForceUndelegateThemself(
-//         address delegationApprover,
-//         bool callFromOperatorOrApprover
-//     ) public {
-//         // register *this contract* as an operator with the default `delegationApprover`
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-
-//         address caller;
-//         if (callFromOperatorOrApprover) {
-//             caller = delegationApprover;
-//         } else {
-//             caller = defaultOperator;
-//         }
-
-//         // try to call the `undelegate` function and check for reversion
-//         cheats.prank(caller);
-//         cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
-//         delegationManager.undelegate(defaultOperator);
-//     }
-
-//     //TODO: verify that this check is even needed
-//     function test_undelegate_revert_zeroAddress() public {
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         _delegateToOperatorWhoAcceptsAllStakers(address(0), defaultOperator);
-
-//         cheats.prank(address(0));
-//         cheats.expectRevert("DelegationManager.undelegate: cannot undelegate zero address");
-//         delegationManager.undelegate(address(0));
-//     }
-
-//     /**
-//      * @notice Verifies that the `undelegate` function has proper access controls (can only be called by the operator who the `staker` has delegated
-//      * to or the operator's `delegationApprover`), or the staker themselves
-//      */
-//     function testFuzz_undelegate_revert_invalidCaller(
-//         address invalidCaller
-//     ) public filterFuzzedAddressInputs(invalidCaller) {
-//         address staker = address(0x123);
-//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-//         // filter out addresses that are actually allowed to call the function
-//         cheats.assume(invalidCaller != staker);
-//         cheats.assume(invalidCaller != defaultOperator);
-//         cheats.assume(invalidCaller != delegationApprover);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-//         _delegateToOperatorWhoRequiresSig(staker, defaultOperator);
-
-//         cheats.prank(invalidCaller);
-//         cheats.expectRevert("DelegationManager.undelegate: caller cannot undelegate staker");
-//         delegationManager.undelegate(staker);
-//     }
-
-//     /**
-//      * Staker is undelegated from an operator, via a call to `undelegate`, properly originating from the staker's address.
-//      * Reverts if the staker is themselves an operator (i.e. they are delegated to themselves)
-//      * Does nothing if the staker is already undelegated
-//      * Properly undelegates the staker, i.e. the staker becomes “delegated to” the zero address, and `isDelegated(staker)` returns ‘false’
-//      * Emits a `StakerUndelegated` event
-//      */
-//     function testFuzz_undelegate_noDelegateableShares(address staker) public filterFuzzedAddressInputs(staker) {
-//         // register *this contract* as an operator and delegate from the `staker` to them
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerUndelegated(staker, delegationManager.delegatedTo(staker));
-//         cheats.prank(staker);
-//         bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
-
-//         assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
-//         assertEq(
-//             delegationManager.delegatedTo(staker),
-//             address(0),
-//             "undelegated staker should be delegated to zero address"
-//         );
-//         assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
-//     }
-
-//     /**
-//      * @notice Verifies that the `undelegate` function allows for a force undelegation
-//      */
-//     function testFuzz_undelegate_forceUndelegation_noDelegateableShares(
-//         address staker,
-//         bytes32 salt,
-//         bool callFromOperatorOrApprover
-//     ) public filterFuzzedAddressInputs(staker) {
-//         cheats.assume(staker != defaultOperator);
-//         address delegationApprover = cheats.addr(delegationSignerPrivateKey);
-
-//         _registerOperatorWithDelegationApprover(defaultOperator);
-//         _delegateToOperatorWhoRequiresSig(staker, defaultOperator, salt);
-
-//         address caller;
-//         if (callFromOperatorOrApprover) {
-//             caller = delegationApprover;
-//         } else {
-//             caller = defaultOperator;
-//         }
-
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerForceUndelegated(staker, defaultOperator);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit StakerUndelegated(staker, defaultOperator);
-//         cheats.prank(caller);
-//         bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
-
-//         assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
-//         assertEq(
-//             delegationManager.delegatedTo(staker),
-//             address(0),
-//             "undelegated staker should be delegated to zero address"
-//         );
-//         assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
-//     }
-// }
-
-// contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTests {
-//     function test_Revert_WhenEnterQueueWithdrawalsPaused() public {
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
-//         (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
-//             staker: defaultStaker,
-//             withdrawer: defaultStaker,
-//             strategy: strategyMock,
-//             withdrawalAmount: 100
-//         });
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-//     }
-
-//     function test_Revert_WhenQueueWithdrawalParamsLengthMismatch() public {
-//         IStrategy[] memory strategyArray = new IStrategy[](1);
-//         strategyArray[0] = strategyMock;
-//         uint256[] memory shareAmounts = new uint256[](2);
-//         shareAmounts[0] = 100;
-//         shareAmounts[1] = 100;
-
-//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-//             strategies: strategyArray,
-//             shares: shareAmounts,
-//             withdrawer: defaultStaker
-//         });
-
-//         cheats.expectRevert("DelegationManager.queueWithdrawal: input length mismatch");
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-//     }
-
-//     function test_Revert_WhenZeroAddressWithdrawer() public {
-//         (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
-//             staker: defaultStaker,
-//             withdrawer: address(0),
-//             strategy: strategyMock,
-//             withdrawalAmount: 100
-//         });
-//         cheats.expectRevert("DelegationManager.queueWithdrawal: must provide valid withdrawal address");
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-//     }
-
-//     function test_Revert_WhenEmptyStrategiesArray() public {
-//         IStrategy[] memory strategyArray = new IStrategy[](0);
-//         uint256[] memory shareAmounts = new uint256[](0);
-//         address withdrawer = defaultOperator;
-
-//         IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
-//         queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
-//             strategies: strategyArray,
-//             shares: shareAmounts,
-//             withdrawer: withdrawer
-//         });
-
-//         cheats.expectRevert("DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
-//      * from the `strategy` for the `sharesAmount`. 
-//      * - Asserts that staker is delegated to the operator
-//      * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
-//      * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
-//      * - Checks that event was emitted with correct withdrawalRoot and withdrawal
-//      */
-//     function testFuzz_queueWithdrawal_SingleStrat(
-//         address staker,
-//         uint256 depositAmount,
-//         uint256 withdrawalAmount
-//     ) public filterFuzzedAddressInputs(staker) {
-//         cheats.assume(staker != defaultOperator);
-//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-//         uint256[] memory sharesAmounts = new uint256[](1);
-//         sharesAmounts[0] = depositAmount;
-//         // sharesAmounts is single element so returns single strategy
-//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, sharesAmounts);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         (
-//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             bytes32 withdrawalRoot
-//         ) = _setUpQueueWithdrawalsSingleStrat({
-//             staker: staker,
-//             withdrawer: staker,
-//             strategy: strategies[0],
-//             withdrawalAmount: withdrawalAmount
-//         });
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
-//         uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
-//         uint256 delegatedSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[0]);
-
-//         // queueWithdrawals
-//         cheats.prank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit WithdrawalQueued(withdrawalRoot, withdrawal);
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-//         uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
-//         uint256 delegatedSharesAfter = delegationManager.operatorShares(defaultOperator, strategies[0]);
-//         assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
-//         assertEq(delegatedSharesBefore - withdrawalAmount, delegatedSharesAfter, "delegated shares not decreased correctly");
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
-//      * with multiple strategies and sharesAmounts. Depending on length sharesAmounts, deploys corresponding number of strategies
-//      * and deposits sharesAmounts into each strategy for the staker and delegates to operator.
-//      * For each strategy, withdrawAmount <= depositAmount
-//      * - Asserts that staker is delegated to the operator
-//      * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
-//      * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
-//      * - Checks that event was emitted with correct withdrawalRoot and withdrawal
-//      */
-//     function testFuzz_queueWithdrawal_MultipleStrats(
-//         address staker,
-//         uint256[] memory depositAmounts
-//     ) public filterFuzzedAddressInputs(staker){
-//         cheats.assume(depositAmounts.length > 0 && depositAmounts.length <= 32);
-//         uint256[] memory withdrawalAmounts = _fuzzWithdrawalAmounts(depositAmounts);
-
-//         IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         (
-//             IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             bytes32 withdrawalRoot
-//         ) = _setUpQueueWithdrawals({
-//             staker: staker,
-//             withdrawer: staker,
-//             strategies: strategies,
-//             withdrawalAmounts: withdrawalAmounts
-//         });
-//         // Before queueWithdrawal state values
-//         uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
-//         assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
-//         uint256[] memory delegatedSharesBefore = new uint256[](strategies.length);
-//         for (uint256 i = 0; i < strategies.length; i++) {
-//             delegatedSharesBefore[i] = delegationManager.operatorShares(defaultOperator, strategies[i]);
-//         }
-
-//         // queueWithdrawals
-//         cheats.prank(staker);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit WithdrawalQueued(withdrawalRoot, withdrawal);
-//         delegationManager.queueWithdrawals(queuedWithdrawalParams);
-
-//         // Post queueWithdrawal state values
-//         for (uint256 i = 0; i < strategies.length; i++) {
-//             assertEq(
-//                 delegatedSharesBefore[i] - withdrawalAmounts[i], // Shares before - withdrawal amount
-//                 delegationManager.operatorShares(defaultOperator, strategies[i]), // Shares after
-//                 "delegated shares not decreased correctly"
-//             );
-//         }
-//         uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
-//         assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
-//     }
-// }
-
-// contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManagerUnitTests {
-//     function test_Revert_WhenExitWithdrawalQueuePaused() public {
-//         cheats.prank(pauser);
-//         delegationManager.pause(2 ** PAUSED_EXIT_WITHDRAWAL_QUEUE);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             IERC20[] memory tokens,
-//             /* bytes32 withdrawalRoot */
-//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: defaultStaker,
-//             operator: defaultOperator,
-//             withdrawer: defaultStaker,
-//             depositAmount: 100,
-//             withdrawalAmount: 100
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-//         cheats.expectRevert("Pausable: index is paused");
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-//     }
-
-//     function test_Revert_WhenInvalidWithdrawalRoot() public {
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             IERC20[] memory tokens,
-//             bytes32 withdrawalRoot
-//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: defaultStaker,
-//             operator: defaultOperator,
-//             withdrawer: defaultStaker,
-//             depositAmount: 100,
-//             withdrawalAmount: 100
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-//         cheats.prank(defaultStaker);
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-
-//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: action is not in queue");
-//         cheats.prank(defaultStaker);
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-//     }
-
-//     // TODO: Fix withdrawal delay blocks test
-//     // function test_Revert_WhenWithdrawalDelayBlocksNotPassed() public {
-//     //     _registerOperatorWithBaseDetails(defaultOperator);
-//     //     (
-//     //         IDelegationManager.Withdrawal memory withdrawal,
-//     //         IERC20[] memory tokens,
-//     //         /* bytes32 withdrawalRoot */
-//     //     ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//     //         staker: defaultStaker,
-//     //         operator: defaultOperator,
-//     //         withdrawer: defaultStaker,
-//     //         depositAmount: 100,
-//     //         withdrawalAmount: 100
-//     //     });
-//     //     _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-//     //     cheats.expectRevert("DelegationManager.completeQueuedAction: withdrawalDelayBlocks period has not yet passed");
-//     //     delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-//     // }
-
-//     function test_Revert_WhenNotCalledByWithdrawer() public {
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             IERC20[] memory tokens,
-//             bytes32 withdrawalRoot
-//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: defaultStaker,
-//             operator: defaultOperator,
-//             withdrawer: defaultStaker,
-//             depositAmount: 100,
-//             withdrawalAmount: 100
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action");
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-//     }
-
-//     function test_Revert_WhenTokensArrayLengthMismatch() public {
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (IDelegationManager.Withdrawal memory withdrawal, , ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: defaultStaker,
-//             operator: defaultOperator,
-//             withdrawer: defaultStaker,
-//             depositAmount: 100,
-//             withdrawalAmount: 100
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
-
-//         IERC20[] memory tokens = new IERC20[](0);
-//         cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: input length mismatch");
-//         cheats.prank(defaultStaker);
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
-//      * for a single strategy. Withdraws as tokens so there are no operator shares increase.
-//      * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
-//      * - Asserts operatorShares is unchanged after `completeQueuedWithdrawal`
-//      * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
-//      */
-//     function test_completeQueuedWithdrawal_SingleStratWithdrawAsTokens(
-//         address staker,
-//         address withdrawer,
-//         uint256 depositAmount,
-//         uint256 withdrawalAmount
-//     ) public filterFuzzedAddressInputs(staker) {
-//         cheats.assume(staker != defaultOperator);
-//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             IERC20[] memory tokens,
-//             bytes32 withdrawalRoot
-//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: staker,
-//             operator: defaultOperator,
-//             withdrawer: withdrawer,
-//             depositAmount: depositAmount,
-//             withdrawalAmount: withdrawalAmount
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-
-//         // completeQueuedWithdrawal
-//         cheats.prank(withdrawer);
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit WithdrawalCompleted(withdrawalRoot);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
-
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-//         assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
-//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-//     }
-
-//     /**
-//      * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
-//      * for a single strategy. Withdraws as shares so if the withdrawer is delegated, operator shares increase. In the test case, this only
-//      * happens if staker and withdrawer are fuzzed the same address (i.e. staker == withdrawer)
-//      * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
-//      * - Asserts if staker == withdrawer, operatorShares increase, otherwise operatorShares are unchanged
-//      * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
-//      */
-//     function test_completeQueuedWithdrawal_SingleStratWithdrawAsShares(
-//         address staker,
-//         address withdrawer,
-//         uint256 depositAmount,
-//         uint256 withdrawalAmount
-//     ) public filterFuzzedAddressInputs(staker) {
-//         cheats.assume(staker != defaultOperator);
-//         cheats.assume(withdrawer != defaultOperator);
-//         cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
-//         _registerOperatorWithBaseDetails(defaultOperator);
-//         (
-//             IDelegationManager.Withdrawal memory withdrawal,
-//             IERC20[] memory tokens,
-//             bytes32 withdrawalRoot
-//         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
-//             staker: staker,
-//             operator: defaultOperator,
-//             withdrawer: withdrawer,
-//             depositAmount: depositAmount,
-//             withdrawalAmount: withdrawalAmount
-//         });
-//         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-//         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-//         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-
-//         // completeQueuedWithdrawal
-//         cheats.prank(withdrawer);
-//         cheats.roll(block.number + minWithdrawalDelayBlocks);
-//         cheats.expectEmit(true, true, true, true, address(delegationManager));
-//         emit WithdrawalCompleted(withdrawalRoot);
-//         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
-
-//         uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
-//         if (staker == withdrawer) {
-//             // Since staker is delegated, operatorShares get incremented
-//             assertEq(operatorSharesAfter, operatorSharesBefore + withdrawalAmount, "operator shares not increased correctly");
-//         } else {
-//             // Since withdrawer is not the staker and isn't delegated, staker's oeprator shares are unchanged
-//             assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
-//         }
-//         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
-//     }
-// }
+        return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
+    }
+
+    /**
+     * Deploy and deposit staker into a single strategy, then set up a queued withdrawal for the staker
+     * Assumptions: 
+     * - operator is already a registered operator.
+     * - withdrawalAmount <= depositAmount
+     */
+    function _setUpCompleteQueuedWithdrawalSingleStrat(
+        address staker,
+        address operator,
+        address withdrawer,
+        uint256 depositAmount,
+        uint256 withdrawalAmount
+    ) internal returns (IDelegationManager.Withdrawal memory, IERC20[] memory, bytes32) {
+        uint256[] memory depositAmounts = new uint256[](1);
+        depositAmounts[0] = depositAmount;
+        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+        (
+            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            IDelegationManager.Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: staker,
+            withdrawer: withdrawer,
+            strategy: strategies[0],
+            withdrawalAmount: withdrawalAmount
+        });
+
+        cheats.prank(staker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+        // Set the current deposits to be the depositAmount - withdrawalAmount
+        uint256[] memory currentAmounts = new uint256[](1);
+        currentAmounts[0] = depositAmount - withdrawalAmount;
+        strategyManagerMock.setDeposits(staker, strategies, currentAmounts);
+
+        IERC20[] memory tokens = new IERC20[](1);
+        tokens[0] = strategies[0].underlyingToken();
+        return (withdrawal, tokens, withdrawalRoot);
+    }
+
+    /**
+     * Deploy and deposit staker into strategies, then set up a queued withdrawal for the staker
+     * Assumptions: 
+     * - operator is already a registered operator.
+     * - for each i, withdrawalAmount[i] <= depositAmount[i] (see filterFuzzedDepositWithdrawInputs above)
+     */
+    function _setUpCompleteQueuedWithdrawal(
+        address staker,
+        address operator,
+        address withdrawer,
+        uint256[] memory depositAmounts,
+        uint256[] memory withdrawalAmounts
+    ) internal returns (IDelegationManager.Withdrawal memory, bytes32) {
+        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+        (
+            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            IDelegationManager.Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawals({
+            staker: staker,
+            withdrawer: withdrawer,
+            strategies: strategies,
+            withdrawalAmounts: withdrawalAmounts
+        });
+
+        cheats.prank(staker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        return (withdrawal, withdrawalRoot);
+    }
+}
+
+contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerUnitTests {
+    function test_initialization() public {
+        assertEq(
+            address(delegationManager.strategyManager()),
+            address(strategyManagerMock),
+            "constructor / initializer incorrect, strategyManager set wrong"
+        );
+        assertEq(
+            address(delegationManager.slasher()),
+            address(slasherMock),
+            "constructor / initializer incorrect, slasher set wrong"
+        );
+        assertEq(
+            address(delegationManager.pauserRegistry()),
+            address(pauserRegistry),
+            "constructor / initializer incorrect, pauserRegistry set wrong"
+        );
+        assertEq(delegationManager.owner(), address(this), "constructor / initializer incorrect, owner set wrong");
+        assertEq(delegationManager.paused(), 0, "constructor / initializer incorrect, paused status set wrong");
+    }
+
+    /// @notice Verifies that the DelegationManager cannot be iniitalized multiple times
+    function test_initialize_revert_reinitialization() public {
+        cheats.expectRevert("Initializable: contract is already initialized");
+        delegationManager.initialize(
+            address(this),
+            pauserRegistry,
+            0,
+            0, // minWithdrawalDelayBLocks
+            initializeStrategiesToSetDelayBlocks,
+            initializeWithdrawalDelayBlocks
+        );
+    }
+
+    function testFuzz_initialize_Revert_WhenWithdrawalDelayBlocksTooLarge(
+        uint256[] memory withdrawalDelayBlocks,
+        uint256 invalidStrategyIndex
+    ) public {
+        // set withdrawalDelayBlocks to be too large
+        cheats.assume(withdrawalDelayBlocks.length > 0);
+        uint256 numStrats = withdrawalDelayBlocks.length;
+        IStrategy[] memory strategiesToSetDelayBlocks = new IStrategy[](numStrats);
+        for (uint256 i = 0; i < numStrats; i++) {
+            strategiesToSetDelayBlocks[i] = IStrategy(address(uint160(uint256(keccak256(abi.encode(strategyMock, i))))));
+        }
+
+        // set at least one index to be too large for withdrawalDelayBlocks
+        invalidStrategyIndex = invalidStrategyIndex % numStrats;
+        withdrawalDelayBlocks[invalidStrategyIndex] = MAX_WITHDRAWAL_DELAY_BLOCKS + 1;
+
+        // Deploy DelegationManager implmentation and proxy
+        delegationManagerImplementation = new DelegationManager(strategyManagerMock, slasherMock, eigenPodManagerMock);
+        cheats.expectRevert(
+            "DelegationManager._setStrategyWithdrawalDelayBlocks: _withdrawalDelayBlocks cannot be > MAX_WITHDRAWAL_DELAY_BLOCKS"
+        );
+        delegationManager = DelegationManager(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(delegationManagerImplementation),
+                    address(eigenLayerProxyAdmin),
+                    abi.encodeWithSelector(
+                        DelegationManager.initialize.selector,
+                        address(this),
+                        pauserRegistry,
+                        0, // 0 is initialPausedStatus
+                        minWithdrawalDelayBlocks,
+                        strategiesToSetDelayBlocks,
+                        withdrawalDelayBlocks
+                    )
+                )
+            )
+        );
+    }
+}
+
+contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerUnitTests {
+    function test_registerAsOperator_revert_paused() public {
+        // set the pausing flag
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.registerAsOperator(
+            IDelegationManager.OperatorDetails({
+                earningsReceiver: defaultOperator,
+                delegationApprover: address(0),
+                stakerOptOutWindowBlocks: 0
+            }),
+            emptyStringForMetadataURI
+        );
+    }
+
+    // @notice Verifies that someone cannot successfully call `DelegationManager.registerAsOperator(operatorDetails)` again after registering for the first time
+    function testFuzz_registerAsOperator_revert_cannotRegisterMultipleTimes(
+        address operator,
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) public filterFuzzedAddressInputs(operator) {
+        _filterOperatorDetails(operator, operatorDetails);
+
+        // Register once
+        cheats.startPrank(operator);
+        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+
+        // Expect revert when register again
+        cheats.expectRevert("DelegationManager.registerAsOperator: operator has already registered");
+        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice Verifies that an operator cannot register with `earningsReceiver` set to the zero address
+     * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
+     */
+    function testFuzz_registerAsOperator_revert_earningsReceiverZeroAddress() public {
+        IDelegationManager.OperatorDetails memory operatorDetails;
+
+        cheats.prank(defaultOperator);
+        cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
+        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+    }
+
+    /**
+     * @notice Verifies that an operator cannot register with `stakerOptOutWindowBlocks` set larger than `MAX_STAKER_OPT_OUT_WINDOW_BLOCKS`
+     */
+    function testFuzz_registerAsOperator_revert_optOutBlocksTooLarge(
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) public {
+        // filter out zero address since people can't set their earningsReceiver address to the zero address (special test case to verify)
+        cheats.assume(operatorDetails.earningsReceiver != address(0));
+        // filter out *allowed* stakerOptOutWindowBlocks values
+        cheats.assume(operatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
+
+        cheats.prank(defaultOperator);
+        cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS");
+        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+    }
+
+    /**
+     * @notice `operator` registers via calling `DelegationManager.registerAsOperator(operatorDetails, metadataURI)`
+     * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
+     * The set parameters should match the desired parameters (correct storage update)
+     * Operator becomes delegated to themselves
+     * Properly emits events – especially the `OperatorRegistered` event, but also `StakerDelegated` & `OperatorDetailsModified` events
+     * Reverts appropriately if operator was already delegated to someone (including themselves, i.e. they were already an operator)
+     * @param operator and @param operatorDetails are fuzzed inputs
+     */
+    function testFuzz_registerAsOperator(
+        address operator,
+        IDelegationManager.OperatorDetails memory operatorDetails,
+        string memory metadataURI
+    ) public filterFuzzedAddressInputs(operator) {
+        _filterOperatorDetails(operator, operatorDetails);
+
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorDetailsModified(operator, operatorDetails);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(operator, operator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorRegistered(operator, operatorDetails);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorMetadataURIUpdated(operator, metadataURI);
+
+        cheats.prank(operator);
+        delegationManager.registerAsOperator(operatorDetails, metadataURI);
+
+        // Storage checks
+        assertEq(
+            operatorDetails.earningsReceiver,
+            delegationManager.earningsReceiver(operator),
+            "earningsReceiver not set correctly"
+        );
+        assertEq(
+            operatorDetails.delegationApprover,
+            delegationManager.delegationApprover(operator),
+            "delegationApprover not set correctly"
+        );
+        assertEq(
+            operatorDetails.stakerOptOutWindowBlocks,
+            delegationManager.stakerOptOutWindowBlocks(operator),
+            "stakerOptOutWindowBlocks not set correctly"
+        );
+        assertEq(delegationManager.delegatedTo(operator), operator, "operator not delegated to self");
+    }
+
+    // @notice Verifies that a staker who is actively delegated to an operator cannot register as an operator (without first undelegating, at least)
+    function testFuzz_registerAsOperator_cannotRegisterWhileDelegated(
+        address staker,
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        // Staker becomes an operator, so filter against staker's address
+        _filterOperatorDetails(staker, operatorDetails);
+
+        // register *this contract* as an operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+
+        // expect revert if attempt to register as operator
+        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+        delegationManager.registerAsOperator(operatorDetails, emptyStringForMetadataURI);
+
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice Verifies that an operator cannot modify their `earningsReceiver` address to set it to the zero address
+     * @dev This is an important check since we check `earningsReceiver != address(0)` to check if an address is an operator!
+     */
+    function test_modifyOperatorParameters_revert_earningsReceiverZeroAddress() public {
+        // register *this contract* as an operator
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: defaultOperator,
+            delegationApprover: address(0),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+        operatorDetails.earningsReceiver = address(0);
+        cheats.expectRevert("DelegationManager._setOperatorDetails: cannot set `earningsReceiver` to zero address");
+        delegationManager.modifyOperatorDetails(operatorDetails);
+    }
+
+    /**
+     * @notice Tests that an operator can modify their OperatorDetails by calling `DelegationManager.modifyOperatorDetails`
+     * Should be able to set any parameters, other than setting their `earningsReceiver` to the zero address or too high value for `stakerOptOutWindowBlocks`
+     * The set parameters should match the desired parameters (correct storage update)
+     * Properly emits an `OperatorDetailsModified` event
+     * Reverts appropriately if the caller is not an operator
+     * Reverts if operator tries to decrease their `stakerOptOutWindowBlocks` parameter
+     * @param initialOperatorDetails and @param modifiedOperatorDetails are fuzzed inputs
+     */
+    function testFuzz_modifyOperatorParameters(
+        IDelegationManager.OperatorDetails memory initialOperatorDetails,
+        IDelegationManager.OperatorDetails memory modifiedOperatorDetails
+    ) public {
+        // filter out zero address since people can't set their earningsReceiver address to the zero address (test case verified above)
+        cheats.assume(modifiedOperatorDetails.earningsReceiver != address(0));
+
+        _registerOperator(defaultOperator, initialOperatorDetails, emptyStringForMetadataURI);
+
+        cheats.startPrank(defaultOperator);
+
+        // either it fails for trying to set the stakerOptOutWindowBlocks
+        if (modifiedOperatorDetails.stakerOptOutWindowBlocks > delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS()) {
+            cheats.expectRevert(
+                "DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be > MAX_STAKER_OPT_OUT_WINDOW_BLOCKS"
+            );
+            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+            // or the transition is allowed,
+        } else if (
+            modifiedOperatorDetails.stakerOptOutWindowBlocks >= initialOperatorDetails.stakerOptOutWindowBlocks
+        ) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorDetailsModified(defaultOperator, modifiedOperatorDetails);
+            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+
+            assertEq(
+                modifiedOperatorDetails.earningsReceiver,
+                delegationManager.earningsReceiver(defaultOperator),
+                "earningsReceiver not set correctly"
+            );
+            assertEq(
+                modifiedOperatorDetails.delegationApprover,
+                delegationManager.delegationApprover(defaultOperator),
+                "delegationApprover not set correctly"
+            );
+            assertEq(
+                modifiedOperatorDetails.stakerOptOutWindowBlocks,
+                delegationManager.stakerOptOutWindowBlocks(defaultOperator),
+                "stakerOptOutWindowBlocks not set correctly"
+            );
+            assertEq(delegationManager.delegatedTo(defaultOperator), defaultOperator, "operator not delegated to self");
+            // or else the transition is disallowed
+        } else {
+            cheats.expectRevert("DelegationManager._setOperatorDetails: stakerOptOutWindowBlocks cannot be decreased");
+            delegationManager.modifyOperatorDetails(modifiedOperatorDetails);
+        }
+
+        cheats.stopPrank();
+    }
+
+    // @notice Tests that an address which is not an operator cannot successfully call `updateOperatorMetadataURI`.
+    function test_updateOperatorMetadataUri_notRegistered() public {
+        assertFalse(delegationManager.isOperator(defaultOperator), "bad test setup");
+
+        cheats.prank(defaultOperator);
+        cheats.expectRevert("DelegationManager.updateOperatorMetadataURI: caller must be an operator");
+        delegationManager.updateOperatorMetadataURI(emptyStringForMetadataURI);
+    }
+
+    /**
+     * @notice Verifies that a staker cannot call cannot modify their `OperatorDetails` without first registering as an operator
+     * @dev This is an important check to ensure that our definition of 'operator' remains consistent, in particular for preserving the
+     * invariant that 'operators' are always delegated to themselves
+     */
+    function testFuzz_updateOperatorMetadataUri_revert_notOperator(
+        IDelegationManager.OperatorDetails memory operatorDetails
+    ) public {
+        cheats.expectRevert("DelegationManager.modifyOperatorDetails: caller must be an operator");
+        delegationManager.modifyOperatorDetails(operatorDetails);
+    }
+
+    // @notice Tests that an operator who calls `updateOperatorMetadataURI` will correctly see an `OperatorMetadataURIUpdated` event emitted with their input
+    function testFuzz_UpdateOperatorMetadataURI(string memory metadataURI) public {
+        // register *this contract* as an operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // call `updateOperatorMetadataURI` and check for event
+        cheats.prank(defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorMetadataURIUpdated(defaultOperator, metadataURI);
+        delegationManager.updateOperatorMetadataURI(metadataURI);
+    }
+}
+
+contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
+    function test_Revert_WhenPaused() public {
+        // set the pausing flag
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        cheats.prank(defaultStaker);
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+    }
+
+    /**
+     * @notice Delegates from `staker` to an operator, then verifies that the `staker` cannot delegate to another `operator` (at least without first undelegating)
+     */
+    function testFuzz_Revert_WhenDelegateWhileDelegated(
+        address staker,
+        address operator,
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 salt
+    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+        // filter out input since if the staker tries to delegate again after registering as an operator, we will revert earlier than this test is designed to check
+        cheats.assume(staker != operator);
+
+        // delegate from the staker to an operator
+        cheats.assume(operator != address(this));
+        _registerOperatorWithBaseDetails(operator);
+        _delegateToOperatorWhoAcceptsAllStakers(staker, operator);
+
+        // try to delegate again and check that the call reverts
+        cheats.startPrank(staker);
+        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+    }
+
+    // @notice Verifies that `staker` cannot delegate to an unregistered `operator`
+    function testFuzz_Revert_WhenDelegateToUnregisteredOperator(
+        address staker,
+        address operator
+    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+        assertFalse(delegationManager.isOperator(operator), "incorrect test input?");
+
+        // try to delegate and check that the call reverts
+        cheats.startPrank(staker);
+        cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateTo(operator, approverSignatureAndExpiry, emptySalt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass with any `operatorSignature` input (since it should be unused)
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoAcceptsAllStakers_StrategyManagerShares(
+        address staker,
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 salt,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(staker) {
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // Set staker shares in StrategyManager
+        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+        strategiesToReturn[0] = strategyMock;
+        uint256[] memory sharesToReturn = new uint256[](1);
+        sharesToReturn[0] = shares;
+        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+
+        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass with any `operatorSignature` input (since it should be unused)
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * OperatorSharesIncreased event should only be emitted if beaconShares is > 0. Since a staker can have negative shares nothing should happen in that case
+     */
+    function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainStrategyShares(
+        address staker,
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 salt,
+        int256 beaconShares
+    ) public filterFuzzedAddressInputs(staker) {
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // Set staker shares in BeaconChainStrategy
+        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+        if (beaconShares <= 0) {
+            assertEq(
+                beaconSharesBefore,
+                beaconSharesAfter,
+                "operator beaconchain shares should not have increased with negative shares"
+            );
+        } else {
+            assertEq(
+                beaconSharesBefore + uint256(beaconShares),
+                beaconSharesAfter,
+                "operator beaconchain shares not increased correctly"
+            );
+        }
+        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * Similar to tests above but now with staker who has both EigenPod and StrategyManager shares.
+     */
+    function testFuzz_OperatorWhoAcceptsAllStakers_BeaconChainAndStrategyManagerShares(
+        address staker,
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 salt,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(staker) {
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // Set staker shares in BeaconChainStrategy and StrategyMananger
+        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+        strategiesToReturn[0] = strategyMock;
+        uint256[] memory sharesToReturn = new uint256[](1);
+        sharesToReturn[0] = shares;
+        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+        if (beaconShares <= 0) {
+            assertEq(
+                beaconSharesBefore,
+                beaconSharesAfter,
+                "operator beaconchain shares should not have increased with negative shares"
+            );
+        } else {
+            assertEq(
+                beaconSharesBefore + uint256(beaconShares),
+                beaconSharesAfter,
+                "operator beaconchain shares not increased correctly"
+            );
+        }
+        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+    }
+
+    /**
+     * @notice `staker` delegates to a operator who does not require any signature verification similar to test above.
+     * In this scenario, staker doesn't have any delegatable shares and operator shares should not increase. Staker
+     * should still be correctly delegated to the operator after the call.
+     */
+    function testFuzz_OperatorWhoAcceptsAllStakers_ZeroDelegatableShares(
+        address staker,
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 salt
+    ) public filterFuzzedAddressInputs(staker) {
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+
+        assertTrue(delegationManager.isOperator(defaultOperator), "staker not registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+    }
+
+    /**
+     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an invalid expiry on purpose and checking that reversion occurs
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_ExpiredDelegationApproverSignature(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // roll to a very late timestamp
+        cheats.roll(type(uint256).max / 2);
+        // filter to only *invalid* `expiry` values
+        cheats.assume(expiry < block.timestamp);
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but undelegating after delegating and trying the same approveSignature
+     * and checking that reversion occurs with the same salt
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_PreviouslyUsedSalt(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        // staker also must not be the delegationApprover so that signature verification process takes place
+        cheats.assume(staker != defaultOperator);
+        cheats.assume(staker != delegationApprover);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, undelegate, and then try to delegate again with same approversalt
+        // to check that call reverts
+        cheats.startPrank(staker);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        assertTrue(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent not spent?"
+        );
+        delegationManager.undelegate(staker);
+        cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice Like `testDelegateToOperatorWhoRequiresECDSASignature` but using an incorrect signature on purpose and checking that reversion occurs
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresECDSASignature_WithBadSignature(
+        address staker,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // calculate the signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        approverSignatureAndExpiry.expiry = expiry;
+        {
+            bytes32 digestHash = delegationManager.calculateDelegationApprovalDigestHash(
+                staker,
+                defaultOperator,
+                delegationManager.delegationApprover(defaultOperator),
+                emptySalt,
+                expiry
+            );
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(delegationSignerPrivateKey, digestHash);
+            // mess up the signature by flipping v's parity
+            v = (v == 27 ? 28 : 27);
+            approverSignatureAndExpiry.signature = abi.encodePacked(r, s, v);
+        }
+
+        // try to delegate from the `staker` to the operator, and check reversion
+        cheats.startPrank(staker);
+        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoRequiresECDSASignature(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+        if (staker == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Operator shares should increase by the amount of shares delegated
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoRequiresECDSASignature_StrategyManagerShares(
+        address staker,
+        bytes32 salt,
+        uint256 expiry,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // Set staker shares in StrategyManager
+        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+        strategiesToReturn[0] = strategyMock;
+        uint256[] memory sharesToReturn = new uint256[](1);
+        sharesToReturn[0] = shares;
+        strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+        if (staker == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Operator beaconShares should increase by the amount of shares delegated if beaconShares > 0
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainStrategyShares(
+        address staker,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // Set staker shares in BeaconChainStrategy
+        eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+        if (beaconShares <= 0) {
+            assertEq(
+                beaconSharesBefore,
+                beaconSharesAfter,
+                "operator beaconchain shares should not have increased with negative shares"
+            );
+        } else {
+            assertEq(
+                beaconSharesBefore + uint256(beaconShares),
+                beaconSharesAfter,
+                "operator beaconchain shares not increased correctly"
+            );
+        }
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+        if (staker == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+     * via the `staker` calling `DelegationManager.delegateTo`
+     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Operator beaconshares should increase by the amount of beaconShares delegated if beaconShares > 0
+     * Operator strategy manager shares should icnrease by amount of shares
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoRequiresECDSASignature_BeaconChainAndStrategyManagerShares(
+        address staker,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // Set staker shares in BeaconChainStrategy and StrategyMananger
+        {
+            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+            strategiesToReturn[0] = strategyMock;
+            uint256[] memory sharesToReturn = new uint256[](1);
+            sharesToReturn[0] = shares;
+            strategyManagerMock.setDeposits(staker, strategiesToReturn, sharesToReturn);
+            eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
+        }
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(staker, beaconChainETHStrategy);
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, staker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+        if (beaconShares <= 0) {
+            assertEq(
+                beaconSharesBefore,
+                beaconSharesAfter,
+                "operator beaconchain shares should not have increased with negative shares"
+            );
+        } else {
+            assertEq(
+                beaconSharesBefore + uint256(beaconShares),
+                beaconSharesAfter,
+                "operator beaconchain shares not increased correctly"
+            );
+        }
+        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+        if (staker == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+    }
+
+    /**
+     * @notice delegateTo test with operator's delegationApprover address set to a contract address
+     * and check that reversion occurs when the signature is expired
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_ExpiredDelegationApproverSignature(
+        address staker,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // roll to a very late timestamp
+        cheats.roll(type(uint256).max / 2);
+        // filter to only *invalid* `expiry` values
+        cheats.assume(expiry < block.timestamp);
+
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // create the signature struct
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        approverSignatureAndExpiry.expiry = expiry;
+
+        // try to delegate from the `staker` to the operator, and check reversion
+        cheats.startPrank(staker);
+        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice delegateTo test with operator's delegationApprover address set to a contract address
+     * and check that reversion occurs when the signature approverSalt is already used.
+     * Performed by delegating to operator, undelegating, and trying to reuse the same signature
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_PreviouslyUsedSalt(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        ERC1271WalletMock wallet = _registerOperatorWith1271DelegationApprover(defaultOperator);
+        cheats.assume(staker != address(wallet) && staker != defaultOperator);
+
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        delegationManager.undelegate(staker);
+        // Reusing same signature should revert with salt already being used
+        cheats.expectRevert("DelegationManager._delegate: approverSalt already spent");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice delegateTo test with operator's delegationApprover address set to a contract address that
+     * is non compliant with EIP1271
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_NonCompliantWallet(
+        address staker,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        // deploy a ERC1271MaliciousMock contract that will return an incorrect value when called
+        ERC1271MaliciousMock wallet = new ERC1271MaliciousMock();
+
+        // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
+        // then we don't even trigger the signature verification call, so we won't get a revert as expected
+        cheats.assume(staker != address(wallet));
+
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: defaultOperator,
+            delegationApprover: address(wallet),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+        // create the signature struct
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        approverSignatureAndExpiry.expiry = expiry;
+
+        // try to delegate from the `staker` to the operator, and check reversion
+        cheats.startPrank(staker);
+        // because the ERC1271MaliciousMock contract returns the wrong amount of data, we get a low-level "EvmError: Revert" message here rather than the error message bubbling up
+        cheats.expectRevert();
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice delegateTo test with operator's delegationApprover address set to a contract address that
+     * returns a value other than the EIP1271 "magic bytes" and checking that reversion occurs appropriately
+     */
+    function testFuzz_Revert_WhenOperatorWhoRequiresEIP1271Signature_IsValidSignatureFails(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        // deploy a ERC1271WalletMock contract that will return an incorrect value when called
+        // owner is the 0 address
+        ERC1271WalletMock wallet = new ERC1271WalletMock(address(1));
+
+        // filter fuzzed input, since otherwise we can get a flaky failure here. if the caller itself is the 'delegationApprover'
+        // then we don't even trigger the signature verification call, so we won't get a revert as expected
+        cheats.assume(staker != address(wallet));
+
+        IDelegationManager.OperatorDetails memory operatorDetails = IDelegationManager.OperatorDetails({
+            earningsReceiver: defaultOperator,
+            delegationApprover: address(wallet),
+            stakerOptOutWindowBlocks: 0
+        });
+        _registerOperator(defaultOperator, operatorDetails, emptyStringForMetadataURI);
+
+        // calculate the delegationSigner's but this is not the correct signature from the wallet contract
+        // since the wallet owner is address(1)
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // try to delegate from the `staker` to the operator, and check reversion
+        cheats.startPrank(staker);
+        // Signature should fail as the wallet will not return EIP1271_MAGICVALUE
+        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, emptySalt);
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice `staker` delegates to an operator who requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
+     * set to a nonzero and code-containing address) via the `staker` calling `DelegationManager.delegateTo`
+     * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
+     * OR if called by the operator or their delegationApprover themselves
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_OperatorWhoRequiresEIP1271Signature(
+        address staker,
+        bytes32 salt,
+        uint256 expiry
+    ) public filterFuzzedAddressInputs(staker) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+
+        // register *this contract* as an operator
+        // filter inputs, since this will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        _registerOperatorWith1271DelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            staker,
+            defaultOperator,
+            salt,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator
+        cheats.startPrank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(staker, defaultOperator);
+        delegationManager.delegateTo(defaultOperator, approverSignatureAndExpiry, salt);
+        cheats.stopPrank();
+
+        assertTrue(delegationManager.isDelegated(staker), "staker not delegated correctly");
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker delegated to the wrong address");
+        assertFalse(delegationManager.isOperator(staker), "staker incorrectly registered as operator");
+
+        // check that the nonce incremented appropriately
+        if (staker == defaultOperator || staker == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+    }
+}
+
+contract DelegationManagerUnitTests_delegateToBySignature is DelegationManagerUnitTests {
+    function test_revert_paused() public {
+        // set the pausing flag
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_NEW_DELEGATION);
+
+        uint256 expiry = type(uint256).max;
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.delegateToBySignature(
+            defaultStaker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+    }
+
+    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's signature has expired
+    function testFuzz_Revert_WhenStakerSignatureExpired(
+        address staker,
+        address operator,
+        uint256 expiry,
+        bytes memory signature
+    ) public filterFuzzedAddressInputs(staker) filterFuzzedAddressInputs(operator) {
+        cheats.assume(expiry < block.timestamp);
+        cheats.expectRevert("DelegationManager.delegateToBySignature: staker signature expired");
+        ISignatureUtils.SignatureWithExpiry memory signatureWithExpiry = ISignatureUtils.SignatureWithExpiry({
+            signature: signature,
+            expiry: expiry
+        });
+        delegationManager.delegateToBySignature(staker, operator, signatureWithExpiry, signatureWithExpiry, emptySalt);
+    }
+
+    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's ECDSA signature verification fails
+    function test_Revert_EOAStaker_WhenStakerSignatureVerificationFails() public {
+        address invalidStaker = address(1000);
+        address caller = address(2000);
+        uint256 expiry = type(uint256).max;
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        // Should revert from invalid signature as staker is not set as the address of signer
+        cheats.startPrank(caller);
+        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+        // use an empty approver signature input since none is needed / the input is unchecked
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateToBySignature(
+            invalidStaker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+        cheats.stopPrank();
+    }
+
+    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts if the staker's contract signature verification fails
+    function test_Revert_ERC1271Staker_WhenStakerSignatureVerficationFails() public {
+        address staker = address(new ERC1271WalletMock(address(1)));
+        address caller = address(2000);
+        uint256 expiry = type(uint256).max;
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        // Should revert from invalid signature as staker is not set as the address of signer
+        cheats.startPrank(caller);
+        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: ERC1271 signature verification failed");
+        // use an empty approver signature input since none is needed / the input is unchecked
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateToBySignature(
+            staker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+        cheats.stopPrank();
+    }
+
+    /// @notice Checks that `DelegationManager.delegateToBySignature` reverts when the staker is already delegated
+    function test_Revert_Staker_WhenAlreadyDelegated() public {
+        address staker = cheats.addr(stakerPrivateKey);
+        address caller = address(2000);
+        uint256 expiry = type(uint256).max;
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        // Should revert as `staker` has already delegated to `operator`
+        cheats.startPrank(caller);
+        cheats.expectRevert("DelegationManager._delegate: staker is already actively delegated");
+        // use an empty approver signature input since none is needed / the input is unchecked
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateToBySignature(
+            staker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+        cheats.stopPrank();
+    }
+
+    /// @notice Checks that `delegateToBySignature` reverts when operator is not registered after successful staker signature verification
+    function test_Revert_EOAStaker_OperatorNotRegistered() public {
+        address staker = cheats.addr(stakerPrivateKey);
+        address caller = address(2000);
+        uint256 expiry = type(uint256).max;
+
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        // Should revert as `operator` is not registered
+        cheats.startPrank(caller);
+        cheats.expectRevert("DelegationManager._delegate: operator is not registered in EigenLayer");
+        // use an empty approver signature input since none is needed / the input is unchecked
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry;
+        delegationManager.delegateToBySignature(
+            staker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice Checks that `DelegationManager.delegateToBySignature` reverts if the delegationApprover's signature has expired
+     * after successful staker signature verification
+     */
+    function testFuzz_Revert_WhenDelegationApproverSignatureExpired(
+        address caller,
+        uint256 stakerExpiry,
+        uint256 delegationApproverExpiry
+    ) public filterFuzzedAddressInputs(caller) {
+        // filter to only valid `stakerExpiry` values
+        cheats.assume(stakerExpiry >= block.timestamp);
+        // roll to a very late timestamp
+        cheats.roll(type(uint256).max / 2);
+        // filter to only *invalid* `delegationApproverExpiry` values
+        cheats.assume(delegationApproverExpiry < block.timestamp);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // calculate the delegationSigner's signature
+        ISignatureUtils.SignatureWithExpiry memory approverSignatureAndExpiry = _getApproverSignature(
+            delegationSignerPrivateKey,
+            defaultStaker,
+            defaultOperator,
+            emptySalt,
+            delegationApproverExpiry
+        );
+
+        // calculate the staker signature
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            stakerExpiry
+        );
+
+        // try delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`, and check for reversion
+        cheats.startPrank(caller);
+        cheats.expectRevert("DelegationManager._delegate: approver signature expired");
+        delegationManager.delegateToBySignature(
+            defaultStaker,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            approverSignatureAndExpiry,
+            emptySalt
+        );
+        cheats.stopPrank();
+    }
+
+    /**
+     * @notice `staker` becomes delegated to an operator who does not require any signature verification (i.e. the operator’s `delegationApprover` address is set to the zero address)
+     * via the `caller` calling `DelegationManager.delegateToBySignature`
+     * The function should pass with any `operatorSignature` input (since it should be unused)
+     * The function should pass only with a valid `stakerSignatureAndExpiry` input
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * BeaconChainStrategy and StrategyManager operator shares should increase for operator
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(
+        address caller,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        cheats.assume(expiry >= block.timestamp);
+        cheats.assume(shares > 0);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                emptySalt
+            ),
+            "salt somehow spent too early?"
+        );
+        {
+            // Set staker shares in BeaconChainStrategy and StrategyMananger
+            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+            strategiesToReturn[0] = strategyMock;
+            uint256[] memory sharesToReturn = new uint256[](1);
+            sharesToReturn[0] = shares;
+            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+        }
+
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+        // fetch the staker's current nonce
+        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+        // calculate the staker signature
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(defaultStaker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        _delegateToBySignatureOperatorWhoAcceptsAllStakers(
+            defaultStaker,
+            caller,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            emptySalt
+        );
+
+        // Check operator shares increases
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+        if (beaconShares <= 0) {
+            assertEq(
+                beaconSharesBefore,
+                beaconSharesAfter,
+                "operator beaconchain shares should not have increased with negative shares"
+            );
+        } else {
+            assertEq(
+                beaconSharesBefore + uint256(beaconShares),
+                beaconSharesAfter,
+                "operator beaconchain shares not increased correctly"
+            );
+        }
+        assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        // check all the delegation status changes
+        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+        assertEq(
+            delegationManager.delegatedTo(defaultStaker),
+            defaultOperator,
+            "staker delegated to the wrong address"
+        );
+        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+        // check that the staker nonce incremented appropriately
+        assertEq(
+            delegationManager.stakerNonce(defaultStaker),
+            currentStakerNonce + 1,
+            "staker nonce did not increment"
+        );
+        // verify that the salt is still marked as unused (since it wasn't checked or used)
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                emptySalt
+            ),
+            "salt somehow spent too incorrectly?"
+        );
+    }
+
+    /**
+     * @notice `staker` becomes delegated to an operator who requires signature verification through an EOA (i.e. the operator’s `delegationApprover` address is set to a nonzero EOA)
+     * via the `caller` calling `DelegationManager.delegateToBySignature`
+     * The function should pass *only with a valid ECDSA signature from the `delegationApprover`, OR if called by the operator or their delegationApprover themselves
+     * AND with a valid `stakerSignatureAndExpiry` input
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * BeaconChainStrategy and StrategyManager operator shares should increase for operator
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(
+        address caller,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        // filter to only valid `expiry` values
+        cheats.assume(expiry >= block.timestamp);
+        cheats.assume(shares > 0);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        {
+            // Set staker shares in BeaconChainStrategy and StrategyMananger
+            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+            strategiesToReturn[0] = strategyMock;
+            uint256[] memory sharesToReturn = new uint256[](1);
+            sharesToReturn[0] = shares;
+            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+        }
+
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+        // fetch the staker's current nonce
+        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+        // calculate the staker signature
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(defaultStaker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        _delegateToBySignatureOperatorWhoRequiresSig(
+            defaultStaker,
+            caller,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            salt
+        );
+        {
+            // Check operator shares increases
+            uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+            uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+            if (beaconShares <= 0) {
+                assertEq(
+                    beaconSharesBefore,
+                    beaconSharesAfter,
+                    "operator beaconchain shares should not have increased with negative shares"
+                );
+            } else {
+                assertEq(
+                    beaconSharesBefore + uint256(beaconShares),
+                    beaconSharesAfter,
+                    "operator beaconchain shares not increased correctly"
+                );
+            }
+            assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        }
+        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+        assertEq(
+            delegationManager.delegatedTo(defaultStaker),
+            defaultOperator,
+            "staker delegated to the wrong address"
+        );
+        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+
+        // check that the delegationApprover nonce incremented appropriately
+        if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+
+        // check that the staker nonce incremented appropriately
+        assertEq(
+            delegationManager.stakerNonce(defaultStaker),
+            currentStakerNonce + 1,
+            "staker nonce did not increment"
+        );
+    }
+
+    /**
+     * @notice `staker` becomes delegated to an operatorwho requires signature verification through an EIP1271-compliant contract (i.e. the operator’s `delegationApprover` address is
+     * set to a nonzero and code-containing address) via the `caller` calling `DelegationManager.delegateToBySignature`
+     * The function uses OZ's ERC1271WalletMock contract, and thus should pass *only when a valid ECDSA signature from the `owner` of the ERC1271WalletMock contract,
+     * OR if called by the operator or their delegationApprover themselves
+     * AND with a valid `stakerSignatureAndExpiry` input
+     * Properly emits a `StakerDelegated` event
+     * Staker is correctly delegated after the call (i.e. correct storage update)
+     * Reverts if the staker is already delegated (to the operator or to anyone else)
+     * Reverts if the ‘operator’ is not actually registered as an operator
+     */
+    function testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(
+        address caller,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        cheats.assume(expiry >= block.timestamp);
+        cheats.assume(shares > 0);
+
+        _registerOperatorWith1271DelegationApprover(defaultOperator);
+
+        // verify that the salt hasn't been used before
+        assertFalse(
+            delegationManager.delegationApproverSaltIsSpent(
+                delegationManager.delegationApprover(defaultOperator),
+                salt
+            ),
+            "salt somehow spent too early?"
+        );
+        {
+            // Set staker shares in BeaconChainStrategy and StrategyMananger
+            IStrategy[] memory strategiesToReturn = new IStrategy[](1);
+            strategiesToReturn[0] = strategyMock;
+            uint256[] memory sharesToReturn = new uint256[](1);
+            sharesToReturn[0] = shares;
+            strategyManagerMock.setDeposits(defaultStaker, strategiesToReturn, sharesToReturn);
+            eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
+        }
+
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategyMock);
+        uint256 beaconSharesBefore = delegationManager.operatorShares(defaultStaker, beaconChainETHStrategy);
+        // fetch the staker's current nonce
+        uint256 currentStakerNonce = delegationManager.stakerNonce(defaultStaker);
+        // calculate the staker signature
+        ISignatureUtils.SignatureWithExpiry memory stakerSignatureAndExpiry = _getStakerSignature(
+            stakerPrivateKey,
+            defaultOperator,
+            expiry
+        );
+
+        // delegate from the `staker` to the operator, via having the `caller` call `DelegationManager.delegateToBySignature`
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerDelegated(defaultStaker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesIncreased(defaultOperator, defaultStaker, strategyMock, shares);
+        if (beaconShares > 0) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, defaultStaker, beaconChainETHStrategy, uint256(beaconShares));
+        }
+        _delegateToBySignatureOperatorWhoRequiresSig(
+            defaultStaker,
+            caller,
+            defaultOperator,
+            stakerSignatureAndExpiry,
+            salt
+        );
+
+        {
+            // Check operator shares increases
+            uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, strategyMock);
+            uint256 beaconSharesAfter = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
+            if (beaconShares <= 0) {
+                assertEq(
+                    beaconSharesBefore,
+                    beaconSharesAfter,
+                    "operator beaconchain shares should not have increased with negative shares"
+                );
+            } else {
+                assertEq(
+                    beaconSharesBefore + uint256(beaconShares),
+                    beaconSharesAfter,
+                    "operator beaconchain shares not increased correctly"
+                );
+            }
+            assertEq(operatorSharesBefore + shares, operatorSharesAfter, "operator shares not increased correctly");
+        }
+        assertTrue(delegationManager.isDelegated(defaultStaker), "staker not delegated correctly");
+        assertEq(
+            delegationManager.delegatedTo(defaultStaker),
+            defaultOperator,
+            "staker delegated to the wrong address"
+        );
+        assertFalse(delegationManager.isOperator(defaultStaker), "staker incorrectly registered as operator");
+
+        // check that the delegationApprover nonce incremented appropriately
+        if (caller == defaultOperator || caller == delegationManager.delegationApprover(defaultOperator)) {
+            // verify that the salt is still marked as unused (since it wasn't checked or used)
+            assertFalse(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent too incorrectly?"
+            );
+        } else {
+            // verify that the salt is marked as used
+            assertTrue(
+                delegationManager.delegationApproverSaltIsSpent(
+                    delegationManager.delegationApprover(defaultOperator),
+                    salt
+                ),
+                "salt somehow spent not spent?"
+            );
+        }
+
+        // check that the staker nonce incremented appropriately
+        assertEq(
+            delegationManager.stakerNonce(defaultStaker),
+            currentStakerNonce + 1,
+            "staker nonce did not increment"
+        );
+    }
+
+    /**
+     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+     * Generates valid signatures from the staker to delegate to operator `defaultOperator`
+     */
+    function testFuzz_ERC1271Staker_OperatorWhoAcceptsAllStakers(
+        address caller,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+        testFuzz_EOAStaker_OperatorWhoAcceptsAllStakers(caller, expiry, beaconShares, shares);
+    }
+
+    /**
+     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+     * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
+     * a delegationApprover address set to a nonzero EOA
+     */
+    function testFuzz_ERC1271Staker_OperatorWhoRequiresECDSASignature(
+        address caller,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        // Call same test but with the staker address being a ERC1271WalletMock
+        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+        testFuzz_EOAStaker_OperatorWhoRequiresECDSASignature(caller, salt, expiry, beaconShares, shares);
+    }
+
+    /**
+     * @notice Calls same delegateToBySignature test but with the staker address being a ERC1271WalletMock
+     * Generates valid signatures from the staker to delegate to operator `defaultOperator` who has
+     * a delegationApprover address set to a nonzero ERC1271 compliant contract
+     */
+    function testFuzz_ERC1271Staker_OperatorWhoRequiresEIP1271Signature(
+        address caller,
+        bytes32 salt,
+        uint256 expiry,
+        int256 beaconShares,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(caller) {
+        // Call same test but with the staker address being a ERC1271WalletMock
+        defaultStaker = address(ERC1271WalletMock(cheats.addr(stakerPrivateKey)));
+        testFuzz_EOAStaker_OperatorWhoRequiresEIP1271Signature(caller, salt, expiry, beaconShares, shares);
+    }
+}
+
+contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTests {
+    // @notice Verifies that `DelegationManager.increaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
+    function testFuzz_increaseDelegatedShares_revert_invalidCaller(
+        address invalidCaller,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(invalidCaller) {
+        cheats.assume(invalidCaller != address(strategyManagerMock));
+        cheats.assume(invalidCaller != address(eigenPodManagerMock));
+        cheats.assume(invalidCaller != address(eigenLayerProxyAdmin));
+
+        cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
+        delegationManager.increaseDelegatedShares(invalidCaller, strategyMock, shares);
+    }
+
+    // @notice Verifies that there is no change in shares if the staker is not delegated
+    function testFuzz_increaseDelegatedShares_noop(address staker) public {
+        cheats.assume(staker != defaultOperator);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        assertFalse(delegationManager.isDelegated(staker), "bad test setup");
+
+        cheats.prank(address(strategyManagerMock));
+        delegationManager.increaseDelegatedShares(staker, strategyMock, 1);
+        assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.increaseDelegatedShares` properly increases the delegated `shares` that the operator
+     * who the `staker` is delegated to has in the strategy
+     * @dev Checks that there is no change if the staker is not delegated
+     */
+    function testFuzz_increaseDelegatedShares(
+        address staker,
+        uint256 shares,
+        bool delegateFromStakerToOperator
+    ) public {
+        // filter inputs, since delegating to the operator will fail when the staker is already registered as an operator
+        cheats.assume(staker != defaultOperator);
+
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
+        if (delegateFromStakerToOperator) {
+            _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        }
+
+        uint256 _delegatedSharesBefore = delegationManager.operatorShares(
+            delegationManager.delegatedTo(staker),
+            strategyMock
+        );
+
+        if (delegationManager.isDelegated(staker)) {
+            cheats.expectEmit(true, true, true, true, address(delegationManager));
+            emit OperatorSharesIncreased(defaultOperator, staker, strategyMock, shares);
+        }
+
+        cheats.prank(address(strategyManagerMock));
+        delegationManager.increaseDelegatedShares(staker, strategyMock, shares);
+
+        uint256 delegatedSharesAfter = delegationManager.operatorShares(
+            delegationManager.delegatedTo(staker),
+            strategyMock
+        );
+
+        if (delegationManager.isDelegated(staker)) {
+            assertEq(
+                delegatedSharesAfter,
+                _delegatedSharesBefore + shares,
+                "delegated shares did not increment correctly"
+            );
+        } else {
+            assertEq(delegatedSharesAfter, _delegatedSharesBefore, "delegated shares incremented incorrectly");
+            assertEq(_delegatedSharesBefore, 0, "nonzero shares delegated to zero address!");
+        }
+    }
+
+    // @notice Verifies that `DelegationManager.decreaseDelegatedShares` reverts if not called by the StrategyManager nor EigenPodManager
+    function testFuzz_decreaseDelegatedShares_revert_invalidCaller(
+        address invalidCaller,
+        uint256 shares
+    ) public filterFuzzedAddressInputs(invalidCaller) {
+        cheats.assume(invalidCaller != address(strategyManagerMock));
+        cheats.assume(invalidCaller != address(eigenPodManagerMock));
+
+        cheats.startPrank(invalidCaller);
+        cheats.expectRevert("DelegationManager: onlyStrategyManagerOrEigenPodManager");
+        delegationManager.decreaseDelegatedShares(invalidCaller, strategyMock, shares);
+    }
+
+    // @notice Verifies that there is no change in shares if the staker is not delegated
+    function testFuzz_decreaseDelegatedShares_noop(address staker) public {
+        cheats.assume(staker != defaultOperator);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        assertFalse(delegationManager.isDelegated(staker), "bad test setup");
+
+        cheats.prank(address(strategyManagerMock));
+        delegationManager.decreaseDelegatedShares(staker, strategyMock, 1);
+        assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.decreaseDelegatedShares` properly decreases the delegated `shares` that the operator
+     * who the `staker` is delegated to has in the strategies
+     * @dev Checks that there is no change if the staker is not delegated
+     */
+    function testFuzz_decreaseDelegatedShares(
+        address staker,
+        IStrategy[] memory strategies,
+        uint128 shares,
+        bool delegateFromStakerToOperator
+    ) public filterFuzzedAddressInputs(staker) {
+        // sanity-filtering on fuzzed input length & staker
+        cheats.assume(strategies.length <= 32);
+        cheats.assume(staker != defaultOperator);
+
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+
+        // delegate from the `staker` to the operator *if `delegateFromStakerToOperator` is 'true'*
+        if (delegateFromStakerToOperator) {
+            _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        }
+
+        uint256[] memory sharesInputArray = new uint256[](strategies.length);
+
+        address delegatedTo = delegationManager.delegatedTo(staker);
+
+        // for each strategy in `strategies`, increase delegated shares by `shares`
+        // noop if the staker is not delegated
+        cheats.startPrank(address(strategyManagerMock));
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            delegationManager.increaseDelegatedShares(staker, strategies[i], shares);
+            // store delegated shares in a mapping
+            delegatedSharesBefore[strategies[i]] = delegationManager.operatorShares(delegatedTo, strategies[i]);
+            // also construct an array which we'll use in another loop
+            sharesInputArray[i] = shares;
+            totalSharesForStrategyInArray[address(strategies[i])] += sharesInputArray[i];
+        }
+        cheats.stopPrank();
+
+        bool isDelegated = delegationManager.isDelegated(staker);
+
+        // for each strategy in `strategies`, decrease delegated shares by `shares`
+        {
+            cheats.startPrank(address(strategyManagerMock));
+            address operatorToDecreaseSharesOf = delegationManager.delegatedTo(staker);
+            if (isDelegated) {
+                for (uint256 i = 0; i < strategies.length; ++i) {
+                    cheats.expectEmit(true, true, true, true, address(delegationManager));
+                    emit OperatorSharesDecreased(
+                        operatorToDecreaseSharesOf,
+                        staker,
+                        strategies[i],
+                        sharesInputArray[i]
+                    );
+                    delegationManager.decreaseDelegatedShares(staker, strategies[i], sharesInputArray[i]);
+                }
+            }
+            cheats.stopPrank();
+        }
+
+        // check shares after call to `decreaseDelegatedShares`
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            uint256 delegatedSharesAfter = delegationManager.operatorShares(delegatedTo, strategies[i]);
+
+            if (isDelegated) {
+                assertEq(
+                    delegatedSharesAfter + totalSharesForStrategyInArray[address(strategies[i])],
+                    delegatedSharesBefore[strategies[i]],
+                    "delegated shares did not decrement correctly"
+                );
+                assertEq(delegatedSharesAfter, 0, "nonzero shares delegated to");
+            } else {
+                assertEq(
+                    delegatedSharesAfter,
+                    delegatedSharesBefore[strategies[i]],
+                    "delegated shares decremented incorrectly"
+                );
+                assertEq(delegatedSharesBefore[strategies[i]], 0, "nonzero shares delegated to zero address!");
+            }
+        }
+    }
+}
+
+contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
+    // @notice Verifies that undelegating is not possible when the "undelegation paused" switch is flipped
+    function test_undelegate_revert_paused(address staker) public filterFuzzedAddressInputs(staker) {
+        // set the pausing flag
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
+
+        cheats.prank(staker);
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.undelegate(staker);
+    }
+
+    function testFuzz_undelegate_revert_notDelgated(
+        address undelegatedStaker
+    ) public filterFuzzedAddressInputs(undelegatedStaker) {
+        cheats.assume(undelegatedStaker != defaultOperator);
+        assertFalse(delegationManager.isDelegated(undelegatedStaker), "bad test setup");
+
+        cheats.prank(undelegatedStaker);
+        cheats.expectRevert("DelegationManager.undelegate: staker must be delegated to undelegate");
+        delegationManager.undelegate(undelegatedStaker);
+    }
+
+    // @notice Verifies that an operator cannot undelegate from themself (this should always be forbidden)
+    function testFuzz_undelegate_revert_stakerIsOperator(address operator) public filterFuzzedAddressInputs(operator) {
+        _registerOperatorWithBaseDetails(operator);
+
+        cheats.prank(operator);
+        cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
+        delegationManager.undelegate(operator);
+    }
+
+    /**
+     * @notice verifies that `DelegationManager.undelegate` reverts if trying to undelegate an operator from themselves
+     * @param callFromOperatorOrApprover -- calls from the operator if 'false' and the 'approver' if true
+     */
+    function testFuzz_undelegate_operatorCannotForceUndelegateThemself(
+        address delegationApprover,
+        bool callFromOperatorOrApprover
+    ) public {
+        // register *this contract* as an operator with the default `delegationApprover`
+        _registerOperatorWithDelegationApprover(defaultOperator);
+
+        address caller;
+        if (callFromOperatorOrApprover) {
+            caller = delegationApprover;
+        } else {
+            caller = defaultOperator;
+        }
+
+        // try to call the `undelegate` function and check for reversion
+        cheats.prank(caller);
+        cheats.expectRevert("DelegationManager.undelegate: operators cannot be undelegated");
+        delegationManager.undelegate(defaultOperator);
+    }
+
+    //TODO: verify that this check is even needed
+    function test_undelegate_revert_zeroAddress() public {
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(address(0), defaultOperator);
+
+        cheats.prank(address(0));
+        cheats.expectRevert("DelegationManager.undelegate: cannot undelegate zero address");
+        delegationManager.undelegate(address(0));
+    }
+
+    /**
+     * @notice Verifies that the `undelegate` function has proper access controls (can only be called by the operator who the `staker` has delegated
+     * to or the operator's `delegationApprover`), or the staker themselves
+     */
+    function testFuzz_undelegate_revert_invalidCaller(
+        address invalidCaller
+    ) public filterFuzzedAddressInputs(invalidCaller) {
+        address staker = address(0x123);
+        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+        // filter out addresses that are actually allowed to call the function
+        cheats.assume(invalidCaller != staker);
+        cheats.assume(invalidCaller != defaultOperator);
+        cheats.assume(invalidCaller != delegationApprover);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+        _delegateToOperatorWhoRequiresSig(staker, defaultOperator);
+
+        cheats.prank(invalidCaller);
+        cheats.expectRevert("DelegationManager.undelegate: caller cannot undelegate staker");
+        delegationManager.undelegate(staker);
+    }
+
+    /**
+     * Staker is undelegated from an operator, via a call to `undelegate`, properly originating from the staker's address.
+     * Reverts if the staker is themselves an operator (i.e. they are delegated to themselves)
+     * Does nothing if the staker is already undelegated
+     * Properly undelegates the staker, i.e. the staker becomes “delegated to” the zero address, and `isDelegated(staker)` returns ‘false’
+     * Emits a `StakerUndelegated` event
+     */
+    function testFuzz_undelegate_noDelegateableShares(address staker) public filterFuzzedAddressInputs(staker) {
+        // register *this contract* as an operator and delegate from the `staker` to them
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerUndelegated(staker, delegationManager.delegatedTo(staker));
+        cheats.prank(staker);
+        bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
+
+        assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
+        assertEq(
+            delegationManager.delegatedTo(staker),
+            address(0),
+            "undelegated staker should be delegated to zero address"
+        );
+        assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
+    }
+
+    /**
+     * @notice Verifies that the `undelegate` function allows for a force undelegation
+     */
+    function testFuzz_undelegate_forceUndelegation_noDelegateableShares(
+        address staker,
+        bytes32 salt,
+        bool callFromOperatorOrApprover
+    ) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        address delegationApprover = cheats.addr(delegationSignerPrivateKey);
+
+        _registerOperatorWithDelegationApprover(defaultOperator);
+        _delegateToOperatorWhoRequiresSig(staker, defaultOperator, salt);
+
+        address caller;
+        if (callFromOperatorOrApprover) {
+            caller = delegationApprover;
+        } else {
+            caller = defaultOperator;
+        }
+
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerForceUndelegated(staker, defaultOperator);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit StakerUndelegated(staker, defaultOperator);
+        cheats.prank(caller);
+        bytes32[] memory withdrawalRoots = delegationManager.undelegate(staker);
+
+        assertEq(withdrawalRoots.length, 0, "withdrawalRoot should be an empty array");
+        assertEq(
+            delegationManager.delegatedTo(staker),
+            address(0),
+            "undelegated staker should be delegated to zero address"
+        );
+        assertFalse(delegationManager.isDelegated(staker), "staker not undelegated");
+    }
+}
+
+contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTests {
+    function test_Revert_WhenEnterQueueWithdrawalsPaused() public {
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
+        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            withdrawer: defaultStaker,
+            strategy: strategyMock,
+            withdrawalAmount: 100
+        });
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+    }
+
+    function test_Revert_WhenQueueWithdrawalParamsLengthMismatch() public {
+        IStrategy[] memory strategyArray = new IStrategy[](1);
+        strategyArray[0] = strategyMock;
+        uint256[] memory shareAmounts = new uint256[](2);
+        shareAmounts[0] = 100;
+        shareAmounts[1] = 100;
+
+        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategyArray,
+            shares: shareAmounts,
+            withdrawer: defaultStaker
+        });
+
+        cheats.expectRevert("DelegationManager.queueWithdrawal: input length mismatch");
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+    }
+
+    function test_Revert_WhenZeroAddressWithdrawer() public {
+        (IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            withdrawer: address(0),
+            strategy: strategyMock,
+            withdrawalAmount: 100
+        });
+        cheats.expectRevert("DelegationManager.queueWithdrawal: must provide valid withdrawal address");
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+    }
+
+    function test_Revert_WhenEmptyStrategiesArray() public {
+        IStrategy[] memory strategyArray = new IStrategy[](0);
+        uint256[] memory shareAmounts = new uint256[](0);
+        address withdrawer = defaultOperator;
+
+        IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalParams[](1);
+        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalParams({
+            strategies: strategyArray,
+            shares: shareAmounts,
+            withdrawer: withdrawer
+        });
+
+        cheats.expectRevert("DelegationManager._removeSharesAndQueueWithdrawal: strategies cannot be empty");
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
+     * from the `strategy` for the `sharesAmount`. 
+     * - Asserts that staker is delegated to the operator
+     * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
+     * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
+     * - Checks that event was emitted with correct withdrawalRoot and withdrawal
+     */
+    function testFuzz_queueWithdrawal_SingleStrat(
+        address staker,
+        uint256 depositAmount,
+        uint256 withdrawalAmount
+    ) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+        uint256[] memory sharesAmounts = new uint256[](1);
+        sharesAmounts[0] = depositAmount;
+        // sharesAmounts is single element so returns single strategy
+        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, sharesAmounts);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        (
+            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            IDelegationManager.Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: staker,
+            withdrawer: staker,
+            strategy: strategies[0],
+            withdrawalAmount: withdrawalAmount
+        });
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
+        uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
+        uint256 delegatedSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[0]);
+
+        // queueWithdrawals
+        cheats.prank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit WithdrawalQueued(withdrawalRoot, withdrawal);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
+        uint256 delegatedSharesAfter = delegationManager.operatorShares(defaultOperator, strategies[0]);
+        assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
+        assertEq(delegatedSharesBefore - withdrawalAmount, delegatedSharesAfter, "delegated shares not decreased correctly");
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
+     * with multiple strategies and sharesAmounts. Depending on length sharesAmounts, deploys corresponding number of strategies
+     * and deposits sharesAmounts into each strategy for the staker and delegates to operator.
+     * For each strategy, withdrawAmount <= depositAmount
+     * - Asserts that staker is delegated to the operator
+     * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
+     * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
+     * - Checks that event was emitted with correct withdrawalRoot and withdrawal
+     */
+    function testFuzz_queueWithdrawal_MultipleStrats(
+        address staker,
+        uint256[] memory depositAmounts
+    ) public filterFuzzedAddressInputs(staker){
+        cheats.assume(depositAmounts.length > 0 && depositAmounts.length <= 32);
+        uint256[] memory withdrawalAmounts = _fuzzWithdrawalAmounts(depositAmounts);
+
+        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(staker, depositAmounts);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        (
+            IDelegationManager.QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            IDelegationManager.Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawals({
+            staker: staker,
+            withdrawer: staker,
+            strategies: strategies,
+            withdrawalAmounts: withdrawalAmounts
+        });
+        // Before queueWithdrawal state values
+        uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(staker);
+        assertEq(delegationManager.delegatedTo(staker), defaultOperator, "staker should be delegated to operator");
+        uint256[] memory delegatedSharesBefore = new uint256[](strategies.length);
+        for (uint256 i = 0; i < strategies.length; i++) {
+            delegatedSharesBefore[i] = delegationManager.operatorShares(defaultOperator, strategies[i]);
+        }
+
+        // queueWithdrawals
+        cheats.prank(staker);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit WithdrawalQueued(withdrawalRoot, withdrawal);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        // Post queueWithdrawal state values
+        for (uint256 i = 0; i < strategies.length; i++) {
+            assertEq(
+                delegatedSharesBefore[i] - withdrawalAmounts[i], // Shares before - withdrawal amount
+                delegationManager.operatorShares(defaultOperator, strategies[i]), // Shares after
+                "delegated shares not decreased correctly"
+            );
+        }
+        uint256 nonceAfter = delegationManager.cumulativeWithdrawalsQueued(staker);
+        assertEq(nonceBefore + 1, nonceAfter, "staker nonce should have incremented");
+    }
+}
+
+contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManagerUnitTests {
+    function test_Revert_WhenExitWithdrawalQueuePaused() public {
+        cheats.prank(pauser);
+        delegationManager.pause(2 ** PAUSED_EXIT_WITHDRAWAL_QUEUE);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (
+            IDelegationManager.Withdrawal memory withdrawal,
+            IERC20[] memory tokens,
+            /* bytes32 withdrawalRoot */
+        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: defaultStaker,
+            operator: defaultOperator,
+            withdrawer: defaultStaker,
+            depositAmount: 100,
+            withdrawalAmount: 100
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        cheats.expectRevert("Pausable: index is paused");
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+    }
+
+    function test_Revert_WhenInvalidWithdrawalRoot() public {
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (
+            IDelegationManager.Withdrawal memory withdrawal,
+            IERC20[] memory tokens,
+            bytes32 withdrawalRoot
+        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: defaultStaker,
+            operator: defaultOperator,
+            withdrawer: defaultStaker,
+            depositAmount: 100,
+            withdrawalAmount: 100
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+        cheats.prank(defaultStaker);
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+
+        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: action is not in queue");
+        cheats.prank(defaultStaker);
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+    }
+
+    // TODO: Fix withdrawal delay blocks test
+    // function test_Revert_WhenWithdrawalDelayBlocksNotPassed() public {
+    //     _registerOperatorWithBaseDetails(defaultOperator);
+    //     (
+    //         IDelegationManager.Withdrawal memory withdrawal,
+    //         IERC20[] memory tokens,
+    //         /* bytes32 withdrawalRoot */
+    //     ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+    //         staker: defaultStaker,
+    //         operator: defaultOperator,
+    //         withdrawer: defaultStaker,
+    //         depositAmount: 100,
+    //         withdrawalAmount: 100
+    //     });
+    //     _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+    //     cheats.expectRevert("DelegationManager.completeQueuedAction: withdrawalDelayBlocks period has not yet passed");
+    //     delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+    // }
+
+    function test_Revert_WhenNotCalledByWithdrawer() public {
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (
+            IDelegationManager.Withdrawal memory withdrawal,
+            IERC20[] memory tokens,
+            bytes32 withdrawalRoot
+        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: defaultStaker,
+            operator: defaultOperator,
+            withdrawer: defaultStaker,
+            depositAmount: 100,
+            withdrawalAmount: 100
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: only withdrawer can complete action");
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+    }
+
+    function test_Revert_WhenTokensArrayLengthMismatch() public {
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (IDelegationManager.Withdrawal memory withdrawal, , ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: defaultStaker,
+            operator: defaultOperator,
+            withdrawer: defaultStaker,
+            depositAmount: 100,
+            withdrawalAmount: 100
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        IERC20[] memory tokens = new IERC20[](0);
+        cheats.expectRevert("DelegationManager._completeQueuedWithdrawal: input length mismatch");
+        cheats.prank(defaultStaker);
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
+     * for a single strategy. Withdraws as tokens so there are no operator shares increase.
+     * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
+     * - Asserts operatorShares is unchanged after `completeQueuedWithdrawal`
+     * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
+     */
+    function test_completeQueuedWithdrawal_SingleStratWithdrawAsTokens(
+        address staker,
+        address withdrawer,
+        uint256 depositAmount,
+        uint256 withdrawalAmount
+    ) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (
+            IDelegationManager.Withdrawal memory withdrawal,
+            IERC20[] memory tokens,
+            bytes32 withdrawalRoot
+        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: staker,
+            operator: defaultOperator,
+            withdrawer: withdrawer,
+            depositAmount: depositAmount,
+            withdrawalAmount: withdrawalAmount
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+
+        // completeQueuedWithdrawal
+        cheats.prank(withdrawer);
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit WithdrawalCompleted(withdrawalRoot);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, true);
+
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+        assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
+        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+    }
+
+    /**
+     * @notice Verifies that `DelegationManager.completeQueuedWithdrawal` properly completes a queued withdrawal for the `withdrawer`
+     * for a single strategy. Withdraws as shares so if the withdrawer is delegated, operator shares increase. In the test case, this only
+     * happens if staker and withdrawer are fuzzed the same address (i.e. staker == withdrawer)
+     * - Asserts that the withdrawalRoot is True before `completeQueuedWithdrawal` and False after
+     * - Asserts if staker == withdrawer, operatorShares increase, otherwise operatorShares are unchanged
+     * - Checks that event `WithdrawalCompleted` is emitted with withdrawalRoot
+     */
+    function test_completeQueuedWithdrawal_SingleStratWithdrawAsShares(
+        address staker,
+        address withdrawer,
+        uint256 depositAmount,
+        uint256 withdrawalAmount
+    ) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        cheats.assume(withdrawer != defaultOperator);
+        cheats.assume(withdrawalAmount > 0 && withdrawalAmount <= depositAmount);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        (
+            IDelegationManager.Withdrawal memory withdrawal,
+            IERC20[] memory tokens,
+            bytes32 withdrawalRoot
+        ) = _setUpCompleteQueuedWithdrawalSingleStrat({
+            staker: staker,
+            operator: defaultOperator,
+            withdrawer: withdrawer,
+            depositAmount: depositAmount,
+            withdrawalAmount: withdrawalAmount
+        });
+        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
+        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+        assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+
+        // completeQueuedWithdrawal
+        cheats.prank(withdrawer);
+        cheats.roll(block.number + minWithdrawalDelayBlocks);
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit WithdrawalCompleted(withdrawalRoot);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, 0 /* middlewareTimesIndex */, false);
+
+        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawal.strategies[0]);
+        if (staker == withdrawer) {
+            // Since staker is delegated, operatorShares get incremented
+            assertEq(operatorSharesAfter, operatorSharesBefore + withdrawalAmount, "operator shares not increased correctly");
+        } else {
+            // Since withdrawer is not the staker and isn't delegated, staker's oeprator shares are unchanged
+            assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
+        }
+        assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+    }
+}


### PR DESCRIPTION
Due to contract bytecode size of the DelegationManager exceeding the 24KB limit, this is where I created a draft PR to decouple the operatorToAVS registration mapping in the DM and separate it into the AVSDirectory contract. I also removed the "DelegationManager.<error message>" portion out of the require strings to save bytes as well.

Initially marked as a draft to get more thoughts on this and tests need to be fixed.

![image](https://github.com/Layr-Labs/eigenlayer-contracts/assets/35479365/21f0e449-4c3c-4206-a85f-64f8a3dca09c)
