### PR TITLE
feat: add storage to track the epoch in which withdrawals were queued

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -27,14 +27,19 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         return SlashingAccountingUtils.scaleDown(nonNormalizedOperatorShares[operator][strategy], scalingFactor);
     }
 
+    // TODO: decide if this function needs to go in the interface at all
     function pendingWithdrawalData(bytes32 withdrawalRoot) public view returns (PendingWithdrawalData memory) {
         return _pendingWithdrawalData[withdrawalRoot];        
     }
 
+    // @notice Returns 'true' if the `withdrawalRoot` corresponds to a queued-but-not-completed withdrawal, and 'false' otherwise
     function pendingWithdrawals(bytes32 withdrawalRoot) public view returns (bool) {
         return _pendingWithdrawalData[withdrawalRoot].isPending;        
     }
 
+    // TODO: decide if the return type should be int256 instead of int64
+    // @notice Returns the epoch in which the withdrawal corresponding to `withdrawalRoot` was queued
+    // @dev Will return zero for a non-existent (i.e never queued or already completed) withdrawal
     function withdrawalCreationEpoch(bytes32 withdrawalRoot) public view returns (int64) {
         return _pendingWithdrawalData[withdrawalRoot].creationEpoch;        
     }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -594,11 +594,9 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
         // Remove `withdrawalRoot` from pending roots
         delete pendingWithdrawals[withdrawalRoot];
 
-        // TODO: clearly define how this is supposed to work! current withdrawal storage is block-based, which is problematic for epochs!
-        // int256 queuedEpoch;
         // TODO: currently, this _inclusive_, meaning the completed withdrawal will include slashing effects that were enacted in the `epochForEndOfSlashability`
-        // int256 epochForEndOfSlashability = queuedEpoch + 1;
-        int256 epochForEndOfSlashability = 1;
+        // TODO: note that we again probably want the first real epoch to be epoch 1, so that existing queued withdrawals are safe from slashing
+        int256 epochForEndOfSlashability = withdrawalCreationEpoch[withdrawalRoot] + 1;
 
         // Finalize action by converting shares to tokens for each strategy, or
         // by re-awarding shares in each strategy.
@@ -793,6 +791,7 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         // Place withdrawal in queue
         pendingWithdrawals[withdrawalRoot] = true;
+        withdrawalCreationEpoch[withdrawalRoot] = SlashingAccountingUtils.currentEpoch();
 
         emit WithdrawalQueued(withdrawalRoot, withdrawal);
         return withdrawalRoot;

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -102,6 +102,9 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      */
     mapping(IStrategy => uint256) public strategyWithdrawalDelayBlocks;
 
+    // @notice Mapping: withdrawal root => epoch in which the withdrawal was queued
+    mapping(bytes32 => int256) public withdrawalCreationEpoch;
+
     constructor(IStrategyManager _strategyManager, ISlasher _slasher, IEigenPodManager _eigenPodManager) {
         strategyManager = _strategyManager;
         eigenPodManager = _eigenPodManager;
@@ -113,5 +116,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[39] private __gap;
+    uint256[38] private __gap;
 }

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -85,8 +85,9 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      */
     uint256 public minWithdrawalDelayBlocks;
 
-    /// @notice Mapping: hash of withdrawal inputs, aka 'withdrawalRoot' => whether the withdrawal is pending
-    mapping(bytes32 => bool) public pendingWithdrawals;
+    // TODO: verify that changing the value of this mapping from a bool to a struct does not interfere with the existing boolean storage
+    /// @notice Mapping: hash of withdrawal inputs, aka 'withdrawalRoot' => whether the withdrawal is pending, and the epoch in which the withdrawal was queued
+    mapping(bytes32 => PendingWithdrawalData) internal _pendingWithdrawalData;
 
     /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated.
     /// @dev This only increments (doesn't decrement), and is used to help ensure that otherwise identical withdrawals have unique hashes.
@@ -101,9 +102,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
      */
     mapping(IStrategy => uint256) public strategyWithdrawalDelayBlocks;
-
-    // @notice Mapping: withdrawal root => epoch in which the withdrawal was queued
-    mapping(bytes32 => int256) public withdrawalCreationEpoch;
 
     constructor(IStrategyManager _strategyManager, ISlasher _slasher, IEigenPodManager _eigenPodManager) {
         strategyManager = _strategyManager;

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -114,5 +114,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[38] private __gap;
+    uint256[39] private __gap;
 }

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -100,6 +100,11 @@ interface IDelegationManager is ISignatureUtils {
         address withdrawer;
     }
 
+    struct PendingWithdrawalData {
+        bool isPending;
+        int64 creationEpoch;
+    }
+
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, OperatorDetails operatorDetails);
 


### PR DESCRIPTION
Alternative approach to that in https://github.com/Layr-Labs/eigenlayer-contracts/pull/549
This is a much simpler, "lightweight" change, but involves adding additional storage + notably writing to one more storage slot per newly queued withdrawal.
This PR was opened for illustrative purposes; I think we can fairly easily solve the issue here by simply packing the new storage into the existing `pendingWithdrawals` mapping.