### PR TITLE
fix: off-by-one error

### DIFF
--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -118,11 +118,11 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         _;
     }
 
-    /// @notice Checks that `timestamp` is strictly greater than the value stored in `mostRecentWithdrawalTimestamp`
+    /// @notice Checks that `timestamp` is greater than or equal to the value stored in `mostRecentWithdrawalTimestamp`
     modifier proofIsForValidTimestamp(uint64 timestamp) {
         require(
-            timestamp > mostRecentWithdrawalTimestamp,
-            "EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp"
+            timestamp >= mostRecentWithdrawalTimestamp,
+            "EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp"
         );
         _;
     }

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -371,7 +371,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.startPrank(podOwner);
         cheats.expectRevert(
             bytes(
-                "EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp"
+                "EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp"
             )
         );
         newPod.verifyWithdrawalCredentials(

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -345,45 +345,6 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
-    function testDeployEigenPodTooSoon() public {
-        // ./solidityProofGen  -newBalance=32000115173 "ValidatorFieldsProof" 302913 true "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "withdrawal_credential_proof_302913.json"
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
-
-        IEigenPod newPod = eigenPodManager.getPod(podOwner);
-
-        cheats.startPrank(podOwner);
-        
-
-        cheats.expectEmit(true, true, true, true, address(newPod));
-        emit EigenPodStaked(pubkey);
-        eigenPodManager.stake{value: stakeAmount}(pubkey, signature, depositDataRoot);
-        cheats.stopPrank();
-
-        uint64 timestamp = 0;
-        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
-        validatorFieldsArray[0] = getValidatorFields();
-        bytes[] memory proofsArray = new bytes[](1);
-        proofsArray[0] = abi.encodePacked(getWithdrawalCredentialProof());
-        BeaconChainProofs.StateRootProof memory stateRootProofStruct = _getStateRootProof();
-        uint40[] memory validatorIndices = new uint40[](1);
-        validatorIndices[0] = uint40(getValidatorIndex());
-
-        cheats.startPrank(podOwner);
-        cheats.expectRevert(
-            bytes(
-                "EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp"
-            )
-        );
-        newPod.verifyWithdrawalCredentials(
-            timestamp,
-            stateRootProofStruct,
-            validatorIndices,
-            proofsArray,
-            validatorFieldsArray
-        );
-        cheats.stopPrank();
-    }
-
     function testWithdrawNonBeaconChainETHBalanceWei() public {
         IEigenPod pod = testDeployAndVerifyNewEigenPod();
 

--- a/src/test/harnesses/EigenPodHarness.sol
+++ b/src/test/harnesses/EigenPodHarness.sol
@@ -120,4 +120,8 @@ contract EPInternalFunctions is EigenPod, Test {
     function setValidatorRestakedBalance(bytes32 pkhash, uint64 restakedBalanceGwei) public {
         _validatorPubkeyHashToInfo[pkhash].restakedBalanceGwei = restakedBalanceGwei;
     }
+
+    function setMostRecentWithdrawalTimestamp(uint64 _mostRecentWithdrawalTimestamp) public {
+        mostRecentWithdrawalTimestamp = _mostRecentWithdrawalTimestamp;
+    }
  }

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -805,6 +805,30 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
         assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
     }
 
+    // regression test for off-by-one error
+    function test_verifyAndProcessWithdrawal_atLastestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
+        // Set JSON & params
+        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+        _setWithdrawalProofParams();
+
+        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+        // set the `mostRecentWithdrawalTimestamp` to be equal to the withdrawal timestamp
+        eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp);
+
+        // Process withdrawal
+        eigenPodHarness.verifyAndProcessWithdrawal(
+            beaconStateRoot,
+            withdrawalToProve,
+            validatorFieldsProof,
+            validatorFields,
+            withdrawalFields
+        );
+
+        // Verify storage
+        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    }
+
     /// @notice Tests processing a full withdrawal > MAX_RESTAKED_GWEI_PER_VALIDATOR
     function test_processFullWithdrawal_excess32ETH() public setWithdrawalCredentialsExcess {
         // Set JSON & params

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -731,7 +731,7 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
         eigenPodHarness.activateRestaking();
 
         // Expect revert
-        cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be for timestamp after mostRecentWithdrawalTimestamp");
+        cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
         eigenPodHarness.verifyAndProcessWithdrawal(
             beaconStateRoot,
             withdrawalToProve,

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -806,7 +806,7 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
     }
 
     // regression test for off-by-one error
-    function test_verifyAndProcessWithdrawal_atLastestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
+    function test_verifyAndProcessWithdrawal_atLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
         // Set JSON & params
         setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
         _setWithdrawalProofParams();
@@ -827,6 +827,26 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
         // Verify storage
         bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
         assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    }
+
+    function test_revert_verifyAndProcessWithdrawal_beforeLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
+        // Set JSON & params
+        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+        _setWithdrawalProofParams();
+
+        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+        // set the `mostRecentWithdrawalTimestamp` to just after the withdrawal timestamp
+        eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp + 1);
+
+        // Process withdrawal, expect revert
+        cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
+        eigenPodHarness.verifyAndProcessWithdrawal(
+            beaconStateRoot,
+            withdrawalToProve,
+            validatorFieldsProof,
+            validatorFields,
+            withdrawalFields
+        );
     }
 
     /// @notice Tests processing a full withdrawal > MAX_RESTAKED_GWEI_PER_VALIDATOR


### PR DESCRIPTION
Fixes an off-by-one error that could have caused withdrawals to get stuck in EigenPods.
This is because withdrawals are processed at the _end_ of the block in which they are posted (rather than at the top of the block), so the strict inequality of `require(timestamp > mostRecentWithdrawalTimestamp)` could cause withdrawals that are processed in the same block as `mostRecentWithdrawalTimestamp` is set to get stuck.
The fix is simply changing the inequality to be non-strict. PR contains a new regression test for the behavior.