### PR TITLE
test: Fork Integration Testing refactor

### DIFF
--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -32,8 +32,8 @@ contract ExistingDeploymentParser is Script, Test {
     Slasher public slasherImplementation;
     AVSDirectory public avsDirectory;
     AVSDirectory public avsDirectoryImplementation;
-    DelegationManager public delegation;
-    DelegationManager public delegationImplementation;
+    DelegationManager public delegationManager;
+    DelegationManager public delegationManagerImplementation;
     StrategyManager public strategyManager;
     StrategyManager public strategyManagerImplementation;
     EigenPodManager public eigenPodManager;
@@ -41,6 +41,7 @@ contract ExistingDeploymentParser is Script, Test {
     DelayedWithdrawalRouter public delayedWithdrawalRouter;
     DelayedWithdrawalRouter public delayedWithdrawalRouterImplementation;
     UpgradeableBeacon public eigenPodBeacon;
+    EigenPod pod;
     EigenPod public eigenPodImplementation;
     StrategyBase public baseStrategyImplementation;
 
@@ -72,8 +73,8 @@ contract ExistingDeploymentParser is Script, Test {
         eigenLayerPauserReg = PauserRegistry(stdJson.readAddress(existingDeploymentData, ".addresses.eigenLayerPauserReg"));
         slasher = Slasher(stdJson.readAddress(existingDeploymentData, ".addresses.slasher"));
         slasherImplementation = Slasher(stdJson.readAddress(existingDeploymentData, ".addresses.slasherImplementation"));
-        delegation = DelegationManager(stdJson.readAddress(existingDeploymentData, ".addresses.delegation"));
-        delegationImplementation = DelegationManager(stdJson.readAddress(existingDeploymentData, ".addresses.delegationImplementation"));
+        delegationManager = DelegationManager(stdJson.readAddress(existingDeploymentData, ".addresses.delegation"));
+        delegationManagerImplementation = DelegationManager(stdJson.readAddress(existingDeploymentData, ".addresses.delegationImplementation"));
         avsDirectory = AVSDirectory(stdJson.readAddress(existingDeploymentData, ".addresses.avsDirectory"));
         avsDirectoryImplementation = AVSDirectory(stdJson.readAddress(existingDeploymentData, ".addresses.avsDirectoryImplementation"));
         strategyManager = StrategyManager(stdJson.readAddress(existingDeploymentData, ".addresses.strategyManager"));

--- a/script/utils/Goerli_current_deploy.config.json
+++ b/script/utils/Goerli_current_deploy.config.json
@@ -1,0 +1,30 @@
+{
+  "addresses": {
+    "baseStrategyImplementation": "0x81E94e16949AC397d508B5C2557a272faD2F8ebA",
+    "delayedWithdrawalRouter": "0x89581561f1F98584F88b0d57c2180fb89225388f",
+    "delayedWithdrawalRouterImplementation": "0xE576731194EC3d8Ba92E7c2B578ea74238772878",
+    "delegation": "0x1b7b8F6b258f95Cf9596EabB9aa18B62940Eb0a8",
+    "delegationImplementation": "0x56652542926444Ebce46Fd97aFd80824ed51e58C",
+    "eigenLayerPauserReg": "0x7cB9c5D6b9702f2f680e4d35cb1fC945D08208F6",
+    "eigenLayerProxyAdmin": "0x28ceac2ff82B2E00166e46636e2A4818C29902e2",
+    "eigenPodBeacon": "0x3093F3B560352F896F0e9567019902C9Aff8C9a5",
+    "eigenPodImplementation": "0x16a0d8aD2A2b12f3f47d0e8F5929F9840e29a426",
+    "eigenPodManager": "0xa286b84C96aF280a49Fe1F40B9627C2A2827df41",
+    "eigenPodManagerImplementation": "0xDA9B60D3dC7adD40C0e35c628561Ff71C13a189f",
+    "emptyContract": "0xa04bf5170D86833294b5c21c712C69C0Fb5735A4",
+    "slasher": "0xD11d60b669Ecf7bE10329726043B3ac07B380C22",
+    "slasherImplementation": "0x89C5e6e98f79be658e830Ec66b61ED3EE910D262",
+    "strategyManager": "0x779d1b5315df083e3F9E94cB495983500bA8E907",
+    "strategyManagerImplementation": "0x506C21f43e81D9d231d8A13831b42A2a2B5540E4",
+    "avsDirectory": "0x0AC9694c271eFbA6059e9783769e515E8731f935",
+    "avsDirectoryImplementation": "0x871cD8f6CFec8b2EB1ac64d58F6D9e1D36a88cb3"
+  },
+  "chainInfo": {
+    "chainId": 5,
+    "deploymentBlock": 10497389
+  },
+  "parameters": {
+    "executorMultisig": "0x3d9C2c2B40d890ad53E27947402e977155CD2808",
+    "operationsMultisig": "0x040353E9d057689b77DF275c07FFe1A46b98a4a6"
+  }
+}

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import "src/contracts/libraries/BeaconChainProofs.sol";
 import "src/contracts/libraries/Merkle.sol";
+import "src/contracts/pods/EigenPodManager.sol";
 
 import "src/test/integration/TimeMachine.t.sol";
 import "src/test/integration/mocks/BeaconChainOracleMock.t.sol";
@@ -55,14 +56,16 @@ contract BeaconChainMock is Test {
     mapping(uint40 => Validator) validators;
 
     BeaconChainOracleMock oracle;
+    EigenPodManager eigenPodManager;
 
     /// @dev All withdrawals are processed with index == 0
     uint64 constant WITHDRAWAL_INDEX = 0;
     uint constant GWEI_TO_WEI = 1e9;
     
-    constructor(TimeMachine timeMachine, BeaconChainOracleMock beaconChainOracle) {
+    constructor(TimeMachine timeMachine, BeaconChainOracleMock beaconChainOracle, EigenPodManager _eigenPodManager) {
         nextTimestamp = timeMachine.proofGenStartTime();
         oracle = beaconChainOracle;
+        eigenPodManager = _eigenPodManager;
     }
     
     /**
@@ -733,11 +736,20 @@ contract BeaconChainMock is Test {
         uint64 withdrawalIndex,
         uint64 oracleTimestamp
     ) internal view returns (BeaconChainProofs.WithdrawalProof memory) {
+        uint256 withdrawalProofLength;
+        uint256 timestampProofLength;
+        if (block.timestamp > eigenPodManager.denebForkTimestamp()) {
+            withdrawalProofLength = WITHDRAWAL_PROOF_LEN_DENEB;
+            timestampProofLength = TIMESTAMP_PROOF_LEN_DENEB;
+        } else {
+            withdrawalProofLength = WITHDRAWAL_PROOF_LEN_CAPELLA;
+            timestampProofLength = TIMESTAMP_PROOF_LEN_CAPELLA;
+        }
         return BeaconChainProofs.WithdrawalProof({
-            withdrawalProof: new bytes(WITHDRAWAL_PROOF_LEN_CAPELLA),
+            withdrawalProof: new bytes(withdrawalProofLength),
             slotProof: new bytes(SLOT_PROOF_LEN),
             executionPayloadProof: new bytes(EXECPAYLOAD_PROOF_LEN),
-            timestampProof: new bytes(TIMESTAMP_PROOF_LEN_CAPELLA),
+            timestampProof: new bytes(timestampProofLength),
             historicalSummaryBlockRootProof: new bytes(HISTSUMMARY_PROOF_LEN),
             blockRootIndex: 0,
             historicalSummaryIndex: 0,


### PR DESCRIPTION
With the different upgrade paths between Goerli and Mainnet, this is an attempt at having more upgrade testing by using the utils parser `ExistingDeploymentParser` and deploying in `IntegrationDeployer.setUp()` depending on the chainid that tests are being run on.

To run upgrade integration tests

1. Setup anvil node
`anvil -f $RPC_GOERLI`
2. Run integration tests 
`forge test --match-contract Integration -f http://127.0.0.1:8545`