### PR TITLE
fix: certora prover ci

### DIFF
--- a/certora/scripts/core/verifyDelegationManager.sh
+++ b/certora/scripts/core/verifyDelegationManager.sh
@@ -11,7 +11,7 @@ certoraRun certora/harnesses/DelegationManagerHarness.sol \
     src/contracts/core/Slasher.sol src/contracts/permissions/PauserRegistry.sol \
     --verify DelegationManagerHarness:certora/specs/core/DelegationManager.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true' \
+    --optimistic_fallback \
     --optimistic_hashing \
     --parametric_contracts DelegationManagerHarness \
     $RULE \

--- a/certora/scripts/core/verifyStrategyManager.sh
+++ b/certora/scripts/core/verifyStrategyManager.sh
@@ -12,7 +12,7 @@ certoraRun certora/harnesses/StrategyManagerHarness.sol \
     src/contracts/core/Slasher.sol src/contracts/permissions/PauserRegistry.sol \
     --verify StrategyManagerHarness:certora/specs/core/StrategyManager.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true' \
+    --optimistic_fallback \
     --optimistic_hashing \
     --parametric_contracts StrategyManagerHarness \
     $RULE \

--- a/certora/scripts/libraries/verifyStructuredLinkedList.sh
+++ b/certora/scripts/libraries/verifyStructuredLinkedList.sh
@@ -8,7 +8,7 @@ solc-select use 0.8.12
 certoraRun certora/harnesses/StructuredLinkedListHarness.sol \
     --verify StructuredLinkedListHarness:certora/specs/libraries/StructuredLinkedList.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true' \
+    --optimistic_fallback \
     --parametric_contracts StructuredLinkedListHarness \
     $RULE \
     --rule_sanity \

--- a/certora/scripts/permissions/verifyPausable.sh
+++ b/certora/scripts/permissions/verifyPausable.sh
@@ -9,7 +9,8 @@ certoraRun certora/harnesses/PausableHarness.sol \
     src/contracts/permissions/PauserRegistry.sol \
     --verify PausableHarness:certora/specs/permissions/Pausable.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true -recursionErrorAsAssert false -recursionEntryLimit 3' \
+    --optimistic_fallback \
+    --prover_args '-recursionErrorAsAssert false -recursionEntryLimit 3' \
     --loop_iter 3 \
     --link PausableHarness:pauserRegistry=PauserRegistry \
     $RULE \

--- a/certora/scripts/pods/verifyEigenPodManager.sh
+++ b/certora/scripts/pods/verifyEigenPodManager.sh
@@ -10,7 +10,7 @@ certoraRun certora/harnesses/EigenPodManagerHarness.sol \
     src/contracts/core/Slasher.sol src/contracts/permissions/PauserRegistry.sol \
     --verify EigenPodManagerHarness:certora/specs/pods/EigenPodManager.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true' \
+    --optimistic_fallback \
     --optimistic_hashing \
     --parametric_contracts EigenPodManagerHarness \
     $RULE \

--- a/certora/scripts/strategies/verifyStrategyBase.sh
+++ b/certora/scripts/strategies/verifyStrategyBase.sh
@@ -12,7 +12,8 @@ certoraRun src/contracts/strategies/StrategyBase.sol \
     src/contracts/core/Slasher.sol \
     --verify StrategyBase:certora/specs/strategies/StrategyBase.spec \
     --optimistic_loop \
-    --prover_args '-optimisticFallback true -recursionErrorAsAssert false -recursionEntryLimit 3' \
+    --optimistic_fallback \
+    --prover_args '-recursionErrorAsAssert false -recursionEntryLimit 3' \
     --loop_iter 3 \
     --packages @openzeppelin=lib/openzeppelin-contracts @openzeppelin-upgrades=lib/openzeppelin-contracts-upgradeable \
     --link StrategyBase:strategyManager=StrategyManager \


### PR DESCRIPTION
Updates to certora-cli uses cli flag `--optimistic_fallback` instead of `prover_args` with -optimisticFallback as value.
Here is example of error https://github.com/Layr-Labs/eigenlayer-contracts/actions/runs/8330391177/job/22794927969