### PR TITLE
fix: m2_deploy_from_scratch script for devnet

### DIFF
--- a/.github/workflows/run-deploy-scripts.yml
+++ b/.github/workflows/run-deploy-scripts.yml
@@ -1,0 +1,36 @@
+name: Run Deploy Scripts
+# We run the deploy scripts just to make sure they work
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # install foundry to run forge script. Should we run forge script in a container instead?
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Start Anvil chain
+        # need to start Anvil chain with -d to let the container run in the background
+        # if we start with 'anvil &' instead, the process stops when the step ends
+        run: docker run -d --rm -p 8545:8545 --entrypoint anvil ghcr.io/foundry-rs/foundry:nightly-5b7e4cb3c882b28f3c32ba580de27ce7381f415a --host 0.0.0.0
+
+      - name: Wait for Anvil chain to start
+        run: sleep 3
+
+      # Run Forge script against the Anvil chain
+      - name: Run M2_Deploy_From_Scratch
+        run: |
+          forge script script/deploy/devnet/M2_Deploy_From_Scratch.s.sol --rpc-url http://localhost:8545 \
+            --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 --broadcast \
+            --sig "run(string memory configFileName)" -- M2_deploy_from_scratch.anvil.config.json

--- a/.github/workflows/run-deploy-scripts.yml
+++ b/.github/workflows/run-deploy-scripts.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       # install foundry to run forge script. Should we run forge script in a container instead?
       - name: Install Foundry

--- a/script/configs/devnet/M2_deploy_from_scratch.anvil.config.json
+++ b/script/configs/devnet/M2_deploy_from_scratch.anvil.config.json
@@ -15,7 +15,6 @@
           "MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR": "32000000000"
      },
      "eigenPodManager": {
-          "max_pods": 0,
           "init_paused_status": 30
      },
      "delayedWithdrawalRouter": {


### PR DESCRIPTION
This PR:
1. fixes the deploy from scratch script for anvil
2. moves the script into a /devnet subfolder (not sure why it wasn't like the others in goerli, holesky, miannet)
3. adds a github action to run this deploy script to make sure its always kept up-to-date

For 3.... should we be running this inside the `run parallel` github action to save on checkout/forge build costs?