### PR TITLE
feat: cancel AVS registration salt 

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -127,6 +127,14 @@ contract AVSDirectory is
         emit AVSMetadataURIUpdated(msg.sender, metadataURI);
     }
 
+    /**
+     * @notice Called by an operator to cancel a salt that has been used to register with an AVS.
+     * @param salt A unique and single use value associated with the approver signature.
+     */
+    function cancelSalt(bytes32 salt) external {
+        operatorSaltIsSpent[msg.sender][salt] = true;
+    }
+
     /*******************************************************************************
                             VIEW FUNCTIONS
     *******************************************************************************/


### PR DESCRIPTION
Adds a function for an operator to mark a salt as spent