### PR TITLE
chore: fix numerous compiler warnings from script + test files

### DIFF
--- a/script/testing/M2_Deploy_From_Scratch.s.sol
+++ b/script/testing/M2_Deploy_From_Scratch.s.sol
@@ -378,7 +378,7 @@ contract Deployer_M2 is Script, Test {
     function _verifyContractsPointAtOneAnother(
         DelegationManager delegationContract,
         StrategyManager strategyManagerContract,
-        Slasher slasherContract,
+        Slasher /*slasherContract*/,
         EigenPodManager eigenPodManagerContract,
         DelayedWithdrawalRouter delayedWithdrawalRouterContract
     ) internal view {

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -444,7 +444,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
     function assert_Snap_Added_QueuedWithdrawal(
         User staker, 
-        IDelegationManager.Withdrawal memory withdrawal,
+        IDelegationManager.Withdrawal memory /*withdrawal*/,
         string memory err
     ) internal {
         uint curQueuedWithdrawal = _getCumulativeWithdrawals(staker);

--- a/src/test/integration/User.t.sol
+++ b/src/test/integration/User.t.sol
@@ -325,7 +325,7 @@ contract User is Test {
 
     /// @notice Gets the expected withdrawals to be created when the staker is undelegated via a call to `DelegationManager.undelegate()`
     /// @notice Assumes staker and withdrawer are the same and that all strategies and shares are withdrawn
-    function _getExpectedWithdrawalStructsForStaker(address staker) internal returns (IDelegationManager.Withdrawal[] memory) {
+    function _getExpectedWithdrawalStructsForStaker(address staker) internal view returns (IDelegationManager.Withdrawal[] memory) {
         (IStrategy[] memory strategies, uint256[] memory shares)
             = delegationManager.getDelegatableShares(staker);
 

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -151,9 +151,17 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         }
 
         // Complete last withdrawal as shares
-        IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[withdrawals.length - 1]);
-        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, shares);
-        check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[withdrawals.length - 1], strategies, shares, tokens, expectedTokens);
+        IERC20[] memory finalWithdrawaltokens = staker.completeWithdrawalAsTokens(withdrawals[withdrawals.length - 1]);
+        uint[] memory finalExpectedTokens = _calculateExpectedTokens(strategies, shares);
+        check_Withdrawal_AsTokens_State(
+            staker,
+            operator2,
+            withdrawals[withdrawals.length - 1],
+            strategies,
+            shares,
+            finalWithdrawaltokens,
+            finalExpectedTokens
+        );
     }
 
     function testFuzz_deposit_delegate_reDelegate_depositAfterRedelegate(uint24 _random) public {

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -75,7 +75,7 @@ contract DelegationManagerMock is IDelegationManager, Test {
         return 0;
     }
 
-    function minWithdrawalDelayBlocks() external view returns (uint256) {
+    function minWithdrawalDelayBlocks() external pure returns (uint256) {
         return 0;
     }
 
@@ -83,11 +83,11 @@ contract DelegationManagerMock is IDelegationManager, Test {
      * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
      * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
      */
-    function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external view returns (uint256) {
+    function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external pure returns (uint256) {
         return 0;
     }
 
-    function getWithdrawalDelay(IStrategy[] calldata /*strategies*/) public view returns (uint256) {
+    function getWithdrawalDelay(IStrategy[] calldata /*strategies*/) public pure returns (uint256) {
         return 0;
     }
 

--- a/src/test/mocks/ERC20Mock.sol
+++ b/src/test/mocks/ERC20Mock.sol
@@ -82,7 +82,7 @@ contract ERC20Mock is Context, IERC20 {
         return _allowances[owner][spender];
     }
 
-    function mint(address to, uint256 amount) public virtual {
+    function mint(address /*to*/, uint256 amount) public virtual {
         address owner = _msgSender();
         _mint(owner, amount);
     }

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -87,7 +87,7 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
     function maxPods() external view returns (uint256) {}
 
 
-    function denebForkTimestamp() external view returns (uint64){
+    function denebForkTimestamp() external pure returns (uint64) {
         return type(uint64).max;
     }
 

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -406,7 +406,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
      */
     function _setUpCompleteQueuedWithdrawalSingleStrat(
         address staker,
-        address operator,
         address withdrawer,
         uint256 depositAmount,
         uint256 withdrawalAmount
@@ -445,7 +444,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
      */
     function _setUpCompleteQueuedWithdrawal(
         address staker,
-        address operator,
+        address /*operator*/,
         address withdrawer,
         uint256[] memory depositAmounts,
         uint256[] memory withdrawalAmounts
@@ -2923,7 +2922,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             /* bytes32 withdrawalRoot */
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            operator: defaultOperator,
             withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100
@@ -2942,7 +2940,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            operator: defaultOperator,
             withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100
@@ -2970,7 +2967,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
     //         /* bytes32 withdrawalRoot */
     //     ) = _setUpCompleteQueuedWithdrawalSingleStrat({
     //         staker: defaultStaker,
-    //         operator: defaultOperator,
     //         withdrawer: defaultStaker,
     //         depositAmount: 100,
     //         withdrawalAmount: 100
@@ -2986,10 +2982,9 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         (
             IDelegationManager.Withdrawal memory withdrawal,
             IERC20[] memory tokens,
-            bytes32 withdrawalRoot
+            /*bytes32 withdrawalRoot*/
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            operator: defaultOperator,
             withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100
@@ -3005,7 +3000,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _registerOperatorWithBaseDetails(defaultOperator);
         (IDelegationManager.Withdrawal memory withdrawal, , ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            operator: defaultOperator,
             withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100
@@ -3042,7 +3036,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: staker,
-            operator: defaultOperator,
             withdrawer: withdrawer,
             depositAmount: depositAmount,
             withdrawalAmount: withdrawalAmount
@@ -3087,7 +3080,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: staker,
-            operator: defaultOperator,
             withdrawer: withdrawer,
             depositAmount: depositAmount,
             withdrawalAmount: withdrawalAmount

--- a/src/test/unit/EigenPod-PodManagerUnit.t.sol
+++ b/src/test/unit/EigenPod-PodManagerUnit.t.sol
@@ -372,6 +372,7 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
         assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
         assertGt(updatedShares - initialShares, 0, "Shares delta should be positive");
         assertEq(updatedShares, 32e18, "Shares should be 32ETH");
+        assertEq(newValidatorBalance, 32e9, "validator balance should be 32e9 Gwei");
     }
 
     function test_fullWithdrawal_excess32ETH() public {
@@ -536,9 +537,6 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
         uint64 oracleTimestamp = 0;
         _setOracleBlockRoot();
         cheats.warp(oracleTimestamp+=1);
-
-        // Save state for checks 
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
 
         // Act: Verify withdrawal credentials and record the balance update
         cheats.prank(podOwner);

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -844,7 +844,6 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
 
         // Get params to check against
         uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        uint40 validatorIndex = uint40(getValidatorIndex());
         uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
         assertLt(withdrawalAmountGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Withdrawal amount should be greater than max restaked balance for this test");
 
@@ -859,7 +858,7 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
 
         // Storage checks in _verifyAndProcessWithdrawal
         bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        // assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
 
         // Checks from  _processFullWithdrawal
         assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), withdrawalAmountGwei, "Incorrect withdrawable restaked execution layer gwei");


### PR DESCRIPTION
warnings were for unused or shadowed variables, or functions that could have stricter mutability