### PR TITLE
chore: fork test via environment and custom foundry profile

### DIFF
--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -41,7 +41,7 @@ jobs:
       id: build
 
     - name: Run unit tests
-      run: forge test --no-match-contract FFI --no-match-contract Integration
+      run: forge test --no-match-contract Integration
       env:
         RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
         RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}

--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -42,6 +42,14 @@ jobs:
         forge build --sizes
       id: build
 
+    - name: Run integration mainnet fork tests
+      run: forge test --match-contract Integration
+      env:
+        FOUNDRY_PROFILE: "forktest"
+        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+        CHAIN_ID: ${{ secrets.CHAIN_ID }}
+
     - name: Run unit tests
       run: forge test --no-match-contract Integration
       env:
@@ -56,10 +64,4 @@ jobs:
         RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
         CHAIN_ID: ${{ secrets.CHAIN_ID }}
 
-    - name: Run integration mainnet fork tests
-      run: forge test --match-contract Integration
-      env:
-        FOUNDRY_PROFILE: "forktest"
-        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
-        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
-        CHAIN_ID: ${{ secrets.CHAIN_ID }}
+    

--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -24,6 +24,8 @@ jobs:
   run-tests:
     needs: prepare
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
     - name: Checkout code

--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -24,10 +24,7 @@ jobs:
   run-tests:
     needs: prepare
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        file: ${{fromJson(needs.prepare.outputs.matrix)}}
-      fail-fast: false
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -43,8 +40,8 @@ jobs:
         forge build --sizes
       id: build
 
-    - name: Run forge test for the file
-      run: forge test --match-path src/test/${{ matrix.file }} --no-match-contract FFI
+    - name: Run forge test for all files
+      run: forge test --no-match-contract FFI
       env:
         RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
         RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}

--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -42,14 +42,6 @@ jobs:
         forge build --sizes
       id: build
 
-    - name: Run integration mainnet fork tests
-      run: forge test --match-contract Integration
-      env:
-        FOUNDRY_PROFILE: "forktest"
-        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
-        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
-        CHAIN_ID: ${{ secrets.CHAIN_ID }}
-
     - name: Run unit tests
       run: forge test --no-match-contract Integration
       env:
@@ -64,4 +56,10 @@ jobs:
         RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
         CHAIN_ID: ${{ secrets.CHAIN_ID }}
 
-    
+    - name: Run integration mainnet fork tests
+      run: forge test --match-contract Integration
+      env:
+        FOUNDRY_PROFILE: "forktest"
+        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+        CHAIN_ID: ${{ secrets.CHAIN_ID }}

--- a/.github/workflows/testinparallel.yml
+++ b/.github/workflows/testinparallel.yml
@@ -40,9 +40,24 @@ jobs:
         forge build --sizes
       id: build
 
-    - name: Run forge test for all files
-      run: forge test --no-match-contract FFI
+    - name: Run unit tests
+      run: forge test --no-match-contract FFI --no-match-contract Integration
       env:
+        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+        CHAIN_ID: ${{ secrets.CHAIN_ID }}
+
+    - name: Run integration tests
+      run: forge test --match-contract Integration
+      env:
+        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+        CHAIN_ID: ${{ secrets.CHAIN_ID }}
+
+    - name: Run integration mainnet fork tests
+      run: forge test --match-contract Integration
+      env:
+        FOUNDRY_PROFILE: "forktest"
         RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
         RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
         CHAIN_ID: ${{ secrets.CHAIN_ID }}

--- a/foundry.toml
+++ b/foundry.toml
@@ -32,3 +32,6 @@ quote_style = "double"
 tab_width = 4
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config
+
+[profile.forktest.fuzz]
+runs=10

--- a/foundry.toml
+++ b/foundry.toml
@@ -34,4 +34,4 @@ tab_width = 4
 # See more config options https://github.com/gakonst/foundry/tree/master/config
 
 [profile.forktest.fuzz]
-runs=10
+runs=20

--- a/src/test/integration/README.md
+++ b/src/test/integration/README.md
@@ -6,6 +6,13 @@ Good question.
 
 This folder contains the integration framework and tests for Eigenlayer core, which orchestrates the deployment of all EigenLayer core contracts to fuzz high-level user flows across multiple user and asset types, and supports time-travelling state lookups to quickly compare past and present states (please try to avoid preventing your own birth).
 
+**If you want to know how to run the tests**:
+
+* Local: `forge t --mc Integration`
+* Mainnet fork tests: `env FOUNDRY_PROFILE=forktest forge t --mc Integration`
+
+Note that for mainnet fork tests, you'll need to set the `RPC_MAINNET` environment variable to your RPC provider of choice!
+
 **If you want to know where the tests are**, take a look at `/tests`. We're doing one test contract per top-level flow, and defining multiple test functions for variants on that flow. 
 
 e.g. if you're testing the flow "deposit into strategies -> delegate to operator -> queue withdrawal -> complete withdrawal", that's it's own test contract. For variants where withdrawals are completed "as tokens" vs "as shares," those are their own functions inside that contract.
@@ -94,3 +101,15 @@ function testFuzz_deposit_delegate_EXAMPLE(uint24 _random) public {
 
 * Suggest or PR cleanup if you have ideas. Currently, the `IntegrationDeployer` contract is pretty messy.
 * Coordinate in Slack to pick out some user flows to write tests for!
+
+#### Reduce RPC spam for fork tests
+
+Currently our mainnet fork tests spam whatever RPC we use. We can improve this in the future - apparently the meta is:
+
+> Use an anvil node to fork the network, you can write a script to make some changes to the forked network for setup etc, then fork your local node in your test.
+> Effectively you just setup an anvil node with the command
+`anvil -f RPC_URL `
+You can use `anvil -h` for more info on what it can do.
+
+> Then in your test you use the vm.createSelectFork command in your setup with the argument to point to your local anvil node which is basically a copy of the rpc you set it up as. 
+>  If you want to do some setup before running your tests you can write a script file and broadcast the setup transactions to your local anvil node (make sure to use one of the private keys anvil gives you)

--- a/src/test/integration/tests/Delegate_Deposit_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Delegate_Deposit_Queue_Complete.t.sol
@@ -5,14 +5,13 @@ import "src/test/integration/IntegrationChecks.t.sol";
 import "src/test/integration/users/User.t.sol";
 
 contract Integration_Delegate_Deposit_Queue_Complete is IntegrationCheckUtils {
-    
+
     function testFuzz_delegate_deposit_queue_completeAsShares(uint24 _random) public {
         // Configure the random parameters for the test
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
         // Create a staker and an operator with a nonzero balance and corresponding strategies
         (User staker, IStrategy[] memory strategies, uint[] memory tokenBalances) = _newRandomStaker();
@@ -50,8 +49,7 @@ contract Integration_Delegate_Deposit_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         // Create a staker and an operator with a nonzero balance and corresponding strategies

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -20,8 +20,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -83,8 +82,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -149,8 +147,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -215,8 +212,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -287,8 +283,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: NO_ASSETS | HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create a staker and operator

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -18,8 +18,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -91,8 +90,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -177,8 +175,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST, // not holding ETH since we can only deposit 32 ETH multiples
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -270,8 +267,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST, // not holding ETH since we can only deposit 32 ETH multiples
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -363,8 +359,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create operators and a staker
@@ -438,8 +433,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create operators and a staker

--- a/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
@@ -16,8 +16,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -80,8 +79,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -137,8 +135,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:
@@ -195,8 +192,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and a staker with:

--- a/src/test/integration/tests/Deposit_Delegate_UpdateBalance.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_UpdateBalance.t.sol
@@ -16,8 +16,7 @@ contract Integration_Deposit_Delegate_UpdateBalance is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         /// 0. Create an operator and staker with some underlying assets

--- a/src/test/integration/tests/Deposit_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Queue_Complete.t.sol
@@ -15,8 +15,7 @@ contract Integration_Deposit_QueueWithdrawal_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         // Create a staker with a nonzero balance and corresponding strategies
@@ -52,8 +51,7 @@ contract Integration_Deposit_QueueWithdrawal_Complete is IntegrationCheckUtils {
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         // Create a staker with a nonzero balance and corresponding strategies

--- a/src/test/integration/tests/Deposit_Register_QueueWithdrawal_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Register_QueueWithdrawal_Complete.t.sol
@@ -10,8 +10,7 @@ contract Integration_Deposit_Register_QueueWithdrawal_Complete is IntegrationChe
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         // Create a staker with a nonzero balance and corresponding strategies
@@ -46,8 +45,7 @@ contract Integration_Deposit_Register_QueueWithdrawal_Complete is IntegrationChe
         _configRand({
             _randomSeed: _random,
             _assetTypes: HOLDS_LST | HOLDS_ETH | HOLDS_ALL,
-            _userTypes: DEFAULT | ALT_METHODS,
-            _forkTypes: LOCAL | MAINNET
+            _userTypes: DEFAULT | ALT_METHODS
         });
 
         // Create a staker with a nonzero balance and corresponding strategies

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -2757,6 +2757,8 @@ contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
      * Emits a `StakerUndelegated` event
      */
     function testFuzz_undelegate_noDelegateableShares(address staker) public filterFuzzedAddressInputs(staker) {
+        cheats.assume(staker != defaultOperator);
+        
         // register *this contract* as an operator and delegate from the `staker` to them
         _registerOperatorWithBaseDetails(defaultOperator);
         _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);


### PR DESCRIPTION
* regular, non-forking integration tests are run with `forge t --mc Integration`
* mainnet fork tests are run with `env FOUNDRY_PROFILE=forktest forge t --mc Integration`
* mainnet fork tests use the `forktest` foundry profile, which i've defined to only have 20 fuzz runs to limit RPC spam
* i added some notes to the integration test README that describe future directions for reducing RPC spam so we can bump the mainnet fork test intensity up, but for now this works