### PR TITLE
feat: prevent queuing withdrawals to other addresses

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -272,7 +272,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         for (uint256 i = 0; i < queuedWithdrawalParams.length; i++) {
             require(queuedWithdrawalParams[i].strategies.length == queuedWithdrawalParams[i].shares.length, "DelegationManager.queueWithdrawal: input length mismatch");
-            require(queuedWithdrawalParams[i].withdrawer != address(0), "DelegationManager.queueWithdrawal: must provide valid withdrawal address");
+            require(queuedWithdrawalParams[i].withdrawer == msg.sender, "DelegationManager.queueWithdrawal: withdrawer must be staker");
 
             // Remove shares from staker's strategies and place strategies/shares in queue.
             // If the staker is delegated to an operator, the operator's delegated shares are also reduced

--- a/src/test/Withdrawals.t.sol
+++ b/src/test/Withdrawals.t.sol
@@ -22,15 +22,16 @@ contract WithdrawalTests is EigenLayerTestHelper {
     function testWithdrawalWrapper(
         address operator,
         address depositor,
-        address withdrawer,
         uint96 ethAmount,
         uint96 eigenAmount,
         bool withdrawAsTokens,
         bool RANDAO
-    ) public fuzzedAddress(operator) fuzzedAddress(depositor) fuzzedAddress(withdrawer) {
+    ) public fuzzedAddress(operator) fuzzedAddress(depositor) {
         cheats.assume(depositor != operator);
         cheats.assume(ethAmount >= 1 && ethAmount <= 1e18);
         cheats.assume(eigenAmount >= 1 && eigenAmount <= 1e18);
+
+        address withdrawer = depositor;
 
         if (RANDAO) {
             _testWithdrawalAndDeregistration(operator, depositor, withdrawer, ethAmount, eigenAmount, withdrawAsTokens);
@@ -244,14 +245,13 @@ contract WithdrawalTests is EigenLayerTestHelper {
     function testRedelegateAfterWithdrawal(
         address operator,
         address depositor,
-        address withdrawer,
         uint96 ethAmount,
         uint96 eigenAmount,
         bool withdrawAsShares
-    ) public fuzzedAddress(operator) fuzzedAddress(depositor) fuzzedAddress(withdrawer) {
+    ) public fuzzedAddress(operator) fuzzedAddress(depositor) {
         cheats.assume(depositor != operator);
         //this function performs delegation and subsequent withdrawal
-        testWithdrawalWrapper(operator, depositor, withdrawer, ethAmount, eigenAmount, withdrawAsShares, true);
+        testWithdrawalWrapper(operator, depositor, ethAmount, eigenAmount, withdrawAsShares, true);
 
         cheats.prank(depositor);
         delegation.undelegate(depositor);
@@ -260,50 +260,6 @@ contract WithdrawalTests is EigenLayerTestHelper {
         cheats.warp(block.timestamp + 7 days + 1);
         _initiateDelegation(operator, depositor, ethAmount, eigenAmount);
     }
-
-    // onlyNotFrozen modifier is not used in current DelegationManager implementation.
-    // commented out test case for now
-    // /// @notice test to see if an operator who is slashed/frozen
-    // ///         cannot be undelegated from by their stakers.
-    // /// @param operator is the operator being delegated to.
-    // /// @param staker is the staker delegating stake to the operator.
-    // function testSlashedOperatorWithdrawal(address operator, address staker, uint96 ethAmount, uint96 eigenAmount)
-    //     public
-    //     fuzzedAddress(operator)
-    //     fuzzedAddress(staker)
-    // {
-    //     cheats.assume(staker != operator);
-    //     testDelegation(operator, staker, ethAmount, eigenAmount);
-
-    //     {
-    //         address slashingContract = slasher.owner();
-
-    //         cheats.startPrank(operator);
-    //         slasher.optIntoSlashing(address(slashingContract));
-    //         cheats.stopPrank();
-
-    //         cheats.startPrank(slashingContract);
-    //         slasher.freezeOperator(operator);
-    //         cheats.stopPrank();
-    //     }
-
-    //     (IStrategy[] memory updatedStrategies, uint256[] memory updatedShares) =
-    //         strategyManager.getDeposits(staker);
-
-    //     uint256[] memory strategyIndexes = new uint256[](2);
-    //     strategyIndexes[0] = 0;
-    //     strategyIndexes[1] = 1;
-
-    //     IERC20[] memory tokensArray = new IERC20[](2);
-    //     tokensArray[0] = weth;
-    //     tokensArray[0] = eigenToken;
-
-    //     //initiating queued withdrawal
-    //     cheats.expectRevert(
-    //         bytes("StrategyManager.onlyNotFrozen: staker has been frozen and may be subject to slashing")
-    //     );
-    //     _testQueueWithdrawal(staker, strategyIndexes, updatedStrategies, updatedShares, staker);
-    // }
 
     // Helper function to begin a delegation
     function _initiateDelegation(


### PR DESCRIPTION
- Prevents calls to `queueWithdrawal` if any `QueuedWithdrawalParams` contains a `withdrawer` that is not the caller
- `completeQueuedWithdrawal` is unaffected, so existing queued withdrawals should not change