### PR TITLE
feat: Operator shares view for avs-sync

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -852,6 +852,18 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         return _operatorDetails[operator].stakerOptOutWindowBlocks;
     }
 
+    /// @notice Given array of strategies, returns array of shares for the operator
+    function getOperatorShares(
+        address operator,
+        IStrategy[] memory strategies
+    ) public view returns (uint256[] memory) {
+        uint256[] memory shares = new uint256[](strategies.length);
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            shares[i] = operatorShares[operator][strategies[i]];
+        }
+        return shares;
+    }
+
     /**
      * @notice Returns the number of actively-delegatable shares a staker has across all strategies.
      * @dev Returns two empty arrays in the case that the Staker has no actively-delegateable shares.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -338,6 +338,14 @@ interface IDelegationManager is ISignatureUtils {
     function stakerOptOutWindowBlocks(address operator) external view returns (uint256);
 
     /**
+     * @notice Given array of strategies, returns array of shares for the operator
+     */
+    function getOperatorShares(
+        address operator,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[] memory);
+
+    /**
      * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
      * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
      * @param strategies The strategies to check withdrawal delays for

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -86,6 +86,11 @@ contract DelegationManagerMock is IDelegationManager, Test {
     function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external pure returns (uint256) {
         return 0;
     }
+    
+    function getOperatorShares(
+        address operator,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[] memory) {}
 
     function getWithdrawalDelay(IStrategy[] calldata /*strategies*/) public pure returns (uint256) {
         return 0;


### PR DESCRIPTION
Used to reduce gas costs for `_weightOfOperator` calls for avs-syncs. Below is the middleware PR that uses this addition.
https://github.com/Layr-Labs/eigenlayer-middleware/pull/170