### PR TITLE
feat: add payments off-chain assumptions

### DIFF
--- a/docs/core/PaymentCoordinator.md
+++ b/docs/core/PaymentCoordinator.md
@@ -28,7 +28,7 @@ This document is organized according to the following themes (click each to be t
 * [Distributing and Claiming Payments](#distributing-and-claiming-payments)
 * [System Configuration](#system-configuration)
 * [Payments Merkle Tree Structure](#payments-merkle-tree-structure)
-* [Off-Chain Calculation](#offchain-calculation)
+* [Off Chain Calculation](#off-chain-calculation)
 
 #### Important state variables
 
@@ -356,7 +356,7 @@ The payment merkle tree is structured in the diagram below:
 
 ![.](../images/PaymentCoordinator_Merkle_Tree.png)
 
-### Off-Chain Integrations
+### Off Chain Calcalculation
 
 Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Every `CALCULATION_INTERVAL_SECONDS` payouts are accumulated up to `lastPaymentTimestamp + CALCULATION_INTERVAL_SECONDS` and posted on-chain by the entity with the `paymentUpdater` role. 
 

--- a/docs/core/PaymentCoordinator.md
+++ b/docs/core/PaymentCoordinator.md
@@ -356,7 +356,9 @@ The payment merkle tree is structured in the diagram below:
 
 ![.](../images/PaymentCoordinator_Merkle_Tree.png)
 
-### Off Chain Calcalculation
+---
+
+### Off Chain Calculation
 
 Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Every `CALCULATION_INTERVAL_SECONDS` payouts are accumulated up to `lastPaymentTimestamp + CALCULATION_INTERVAL_SECONDS` and posted on-chain by the entity with the `paymentUpdater` role. 
 

--- a/docs/core/PaymentCoordinator.md
+++ b/docs/core/PaymentCoordinator.md
@@ -28,6 +28,7 @@ This document is organized according to the following themes (click each to be t
 * [Distributing and Claiming Payments](#distributing-and-claiming-payments)
 * [System Configuration](#system-configuration)
 * [Payments Merkle Tree Structure](#payments-merkle-tree-structure)
+* [Off-Chain Calculation](#offchain-calculation)
 
 #### Important state variables
 
@@ -105,6 +106,7 @@ The payment distribution amongst the AVS's Operators and delegated Stakers is de
     * Requirements from calling internal function `_payForRange()`
         * `rangePayment.strategiesAndMultipliers.length > 0`
         * `rangePayment.amount > 0`
+        * `rangePayment.amount < MAX_PAYMENT_AMOUNT`
         * `rangePayment.duration <= MAX_PAYMENT_DURATION`
         * `rangePayment.duration % calculationIntervalSeconds == 0`
         * `rangePayment.startTimestamp % calculationIntervalSeconds == 0`
@@ -353,3 +355,9 @@ Claimers can selectively choose which token leaves to prove against and claim ac
 The payment merkle tree is structured in the diagram below:
 
 ![.](../images/PaymentCoordinator_Merkle_Tree.png)
+
+### Off-Chain Integrations
+
+Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Payouts are accumulated in the range of [`lastPaymentTimestamp`, `lastPaymentTimestamp + calculationIntervalSeconds`] and posted on-chain by the entity with the `paymentUpdater` role. 
+
+`MAX_PAYMENT_AMOUNT` is set to `1e38-1` given the precision bounds of the off-chain pipeline. 

--- a/docs/core/PaymentCoordinator.md
+++ b/docs/core/PaymentCoordinator.md
@@ -358,6 +358,6 @@ The payment merkle tree is structured in the diagram below:
 
 ### Off-Chain Integrations
 
-Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Payouts are accumulated in the range of [`lastPaymentTimestamp`, `lastPaymentTimestamp + calculationIntervalSeconds`] and posted on-chain by the entity with the `paymentUpdater` role. 
+Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Every `CALCULATION_INTERVAL_SECONDS` payouts are accumulated up to `lastPaymentTimestamp + CALCULATION_INTERVAL_SECONDS` and posted on-chain by the entity with the `paymentUpdater` role. 
 
 `MAX_PAYMENT_AMOUNT` is set to `1e38-1` given the precision bounds of the off-chain pipeline. 

--- a/docs/core/PaymentCoordinator.md
+++ b/docs/core/PaymentCoordinator.md
@@ -106,7 +106,7 @@ The payment distribution amongst the AVS's Operators and delegated Stakers is de
     * Requirements from calling internal function `_payForRange()`
         * `rangePayment.strategiesAndMultipliers.length > 0`
         * `rangePayment.amount > 0`
-        * `rangePayment.amount < MAX_PAYMENT_AMOUNT`
+        * `rangePayment.amount <= MAX_PAYMENT_AMOUNT`
         * `rangePayment.duration <= MAX_PAYMENT_DURATION`
         * `rangePayment.duration % calculationIntervalSeconds == 0`
         * `rangePayment.startTimestamp % calculationIntervalSeconds == 0`
@@ -360,6 +360,6 @@ The payment merkle tree is structured in the diagram below:
 
 ### Off Chain Calculation
 
-Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently said to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Every `CALCULATION_INTERVAL_SECONDS` payouts are accumulated up to `lastPaymentTimestamp + CALCULATION_INTERVAL_SECONDS` and posted on-chain by the entity with the `paymentUpdater` role. 
+Payments are calculated via an off-chain data pipeline. The pipeline takes snapshots of core contract state at the `SNAPSHOT_CADENCE`, currently set to once per day. It then combines these snapshots with any active payments to calculate what the single day payout of an earner is. Every `CALCULATION_INTERVAL_SECONDS` payouts are accumulated up to `lastPaymentTimestamp + CALCULATION_INTERVAL_SECONDS` and posted on-chain by the entity with the `paymentUpdater` role. 
 
 `MAX_PAYMENT_AMOUNT` is set to `1e38-1` given the precision bounds of the off-chain pipeline. 

--- a/src/contracts/core/PaymentCoordinator.sol
+++ b/src/contracts/core/PaymentCoordinator.sol
@@ -33,6 +33,8 @@ contract PaymentCoordinator is
         keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
     /// @dev Chain ID at the time of contract deployment
     uint256 internal immutable ORIGINAL_CHAIN_ID;
+    /// @notice The maximum payment token amount for a single range payment, constrained by off-chain calculation
+    uint256 internal constant MAX_PAYMENT_AMOUNT = 1e38 - 1;
 
     /// @dev Index for flag that pauses payForRange payments
     uint8 internal constant PAUSED_PAY_FOR_RANGE = 0;

--- a/src/contracts/core/PaymentCoordinator.sol
+++ b/src/contracts/core/PaymentCoordinator.sol
@@ -308,6 +308,7 @@ contract PaymentCoordinator is
     function _validateRangePayment(RangePayment calldata rangePayment) internal view {
         require(rangePayment.strategiesAndMultipliers.length > 0, "PaymentCoordinator._payForRange: no strategies set");
         require(rangePayment.amount > 0, "PaymentCoordinator._payForRange: amount cannot be 0");
+        require(rangePayment.amount <= MAX_PAYMENT_AMOUNT, "PaymentCoordinator._payForRange: amount too large");
         require(
             rangePayment.duration <= MAX_PAYMENT_DURATION,
             "PaymentCoordinator._payForRange: duration exceeds MAX_PAYMENT_DURATION"

--- a/src/contracts/core/PaymentCoordinatorStorage.sol
+++ b/src/contracts/core/PaymentCoordinatorStorage.sol
@@ -31,9 +31,7 @@ abstract contract PaymentCoordinatorStorage is IPaymentCoordinator {
     /// @notice absolute min timestamp (seconds) that a payment can start at
     uint32 public immutable GENESIS_PAYMENT_TIMESTAMP;
     /// @notice The cadence at which a snapshot is taken offchain for calculating payment distributions
-    uint32 public constant SNAPSHOT_CADENCE = 1 days;   
-    /// @notice The maximum payment token amount for a single range payment, constrained by off-chain calculation
-    uint256 public constant MAX_PAYMENT_AMOUNT = 1e38 - 1;
+    uint32 internal constant SNAPSHOT_CADENCE = 1 days;   
 
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegationManager;

--- a/src/contracts/core/PaymentCoordinatorStorage.sol
+++ b/src/contracts/core/PaymentCoordinatorStorage.sol
@@ -30,6 +30,10 @@ abstract contract PaymentCoordinatorStorage is IPaymentCoordinator {
     uint32 public immutable MAX_FUTURE_LENGTH;
     /// @notice absolute min timestamp (seconds) that a payment can start at
     uint32 public immutable GENESIS_PAYMENT_TIMESTAMP;
+    /// @notice The cadence at which a snapshot is taken offchain for calculating payment distributions
+    uint32 public constant SNAPSHOT_CADENCE = 1 days;   
+    /// @notice The maximum payment token amount for a single range payment, constrained by off-chain calculation
+    uint256 public constant MAX_PAYMENT_AMOUNT = 1e38 - 1;
 
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegationManager;
@@ -90,6 +94,10 @@ abstract contract PaymentCoordinatorStorage is IPaymentCoordinator {
         require(
             _GENESIS_PAYMENT_TIMESTAMP % _CALCULATION_INTERVAL_SECONDS == 0,
             "PaymentCoordinator: GENESIS_PAYMENT_TIMESTAMP must be a multiple of CALCULATION_INTERVAL_SECONDS"
+        );
+        require(
+            _CALCULATION_INTERVAL_SECONDS % SNAPSHOT_CADENCE == 0,
+            "PaymentCoordinator: CALCULATION_INTERVAL_SECONDS must be a multiple of SNAPSHOT_CADENCE"
         );
         delegationManager = _delegationManager;
         strategyManager = _strategyManager;


### PR DESCRIPTION
Add off-chain assumptions from payments calculation

- `SNAPSHOT_CADENCE`: Requirement for `CALCULATION_INTERVAL_SECONDS ` to be a multiple of this value
- `amount <= MAX_PAYMENT_AMOUNT`. This is 1e38-1, the max possible value in iceberg to do math without a loss of precision 