### PR TITLE
chore: remove maxPods

### DIFF
--- a/certora/specs/pods/EigenPodManager.spec
+++ b/certora/specs/pods/EigenPodManager.spec
@@ -46,7 +46,6 @@ methods {
     function slasher() external returns (address) envfree;
     function hasPod(address podOwner) external returns (bool) envfree;
     function numPods() external returns (uint256) envfree;
-    function maxPods() external returns (uint256) envfree;
     function podOwnerShares(address podOwner) external returns (int256) envfree;
     function beaconChainETHStrategy() external returns (address) envfree;
 

--- a/docs/core/EigenPodManager.md
+++ b/docs/core/EigenPodManager.md
@@ -527,23 +527,8 @@ This method loops over up to `maxNumberOfDelayedWithdrawalsToClaim` withdrawals,
 
 ### System Configuration
 
-* [`EigenPodManager.setMaxPods`](#eigenpodmanagersetmaxpods)
 * [`EigenPodManager.updateBeaconChainOracle`](#eigenpodmanagerupdatebeaconchainoracle)
 * [`DelayedWithdrawalRouter.setWithdrawalDelayBlocks`](#delayedwithdrawalroutersetwithdrawaldelayblocks)
-
-#### `EigenPodManager.setMaxPods`
-
-```solidity
-function setMaxPods(uint256 newMaxPods) external onlyUnpauser
-```
-
-Allows the unpauser to update the maximum number of `EigenPods` that the `EigenPodManager` can create.
-
-*Effects*:
-* Updates `EigenPodManager.maxPods`
-
-*Requirements*:
-* Caller MUST be the unpauser
 
 #### `EigenPodManager.updateBeaconChainOracle`
 

--- a/script/deploy/mainnet/M2Deploy.s.sol
+++ b/script/deploy/mainnet/M2Deploy.s.sol
@@ -62,7 +62,6 @@ contract M2Deploy is Script, Test {
     uint256 public withdrawalDelayBlocks;
     bytes32 public delegationManagerDomainSeparator;
     uint256 public numPods;
-    uint256 public maxPods;
 
     // Pointers to pre-upgrade values for lstDepositor
     address public lstDepositor;
@@ -122,7 +121,6 @@ contract M2Deploy is Script, Test {
         withdrawalDelayBlocks = m1StrategyManager(address(strategyManager)).withdrawalDelayBlocks();
         delegationManagerDomainSeparator = IDelegationManagerV0(address(delegation)).DOMAIN_SEPARATOR();
         numPods = eigenPodManager.numPods();
-        maxPods = eigenPodManager.maxPods();
         delayedWithdrawalRouter = EigenPod(payable(eigenPodBeacon.implementation())).delayedWithdrawalRouter();
 
         // Set chain-specific values
@@ -277,7 +275,7 @@ contract M2Deploy is Script, Test {
     // Call contracts to ensure that all simple view functions return the same values (e.g. the return value of `StrategyManager.delegation()` hasn’t changed)
     // StrategyManager: delegation, eigenPodManager, slasher, strategyWhitelister, withdrawalDelayBlocks all unchanged
     // DelegationManager: DOMAIN_SEPARATOR, strategyManager, slasher, eigenPodManager  all unchanged
-    // EigenPodManager: ethPOS, eigenPodBeacon, strategyManager, slasher, beaconChainOracle, numPods, maxPods  all unchanged
+    // EigenPodManager: ethPOS, eigenPodBeacon, strategyManager, slasher, beaconChainOracle, numPods  all unchanged
     // delegationManager is now correct (added immutable)
     // Call contracts to make sure they are still “initialized” (ensure that trying to call initializer reverts)
     function _verifyStorageSlots() internal view {
@@ -311,7 +309,6 @@ contract M2Deploy is Script, Test {
             "eigenPodManager.beaconChainOracle incorrect"
         );
         require(eigenPodManager.numPods() == numPods, "eigenPodManager.numPods incorrect");
-        require(eigenPodManager.maxPods() == maxPods, "eigenPodManager.maxPods incorrect");
         require(EigenPodManagerStorage(address(eigenPodManager)).delegationManager() == delegation, "eigenPodManager.delegationManager incorrect");
     }
 
@@ -339,7 +336,6 @@ contract M2Deploy is Script, Test {
 
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
         EigenPodManager(address(eigenPodManager)).initialize(
-            0,
             IBeaconChainOracle(address(this)),
             address(this),
             PauserRegistry(address(this)),

--- a/script/utils/validateStorage/validateUpgrade.sh
+++ b/script/utils/validateStorage/validateUpgrade.sh
@@ -69,7 +69,7 @@ echo "Comparing storage layouts..."
 # Add -k operator if present
 if [ ! -k "$1" ]; then
   echo "Keeping old storage layout files"
-  eval "npx ts-node script/upgrade/validateStorage.ts --old onChainLayout.csv --new localLayout.csv --keep"
+  eval "npx ts-node script/utils/validateStorage/validateStorage.ts --old onChainLayout.csv --new localLayout.csv --keep"
 else
-  eval "npx ts-node script/upgrade/validateStorage.ts --old onChainLayout.csv --new localLayout.csv"
+  eval "npx ts-node script/utils/validateStorage/validateStorage.ts --old onChainLayout.csv --new localLayout.csv"
 fi

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -26,9 +26,6 @@ interface IEigenPodManager is IPausable {
     /// @notice Emitted to notify a deposit of beacon chain ETH recorded in the strategy manager
     event BeaconChainETHDeposited(address indexed podOwner, uint256 amount);
 
-    /// @notice Emitted when `maxPods` value is updated from `previousValue` to `newValue`
-    event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
-
     /// @notice Emitted when the balance of an EigenPod is updated
     event PodSharesUpdated(address indexed podOwner, int256 sharesDelta);
 
@@ -106,9 +103,6 @@ interface IEigenPodManager is IPausable {
 
     /// @notice Returns the number of EigenPods that have been created
     function numPods() external view returns (uint256);
-
-    /// @notice Returns the maximum number of EigenPods that can be created
-    function maxPods() external view returns (uint256);
 
     /**
      * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -55,13 +55,11 @@ contract EigenPodManager is
     }
 
     function initialize(
-        uint256 _maxPods,
         IBeaconChainOracle _beaconChainOracle,
         address initialOwner,
         IPauserRegistry _pauserRegistry,
         uint256 _initPausedStatus
     ) external initializer {
-        _setMaxPods(_maxPods);
         _updateBeaconChainOracle(_beaconChainOracle);
         _transferOwnership(initialOwner);
         _initializePauser(_pauserRegistry, _initPausedStatus);
@@ -224,15 +222,6 @@ contract EigenPodManager is
     }
 
     /**
-     * Sets the maximum number of pods that can be deployed
-     * @param newMaxPods The new maximum number of pods that can be deployed
-     * @dev Callable by the unpauser of this contract
-     */
-    function setMaxPods(uint256 newMaxPods) external onlyUnpauser {
-        _setMaxPods(newMaxPods);
-    }
-
-    /**
      * @notice Updates the oracle contract that provides the beacon chain state root
      * @param newBeaconChainOracle is the new oracle contract being pointed to
      * @dev Callable only by the owner of this contract (i.e. governance)
@@ -256,8 +245,6 @@ contract EigenPodManager is
     // INTERNAL FUNCTIONS
 
     function _deployPod() internal returns (IEigenPod) {
-        // check that the limit of EigenPods has not been hit, and increment the EigenPod count
-        require(numPods + 1 <= maxPods, "EigenPodManager._deployPod: pod limit reached");
         ++numPods;
         // create the pod
         IEigenPod pod = IEigenPod(
@@ -279,12 +266,6 @@ contract EigenPodManager is
     function _updateBeaconChainOracle(IBeaconChainOracle newBeaconChainOracle) internal {
         beaconChainOracle = newBeaconChainOracle;
         emit BeaconOracleUpdated(address(newBeaconChainOracle));
-    }
-
-    /// @notice Internal setter for `maxPods` that also emits an event
-    function _setMaxPods(uint256 _maxPods) internal {
-        emit MaxPodsUpdated(maxPods, _maxPods);
-        maxPods = _maxPods;
     }
 
     /**

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -50,8 +50,9 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
     /// @notice The number of EigenPods that have been deployed
     uint256 public numPods;
 
-    /// @notice The maximum number of EigenPods that can be deployed
-    uint256 public maxPods;
+    /// @notice Deprecated from old mainnet release. Was initially used to limit growth early on but there is no longer
+    /// a maximum number of EigenPods that can be deployed.
+    uint256 public __deprecated_maxPods;
 
     // BEGIN STORAGE VARIABLES ADDED AFTER MAINNET DEPLOYMENT -- DO NOT SUGGEST REORDERING TO CONVENTIONAL ORDER
     /**

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -52,7 +52,7 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     /// @notice Deprecated from old mainnet release. Was initially used to limit growth early on but there is no longer
     /// a maximum number of EigenPods that can be deployed.
-    uint256 public __deprecated_maxPods;
+    uint256 private __deprecated_maxPods;
 
     // BEGIN STORAGE VARIABLES ADDED AFTER MAINNET DEPLOYMENT -- DO NOT SUGGEST REORDERING TO CONVENTIONAL ORDER
     /**

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -416,7 +416,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                type(uint256).max,
                 beaconChainOracleAddress,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -303,7 +303,6 @@ contract EigenLayerDeployer is Operators {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                type(uint256).max, // maxPods
                 beaconChainOracleAddress,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,

--- a/src/test/events/IEigenPodManagerEvents.sol
+++ b/src/test/events/IEigenPodManagerEvents.sol
@@ -8,12 +8,8 @@ interface IEigenPodManagerEvents {
     /// @notice Emitted to notify that the denebForkTimestamp has been set
     event DenebForkTimestampUpdated(uint64 denebForkTimestamp);
 
-
     /// @notice Emitted to notify the deployment of an EigenPod
     event PodDeployed(address indexed eigenPod, address indexed podOwner);
-
-    /// @notice Emitted when `maxPods` value is updated from `previousValue` to `newValue`
-    event MaxPodsUpdated(uint256 previousValue, uint256 newValue);
 
     /// @notice Emitted when the balance of an EigenPod is updated
     event PodSharesUpdated(address indexed podOwner, int256 sharesDelta);

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -235,7 +235,6 @@ abstract contract IntegrationDeployer is Test, IUserDeployer {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                type(uint).max, // maxPods
                 address(beaconChainOracle),
                 eigenLayerReputedMultisig, // initialOwner
                 pauserRegistry,

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -84,9 +84,6 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
 
     function numPods() external view returns (uint256) {}
 
-    function maxPods() external view returns (uint256) {}
-
-
     function denebForkTimestamp() external pure returns (uint64) {
         return type(uint64).max;
     }

--- a/src/test/tree/EigenPodManagerUnit.tree
+++ b/src/test/tree/EigenPodManagerUnit.tree
@@ -6,8 +6,6 @@
 ├── when createPod called
 │   ├── given the user has already created a pod
 │   │   └── it should revert
-│   ├── given that the max number of pods has been deployed
-│   │   └── it should revert
 │   └── given the user has not created a pod
 │       └── it should deploy a pod
 ├── when stake is called
@@ -15,11 +13,6 @@
 │   │   └── it should deploy a pod
 │   └── given the user has already created a pod
 │       └── it should call stake on the eigenPod
-├── when setMaxPods is called
-│   ├── given the user is not the pauser
-│   │   └── it should revert
-│   └── given the user is the pauser
-│       └── it should set the max pods
 ├── when updateBeaconChainOracle is called
 │   ├── given the user is not the owner
 │   │   └── it should revert

--- a/src/test/unit/EigenPod-PodManagerUnit.t.sol
+++ b/src/test/unit/EigenPod-PodManagerUnit.t.sol
@@ -85,7 +85,6 @@ contract EigenPod_PodManager_UnitTests is EigenLayerUnitTestSetup {
             address(eigenPodManagerWrapper),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                type(uint256).max /*maxPods*/,
                 beaconChainOracle,
                 initialOwner,
                 pauserRegistry,
@@ -228,9 +227,7 @@ contract EigenPod_PodManager_UnitTests_EigenPod is EigenPod_PodManager_UnitTests
     function test_stake_podAlreadyDeployed(bytes memory signature, bytes32 depositDataRoot) public {
         uint256 stakeAmount = 32e18;
 
-        uint256 maxPods = eigenPodManager.maxPods();
         uint256 numPods = eigenPodManager.numPods();
-        emit log_named_uint("maxPods", maxPods);
         emit log_named_uint("numPods", numPods);
 
         cheats.startPrank(podOwner);


### PR DESCRIPTION
We are no longer limiting maximum number of deployed eigenpods. EigenPodManager on mainnet has `maxPods` set to uint256 max https://etherscan.io/address/0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338#readProxyContract

This is removing unused `maxPods` code