### PR TITLE
feat: modify withdrawal storage model

### DIFF
--- a/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
-import "@openzeppelin/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
@@ -23,7 +22,6 @@ import "../../../src/contracts/pods/DelayedWithdrawalRouter.sol";
 import "../../../src/contracts/permissions/PauserRegistry.sol";
 
 import "../../../src/test/mocks/EmptyContract.sol";
-import "../../../src/test/mocks/ETHDepositMock.sol";
 
 import "forge-std/Script.sol";
 import "forge-std/Test.sol";
@@ -219,7 +217,6 @@ contract Deployer_M2 is Script, Test {
                     executorMultisig,
                     eigenLayerPauserReg,
                     DELEGATION_INIT_PAUSED_STATUS,
-                    DELEGATION_WITHDRAWAL_DELAY_BLOCKS,
                     _strategies,
                     _withdrawalDelayBlocks
                 )

--- a/script/deploy/mainnet/M2Deploy.s.sol
+++ b/script/deploy/mainnet/M2Deploy.s.sol
@@ -329,7 +329,6 @@ contract M2Deploy is Script, Test {
             address(this),
             PauserRegistry(address(this)),
             0, // initialPausedStatus
-            0, // minWithdrawalDelayBLocks
             strategyArray,
             withdrawalDelayBlocksArray
         );
@@ -402,7 +401,7 @@ contract M2Deploy is Script, Test {
             delegatedTo: queuedWithdrawalLst.delegatedAddress,
             withdrawer: queuedWithdrawalLst.withdrawerAndNonce.withdrawer,
             nonce: 0, // first withdrawal, so 0 nonce
-            startBlock: queuedWithdrawalLst.withdrawalStartBlock,
+            startEpoch: queuedWithdrawalLst.withdrawalStartBlock,
             strategies: queuedWithdrawalLst.strategies,
             shares: queuedWithdrawalLst.shares
         });

--- a/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
+++ b/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
@@ -119,7 +119,6 @@ contract M2_Mainnet_Upgrade is ExistingDeploymentParser {
         );
 
         // Second, configure additional settings and paused statuses
-        delegationManager.setMinWithdrawalDelayBlocks(DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS);
         delegationManager.unpause(0);
         eigenPodManager.unpause(0);
 
@@ -204,11 +203,11 @@ contract Queue_M2_Upgrade is M2_Mainnet_Upgrade, TimelockEncoding {
         );
 
         // set the min withdrawal delay blocks on the DelegationManager
-        txs[6] = Tx(
-            address(delegationManager), 
-            0, // value
-            abi.encodeWithSelector(DelegationManager.setMinWithdrawalDelayBlocks.selector, DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS)
-        );
+        // txs[6] = Tx(
+        //     address(delegationManager), 
+        //     0, // value
+        //     abi.encodeWithSelector(DelegationManager.setMinWithdrawalDelayBlocks.selector, DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS)
+        // );
 
         // set beacon chain oracle on EigenPodManager
         txs[7] = Tx(

--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -298,11 +298,6 @@ contract ExistingDeploymentParser is Script, Test {
         );
         // Slasher
         SLASHER_INIT_PAUSED_STATUS = stdJson.readUint(initialDeploymentData, ".slasher.init_paused_status");
-        // DelegationManager
-        DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS = stdJson.readUint(
-            initialDeploymentData,
-            ".delegationManager.init_minWithdrawalDelayBlocks"
-        );
         DELEGATION_MANAGER_INIT_PAUSED_STATUS = stdJson.readUint(
             initialDeploymentData,
             ".delegationManager.init_paused_status"
@@ -504,7 +499,6 @@ contract ExistingDeploymentParser is Script, Test {
             address(0),
             eigenLayerPauserReg,
             0,
-            0, // minWithdrawalDelayBLocks
             initializeStrategiesToSetDelayBlocks,
             initializeWithdrawalDelayBlocks
         );
@@ -600,10 +594,6 @@ contract ExistingDeploymentParser is Script, Test {
         require(
             delegationManager.paused() == DELEGATION_MANAGER_INIT_PAUSED_STATUS,
             "delegationManager: init paused status set incorrectly"
-        );
-        require(
-            delegationManager.minWithdrawalDelayBlocks() == DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS,
-            "delegationManager: minWithdrawalDelayBlocks not set correctly"
         );
         // StrategyManager
         require(

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -36,7 +36,6 @@ contract AVSDirectory is
 
     /**
      * @dev Initializes the addresses of the initial owner, pauser registry, and paused status.
-     * minWithdrawalDelayBlocks is set only once here
      */
     function initialize(
         address initialOwner,

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -41,8 +41,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @notice The EigenPodManager contract for EigenLayer
     IEigenPodManager public immutable eigenPodManager;
 
-    // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
-    uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = 216000;
+    uint256 public constant MIN_WITHDRAWAL_DELAY_EPOCHS = 1;
 
     /**
      * @notice returns the total number of shares in `strategy` that are delegated to `operator`.
@@ -80,10 +79,10 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * @notice Global minimum withdrawal delay for all strategy withdrawals.
      * In a prior Goerli release, we only had a global min withdrawal delay across all strategies.
      * In addition, we now also configure withdrawal delays on a per-strategy basis.
-     * To withdraw from a strategy, max(minWithdrawalDelayBlocks, strategyWithdrawalDelayBlocks[strategy]) number of blocks must have passed. 
+     * To withdraw from a strategy, max(MIN_WITHDRAWAL_DELAY_EPOCHS, strategyWithdrawalDelayBlocks[strategy]) number of blocks must have passed. 
      * See mapping strategyWithdrawalDelayBlocks below for per-strategy withdrawal delays.
      */
-    uint256 public minWithdrawalDelayBlocks;
+    uint256 private __deprecated_minWithdrawalDelayBlocks;
 
     /// @notice Mapping: hash of withdrawal inputs, aka 'withdrawalRoot' => whether the withdrawal is pending
     mapping(bytes32 => bool) public pendingWithdrawals;

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -83,8 +83,9 @@ interface IDelegationManager is ISignatureUtils {
         address withdrawer;
         // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
         uint256 nonce;
-        // Block number when the Withdrawal was created
-        uint32 startBlock;
+        // epoch when the Withdrawal was created
+        // @dev note that this used to be the *block* when the withdrawal was created. use the `startEpochOfWithdrawal` function to disambiguate.
+        uint32 startEpoch;
         // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
         // Array containing the amount of shares in each Strategy in the `strategies` array
@@ -140,9 +141,6 @@ interface IDelegationManager is ISignatureUtils {
     /// @notice Emitted when a queued withdrawal is *migrated* from the StrategyManager to the DelegationManager
     event WithdrawalMigrated(bytes32 oldWithdrawalRoot, bytes32 newWithdrawalRoot);
     
-    /// @notice Emitted when the `minWithdrawalDelayBlocks` variable is modified from `previousValue` to `newValue`.
-    event MinWithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue);
-
     /// @notice Emitted when the `strategyWithdrawalDelayBlocks` variable is modified from `previousValue` to `newValue`.
     event StrategyWithdrawalDelayBlocksSet(IStrategy strategy, uint256 previousValue, uint256 newValue);
 
@@ -347,7 +345,7 @@ interface IDelegationManager is ISignatureUtils {
 
     /**
      * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
-     * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
+     * from all the inputted strategies. Return value is >= MIN_WITHDRAWAL_DELAY_EPOCHS as this is the global min withdrawal delay.
      * @param strategies The strategies to check withdrawal delays for
      */
     function getWithdrawalDelay(IStrategy[] calldata strategies) external view returns (uint256);
@@ -384,10 +382,10 @@ interface IDelegationManager is ISignatureUtils {
     /**
      * @notice Minimum delay enforced by this contract for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
      * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
-     * Note that strategies each have a separate withdrawal delay, which can be greater than this value. So the minimum number of blocks that must pass
-     * to withdraw a strategy is MAX(minWithdrawalDelayBlocks, strategyWithdrawalDelayBlocks[strategy])
+     * Note that strategies each have a separate withdrawal delay, which can be greater than this value. So the minimum number of epochs that must pass
+     * to withdraw a strategy is MAX(MIN_WITHDRAWAL_DELAY_EPOCHS, strategyWithdrawalDelayBlocks[strategy])
      */
-    function minWithdrawalDelayBlocks() external view returns (uint256);
+    function MIN_WITHDRAWAL_DELAY_EPOCHS() external view returns (uint256);
 
     /**
      * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,

--- a/src/contracts/libraries/SlashingAccountingUtils.sol
+++ b/src/contracts/libraries/SlashingAccountingUtils.sol
@@ -32,6 +32,11 @@ library SlashingAccountingUtils {
         return getEpochFromTimestamp(block.timestamp);
     }
 
+    // @notice returns the UTC timestamp at which the epoch starts
+    function startOfEpoch(int256 epoch) internal pure returns (uint256) {
+        return uint256(int256(EPOCH_GENESIS_TIMESTAMP) + (epoch * int256(EPOCH_LENGTH_SECONDS)));
+    }
+
     function scaleUp(uint256 shares, uint256 scalingFactor) internal pure returns (uint256) {
         return (shares * scalingFactor) / SHARE_CONVERSION_SCALE;
     }

--- a/src/test/Delegation.t.sol
+++ b/src/test/Delegation.t.sol
@@ -330,7 +330,6 @@ contract DelegationTests is EigenLayerTestHelper {
             address(this),
             eigenLayerPauserReg,
             0,
-            minWithdrawalDelayBlocks,
             initializeStrategiesToSetDelayBlocks,
             initializeWithdrawalDelayBlocks
         );
@@ -374,7 +373,6 @@ contract DelegationTests is EigenLayerTestHelper {
             _attacker,
             eigenLayerPauserReg,
             0,
-            0, // minWithdrawalDelayBLocks
             initializeStrategiesToSetDelayBlocks,
             initializeWithdrawalDelayBlocks
         );

--- a/src/test/DelegationFaucet.t.sol
+++ b/src/test/DelegationFaucet.t.sol
@@ -344,7 +344,7 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
                 staker: stakerContract,
                 withdrawer: stakerContract,
                 nonce: (nonce - 1),
-                startBlock: uint32(block.number),
+                startEpoch: uint32(block.number),
                 delegatedTo: strategyManager.delegation().delegatedTo(stakerContract)
             });
         }
@@ -405,7 +405,7 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
                 staker: stakerContract,
                 withdrawer: stakerContract,
                 nonce: (nonce - 1),
-                startBlock: uint32(block.number),
+                startEpoch: uint32(block.number),
                 delegatedTo: strategyManager.delegation().delegatedTo(stakerContract)
             });
         }
@@ -502,7 +502,7 @@ contract DelegationFaucetTests is EigenLayerTestHelper {
             staker: staker,
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
-            startBlock: uint32(block.number),
+            startEpoch: uint32(block.number),
             delegatedTo: strategyManager.delegation().delegatedTo(staker)
         });
         // calculate the withdrawal root

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -142,7 +142,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
             delegatedTo: delegation.delegatedTo(staker),
-            startBlock: uint32(block.number)
+            startEpoch: uint32(block.number)
         });
 
 
@@ -385,7 +385,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
                 0 /*initialPausedStatus*/,
-                minWithdrawalDelayBlocks,
                 initializeStrategiesToSetDelayBlocks,
                 initializeWithdrawalDelayBlocks
             )

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -75,7 +75,6 @@ contract EigenLayerDeployer is Operators {
     uint256 public gasLimit = 750000;
     IStrategy[] public initializeStrategiesToSetDelayBlocks;
     uint256[] public initializeWithdrawalDelayBlocks;
-    uint256 minWithdrawalDelayBlocks = 0;
     uint32 PARTIAL_WITHDRAWAL_FRAUD_PROOF_PERIOD_BLOCKS = 7 days / 12 seconds;
     uint256 REQUIRED_BALANCE_WEI = 32 ether;
     uint64 MAX_PARTIAL_WTIHDRAWAL_AMOUNT_GWEI = 1 ether / 1e9;
@@ -272,7 +271,6 @@ contract EigenLayerDeployer is Operators {
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
                 0 /*initialPausedStatus*/,
-                minWithdrawalDelayBlocks,
                 initializeStrategiesToSetDelayBlocks,
                 initializeWithdrawalDelayBlocks
             )

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -291,7 +291,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
             delegatedTo: delegation.delegatedTo(staker),
-            startBlock: uint32(block.number)
+            startEpoch: uint32(block.number)
         });
 
         {
@@ -409,7 +409,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             staker: depositor,
             withdrawer: withdrawer,
             nonce: nonce,
-            startBlock: withdrawalStartBlock,
+            startEpoch: withdrawalStartBlock,
             delegatedTo: delegatedTo
         });
 
@@ -460,7 +460,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             staker: depositor,
             withdrawer: withdrawer,
             nonce: nonce,
-            startBlock: withdrawalStartBlock,
+            startEpoch: withdrawalStartBlock,
             delegatedTo: delegatedTo
         });
         // complete the queued withdrawal

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -1774,7 +1774,7 @@ contract Relayer is Test {
     //         shares: amountWei,
     //         podOwner: staker,
     //         nonce: eigenPodManager.cumulativeWithdrawalsQueued(staker),
-    //         startBlock: uint32(block.number),
+    //         startEpoch: uint32(block.number),
     //         delegatedTo: delegationManagerMock.delegatedTo(staker),
     //         withdrawer: withdrawer
     //     });

--- a/src/test/WithdrawalMigration.t.sol
+++ b/src/test/WithdrawalMigration.t.sol
@@ -92,7 +92,7 @@ contract WithdrawalMigrationTests is EigenLayerTestHelper, Utils {
             delegatedTo: queuedWithdrawal.delegatedAddress,
             withdrawer: queuedWithdrawal.withdrawerAndNonce.withdrawer,
             nonce: queuedWithdrawal.withdrawerAndNonce.nonce,
-            startBlock: queuedWithdrawal.withdrawalStartBlock,
+            startEpoch: queuedWithdrawal.withdrawalStartBlock,
             strategies: queuedWithdrawal.strategies,
             shares: queuedWithdrawal.shares
         });
@@ -144,7 +144,7 @@ contract WithdrawalMigrationTests is EigenLayerTestHelper, Utils {
             delegatedTo: queuedWithdrawal1.delegatedAddress,
             withdrawer: queuedWithdrawal1.withdrawerAndNonce.withdrawer,
             nonce: queuedWithdrawal1.withdrawerAndNonce.nonce,
-            startBlock: queuedWithdrawal1.withdrawalStartBlock,
+            startEpoch: queuedWithdrawal1.withdrawalStartBlock,
             strategies: queuedWithdrawal1.strategies,
             shares: queuedWithdrawal1.shares
         });
@@ -154,7 +154,7 @@ contract WithdrawalMigrationTests is EigenLayerTestHelper, Utils {
             delegatedTo: queuedWithdrawal2.delegatedAddress,
             withdrawer: queuedWithdrawal2.withdrawerAndNonce.withdrawer,
             nonce: queuedWithdrawal2.withdrawerAndNonce.nonce,
-            startBlock: queuedWithdrawal2.withdrawalStartBlock,
+            startEpoch: queuedWithdrawal2.withdrawalStartBlock,
             strategies: queuedWithdrawal2.strategies,
             shares: queuedWithdrawal2.shares
         });

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -758,13 +758,13 @@ abstract contract IntegrationBase is IntegrationDeployer {
     /// @dev Given a list of strategies, roll the block number forward to the
     /// a valid blocknumber to completeWithdrawals
     function _rollBlocksForCompleteWithdrawals(IStrategy[] memory strategies) internal {
-        // uint256 blocksToRoll = delegationManager.minWithdrawalDelayBlocks();
         // for (uint i = 0; i < strategies.length; i++) {
         //     uint256 withdrawalDelayBlocks = delegationManager.strategyWithdrawalDelayBlocks(strategies[i]);
         //     if (withdrawalDelayBlocks > blocksToRoll) {
         //         blocksToRoll = withdrawalDelayBlocks;
         //     }
         // }
+        // TODO: fix this by warping forward instead
         cheats.roll(block.number + delegationManager.getWithdrawalDelay(strategies));
     }
 

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -224,7 +224,7 @@ contract User is Test {
             delegatedTo: operator,
             withdrawer: withdrawer,
             nonce: nonce,
-            startBlock: uint32(block.number),
+            startEpoch: uint32(block.number),
             strategies: strategies,
             shares: shares
         });
@@ -364,7 +364,7 @@ contract User is Test {
                 delegatedTo: delegatedTo,
                 withdrawer: staker,
                 nonce: (nonce + i),
-                startBlock: uint32(block.number),
+                startEpoch: uint32(block.number),
                 strategies: singleStrategy,
                 shares: singleShares
             });

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -75,7 +75,7 @@ contract DelegationManagerMock is IDelegationManager, Test {
         return 0;
     }
 
-    function minWithdrawalDelayBlocks() external pure returns (uint256) {
+    function MIN_WITHDRAWAL_DELAY_EPOCHS() external pure returns (uint256) {
         return 0;
     }
 

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -34,7 +34,6 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
     // reused in various tests. in storage to help handle stack-too-deep errors
     address defaultAVS = address(this);
 
-    uint256 minWithdrawalDelayBlocks = 216_000;
     IStrategy[] public initializeStrategiesToSetDelayBlocks;
     uint256[] public initializeWithdrawalDelayBlocks;
 
@@ -59,7 +58,6 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
                         address(this),
                         pauserRegistry,
                         0, // 0 is initialPausedStatus
-                        minWithdrawalDelayBlocks,
                         initializeStrategiesToSetDelayBlocks,
                         initializeWithdrawalDelayBlocks
                     )


### PR DESCRIPTION
This is one option for how to migrate from existing storage to new, epoch-focused behavior.
The work is certainly incomplete; I'm opening this draft PR as a demonstration of the work involved + potential first step towards completing it.