### PR TITLE
feat: poc for checkpointed partial withdrawals

### DIFF
--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -43,8 +43,8 @@ interface IEigenPod {
      * manage stack depth and optimize the number of external calls, when batching withdrawal operations.
      */
     struct VerifiedWithdrawal {
-        // amount to send to a podOwner from a proven withdrawal
-        uint256 amountToSendGwei;
+        // amount of ETH withdrawn via a full validator withdrawal
+        uint256 amountToQueueGwei;
         // difference in shares to be recorded in the eigenPodManager, as a result of the withdrawal
         int256 sharesDeltaGwei;
     }

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -55,6 +55,7 @@ library BeaconChainProofs {
     uint256 internal constant VALIDATOR_PUBKEY_INDEX = 0;
     uint256 internal constant VALIDATOR_WITHDRAWAL_CREDENTIALS_INDEX = 1;
     uint256 internal constant VALIDATOR_BALANCE_INDEX = 2;
+    uint256 internal constant VALIDATOR_EXIT_EPOCH_INDEX = 6;
     uint256 internal constant VALIDATOR_WITHDRAWABLE_EPOCH_INDEX = 7;
 
     // in execution payload header
@@ -77,6 +78,10 @@ library BeaconChainProofs {
 
     /// @notice Number of seconds per epoch: 384 == 32 slots/epoch * 12 seconds/slot 
     uint64 internal constant SECONDS_PER_EPOCH = SLOTS_PER_EPOCH * SECONDS_PER_SLOT;
+
+    /// @notice When a validator is created on the beacon chain, its status epochs
+    /// are all initially set to this value
+    uint64 internal constant FAR_FUTURE_EPOCH = type(uint64).max;
 
     bytes8 internal constant UINT64_MASK = 0xffffffffffffffff;
 
@@ -373,6 +378,14 @@ library BeaconChainProofs {
     function getEffectiveBalanceGwei(bytes32[] memory validatorFields) internal pure returns (uint64) {
         return 
             Endian.fromLittleEndianUint64(validatorFields[VALIDATOR_BALANCE_INDEX]);
+    }
+
+    /**
+     * @dev Returns true if the validator has initiated an exit by any means, including being slashed
+     */
+    function hasInitiatedExit(bytes32[] memory validatorFields) internal pure returns (bool) {
+        return
+            Endian.fromLittleEndianUint64(validatorFields[VALIDATOR_EXIT_EPOCH_INDEX]) == FAR_FUTURE_EPOCH;
     }
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -750,7 +750,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
          */
  
         VerifiedWithdrawal memory verifiedWithdrawal;
-        verifiedWithdrawal.amountToQueueGwei = uint256(withdrawalAmountGwei - amountToQueueGwei);
+        verifiedWithdrawal.amountToQueueGwei = amountToQueueGwei;
         withdrawableRestakedExecutionLayerGwei += amountToQueueGwei;
          
         /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -366,7 +366,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             if (updateCheckpoint && !validatorProven[oracleTimestamp][pubkeyHash]) {
                 validatorProven[oracleTimestamp][pubkeyHash] = true;
                 checkpoint.proofsRemaining--;
-                checkpoint.eligibleBalance -= verifiedWithdrawal.amountToQueueGwei;
+                checkpoint.eligibleBalance -= uint232(verifiedWithdrawal.amountToQueueGwei * GWEI_TO_WEI);
             }
         }
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -205,7 +205,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         uint256 eligibleBalance = 
             address(this).balance 
                 - nonBeaconChainETHBalanceWei 
-                - withdrawableRestakedExecutionLayerGwei;
+                - (withdrawableRestakedExecutionLayerGwei * GWEI_TO_WEI);
         require(eligibleBalance != 0, "No eligible balance to withdraw");
 
         // If we have no active validators, there are no additional steps needed!


### PR DESCRIPTION
Pod Owners create a partial withdrawal checkpoint by calling `EigenPod.startNonRestakedWithdrawal`. This sets `EigenPod.currentCheckpoint` to the current block timestamp, and records the pod's current:
* `activeValidatorCount`: the number of validators with proven withdrawal credentials in the ACTIVE state in the pod. This becomes the `proofsRemaining` required to complete the checkpoint.
* `eligibleBalance`: the unaccounted for balance in the pod as of the checkpoint's creation (`this.balance - nonBeaconChainETHBalanceWei - withdrawableRestakedExecutionLayerWei`)

A checkpoint's progress is tracked using the following state variables:
```solidity
/// (optimized for a single SLOAD)
struct Checkpoint {
    uint24 proofsRemaining;
    uint232 eligibleBalance;
}

/// @dev The current non-restaked withdrawal checkpoint, and the timestamp used to prove
/// the checkpoint's validator set.
///
/// Note: If there is no currently-active checkpoint, `currentCheckpointTimestamp` will be 0
Checkpoint currentCheckpoint;
uint64 currentCheckpointTimestamp;
    
/// @dev Tracks whether a validator's balance has been accounted for at a checkpoint
/// timestamp. We keep track of this to ensure that a checkpoint's `proofsRemaining`
/// is only decremented for proofs on validators who were active when the checkpoint
/// was created.
///
/// checkpointTimestamp -> validator pubkeyHash -> valid proof submitted
mapping(uint64 => mapping(bytes32 => bool)) validatorProven;
```

`currentCheckpoint` keeps track of the `Checkpoint` being proven at the oracle timestamp given by `currentCheckpointTimestamp`.

`validatorProven` keeps track of any validators whose balance we've accounted for at specific oracle timestamps.

When any proof is submitted where the proof's `oracleTimestamp` matches this checkpoint timestamp, the checkpoint is updated. Users can use both `verifyBalanceUpdates` or `verifyAndProcessWithdrawals` to make progress on the `proofsRemaining` for the current checkpoint. When any validator is proven at a given timestamp, `validatorProven[oracleTimestamp][pubkeyHash]` is set to true so that only one proof can be submitted for that validator at that timestamp.

Additional notes:
* Adds a new state variable `activeValidatorCount`. This is incremented when a new set of withdrawal credentials are proven, and decremented when a full withdrawal is proven. When a checkpoint is created, the current value of `activeValidatorCount` is used to determine how many proofs are needed to finish the checkpoint and withdraw the eligible balance.
* Adds new state variable `cachedStateRoots`, which caches state root proofs for any of the 3 proving methods. If a user is submitting a proof using an oracle timestamp that has already been used, they won't need to submit another `StateRootProof` (or read from the beacon chain oracle).
* This PR gets rid of some of the timing restrictions for balance update proofs, because the checkpointing system implies we allow "stale" proofs on unaccounted-for balance. To account for this, I used the same "staleness check" to instead determine whether a balance update should calculate a share delta and send that to the EigenPodManager.
* Partial withdrawal proofs have been removed from `verifyAndProcessWithdrawals`, since those can now be accounted for using the checkpoint system (even if a checkpoint is created after a full withdrawal proof is submitted!)

Finally - the withdrawal flow right now is the biggest WIP, and I need to think a bit more about beacon state changes and transitions!

