### PR TITLE
test: unit tests for strategy config additions

### DIFF
--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -32,6 +32,8 @@ contract StrategyManagerMock is
 
     /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated. only increments (doesn't decrement)
     mapping(address => uint256) public cumulativeWithdrawalsQueued;
+    
+    mapping(IStrategy => bool) public thirdPartyTransfersForbidden;
 
     function setAddresses(IDelegationManager _delegation, IEigenPodManager _eigenPodManager, ISlasher _slasher) external
     {
@@ -77,6 +79,11 @@ contract StrategyManagerMock is
         sharesToReturn[staker] = _sharesToReturn;
     }
 
+    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external {
+        emit UpdatedThirdPartyTransfersForbidden(strategy, value);
+        thirdPartyTransfersForbidden[strategy] = value;
+    }
+
     /**
      * @notice Get all details on the staker's deposits and corresponding shares
      * @return (staker's strategies, shares in these strategies)
@@ -106,8 +113,6 @@ contract StrategyManagerMock is
 
     /// @notice returns the enshrined beaconChainETH Strategy
     function beaconChainETHStrategy() external view returns (IStrategy) {}
-
-    function thirdPartyTransfersForbidden(IStrategy strategy) external view returns (bool) {}
 
     // function withdrawalDelayBlocks() external view returns (uint256) {}
 

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -785,6 +785,19 @@ contract StrategyManagerUnitTests_depositIntoStrategyWithSignature is StrategyMa
             memory expectedRevertMessage = "StrategyManager.onlyStrategiesWhitelistedForDeposit: strategy not whitelisted";
         _depositIntoStrategyWithSignature(staker, amount, type(uint256).max, expectedRevertMessage);
     }
+    
+    function testFuzz_Revert_WhenThirdPartyTransfersForbidden(uint256 amount, uint256 expiry) public {
+        // min shares must be minted on strategy
+        cheats.assume(amount >= 1);
+
+        cheats.prank(strategyManager.strategyWhitelister());
+        strategyManager.setThirdPartyTransfersForbidden(dummyStrat, true);
+
+        address staker = cheats.addr(privateKey);
+        // not expecting a revert, so input an empty string
+        string memory expectedRevertMessage = "StrategyManager.depositIntoStrategyWithSignature: third transfers disabled";
+        _depositIntoStrategyWithSignature(staker, amount, expiry, expectedRevertMessage);
+    }
 }
 
 contract StrategyManagerUnitTests_removeShares is StrategyManagerUnitTests {


### PR DESCRIPTION
Test additions:
- reverting tests for `thirdPartyTransfersForbidden` in StrategyManagerUnit.t.sol and DelegationUnit.t.sol
- Setting `strategyWithdrawalDelayBlocks` in `_deployAndDepositIntoStrategies` helper. So now rolling to the earliest valid block to complete withdrawals is `block.number + delegationManager.getWithdrawalDelay(withdrawal.strategies)`
- Added back revert tests for "withdrawalDelayBlocks not passed" for both SM strategies and beaconStrat
- fixed some tests failing on high # of fuzz runs