### PR TITLE
fix: track exit gwei in checkpoint

### DIFF
--- a/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
@@ -187,7 +187,6 @@ contract Deployer_M2 is Script, Test {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -561,19 +560,10 @@ contract Deployer_M2 is Script, Test {
         // require(delayedWithdrawalRouter.withdrawalDelayBlocks() == 7 days / 12 seconds,
         //     "delayedWithdrawalRouter: withdrawalDelayBlocks initialized incorrectly");
         // uint256 MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32 ether;
-        require(
-            eigenPodImplementation.MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR() == 32 gwei,
-            "eigenPod: MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR initialized incorrectly"
-        );
 
         require(
             strategyManager.strategyWhitelister() == operationsMultisig,
             "strategyManager: strategyWhitelister address not set correctly"
-        );
-
-        require(
-            eigenPodManager.beaconChainOracle() == IBeaconChainOracle(address(0)),
-            "eigenPodManager: eigenPodBeacon contract address not set correctly"
         );
 
         require(

--- a/script/deploy/goerli/GoerliUpgrade1.s.sol
+++ b/script/deploy/goerli/GoerliUpgrade1.s.sol
@@ -72,7 +72,6 @@ contract GoerliUpgrade1 is Script, Test {
                 IETHPOSDeposit(0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b),
                 delayedWithdrawalRouter,
                 eigenPodManager,
-                32e9,
                 1616508000
             )
         );

--- a/script/deploy/goerli/GoerliUpgrade2.s.sol
+++ b/script/deploy/goerli/GoerliUpgrade2.s.sol
@@ -91,7 +91,6 @@ contract GoerliUpgrade2 is Script, Test {
                 IETHPOSDeposit(0xff50ed3d0ec03aC01D4C79aAd74928BFF48a7b2b),
                 delayedWithdrawalRouter,
                 eigenPodManager,
-                32e9,
                 1616508000
             )
         );

--- a/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
@@ -76,7 +76,6 @@ contract M2_Deploy_Holesky_From_Scratch is ExistingDeploymentParser {
             IETHPOSDeposit(ETHPOSDepositAddress),
             delayedWithdrawalRouter,
             eigenPodManager,
-            EIGENPOD_MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             EIGENPOD_GENESIS_TIME
         );
 
@@ -151,7 +150,6 @@ contract M2_Deploy_Holesky_From_Scratch is ExistingDeploymentParser {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                beaconOracle,
                 msg.sender, // initialOwner is msg.sender for now to set forktimestamp later
                 eigenLayerPauserReg,
                 EIGENPOD_MANAGER_INIT_PAUSED_STATUS

--- a/script/deploy/mainnet/M1_Deploy.s.sol
+++ b/script/deploy/mainnet/M1_Deploy.s.sol
@@ -183,7 +183,6 @@ contract Deployer_M1 is Script, Test {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            uint64(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR),
             GOERLI_GENESIS_TIME
         );
 
@@ -239,8 +238,6 @@ contract Deployer_M1 is Script, Test {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                EIGENPOD_MANAGER_MAX_PODS,
-                IBeaconChainOracle(address(0)),
                 executorMultisig,
                 eigenLayerPauserReg,
                 EIGENPOD_MANAGER_INIT_PAUSED_STATUS
@@ -540,11 +537,6 @@ contract Deployer_M1 is Script, Test {
         require(
             strategyManager.strategyWhitelister() == operationsMultisig,
             "strategyManager: strategyWhitelister address not set correctly"
-        );
-
-        require(
-            eigenPodManager.beaconChainOracle() == IBeaconChainOracle(address(0)),
-            "eigenPodManager: eigenPodBeacon contract address not set correctly"
         );
 
         require(

--- a/script/deploy/mainnet/M2Deploy.s.sol
+++ b/script/deploy/mainnet/M2Deploy.s.sol
@@ -187,7 +187,6 @@ contract M2Deploy is Script, Test {
             _ethPOS: ethPOS,
             _delayedWithdrawalRouter: delayedWithdrawalRouter,
             _eigenPodManager: eigenPodManager,
-            _MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR: 32 gwei,
             _GENESIS_TIME: 1616508000
         });
 
@@ -304,10 +303,6 @@ contract M2Deploy is Script, Test {
         require(eigenPodManager.eigenPodBeacon() == eigenPodBeacon, "eigenPodManager.eigenPodBeacon incorrect");
         require(eigenPodManager.strategyManager() == strategyManager, "eigenPodManager.strategyManager incorrect");
         require(eigenPodManager.slasher() == slasher, "eigenPodManager.slasher incorrect");
-        require(
-            address(eigenPodManager.beaconChainOracle()) == beaconChainOracle,
-            "eigenPodManager.beaconChainOracle incorrect"
-        );
         require(eigenPodManager.numPods() == numPods, "eigenPodManager.numPods incorrect");
         require(EigenPodManagerStorage(address(eigenPodManager)).delegationManager() == delegation, "eigenPodManager.delegationManager incorrect");
     }
@@ -336,7 +331,6 @@ contract M2Deploy is Script, Test {
 
         cheats.expectRevert(bytes("Initializable: contract is already initialized"));
         EigenPodManager(address(eigenPodManager)).initialize(
-            IBeaconChainOracle(address(this)),
             address(this),
             PauserRegistry(address(this)),
             0

--- a/script/deploy/mainnet/M2Deploy.s.sol
+++ b/script/deploy/mainnet/M2Deploy.s.sol
@@ -451,7 +451,6 @@ contract M2Deploy is Script, Test {
         // Check updated storage values
         require(eigenPod.hasRestaked(), "eigenPod.hasRestaked not set to true");
         require(address(eigenPod).balance == 0, "eigenPod balance not 0 after activating restaking");
-        require(eigenPod.nonBeaconChainETHBalanceWei() == 0, "non beacon chain eth balance not 0");
         require(
             eigenPod.mostRecentWithdrawalTimestamp() == block.timestamp,
             "eigenPod.mostRecentWithdrawalTimestamp not updated"

--- a/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
+++ b/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
@@ -66,7 +66,6 @@ contract M2_Mainnet_Upgrade is ExistingDeploymentParser {
             IETHPOSDeposit(ETHPOSDepositAddress),
             delayedWithdrawalRouter,
             eigenPodManager,
-            EIGENPOD_MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             EIGENPOD_GENESIS_TIME
         );
         delegationManagerImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
@@ -124,7 +123,6 @@ contract M2_Mainnet_Upgrade is ExistingDeploymentParser {
         eigenPodManager.unpause(0);
 
         eigenPodManager.setDenebForkTimestamp(EIGENPOD_MANAGER_DENEB_FORK_TIMESTAMP);
-        eigenPodManager.updateBeaconChainOracle(beaconOracle);
         eigenPodBeacon.upgradeTo(address(eigenPodImplementation));
 
         vm.stopPrank();
@@ -211,11 +209,11 @@ contract Queue_M2_Upgrade is M2_Mainnet_Upgrade, TimelockEncoding {
         );
 
         // set beacon chain oracle on EigenPodManager
-        txs[7] = Tx(
-            address(eigenPodManager), 
-            0, // value
-            abi.encodeWithSelector(EigenPodManager.updateBeaconChainOracle.selector, beaconOracle)
-        );
+        // txs[7] = Tx(
+        //     address(eigenPodManager), 
+        //     0, // value
+        //     abi.encodeWithSelector(EigenPodManager.updateBeaconChainOracle.selector, beaconOracle)
+        // );
 
         // set Deneb fork timestamp on EigenPodManager
         txs[8] = Tx(

--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -426,7 +426,6 @@ contract ExistingDeploymentParser is Script, Test {
         // EigenPodManager
         vm.expectRevert(bytes("Initializable: contract is already initialized"));
         eigenPodManager.initialize(
-            beaconOracle,
             address(0),
             eigenLayerPauserReg,
             EIGENPOD_MANAGER_INIT_PAUSED_STATUS
@@ -506,10 +505,6 @@ contract ExistingDeploymentParser is Script, Test {
             "eigenPodManager: denebForkTimestamp not set correctly"
         );
         require(
-            eigenPodManager.beaconChainOracle() == beaconOracle,
-            "eigenPodManager: beaconChainOracle not set correctly"
-        );
-        require(
             eigenPodManager.ethPOS() == IETHPOSDeposit(ETHPOSDepositAddress),
             "eigenPodManager: ethPOS not set correctly"
         );
@@ -519,12 +514,6 @@ contract ExistingDeploymentParser is Script, Test {
         require(
             eigenPodImplementation.GENESIS_TIME() == EIGENPOD_GENESIS_TIME,
             "eigenPodImplementation: GENESIS TIME not set correctly"
-        );
-        require(
-            eigenPodImplementation.MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR() ==
-                EIGENPOD_MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR
-            && EIGENPOD_MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR % 1 gwei == 0,
-            "eigenPodImplementation: MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR not set correctly"
         );
         require(
             eigenPodImplementation.ethPOS() == IETHPOSDeposit(ETHPOSDepositAddress),

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -79,9 +79,6 @@ interface IEigenPod {
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from beaconchain but not EigenLayer),
     function withdrawableRestakedExecutionLayerGwei() external view returns (uint64);
 
-    /// @notice any ETH deposited into the EigenPod contract via the `receive` fallback function
-    function nonBeaconChainETHBalanceWei() external view returns (uint256);
-
     /// @notice Used to initialize the pointers to contracts crucial to the pod's functionality, in beacon proxy construction from EigenPodManager
     function initialize(address owner) external;
 
@@ -151,12 +148,6 @@ interface IEigenPod {
      * "withdrawBeforeRestaking()"
      */
     function activateRestaking() external;
-
-    /// @notice Called by the pod owner to withdraw the balance of the pod when `hasRestaked` is set to false
-    function withdrawBeforeRestaking() external;
-
-    /// @notice Called by the pod owner to withdraw the nonBeaconChainETHBalanceWei
-    function withdrawNonBeaconChainETHBalanceWei(address recipient, uint256 amountToWithdraw) external;
 
     /// @notice called by owner of a pod to remove any ERC20s deposited in the pod
     function recoverTokens(IERC20[] memory tokenList, uint256[] memory amountsToWithdraw, address recipient) external;

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -42,10 +42,8 @@ interface IEigenPod {
     struct Checkpoint {
         bytes32 beaconBlockRoot;
         bytes32 beaconStateRoot;
-
         uint256 podBalanceGwei;
         int256 balanceDeltasGwei;
-
         uint256 proofsRemaining;
     }
 

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -189,23 +189,6 @@ interface IEigenPod {
     ) external;
 
     /**
-     * @notice This function records full and partial withdrawals on behalf of one of the Ethereum validators for this EigenPod
-     * @param oracleTimestamp is the timestamp of the oracle slot that the withdrawal is being proven against
-     * @param withdrawalProofs is the information needed to check the veracity of the block numbers and withdrawals being proven
-     * @param validatorFieldsProofs is the proof of the validator's fields' in the validator tree
-     * @param withdrawalFields are the fields of the withdrawals being proven
-     * @param validatorFields are the fields of the validators being proven
-     */
-    function verifyAndProcessWithdrawals(
-        uint64 oracleTimestamp,
-        BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.WithdrawalProof[] calldata withdrawalProofs,
-        bytes[] calldata validatorFieldsProofs,
-        bytes32[][] calldata validatorFields,
-        bytes32[][] calldata withdrawalFields
-    ) external;
-
-    /**
      * @notice Called by the pod owner to activate restaking by withdrawing
      * all existing ETH from the pod and preventing further withdrawals via
      * "withdrawBeforeRestaking()"

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -44,7 +44,7 @@ interface IEigenPod {
         bytes32 beaconStateRoot;
 
         uint256 podBalanceGwei;
-        int256 balanceDeltas;
+        int256 balanceDeltasGwei;
 
         uint256 proofsRemaining;
     }

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -41,7 +41,6 @@ interface IEigenPod {
 
     struct Checkpoint {
         bytes32 beaconBlockRoot;
-        bytes32 beaconStateRoot;
         uint256 podBalanceGwei;
         int256 balanceDeltasGwei;
         uint256 proofsRemaining;
@@ -74,6 +73,8 @@ interface IEigenPod {
 
     /// @notice Emitted when a validator is proven for a given checkpoint
     event ValidatorCheckpointed(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
+
+    event ValidatorWithdrawn(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
 
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from beaconchain but not EigenLayer),
     function withdrawableRestakedExecutionLayerGwei() external view returns (uint64);

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -71,6 +71,12 @@ interface IEigenPod {
     /// @notice Emitted when ETH that was previously received via the `receive` fallback is withdrawn
     event NonBeaconChainETHWithdrawn(address indexed recipient, uint256 amountWithdrawn);
 
+    /// @notice Emitted when a checkpoint is created
+    event CheckpointCreated(uint64 indexed checkpointTimestamp, bytes32 indexed beaconBlockRoot);
+
+    /// @notice Emitted when a validator is proven for a given checkpoint
+    event ValidatorCheckpointed(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
+
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from beaconchain but not EigenLayer),
     function withdrawableRestakedExecutionLayerGwei() external view returns (uint64);
 

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -43,6 +43,7 @@ interface IEigenPod {
         bytes32 beaconBlockRoot;
         uint256 podBalanceGwei;
         int256 balanceDeltasGwei;
+        int256 exitBalanceDeltasGwei;
         uint256 proofsRemaining;
     }
 

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -65,9 +65,6 @@ interface IEigenPod {
     /// @notice Emitted when ETH is received via the `receive` fallback
     event NonBeaconChainETHReceived(uint256 amountReceived);
 
-    /// @notice Emitted when ETH that was previously received via the `receive` fallback is withdrawn
-    event NonBeaconChainETHWithdrawn(address indexed recipient, uint256 amountWithdrawn);
-
     /// @notice Emitted when a checkpoint is created
     event CheckpointCreated(uint64 indexed checkpointTimestamp, bytes32 indexed beaconBlockRoot);
 
@@ -122,23 +119,83 @@ interface IEigenPod {
     /// @notice This returns the status of a given validator pubkey
     function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS);
 
+    /// @notice Returns the currently-active checkpoint
+    function currentCheckpoint() external view returns (Checkpoint memory);
+
     /**
-     * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to
-     * this contract. It also verifies the effective balance  of the validator.  It verifies the provided proof of the ETH validator against the beacon chain state
-     * root, marks the validator as 'active' in EigenLayer, and credits the restaked ETH in Eigenlayer.
-     * @param oracleTimestamp is the Beacon Chain timestamp whose state root the `proof` will be proven against.
-     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs
-     * @param withdrawalCredentialProofs is an array of proofs, where each proof proves each ETH validator's balance and withdrawal credentials
-     * against a beacon chain state root
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
-     * for details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     * @dev Create a checkpoint used to prove this pod's active validator set. Checkpoints are completed 
+     * by submitting one checkpoint proof per ACTIVE validator. During the checkpoint process, the total 
+     * change in ACTIVE validator balance is tracked, and any validators with 0 balance are marked `WITHDRAWN`.
+     * @dev Once finalized, the pod owner is awarded shares corresponding to:
+     * - the total change in their ACTIVE validator balances
+     * - any ETH in the pod not already awarded shares
+     * @dev A checkpoint cannot be created if the pod already has an outstanding checkpoint. If
+     * this is the case, the pod owner MUST complete the existing checkpoint before starting a new one.
+     * @param revertIfNoBalance Forces a revert if the pod ETH balance is 0. This allows the pod owner
+     * to prevent accidentally starting a checkpoint that will not increase their shares
+     */
+    function startCheckpoint(bool revertIfNoBalance) external;
+
+    /**
+     * @dev Progress the current checkpoint towards completion by submitting one or more validator
+     * checkpoint proofs. Anyone can call this method to submit proofs towards the current checkpoint.
+     * For each validator proven, the current checkpoint's `proofsRemaining` decreases.
+     * @dev If the checkpoint's `proofsRemaining` reaches 0, the checkpoint is finalized.
+     * (see `_updateCheckpoint` for more details)
+     * @dev This method can only be called when there is a currently-active checkpoint.
+     * @param stateRootProof proves a beacon state root against the checkpoint's `beaconBlockRoot`
+     * @param proofs Proofs for one or more validator current balances against the `beaconStateRoot`
+     */
+    function verifyCheckpointProofs(
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        BeaconChainProofs.BalanceProof[] calldata proofs
+    ) 
+        external;
+
+    /**
+     * @dev Verify one or more validators have their withdrawal credentials pointed at this EigenPod, and award
+     * shares based on their effective balance. Proven validators are marked `ACTIVE` within the EigenPod, and
+     * future checkpoint proofs will need to include them.
+     * @dev Withdrawal credential proofs MUST NOT be older than the `lastCheckpointTimestamp` OR `currentCheckpointTimestamp`.
+     * @dev Validators proven via this method MUST NOT have an exit epoch set already.
+     * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
+     * to the parent beacon block root against which the proof is verified.
+     * @param stateRootProof proves a beacon state root against a beacon block root
+     * @param validatorIndices a list of validator indices being proven stale
+     * @param validatorFieldsProofs proofs of each validator's `validatorFields` against the beacon state root
+     * @param validatorFields the fields of the beacon chain "Validator" container. See consensus specs for
+     * details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      */
     function verifyWithdrawalCredentials(
-        uint64 oracleTimestamp,
+        uint64 beaconTimestamp,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
         uint40[] calldata validatorIndices,
-        bytes[] calldata withdrawalCredentialProofs,
+        bytes[] calldata validatorFieldsProofs,
         bytes32[][] calldata validatorFields
+    )
+        external;
+
+    /**
+     * @dev Prove that one or more validators were slashed on the beacon chain and have not had timely
+     * checkpoint proofs since being slashed. If successful, this allows the caller to start a checkpoint.
+     * @dev Note that in order to start a checkpoint, any existing checkpoint must already be completed!
+     * (See `_startCheckpoint` for details)
+     * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
+     * to the parent beacon block root against which the proof is verified.
+     * @param stateRootProof proves a beacon state root against a beacon block root
+     * @param proof the fields of the beacon chain "Validator" container, along with a merkle proof against
+     * the beacon state root. See the consensus specs for more details:
+     * https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     *
+     * @dev Staleness conditions:
+     * - Validator's last balance update is older than `beaconTimestamp` by `TIME_TILL_STALE_BALANCE`
+     * - Validator MUST be in `ACTIVE` status in the pod
+     * - Validator MUST be slashed on the beacon chain
+     */
+    function verifyStaleBalance(
+        uint64 beaconTimestamp,
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        BeaconChainProofs.ValidatorProof calldata proof
     )
         external;
 

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -68,9 +68,13 @@ interface IEigenPod {
     /// @notice Emitted when a checkpoint is created
     event CheckpointCreated(uint64 indexed checkpointTimestamp, bytes32 indexed beaconBlockRoot);
 
+    /// @notice Emitted when a checkpoint is finalized
+    event CheckpointFinalized(uint64 indexed checkpointTimestamp, int256 totalShareDeltaWei);
+
     /// @notice Emitted when a validator is proven for a given checkpoint
     event ValidatorCheckpointed(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
 
+    /// @notice Emitted when a validaor is proven to have 0 balance at a given checkpoint
     event ValidatorWithdrawn(uint64 indexed checkpointTimestamp, uint40 indexed validatorIndex);
 
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from beaconchain but not EigenLayer),
@@ -118,6 +122,15 @@ interface IEigenPod {
 
     /// @notice This returns the status of a given validator pubkey
     function validatorStatus(bytes calldata validatorPubkey) external view returns (VALIDATOR_STATUS);
+
+    /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
+    function activeValidatorCount() external view returns (uint256);
+
+    /// @notice The timestamp of the last checkpoint finalized
+    function lastCheckpointTimestamp() external view returns (uint64);
+
+    /// @notice The timestamp of the currently-active checkpoint. Will be 0 if there is not active checkpoint
+    function currentCheckpointTimestamp() external view returns (uint64);
 
     /// @notice Returns the currently-active checkpoint
     function currentCheckpoint() external view returns (Checkpoint memory);

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -130,12 +130,6 @@ interface IEigenPodManager is IPausable {
      */
     function withdrawSharesAsTokens(address podOwner, address destination, uint256 shares) external;
 
-    /// @notice Query the 4788 oracle to get the parent block root of the slot with the given `timestamp`
-    /// @param timestamp of the block for which the parent block root will be returned. MUST correspond
-    /// to an existing slot within the last 24 hours. If the slot at `timestamp` was skipped, this method
-    /// will revert.
-    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32);
-
     /**
      * @notice the deneb hard fork timestamp used to determine which proof path to use for proving a withdrawal
      */

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -67,13 +67,6 @@ interface IEigenPodManager is IPausable {
      */
     function recordBeaconChainETHBalanceUpdate(address podOwner, int256 sharesDelta) external;
 
-    /**
-     * @notice Updates the oracle contract that provides the beacon chain state root
-     * @param newBeaconChainOracle is the new oracle contract being pointed to
-     * @dev Callable only by the owner of this contract (i.e. governance)
-     */
-    function updateBeaconChainOracle(IBeaconChainOracle newBeaconChainOracle) external;
-
     /// @notice Returns the address of the `podOwner`'s EigenPod if it has been deployed.
     function ownerToPod(address podOwner) external view returns (IEigenPod);
 
@@ -85,13 +78,7 @@ interface IEigenPodManager is IPausable {
 
     /// @notice Beacon proxy to which the EigenPods point
     function eigenPodBeacon() external view returns (IBeacon);
-
-    /// @notice Oracle contract that provides updates to the beacon chain's state
-    function beaconChainOracle() external view returns (IBeaconChainOracle);
-
-    /// @notice Returns the beacon block root at `timestamp`. Reverts if the Beacon block root at `timestamp` has not yet been finalized.
-    function getBlockRootAtTimestamp(uint64 timestamp) external view returns (bytes32);
-
+    
     /// @notice EigenLayer's StrategyManager contract
     function strategyManager() external view returns (IStrategyManager);
 
@@ -142,6 +129,24 @@ interface IEigenPodManager is IPausable {
      * @dev Reverts if `shares` is not a whole Gwei amount
      */
     function withdrawSharesAsTokens(address podOwner, address destination, uint256 shares) external;
+
+    /// @notice Query the 4788 oracle to get the parent block root of the slot with the given `timestamp`
+    /// @param timestamp of the block for which the parent block root will be returned. MUST correspond
+    /// to an existing slot within the last 24 hours. If the slot at `timestamp` was skipped, this method
+    /// will revert.
+    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32);
+
+    /**
+     * @dev Changes the `podOwner's` stale validator count by `countDelta`. The stale validator
+     * count can be used as an additional weighting mechanism to determine a staker or operator's shares.
+     * @param podOwner the pod owner whose stale validator count is being updated
+     * @param countDelta the change in `podOwner's` stale validator count as a signed integer
+     * @dev Callable only by the `podOwner's` EigenPod contract
+     */
+    function updateStaleValidatorCount(
+        address podOwner,
+        int256 countDelta
+    ) external;
 
     /**
      * @notice the deneb hard fork timestamp used to determine which proof path to use for proving a withdrawal

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -137,18 +137,6 @@ interface IEigenPodManager is IPausable {
     function getParentBlockRoot(uint64 timestamp) external view returns (bytes32);
 
     /**
-     * @dev Changes the `podOwner's` stale validator count by `countDelta`. The stale validator
-     * count can be used as an additional weighting mechanism to determine a staker or operator's shares.
-     * @param podOwner the pod owner whose stale validator count is being updated
-     * @param countDelta the change in `podOwner's` stale validator count as a signed integer
-     * @dev Callable only by the `podOwner's` EigenPod contract
-     */
-    function updateStaleValidatorCount(
-        address podOwner,
-        int256 countDelta
-    ) external;
-
-    /**
      * @notice the deneb hard fork timestamp used to determine which proof path to use for proving a withdrawal
      */
     function denebForkTimestamp() external view returns (uint64);

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -55,6 +55,7 @@ library BeaconChainProofs {
     uint256 internal constant VALIDATOR_PUBKEY_INDEX = 0;
     uint256 internal constant VALIDATOR_WITHDRAWAL_CREDENTIALS_INDEX = 1;
     uint256 internal constant VALIDATOR_BALANCE_INDEX = 2;
+    uint256 internal constant VALIDATOR_SLASHED_INDEX = 3;
     uint256 internal constant VALIDATOR_WITHDRAWABLE_EPOCH_INDEX = 7;
 
     // in execution payload header
@@ -89,6 +90,11 @@ library BeaconChainProofs {
     struct BalanceProof {
         bytes32 pubkeyHash;
         bytes32 balanceRoot;
+        bytes proof;
+    }
+
+    struct ValidatorProof {
+        bytes32[] validatorFields;
         bytes proof;
     }
 
@@ -236,6 +242,13 @@ library BeaconChainProofs {
     function getEffectiveBalanceGwei(bytes32[] memory validatorFields) internal pure returns (uint64) {
         return 
             Endian.fromLittleEndianUint64(validatorFields[VALIDATOR_BALANCE_INDEX]);
+    }
+
+    /**
+     * @dev Returns true IFF the validator is marked slashed
+     */
+    function getSlashStatus(bytes32[] memory validatorFields) internal pure returns (bool) {
+        return validatorFields[VALIDATOR_SLASHED_INDEX] != 0;
     }
 
     /**

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -267,7 +267,7 @@ library BeaconChainProofs {
     /**
      * @dev Returns true IFF the validator is marked slashed
      */
-    function getSlashStatus(bytes32[] memory validatorFields) internal pure returns (bool) {
+    function isValidatorSlashed(bytes32[] memory validatorFields) internal pure returns (bool) {
         return validatorFields[VALIDATOR_SLASHED_INDEX] != 0;
     }
 

--- a/src/contracts/libraries/BeaconChainProofs.sol
+++ b/src/contracts/libraries/BeaconChainProofs.sol
@@ -80,25 +80,15 @@ library BeaconChainProofs {
 
     bytes8 internal constant UINT64_MASK = 0xffffffffffffffff;
 
-    /// @notice This struct contains the merkle proofs and leaves needed to verify a partial/full withdrawal
-    struct WithdrawalProof {
-        bytes withdrawalProof;
-        bytes slotProof;
-        bytes executionPayloadProof;
-        bytes timestampProof;
-        bytes historicalSummaryBlockRootProof;
-        uint64 blockRootIndex;
-        uint64 historicalSummaryIndex;
-        uint64 withdrawalIndex;
-        bytes32 blockRoot;
-        bytes32 slotRoot;
-        bytes32 timestampRoot;
-        bytes32 executionPayloadRoot;
-    }
-
     /// @notice This struct contains the root and proof for verifying the state root against the oracle block root
     struct StateRootProof {
         bytes32 beaconStateRoot;
+        bytes proof;
+    }
+
+    struct BalanceProof {
+        bytes32 pubkeyHash;
+        bytes32 balanceRoot;
         bytes proof;
     }
 
@@ -144,6 +134,37 @@ library BeaconChainProofs {
         );
     }
 
+    function verifyValidatorBalance(
+        bytes32 beaconStateRoot,
+        uint40 validatorIndex,
+        BalanceProof memory proof
+    ) internal view returns (uint64 validatorBalanceGwei) {
+        require(
+            proof.proof.length == 32 * ((BALANCE_TREE_HEIGHT + 1) + BEACON_STATE_FIELD_TREE_HEIGHT),
+            "BeaconChainProofs.verifyValidatorBalance: Proof has incorrect length"
+        );
+
+        // Beacon chain balances are lists of uint64 values which are grouped together in 4s when merkleized
+        uint256 balanceIndex = uint256(validatorIndex / 4);
+        /**
+         * Note: Merkleization of the balance root tree uses MerkleizeWithMixin, i.e., the length of the array is hashed with the root of
+         * the array.  Thus we shift the BALANCE_INDEX over by BALANCE_TREE_HEIGHT + 1 and not just BALANCE_TREE_HEIGHT.
+         */
+        balanceIndex = (BALANCE_INDEX << (BALANCE_TREE_HEIGHT + 1)) | balanceIndex;
+ 
+        require(
+            Merkle.verifyInclusionSha256({
+                proof: proof.proof,
+                root: beaconStateRoot,
+                leaf: proof.balanceRoot,
+                index: balanceIndex
+            }),
+            "BeaconChainProofs.verifyValidatorBalance: Invalid merkle proof"
+        );
+
+        return getBalanceAtIndex(proof.balanceRoot, validatorIndex);
+    }
+
     /**
      * @notice This function verifies the latestBlockHeader against the state root. the latestBlockHeader is
      * a tracked in the beacon state.
@@ -173,148 +194,6 @@ library BeaconChainProofs {
     }
 
     /**
-     * @notice This function verifies the slot and the withdrawal fields for a given withdrawal
-     * @param withdrawalProof is the provided set of merkle proofs
-     * @param withdrawalFields is the serialized withdrawal container to be proven
-     */
-    function verifyWithdrawal(
-        bytes32 beaconStateRoot,
-        bytes32[] calldata withdrawalFields,
-        WithdrawalProof calldata withdrawalProof,
-        uint64 denebForkTimestamp
-    ) internal view {
-        require(
-            withdrawalFields.length == 2 ** WITHDRAWAL_FIELD_TREE_HEIGHT,
-            "BeaconChainProofs.verifyWithdrawal: withdrawalFields has incorrect length"
-        );
-
-        require(
-            withdrawalProof.blockRootIndex < 2 ** BLOCK_ROOTS_TREE_HEIGHT,
-            "BeaconChainProofs.verifyWithdrawal: blockRootIndex is too large"
-        );
-        require(
-            withdrawalProof.withdrawalIndex < 2 ** WITHDRAWALS_TREE_HEIGHT,
-            "BeaconChainProofs.verifyWithdrawal: withdrawalIndex is too large"
-        );
-
-        require(
-            withdrawalProof.historicalSummaryIndex < 2 ** HISTORICAL_SUMMARIES_TREE_HEIGHT,
-            "BeaconChainProofs.verifyWithdrawal: historicalSummaryIndex is too large"
-        );
-
-        //Note: post deneb hard fork, the number of exection payload header fields increased from 15->17, adding an extra level to the tree height
-        uint256 executionPayloadHeaderFieldTreeHeight = (getWithdrawalTimestamp(withdrawalProof) < denebForkTimestamp) ? EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_CAPELLA : EXECUTION_PAYLOAD_HEADER_FIELD_TREE_HEIGHT_DENEB;
-        require(
-            withdrawalProof.withdrawalProof.length ==
-                32 * (executionPayloadHeaderFieldTreeHeight + WITHDRAWALS_TREE_HEIGHT + 1),
-            "BeaconChainProofs.verifyWithdrawal: withdrawalProof has incorrect length"
-        );
-        require(
-            withdrawalProof.executionPayloadProof.length ==
-                32 * (BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT + BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT),
-            "BeaconChainProofs.verifyWithdrawal: executionPayloadProof has incorrect length"
-        );
-        require(
-            withdrawalProof.slotProof.length == 32 * (BEACON_BLOCK_HEADER_FIELD_TREE_HEIGHT),
-            "BeaconChainProofs.verifyWithdrawal: slotProof has incorrect length"
-        );
-        require(
-            withdrawalProof.timestampProof.length == 32 * (executionPayloadHeaderFieldTreeHeight),
-            "BeaconChainProofs.verifyWithdrawal: timestampProof has incorrect length"
-        );
-
-        require(
-            withdrawalProof.historicalSummaryBlockRootProof.length ==
-                32 *
-                    (BEACON_STATE_FIELD_TREE_HEIGHT +
-                        (HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) +
-                        1 +
-                        (BLOCK_ROOTS_TREE_HEIGHT)),
-            "BeaconChainProofs.verifyWithdrawal: historicalSummaryBlockRootProof has incorrect length"
-        );
-        /**
-         * Note: Here, the "1" in "1 + (BLOCK_ROOTS_TREE_HEIGHT)" signifies that extra step of choosing the "block_root_summary" within the individual
-         * "historical_summary". Everywhere else it signifies merkelize_with_mixin, where the length of an array is hashed with the root of the array,
-         * but not here.
-         */
-        uint256 historicalBlockHeaderIndex = (HISTORICAL_SUMMARIES_INDEX <<
-            ((HISTORICAL_SUMMARIES_TREE_HEIGHT + 1) + 1 + (BLOCK_ROOTS_TREE_HEIGHT))) |
-            (uint256(withdrawalProof.historicalSummaryIndex) << (1 + (BLOCK_ROOTS_TREE_HEIGHT))) |
-            (BLOCK_SUMMARY_ROOT_INDEX << (BLOCK_ROOTS_TREE_HEIGHT)) |
-            uint256(withdrawalProof.blockRootIndex);
-
-        require(
-            Merkle.verifyInclusionSha256({
-                proof: withdrawalProof.historicalSummaryBlockRootProof,
-                root: beaconStateRoot,
-                leaf: withdrawalProof.blockRoot,
-                index: historicalBlockHeaderIndex
-            }),
-            "BeaconChainProofs.verifyWithdrawal: Invalid historicalsummary merkle proof"
-        );
-
-        //Next we verify the slot against the blockRoot
-        require(
-            Merkle.verifyInclusionSha256({
-                proof: withdrawalProof.slotProof,
-                root: withdrawalProof.blockRoot,
-                leaf: withdrawalProof.slotRoot,
-                index: SLOT_INDEX
-            }),
-            "BeaconChainProofs.verifyWithdrawal: Invalid slot merkle proof"
-        );
-
-        {
-            // Next we verify the executionPayloadRoot against the blockRoot
-            uint256 executionPayloadIndex = (BODY_ROOT_INDEX << (BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT)) |
-                EXECUTION_PAYLOAD_INDEX;
-            require(
-                Merkle.verifyInclusionSha256({
-                    proof: withdrawalProof.executionPayloadProof,
-                    root: withdrawalProof.blockRoot,
-                    leaf: withdrawalProof.executionPayloadRoot,
-                    index: executionPayloadIndex
-                }),
-                "BeaconChainProofs.verifyWithdrawal: Invalid executionPayload merkle proof"
-            );
-        }
-
-        // Next we verify the timestampRoot against the executionPayload root
-        require(
-            Merkle.verifyInclusionSha256({
-                proof: withdrawalProof.timestampProof,
-                root: withdrawalProof.executionPayloadRoot,
-                leaf: withdrawalProof.timestampRoot,
-                index: TIMESTAMP_INDEX
-            }),
-            "BeaconChainProofs.verifyWithdrawal: Invalid timestamp merkle proof"
-        );
-
-        {
-            /**
-             * Next we verify the withdrawal fields against the executionPayloadRoot:
-             * First we compute the withdrawal_index, then we merkleize the 
-             * withdrawalFields container to calculate the withdrawalRoot.
-             *
-             * Note: Merkleization of the withdrawals root tree uses MerkleizeWithMixin, i.e., the length of the array is hashed with the root of
-             * the array.  Thus we shift the WITHDRAWALS_INDEX over by WITHDRAWALS_TREE_HEIGHT + 1 and not just WITHDRAWALS_TREE_HEIGHT.
-             */
-            uint256 withdrawalIndex = (WITHDRAWALS_INDEX << (WITHDRAWALS_TREE_HEIGHT + 1)) |
-                uint256(withdrawalProof.withdrawalIndex);
-            bytes32 withdrawalRoot = Merkle.merkleizeSha256(withdrawalFields);
-            require(
-                Merkle.verifyInclusionSha256({
-                    proof: withdrawalProof.withdrawalProof,
-                    root: withdrawalProof.executionPayloadRoot,
-                    leaf: withdrawalRoot,
-                    index: withdrawalIndex
-                }),
-                "BeaconChainProofs.verifyWithdrawal: Invalid withdrawal merkle proof"
-            );
-        }
-    }
-
-    /**
      * @notice This function replicates the ssz hashing of a validator's pubkey, outlined below:
      *  hh := ssz.NewHasher()
      *  hh.PutBytes(validatorPubkey[:])
@@ -324,22 +203,6 @@ library BeaconChainProofs {
     function hashValidatorBLSPubkey(bytes memory validatorPubkey) internal pure returns (bytes32 pubkeyHash) {
         require(validatorPubkey.length == 48, "Input should be 48 bytes in length");
         return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
-    }
-
-    /**
-     * @dev Retrieve the withdrawal timestamp
-     */
-    function getWithdrawalTimestamp(WithdrawalProof memory withdrawalProof) internal pure returns (uint64) {
-        return
-            Endian.fromLittleEndianUint64(withdrawalProof.timestampRoot);
-    }
-
-    /**
-     * @dev Converts the withdrawal's slot to an epoch
-     */
-    function getWithdrawalEpoch(WithdrawalProof memory withdrawalProof) internal pure returns (uint64) {
-        return
-            Endian.fromLittleEndianUint64(withdrawalProof.slotRoot) / SLOTS_PER_EPOCH;
     }
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -28,8 +28,13 @@ import "./EigenPodStorage.sol";
  * @dev Note that all beacon chain balances are stored as gwei within the beacon chain datastructures. We choose
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
  */
-contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants {
-    
+contract EigenPod is 
+    Initializable, 
+    ReentrancyGuardUpgradeable, 
+    EigenPodPausingConstants, 
+    EigenPodStorage 
+{
+
     using BytesLib for bytes;
     using SafeERC20 for IERC20;
     using BeaconChainProofs for *;

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -616,6 +616,7 @@ contract EigenPod is
 
             // Update pod owner's shares
             eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, totalShareDeltaWei);
+            emit CheckpointFinalized(lastCheckpointTimestamp, totalShareDeltaWei);
         } else {
             _currentCheckpoint = checkpoint;
         }
@@ -655,7 +656,7 @@ contract EigenPod is
         return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
     }
 
-    /// @dev Calculates the delta between two Gwei amounts, converts to Wei, and returns as an int256
+    /// @dev Calculates the delta between two Gwei amounts and returns as an int256
     function _calcBalanceDelta(uint64 newAmountGwei, uint64 previousAmountGwei) internal pure returns (int256) {
         return
             int256(uint256(newAmountGwei)) - int256(uint256(previousAmountGwei));

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -263,11 +263,7 @@ contract EigenPod is
                 (validatorFieldsProofs.length == validatorFields.length),
             "EigenPod.verifyWithdrawalCredentials: validatorIndices and proofs must be same length"
         );
-
-        // TODO - is == valid?
-        // I think YES, because we enforce no exit epoch is set
-        // However, we could also do strictly greater than if we want to be safe.
-        // TODO pt 2 - what about sub 12 on checkpointTimestamp?
+        
         require(
             beaconTimestamp > lastFinalizedCheckpoint && beaconTimestamp > currentCheckpointTimestamp,
             "EigenPod.verifyWithdrawalCredentials: specified timestamp is too far in past"

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -14,11 +14,11 @@ import "../libraries/Endian.sol";
 
 import "../interfaces/IETHPOSDeposit.sol";
 import "../interfaces/IEigenPodManager.sol";
-import "../interfaces/IEigenPod.sol";
 import "../interfaces/IDelayedWithdrawalRouter.sol";
 import "../interfaces/IPausable.sol";
 
 import "./EigenPodPausingConstants.sol";
+import "./EigenPodStorage.sol";
 
 /**
  * @title The implementation contract used for restaking beacon chain ETH on EigenLayer
@@ -35,12 +35,16 @@ import "./EigenPodPausingConstants.sol";
  * @dev Note that all beacon chain balances are stored as gwei within the beacon chain datastructures. We choose
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
  */
-contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants {
+contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable, EigenPodPausingConstants {
+    
     using BytesLib for bytes;
     using SafeERC20 for IERC20;
     using BeaconChainProofs for *;
 
-    // CONSTANTS + IMMUTABLES
+    /*******************************************************************************
+                               CONSTANTS / IMMUTABLES
+    *******************************************************************************/
+
     // @notice Internal constant used in calculations, since the beacon chain stores balances in Gwei rather than wei
     uint256 internal constant GWEI_TO_WEI = 1e9;
 
@@ -65,37 +69,9 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     /// @notice This is the genesis time of the beacon state, to help us calculate conversions between slot and timestamp
     uint64 public immutable GENESIS_TIME;
 
-    // STORAGE VARIABLES
-    /// @notice The owner of this EigenPod
-    address public podOwner;
-
-    /**
-     * @notice The latest timestamp at which the pod owner withdrew the balance of the pod, via calling `withdrawBeforeRestaking`.
-     * @dev This variable is only updated when the `withdrawBeforeRestaking` function is called, which can only occur before `hasRestaked` is set to true for this pod.
-     * Proofs for this pod are only valid against Beacon Chain state roots corresponding to timestamps after the stored `mostRecentWithdrawalTimestamp`.
-     */
-    uint64 public mostRecentWithdrawalTimestamp;
-
-    /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from the Beacon Chain but not from EigenLayer),
-    uint64 public withdrawableRestakedExecutionLayerGwei;
-
-    /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
-    bool public hasRestaked;
-
-    /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp
-    mapping(bytes32 => mapping(uint64 => bool)) public provenWithdrawal;
-
-    /// @notice This is a mapping that tracks a validator's information by their pubkey hash
-    mapping(bytes32 => ValidatorInfo) internal _validatorPubkeyHashToInfo;
-
-    /// @notice This variable tracks any ETH deposited into this contract via the `receive` fallback function
-    uint256 public nonBeaconChainETHBalanceWei;
-
-    /// @notice This variable tracks the total amount of partial withdrawals claimed via merkle proofs prior to a switch to ZK proofs for claiming partial withdrawals
-    uint64 public sumOfPartialWithdrawalsClaimedGwei;
-
-    /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
-    uint256 activeValidatorCount;
+    /*******************************************************************************
+                                     MODIFIERS
+    *******************************************************************************/
 
     modifier onlyEigenPodManager() {
         require(msg.sender == address(eigenPodManager), "EigenPod.onlyEigenPodManager: not eigenPodManager");
@@ -140,6 +116,10 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         _;
     }
 
+    /*******************************************************************************
+                                  CONSTRUCTOR / INIT
+    *******************************************************************************/
+
     constructor(
         IETHPOSDeposit _ethPOS,
         IDelayedWithdrawalRouter _delayedWithdrawalRouter,
@@ -168,6 +148,10 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         hasRestaked = true;
         emit RestakingActivated(podOwner);
     }
+
+    /*******************************************************************************
+                                    EXTERNAL METHODS
+    *******************************************************************************/
 
     /// @notice payable fallback function that receives ether deposited to the eigenpods contract
     receive() external payable {
@@ -221,62 +205,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
             );
         }
         eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei * int256(GWEI_TO_WEI));
-    }
-
-    /**
-     * @notice This function records full and partial withdrawals on behalf of one or more of this EigenPod's validators
-     * @param oracleTimestamp is the timestamp of the oracle slot that the withdrawal is being proven against
-     * @param stateRootProof proves a `beaconStateRoot` against a block root fetched from the oracle
-     * @param withdrawalProofs proves several withdrawal-related values against the `beaconStateRoot`
-     * @param validatorFieldsProofs proves `validatorFields` against the `beaconStateRoot`
-     * @param withdrawalFields are the fields of the withdrawals being proven
-     * @param validatorFields are the fields of the validators being proven
-     */
-    function verifyAndProcessWithdrawals(
-        uint64 oracleTimestamp,
-        BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.WithdrawalProof[] calldata withdrawalProofs,
-        bytes[] calldata validatorFieldsProofs,
-        bytes32[][] calldata validatorFields,
-        bytes32[][] calldata withdrawalFields
-    ) external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_WITHDRAWAL) {
-        require(
-            (validatorFields.length == validatorFieldsProofs.length) &&
-                (validatorFieldsProofs.length == withdrawalProofs.length) &&
-                (withdrawalProofs.length == withdrawalFields.length),
-            "EigenPod.verifyAndProcessWithdrawals: inputs must be same length"
-        );
-
-        // Verify passed-in beaconStateRoot against oracle-provided block root:
-        BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
-            latestBlockRoot: eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp),
-            beaconStateRoot: stateRootProof.beaconStateRoot,
-            stateRootProof: stateRootProof.proof
-        });
-
-        VerifiedWithdrawal memory withdrawalSummary;
-        for (uint256 i = 0; i < withdrawalFields.length; i++) {
-            VerifiedWithdrawal memory verifiedWithdrawal = _verifyAndProcessWithdrawal(
-                stateRootProof.beaconStateRoot,
-                withdrawalProofs[i],
-                validatorFieldsProofs[i],
-                validatorFields[i],
-                withdrawalFields[i]
-            );
-
-            withdrawalSummary.amountToSendGwei += verifiedWithdrawal.amountToSendGwei;
-            withdrawalSummary.sharesDeltaGwei += verifiedWithdrawal.sharesDeltaGwei;
-        }
-
-        // If any withdrawals are eligible for immediate redemption, send to the pod owner via
-        // DelayedWithdrawalRouter
-        if (withdrawalSummary.amountToSendGwei != 0) {
-            _sendETH_AsDelayedWithdrawal(podOwner, withdrawalSummary.amountToSendGwei * GWEI_TO_WEI);
-        }
-        // If any withdrawals resulted in a change in the pod's shares, update the EigenPodManager
-        if (withdrawalSummary.sharesDeltaGwei != 0) {
-            eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, withdrawalSummary.sharesDeltaGwei * int256(GWEI_TO_WEI));
-        }
     }
 
     /*******************************************************************************
@@ -434,6 +362,7 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
     /*******************************************************************************
                                 INTERNAL FUNCTIONS
     *******************************************************************************/
+
     /**
      * @notice internal function that proves an individual validator's withdrawal credentials
      * @param oracleTimestamp is the timestamp whose state root the `proof` will be proven against.
@@ -567,176 +496,6 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         }
     }
 
-    function _verifyAndProcessWithdrawal(
-        bytes32 beaconStateRoot,
-        BeaconChainProofs.WithdrawalProof calldata withdrawalProof,
-        bytes calldata validatorFieldsProof,
-        bytes32[] calldata validatorFields,
-        bytes32[] calldata withdrawalFields
-    )
-        internal
-        /**
-         * Check that the provided timestamp being proven against is after the `mostRecentWithdrawalTimestamp`.
-         * Without this check, there is an edge case where a user proves a past withdrawal for a validator whose funds they already withdrew,
-         * as a way to "withdraw the same funds twice" without providing adequate proof.
-         * Note that this check is not made using the oracleTimestamp as in the `verifyWithdrawalCredentials` proof; instead this proof
-         * proof is made for the timestamp of the withdrawal, which may be within SLOTS_PER_HISTORICAL_ROOT slots of the oracleTimestamp.
-         * This difference in modifier usage is OK, since it is still not possible to `verifyAndProcessWithdrawal` against a slot that occurred
-         * *prior* to the proof provided in the `verifyWithdrawalCredentials` function.
-         */
-        proofIsForValidTimestamp(withdrawalProof.getWithdrawalTimestamp())
-        returns (VerifiedWithdrawal memory)
-    {
-        uint64 withdrawalTimestamp = withdrawalProof.getWithdrawalTimestamp();
-        bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
-
-        /**
-         * Withdrawal processing should only be performed for "ACTIVE" or "WITHDRAWN" validators.
-         * (WITHDRAWN is allowed because technically you can deposit to a validator even after it exits)
-         */
-        require(
-            _validatorPubkeyHashToInfo[validatorPubkeyHash].status != VALIDATOR_STATUS.INACTIVE,
-            "EigenPod._verifyAndProcessWithdrawal: Validator never proven to have withdrawal credentials pointed to this contract"
-        );
-
-        // Ensure we don't process the same withdrawal twice
-        require(
-            !provenWithdrawal[validatorPubkeyHash][withdrawalTimestamp],
-            "EigenPod._verifyAndProcessWithdrawal: withdrawal has already been proven for this timestamp"
-        );
-
-        provenWithdrawal[validatorPubkeyHash][withdrawalTimestamp] = true;
-
-        // Verifying the withdrawal against verified beaconStateRoot:
-        BeaconChainProofs.verifyWithdrawal({
-            beaconStateRoot: beaconStateRoot, 
-            withdrawalFields: withdrawalFields, 
-            withdrawalProof: withdrawalProof,
-            denebForkTimestamp: eigenPodManager.denebForkTimestamp()
-        });
-
-        uint40 validatorIndex = withdrawalFields.getValidatorIndex();
-
-        // Verify passed-in validatorFields against verified beaconStateRoot:
-        BeaconChainProofs.verifyValidatorFields({
-            beaconStateRoot: beaconStateRoot,
-            validatorFields: validatorFields,
-            validatorFieldsProof: validatorFieldsProof,
-            validatorIndex: validatorIndex
-        });
-
-        uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
-        
-        /**
-         * If the withdrawal's epoch comes after the validator's "withdrawable epoch," we know the validator
-         * has fully withdrawn, and we process this as a full withdrawal.
-         */
-        if (withdrawalProof.getWithdrawalEpoch() >= validatorFields.getWithdrawableEpoch()) {
-            return
-                _processFullWithdrawal(
-                    validatorIndex,
-                    validatorPubkeyHash,
-                    withdrawalTimestamp,
-                    podOwner,
-                    withdrawalAmountGwei,
-                    _validatorPubkeyHashToInfo[validatorPubkeyHash]
-                );
-        } else {
-            return
-                _processPartialWithdrawal(
-                    validatorIndex,
-                    withdrawalTimestamp,
-                    podOwner,
-                    withdrawalAmountGwei
-                );
-        }
-    }
-
-    function _processFullWithdrawal(
-        uint40 validatorIndex,
-        bytes32 validatorPubkeyHash,
-        uint64 withdrawalTimestamp,
-        address recipient,
-        uint64 withdrawalAmountGwei,
-        ValidatorInfo memory validatorInfo
-    ) internal returns (VerifiedWithdrawal memory) {
-
-        /**
-         * First, determine withdrawal amounts. We need to know:
-         * 1. How much can be withdrawn immediately
-         * 2. How much needs to be withdrawn via the EigenLayer withdrawal queue
-         */
-
-        uint64 amountToQueueGwei;
-
-        if (withdrawalAmountGwei > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) {
-            amountToQueueGwei = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-        } else {
-            amountToQueueGwei = withdrawalAmountGwei;
-        }
-
-        /**
-         * If the withdrawal is for more than the max per-validator balance, we mark 
-         * the max as "withdrawable" via the queue, and withdraw the excess immediately
-         */
-
-        VerifiedWithdrawal memory verifiedWithdrawal;
-        verifiedWithdrawal.amountToSendGwei = uint256(withdrawalAmountGwei - amountToQueueGwei);
-        withdrawableRestakedExecutionLayerGwei += amountToQueueGwei;
-        
-        /**
-         * Next, calculate the change in number of shares this validator is "backing":
-         * - Anything that needs to go through the withdrawal queue IS backed
-         * - Anything immediately withdrawn IS NOT backed
-         *
-         * This means that this validator is currently backing `amountToQueueGwei` shares.
-         */
-
-        verifiedWithdrawal.sharesDeltaGwei = _calculateSharesDelta({
-            newAmountGwei: amountToQueueGwei,
-            previousAmountGwei: validatorInfo.restakedBalanceGwei
-        });
-
-        /**
-         * Finally, the validator is fully withdrawn. Update their status and place in state:
-         */
-
-        if (validatorInfo.status != VALIDATOR_STATUS.WITHDRAWN) {
-            activeValidatorCount--;
-            validatorInfo.status = VALIDATOR_STATUS.WITHDRAWN;
-        }
-
-        validatorInfo.restakedBalanceGwei = 0;        
-        _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;
-
-        emit FullWithdrawalRedeemed(validatorIndex, withdrawalTimestamp, recipient, withdrawalAmountGwei);
-
-        return verifiedWithdrawal;
-    }
-
-    function _processPartialWithdrawal(
-        uint40 validatorIndex,
-        uint64 withdrawalTimestamp,
-        address recipient,
-        uint64 partialWithdrawalAmountGwei
-    ) internal returns (VerifiedWithdrawal memory) {
-        emit PartialWithdrawalRedeemed(
-            validatorIndex,
-            withdrawalTimestamp,
-            recipient,
-            partialWithdrawalAmountGwei
-        );
-
-        sumOfPartialWithdrawalsClaimedGwei += partialWithdrawalAmountGwei;
-
-        // For partial withdrawals, the withdrawal amount is immediately sent to the pod owner
-        return
-            VerifiedWithdrawal({
-                amountToSendGwei: uint256(partialWithdrawalAmountGwei),
-                sharesDeltaGwei: 0
-            });
-    }
-
     function _processWithdrawalBeforeRestaking(address _podOwner) internal {
         mostRecentWithdrawalTimestamp = uint32(block.timestamp);
         nonBeaconChainETHBalanceWei = 0;
@@ -801,12 +560,4 @@ contract EigenPod is IEigenPod, Initializable, ReentrancyGuardUpgradeable, Eigen
         bytes32 validatorPubkeyHash = _calculateValidatorPubkeyHash(validatorPubkey);
         return _validatorPubkeyHashToInfo[validatorPubkeyHash].status;
     }
-
-
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[44] private __gap;
 }

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -171,24 +171,7 @@ contract EigenPod is
             "EigenPod.startCheckpoint: must finish previous checkpoint before starting another"
         );
 
-        // Snapshot pod balance at the start of the checkpoint. Once the checkpoint is finalized,
-        // this amount will be added to the total validator balance delta and credited as shares.
-        uint256 podBalanceWei = 
-            address(this).balance
-                - nonBeaconChainETHBalanceWei
-                - (withdrawableRestakedExecutionLayerGwei * GWEI_TO_WEI);
-
-        Checkpoint memory checkpoint = Checkpoint({
-            beaconBlockRoot: eigenPodManager.getParentBlockRoot(uint64(block.timestamp)),
-            beaconStateRoot: bytes32(0),
-            podBalanceGwei: podBalanceWei / GWEI_TO_WEI,
-            balanceDeltasGwei: 0,
-            proofsRemaining: activeValidatorCount
-        });
-
-        // Place checkpoint in storage
-        currentCheckpointTimestamp = uint64(block.timestamp);
-        _updateCheckpoint(checkpoint);
+        _startCheckpoint();
     }
 
     /**
@@ -231,7 +214,6 @@ contract EigenPod is
         }
 
         // Process each checkpoint proof submitted
-        int256 totalStaleValidatorsProven;
         for (uint256 i = 0; i < proofs.length; i++) {
 
             // Process a checkpoint proof for a validator. 
@@ -241,7 +223,7 @@ contract EigenPod is
             // If the proof shows the validator has a balance of 0, they are marked `WITHDRAWN`.
             // The assumption is that if this is the case, any withdrawn ETH was already in
             // the pod when `startCheckpoint` was originally called.
-            (int256 balanceDeltaGwei, bool noLongerStale) = _verifyCheckpointProof({
+            int256 balanceDeltaGwei = _verifyCheckpointProof({
                 beaconTimestamp: beaconTimestamp,
                 beaconStateRoot: checkpoint.beaconStateRoot,
                 proof: proofs[i]
@@ -249,18 +231,10 @@ contract EigenPod is
 
             checkpoint.proofsRemaining--;
             checkpoint.balanceDeltasGwei += balanceDeltaGwei;
-
-            if (noLongerStale) {
-                totalStaleValidatorsProven++;
-            }
         }
 
         // Update and/or finalize the checkpoint
         _updateCheckpoint(checkpoint);
-
-        if (totalStaleValidatorsProven != 0) {
-            eigenPodManager.updateStaleValidatorCount(podOwner, totalStaleValidatorsProven);
-        }
     }
 
     /**
@@ -328,13 +302,11 @@ contract EigenPod is
 
     /**
      * @dev Prove that one or more validators were slashed on the beacon chain and have not had timely
-     * checkpoint proofs since being slashed. If successful, this increases the pod owner's `staleValidatorCount`
-     * in the `EigenPodManager`. Stale validators can be restored by proving their balance in a checkpoint via
-     * `startCheckpoint` and `verifyCheckpointProofs`.
+     * checkpoint proofs since being slashed. If successful, this allows the caller to start a checkpoint.
      * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
      * to the parent beacon block root against which the proof is verified.
      * @param stateRootProof proves a beacon state root against a beacon block root
-     * @param proofs the fields of the beacon chain "Validator" container, along with a merkle proof against
+     * @param proof the fields of the beacon chain "Validator" container, along with a merkle proof against
      * the beacon state root. See the consensus specs for more details:
      * https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      *
@@ -345,68 +317,62 @@ contract EigenPod is
      * - Validator MUST NOT already be marked stale
      * - Validator MUST be slashed on the beacon chain
      */
-    function verifyStaleBalances(
+    function verifyStaleBalance(
         uint64 beaconTimestamp,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.ValidatorProof[] calldata proofs
+        BeaconChainProofs.ValidatorProof calldata proof
     )
         external
         onlyWhenNotPaused(PAUSED_VERIFY_STALE_BALANCE)
     {
         require(
+            currentCheckpointTimestamp == 0, 
+            "EigenPod.verifyStaleBalance: must complete existing checkpoint before starting another"
+        );
+        
+        require(
             beaconTimestamp + STALENESS_GRACE_PERIOD < block.timestamp,
             "EigenPod.verifyStaleBalance: staleness grace period not elapsed"
         );
 
-        // Process each staleness proof
-        for (uint256 i = 0; i < proofs.length; i++) {
-            bytes32 validatorPubkey = proofs[i].validatorFields.getPubkeyHash();
-            ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkey];
+        bytes32 validatorPubkey = proof.validatorFields.getPubkeyHash();
+        ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkey];
 
-            // Validator must be eligible for a staleness proof
-            require(
-                beaconTimestamp > validatorInfo.mostRecentBalanceUpdateTimestamp + TIME_TILL_STALE_BALANCE,
-                "EigenPod.verifyStaleBalance: validator balance is not stale yet"
-            );
+        // Validator must be eligible for a staleness proof
+        require(
+            beaconTimestamp > validatorInfo.mostRecentBalanceUpdateTimestamp + TIME_TILL_STALE_BALANCE,
+            "EigenPod.verifyStaleBalance: validator balance is not stale yet"
+        );
 
-            // Validator must be checkpoint-able
-            require(
-                validatorInfo.status == VALIDATOR_STATUS.ACTIVE,
-                "EigenPod.verifyStaleBalance: validator is not active"
-            );
+        // Validator must be checkpoint-able
+        require(
+            validatorInfo.status == VALIDATOR_STATUS.ACTIVE,
+            "EigenPod.verifyStaleBalance: validator is not active"
+        );
 
-            // Validator should not already be stale
-            require(
-                !isValidatorStale[validatorPubkey],
-                "EigenPod.verifyStaleBalance: validator already marked stale"
-            );
+        // Validator must be slashed on the beacon chain
+        require(
+            proof.validatorFields.getSlashStatus() == true,
+            "EigenPod.verifyStaleBalance: validator must be slashed to be marked stale"
+        );
 
-            // Validator must be slashed on the beacon chain
-            require(
-                proofs[i].validatorFields.getSlashStatus() == true,
-                "EigenPod.verifyStaleBalance: validator must be slashed to be marked stale"
-            );
+        // Verify `beaconStateRoot` against beacon block root
+        BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
+            latestBlockRoot: eigenPodManager.getParentBlockRoot(beaconTimestamp),
+            beaconStateRoot: stateRootProof.beaconStateRoot,
+            stateRootProof: stateRootProof.proof
+        });
 
-            // Verify `beaconStateRoot` against beacon block root
-            BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
-                latestBlockRoot: eigenPodManager.getParentBlockRoot(beaconTimestamp),
-                beaconStateRoot: stateRootProof.beaconStateRoot,
-                stateRootProof: stateRootProof.proof
-            });
-
-            // Verify Validator container proof against `beaconStateRoot`
-            BeaconChainProofs.verifyValidatorFields({
-                beaconStateRoot: stateRootProof.beaconStateRoot,
-                validatorFields: proofs[i].validatorFields,
-                validatorFieldsProof: proofs[i].proof,
-                validatorIndex: uint40(validatorInfo.validatorIndex)
-            });
-
-            isValidatorStale[validatorPubkey] = true;
-        }
+        // Verify Validator container proof against `beaconStateRoot`
+        BeaconChainProofs.verifyValidatorFields({
+            beaconStateRoot: stateRootProof.beaconStateRoot,
+            validatorFields: proof.validatorFields,
+            validatorFieldsProof: proof.proof,
+            validatorIndex: uint40(validatorInfo.validatorIndex)
+        });
         
-        // Increment stale validator count by one for each successful proof
-        eigenPodManager.updateStaleValidatorCount(podOwner, int256(proofs.length));
+        // Validator verified to be stale - start a checkpoint
+        _startCheckpoint();
     }
 
     /// @notice Called by the pod owner to withdraw the nonBeaconChainETHBalanceWei
@@ -560,7 +526,7 @@ contract EigenPod is
         uint64 beaconTimestamp,
         bytes32 beaconStateRoot,
         BeaconChainProofs.BalanceProof calldata proof
-    ) internal returns (int256 balanceDeltaGwei, bool noLongerStale) {
+    ) internal returns (int256 balanceDeltaGwei) {
         ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[proof.pubkeyHash];
 
         require(
@@ -606,17 +572,28 @@ contract EigenPod is
             });
         }
 
-        // If the validator was marked stale and this proof is younger than
-        // `TIME_TILL_STALE_BALANCE`, the validator is no longer stale.
-        if (
-            beaconTimestamp + TIME_TILL_STALE_BALANCE >= block.timestamp && 
-            isValidatorStale[proof.pubkeyHash]
-        ) {
-            isValidatorStale[proof.pubkeyHash] = false;
-            noLongerStale = true;
-        }
+        return balanceDeltaGwei;
+    }
 
-        return (balanceDeltaGwei, noLongerStale);
+    function _startCheckpoint() internal {
+        // Snapshot pod balance at the start of the checkpoint. Once the checkpoint is finalized,
+        // this amount will be added to the total validator balance delta and credited as shares.
+        uint256 podBalanceWei = 
+            address(this).balance
+                - nonBeaconChainETHBalanceWei
+                - (withdrawableRestakedExecutionLayerGwei * GWEI_TO_WEI);
+
+        Checkpoint memory checkpoint = Checkpoint({
+            beaconBlockRoot: eigenPodManager.getParentBlockRoot(uint64(block.timestamp)),
+            beaconStateRoot: bytes32(0),
+            podBalanceGwei: podBalanceWei / GWEI_TO_WEI,
+            balanceDeltasGwei: 0,
+            proofsRemaining: activeValidatorCount
+        });
+
+        // Place checkpoint in storage
+        currentCheckpointTimestamp = uint64(block.timestamp);
+        _updateCheckpoint(checkpoint);
     }
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -63,10 +63,6 @@ contract EigenPod is
     /// via `verifyStaleBalance`.
     uint256 internal constant TIME_TILL_STALE_BALANCE = 2 weeks;
 
-    /// @notice A `verifyStaleBalance` proof MUST be older than `STALENESS_GRACE_PERIOD`, to give time
-    /// to a pod owner to prove the slashed validator's balance
-    uint256 internal constant STALENESS_GRACE_PERIOD = 6 hours;
-
     /// @notice The address of the EIP-4788 beacon block root oracle
     /// (See https://eips.ethereum.org/EIPS/eip-4788)
     address internal constant BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
@@ -303,7 +299,6 @@ contract EigenPod is
      * https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      *
      * @dev Staleness conditions:
-     * - `beaconTimestamp` MUST NOT fall within `STALENESS_GRACE_PERIOD` seconds of `block.timestamp`
      * - Validator's last balance update is older than `beaconTimestamp` by `TIME_TILL_STALE_BALANCE`
      * - Validator MUST be in `ACTIVE` status in the pod
      * - Validator MUST be slashed on the beacon chain
@@ -316,11 +311,6 @@ contract EigenPod is
         external
         onlyWhenNotPaused(PAUSED_VERIFY_STALE_BALANCE)
     {  
-        require(
-            beaconTimestamp + STALENESS_GRACE_PERIOD < block.timestamp,
-            "EigenPod.verifyStaleBalance: staleness grace period not elapsed"
-        );
-
         bytes32 validatorPubkey = proof.validatorFields.getPubkeyHash();
         ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkey];
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -24,13 +24,6 @@ import "./EigenPodStorage.sol";
  * @title The implementation contract used for restaking beacon chain ETH on EigenLayer
  * @author Layr Labs, Inc.
  * @notice Terms of Service: https://docs.eigenlayer.xyz/overview/terms-of-service
- * @notice The main functionalities are:
- * - creating new ETH validators with their withdrawal credentials pointed to this contract
- * - proving from beacon chain state roots that withdrawal credentials are pointed to this contract
- * - proving from beacon chain state roots the balances of ETH validators with their withdrawal credentials
- *   pointed to this contract
- * - updating aggregate balances in the EigenPodManager
- * - withdrawing eth when withdrawals are initiated
  * @notice This EigenPod Beacon Proxy implementation adheres to the current Capella consensus specs
  * @dev Note that all beacon chain balances are stored as gwei within the beacon chain datastructures. We choose
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
@@ -48,12 +41,6 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
     // @notice Internal constant used in calculations, since the beacon chain stores balances in Gwei rather than wei
     uint256 internal constant GWEI_TO_WEI = 1e9;
 
-    /**
-     * @notice Maximum "staleness" of a Beacon Chain state root against which `verifyBalanceUpdate` or `verifyWithdrawalCredentials` may be proven.
-     * We can't allow "stale" roots to be used for restaking as the validator may have been slashed in a more updated beacon state root. 
-     */
-    uint256 internal constant VERIFY_BALANCE_UPDATE_WINDOW_SECONDS = 4.5 hours;
-
     /// @notice This is the beacon chain deposit contract
     IETHPOSDeposit public immutable ethPOS;
 
@@ -63,11 +50,17 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
     /// @notice The single EigenPodManager for EigenLayer
     IEigenPodManager public immutable eigenPodManager;
 
-    ///@notice The maximum amount of ETH, in gwei, a validator can have restaked in the eigenlayer
-    uint64 public immutable MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-
     /// @notice This is the genesis time of the beacon state, to help us calculate conversions between slot and timestamp
     uint64 public immutable GENESIS_TIME;
+
+    /// @notice If a validator is slashed on the beacon chain and their balance has not been checkpointed
+    /// within `TIME_TILL_STALE_BALANCE` of the current block, they are eligible to be marked "stale"
+    /// via `verifyStaleBalance`.
+    uint256 internal constant TIME_TILL_STALE_BALANCE = 2 weeks;
+
+    /// @notice A `verifyStaleBalance` proof MUST be older than `STALENESS_GRACE_PERIOD`, to give time
+    /// to a pod owner to prove the slashed validator's balance
+    uint256 internal constant STALENESS_GRACE_PERIOD = 6 hours;
 
     /*******************************************************************************
                                      MODIFIERS
@@ -88,17 +81,12 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         _;
     }
 
-    /// @notice checks that hasRestaked is set to true by calling activateRestaking()
-    modifier hasEnabledRestaking() {
-        require(hasRestaked, "EigenPod.hasEnabledRestaking: restaking is not enabled");
-        _;
-    }
-
-    /// @notice Checks that `timestamp` is greater than or equal to the value stored in `mostRecentWithdrawalTimestamp`
-    modifier proofIsForValidTimestamp(uint64 timestamp) {
+    /// @notice Checks that `timestamp` is greater than or equal to `mostRecentWithdrawalTimestamp`
+    modifier afterRestaking(uint64 timestamp) {
         require(
+            hasRestaked &&
             timestamp >= mostRecentWithdrawalTimestamp,
-            "EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp"
+            "EigenPod.afterRestaking: timestamp must be at or after restaking was activated"
         );
         _;
     }
@@ -124,13 +112,11 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         IETHPOSDeposit _ethPOS,
         IDelayedWithdrawalRouter _delayedWithdrawalRouter,
         IEigenPodManager _eigenPodManager,
-        uint64 _MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
         uint64 _GENESIS_TIME
     ) {
         ethPOS = _ethPOS;
         delayedWithdrawalRouter = _delayedWithdrawalRouter;
         eigenPodManager = _eigenPodManager;
-        MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = _MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
         GENESIS_TIME = _GENESIS_TIME;
         _disableInitializers();
     }
@@ -160,70 +146,133 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
     }
 
     /**
-     * @notice This function records an update (either increase or decrease) in a validator's balance.
-     * @param oracleTimestamp The oracleTimestamp whose state root the proof will be proven against.
-     *        Must be within `VERIFY_BALANCE_UPDATE_WINDOW_SECONDS` of the current block.
-     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs 
-     * @param stateRootProof proves a `beaconStateRoot` against a block root fetched from the oracle
-     * @param validatorFieldsProofs proofs against the `beaconStateRoot` for each validator in `validatorFields`
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
-     * @dev For more details on the Beacon Chain spec, see: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     * @dev Create a checkpoint used to prove this pod's active validator set. Checkpoints are completed 
+     * by submitting one checkpoint proof per ACTIVE validator. During the checkpoint process, the total 
+     * change in ACTIVE validator balance is tracked, and any validators with 0 balance are marked `WITHDRAWN`.
+     * @dev Once finalized, the pod owner is awarded shares corresponding to:
+     * - the total change in their ACTIVE validator balances
+     * - any ETH in the pod not already awarded shares.
+     * @dev A checkpoint cannot be created if the pod already has an outstanding checkpoint. If
+     * this is the case, the pod owner MUST complete the existing checkpoint before starting a new one.
      */
-    function verifyBalanceUpdates(
-        uint64 oracleTimestamp,
-        uint40[] calldata validatorIndices,
-        BeaconChainProofs.StateRootProof calldata stateRootProof,
-        bytes[] calldata validatorFieldsProofs,
-        bytes32[][] calldata validatorFields
-    ) external onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE) {
+    function startCheckpoint() 
+        onlyEigenPodOwner() 
+        onlyWhenNotPaused(TODO) 
+        afterRestaking(uint64(block.timestamp)) /// TODO - this is the wrong condition
+    {
         require(
-            (validatorIndices.length == validatorFieldsProofs.length) && (validatorFieldsProofs.length == validatorFields.length),
-            "EigenPod.verifyBalanceUpdates: validatorIndices and proofs must be same length"
+            currentCheckpointTimestamp == 0, 
+            "EigenPod.startCheckpoint: must finish previous checkpoint before starting another"
         );
 
-        // Balance updates should not be "stale" (older than VERIFY_BALANCE_UPDATE_WINDOW_SECONDS)
-        require(
-            oracleTimestamp + VERIFY_BALANCE_UPDATE_WINDOW_SECONDS >= block.timestamp,
-            "EigenPod.verifyBalanceUpdates: specified timestamp is too far in past"
-        );
+        // Snapshot pod balance at the start of the checkpoint. Once the checkpoint is finalized,
+        // this amount will be added to the total validator balance delta and credited as shares.
+        uint256 podBalanceWei = 
+            address(this).balance
+                - nonBeaconChainETHBalanceWei
+                - (withdrawableRestakedExecutionLayerGwei * GWEI_TO_WEI);
 
-        // Verify passed-in beaconStateRoot against oracle-provided block root:
-        BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
-            latestBlockRoot: eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp),
-            beaconStateRoot: stateRootProof.beaconStateRoot,
-            stateRootProof: stateRootProof.proof
+        Checkpoint memory checkpoint = Checkpoint({
+            beaconBlockRoot: eigenPodManager.getPrevBlockRoot(),
+            beaconStateRoot: bytes32(0),
+            podBalanceGwei: podBalanceWei / GWEI_TO_WEI,
+            balanceDeltas: 0,
+            proofsRemaining: activeValidatorCount
         });
 
-        int256 sharesDeltaGwei;
-        for (uint256 i = 0; i < validatorIndices.length; i++) {
-            sharesDeltaGwei += _verifyBalanceUpdate(
-                oracleTimestamp,
-                validatorIndices[i],
-                stateRootProof.beaconStateRoot,
-                validatorFieldsProofs[i], // Use validator fields proof because contains the effective balance
-                validatorFields[i]
-            );
-        }
-        eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, sharesDeltaGwei * int256(GWEI_TO_WEI));
+        // Place checkpoint in storage
+        currentCheckpointTimestamp = uint64(block.timestamp);
+        _updateCheckpoint(checkpoint);
     }
 
-    /*******************************************************************************
-                    EXTERNAL FUNCTIONS CALLABLE BY EIGENPOD OWNER
-    *******************************************************************************/
+    /**
+     * @dev Progress the current checkpoint towards completion by submitting one or more validator
+     * checkpoint proofs. Anyone can call this method to submit proofs towards the current checkpoint.
+     * For each validator proven, the current checkpoint's `proofsRemaining` decreases.
+     * @dev If the checkpoint's `proofsRemaining` reaches 0, the checkpoint is finalized.
+     * (see `_updateCheckpoint` for more details)
+     * @dev This method can only be called when there is a currently-active checkpoint.
+     * @param stateRootProof proves a beacon state root against the checkpoint's `beaconBlockRoot`
+     * @dev Note that if the `beaconStateRoot` has already been verified for this checkpoint, it does
+     * not need to be verfied again.
+     * @param proofs Proofs for one or more validator current balances against the checkpoint's `beaconStateRoot`
+     */
+    function verifyCheckpointProof(
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        BeaconChainProofs.BalanceProof[] calldata proofs
+    ) 
+        external 
+        onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE) 
+    {
+        uint64 beaconTimestamp = currentCheckpointTimestamp;
+        require(
+            beaconTimestamp != 0, 
+            "EigenPod.verifyCheckpointProof: must have active checkpoint to perform checkpoint proof"
+        );
+
+        Checkpoint memory checkpoint = currentCheckpoint;
+
+        // If we haven't already proven a state root for this checkpoint, verify
+        // `stateRootProof` against the block root and cache the result
+        if (checkpoint.beaconStateRoot == bytes32(0)) {
+            BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
+                latestBlockRoot: checkpoint.beaconBlockRoot,
+                beaconStateRoot: stateRootProof.beaconStateRoot,
+                stateRootProof: stateRootProof.proof
+            });
+
+            checkpoint.beaconStateRoot = stateRootProof.beaconStateRoot;
+        }
+
+        // Process each checkpoint proof submitted
+        int256 totalStaleValidatorsProven;
+        for (uint256 i = 0; i < proofs.length; i++) {
+
+            // Process a checkpoint proof for a validator. 
+            // - the validator MUST be in the ACTIVE state
+            // - the validator MUST NOT have already been proven for this checkpoint
+            //
+            // If the proof shows the validator has a balance of 0, they are marked `WITHDRAWN`.
+            // The assumption is that if this is the case, any withdrawn ETH was already in
+            // the pod when `startCheckpoint` was originally called.
+            (int256 balanceDeltaWei, bool noLongerStale) = _verifyCheckpointProof({
+                beaconTimestamp: beaconTimestamp,
+                beaconStateRoot: checkpoint.beaconStateRoot,
+                proof: proofs[i]
+            });
+
+            checkpoint.proofsRemaining--;
+            checkpoint.balanceDeltas += balanceDeltaWei;
+
+            if (noLongerStale) {
+                totalStaleValidatorsProven++;
+            }
+        }
+
+        // Update and/or finalize the checkpoint
+        _updateCheckpoint(checkpoint);
+
+        if (totalStaleValidatorsProven != 0) {
+            eigenPodManager.updateStaleValidatorCount(podOwner, totalStaleValidatorsProven);
+        }
+    }
 
     /**
-     * @notice This function verifies that the withdrawal credentials of validator(s) owned by the podOwner are pointed to
-     * this contract. It also verifies the effective balance  of the validator.  It verifies the provided proof of the ETH validator against the beacon chain state
-     * root, marks the validator as 'active' in EigenLayer, and credits the restaked ETH in Eigenlayer.
-     * @param oracleTimestamp is the Beacon Chain timestamp whose state root the `proof` will be proven against.
-     * @param stateRootProof proves a `beaconStateRoot` against a block root fetched from the oracle
-     * @param validatorIndices is the list of indices of the validators being proven, refer to consensus specs
-     * @param validatorFieldsProofs proofs against the `beaconStateRoot` for each validator in `validatorFields`
-     * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
-     * for details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     * @dev Verify one or more validators have their withdrawal credentials pointed at this EigenPod, and award
+     * shares based on their effective balance. Proven validators are marked `ACTIVE` within the EigenPod, and
+     * future checkpoint proofs will need to include them.
+     * @dev Withdrawal credential proofs MUST NOT be older than the `lastFinalizedCheckpoint` OR `currentCheckpointTimestamp`.
+     * @dev Validators proven via this method MUST NOT have an exit epoch set already.
+     * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
+     * to the parent beacon block root against which the proof is verified.
+     * @param stateRootProof proves a beacon state root against a beacon block root
+     * @param validatorIndices a list of validator indices being proven stale
+     * @param validatorFieldsProofs proofs of each validator's `validatorFields` against the beacon state root
+     * @param validatorFields the fields of the beacon chain "Validator" container. See consensus specs for
+     * details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
      */
     function verifyWithdrawalCredentials(
-        uint64 oracleTimestamp,
+        uint64 beaconTimestamp,
         BeaconChainProofs.StateRootProof calldata stateRootProof,
         uint40[] calldata validatorIndices,
         bytes[] calldata validatorFieldsProofs,
@@ -232,10 +281,7 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         external
         onlyEigenPodOwner
         onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CREDENTIALS)
-        // check that the provided `oracleTimestamp` is after the `mostRecentWithdrawalTimestamp`
-        proofIsForValidTimestamp(oracleTimestamp)
-        // ensure that caller has previously enabled restaking by calling `activateRestaking()`
-        hasEnabledRestaking
+        afterRestaking(beaconTimestamp)
     {
         require(
             (validatorIndices.length == validatorFieldsProofs.length) &&
@@ -243,19 +289,18 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
             "EigenPod.verifyWithdrawalCredentials: validatorIndices and proofs must be same length"
         );
 
-        /**
-         * Withdrawal credential proof should not be "stale" (older than VERIFY_BALANCE_UPDATE_WINDOW_SECONDS) as we are doing a balance check here
-         * The validator container persists as the state evolves and even after the validator exits. So we can use a more "fresh" credential proof within
-         * the VERIFY_BALANCE_UPDATE_WINDOW_SECONDS window, not just the first proof where the validator container is registered in the state.
-         */
+        // TODO - is == valid?
+        // I think YES, because we enforce no exit epoch is set
+        // However, we could also do strictly greater than if we want to be safe.
+        // TODO pt 2 - what about sub 12 on checkpointTimestamp?
         require(
-            oracleTimestamp + VERIFY_BALANCE_UPDATE_WINDOW_SECONDS >= block.timestamp,
+            beaconTimestamp > lastFinalizedCheckpoint && beaconTimestamp > currentCheckpointTimestamp,
             "EigenPod.verifyWithdrawalCredentials: specified timestamp is too far in past"
         );
 
         // Verify passed-in beaconStateRoot against oracle-provided block root:
         BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
-            latestBlockRoot: eigenPodManager.getBlockRootAtTimestamp(oracleTimestamp),
+            latestBlockRoot: eigenPodManager.getBlockRootAtTimestamp(beaconTimestamp),
             beaconStateRoot: stateRootProof.beaconStateRoot,
             stateRootProof: stateRootProof.proof
         });
@@ -263,7 +308,7 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         uint256 totalAmountToBeRestakedWei;
         for (uint256 i = 0; i < validatorIndices.length; i++) {
             totalAmountToBeRestakedWei += _verifyWithdrawalCredentials(
-                oracleTimestamp,
+                beaconTimestamp,
                 stateRootProof.beaconStateRoot,
                 validatorIndices[i],
                 validatorFieldsProofs[i],
@@ -273,6 +318,90 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
 
         // Update the EigenPodManager on this pod's new balance
         eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, int256(totalAmountToBeRestakedWei));
+    }
+
+    /**
+     * @dev Prove that one or more validators were slashed on the beacon chain and have not had timely
+     * checkpoint proofs since being slashed. If successful, this increases the pod owner's `staleValidatorCount`
+     * in the `EigenPodManager`. Stale validators can be restored by proving their balance in a checkpoint via
+     * `startCheckpoint` and `verifyCheckpointProof`.
+     * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
+     * to the parent beacon block root against which the proof is verified.
+     * @param stateRootProof proves a beacon state root against a beacon block root
+     * @param validatorIndices a list of validator indices being proven stale
+     * @param validatorFieldsProofs proofs of each validator's `validatorFields` against the beacon state root
+     * @param validatorFields the fields of the beacon chain "Validator" container. See consensus specs for
+     * details: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#validator
+     *
+     * Staleness conditions:
+     * - `beaconTimestamp` MUST NOT fall within `STALENESS_GRACE_PERIOD` seconds of `block.timestamp`
+     * - Last finalized checkpoint is older than `beaconTimestamp` by `TIME_TILL_STALE_BALANCE`
+     * - Validator's last balance update is older than `beaconTimestamp` by `TIME_TILL_STALE_BALANCE`
+     * - Validator MUST be in `ACTIVE` status in the pod
+     * - Validator MUST NOT already be marked stale
+     * - Validator MUST be slashed on the beacon chain
+     *
+     * TODO: plural version of this method!
+     */
+    function verifyStaleBalance(
+        uint64 beaconTimestamp,
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        uint40 calldata validatorIndex,
+        bytes calldata validatorFieldsProof,
+        bytes32[] calldata validatorFields
+    )
+        external
+        onlyWhenNotPaused(TODO)
+    {
+        bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
+        ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkeyHash];
+
+        /// Timestamp validation
+
+        require(
+            beaconTimestamp + STALENESS_GRACE_PERIOD < block.timestamp,
+            "EigenPod.verifyStaleBalance: staleness grace period not elapsed"
+        );
+
+        require(
+            beaconTimestamp > validatorInfo.mostRecentBalanceUpdateTimestamp + TIME_TILL_STALE_BALANCE,
+            "EigenPod.verifyStaleBalance: validator balance is not stale yet"
+        );
+
+        /// Validator status validation
+
+        require(
+            validatorInfo.status == VALIDATOR_STATUS.ACTIVE,
+            "EigenPod.verifyStaleBalance: validator is not active"
+        );
+
+        require(
+            !isValidatorStale[validatorPubkeyHash],
+            "EigenPod.verifyStaleBalance: validator already marked stale"
+        );
+
+        require(
+            validatorFields.getSlashedStatus() == true,
+            "EigenPod.verifyStaleBalance: validator must be slashed to be marked stale"
+        );
+
+        // Verify `beaconStateRoot` against beacon block root
+        BeaconChainProofs.verifyStateRootAgainstLatestBlockRoot({
+            latestBlockRoot: eigenPodManager.getBlockRootAtTimestamp(beaconTimestamp),
+            beaconStateRoot: stateRootProof.beaconStateRoot,
+            stateRootProof: stateRootProof.proof
+        });
+
+        // Verify Validator container proof against `beaconStateRoot`
+        BeaconChainProofs.verifyValidatorFields({
+            beaconStateRoot: stateRootProof.beaconStateRoot,
+            validatorFields: validatorFields,
+            validatorFieldsProof: validatorFieldsProof,
+            validatorIndex: validatorInfo.validatorIndex
+        });
+
+        isValidatorStale[validatorPubkey] = true;
+        eigenPodManager.updateStaleValidatorCount(podOwner, 1);
     }
 
     /// @notice Called by the pod owner to withdraw the nonBeaconChainETHBalanceWei
@@ -326,10 +455,6 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         _processWithdrawalBeforeRestaking(podOwner);
     }
 
-    /*******************************************************************************
-                    EXTERNAL FUNCTIONS CALLABLE BY EIGENPODMANAGER
-    *******************************************************************************/
-
     /// @notice Called by EigenPodManager when the owner wants to create another ETH validator.
     function stake(
         bytes calldata pubkey,
@@ -365,13 +490,13 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
 
     /**
      * @notice internal function that proves an individual validator's withdrawal credentials
-     * @param oracleTimestamp is the timestamp whose state root the `proof` will be proven against.
+     * @param beaconTimestamp is the timestamp whose state root the `proof` will be proven against.
      * @param validatorIndex is the index of the validator being proven
      * @param validatorFieldsProof is the bytes that prove the ETH validator's  withdrawal credentials against a beacon chain state root
      * @param validatorFields are the fields of the "Validator Container", refer to consensus specs
      */
     function _verifyWithdrawalCredentials(
-        uint64 oracleTimestamp,
+        uint64 beaconTimestamp,
         bytes32 beaconStateRoot,
         uint40 validatorIndex,
         bytes calldata validatorFieldsProof,
@@ -383,24 +508,25 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         // Withdrawal credential proofs should only be processed for "INACTIVE" validators
         require(
             validatorInfo.status == VALIDATOR_STATUS.INACTIVE,
-            "EigenPod.verifyCorrectWithdrawalCredentials: Validator must be inactive to prove withdrawal credentials"
+            "EigenPod._verifyWithdrawalCredentials: validator must be inactive to prove withdrawal credentials"
         );
 
-        // Ensure the `validatorFields` we're proving have the correct withdrawal credentials
+        // Validator should not already be in the process of exiting
+        require(
+            validatorFields.getExitEpoch() == FAR_FUTURE_EPOCH,
+            "EigenPod._verifyWithdrawalCredentials: validator must not be exiting"
+        );
+
+        // Ensure the validator's withdrawal credentials are pointed at this pod
         require(
             validatorFields.getWithdrawalCredentials() == bytes32(_podWithdrawalCredentials()),
-            "EigenPod.verifyCorrectWithdrawalCredentials: Proof is not for this EigenPod"
+            "EigenPod._verifyWithdrawalCredentials: proof is not for this EigenPod"
         );
 
-        /**
-         * Deserialize the balance field from the Validator struct.  Note that this is the "effective" balance of the validator
-         * rather than the current balance.  Effective balance is generated via a hystersis function such that an effective
-         * balance, always a multiple of 1 ETH, will only lower to the next multiple of 1 ETH if the current balance is less
-         * than 0.25 ETH below their current effective balance.  For example, if the effective balance is 31ETH, it only falls to
-         * 30ETH when the true balance falls below 30.75ETH.  Thus in the worst case, the effective balance is overestimating the
-         * actual validator balance by 0.25 ETH. 
-         */
-        uint64 validatorEffectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
+        // Get the validator's effective balance. Note that this method uses effective balance, while
+        // `verifyBalanceUpdates` uses current balance. Effective balance is updated per-epoch - so it's
+        // less accurate, but is good enough for verifying withdrawal credentials.
+        uint64 restakedBalanceGwei = validatorFields.getEffectiveBalanceGwei();
 
         // Verify passed-in validatorFields against verified beaconStateRoot:
         BeaconChainProofs.verifyValidatorFields({
@@ -414,85 +540,107 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         activeValidatorCount++;
         validatorInfo.status = VALIDATOR_STATUS.ACTIVE;
         validatorInfo.validatorIndex = validatorIndex;
-        validatorInfo.mostRecentBalanceUpdateTimestamp = oracleTimestamp;
+        validatorInfo.mostRecentBalanceUpdateTimestamp = beaconTimestamp;
+        validatorInfo.restakedBalanceGwei = restakedBalanceGwei;
 
-        if (validatorEffectiveBalanceGwei > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) {
-            validatorInfo.restakedBalanceGwei = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-        } else {
-            validatorInfo.restakedBalanceGwei = validatorEffectiveBalanceGwei;
-        }
         _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;
 
         emit ValidatorRestaked(validatorIndex);
-        emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, validatorInfo.restakedBalanceGwei);
+        emit ValidatorBalanceUpdated(validatorIndex, beaconTimestamp, restakedBalanceGwei);
 
-        return validatorInfo.restakedBalanceGwei * GWEI_TO_WEI;
+        return restakedBalanceGwei * GWEI_TO_WEI;
     }
 
-    function _verifyBalanceUpdate(
-        uint64 oracleTimestamp,
-        uint40 validatorIndex,
+    function _verifyCheckpointProof(
+        uint64 beaconTimestamp,
         bytes32 beaconStateRoot,
-        bytes calldata validatorFieldsProof,
-        bytes32[] calldata validatorFields
-    ) internal returns(int256 sharesDeltaGwei){
-        uint64 validatorEffectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
-        bytes32 validatorPubkeyHash = validatorFields.getPubkeyHash();
-        ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[validatorPubkeyHash];
+        BeaconChainProofs.BalanceProof memory proof
+    ) internal returns (int256 balanceDeltaWei, bool noLongerStale) {
+        ValidatorInfo memory validatorInfo = _validatorPubkeyHashToInfo[proof.pubkeyHash];
 
-        // 1. Balance updates should be more recent than the most recent update
         require(
-            validatorInfo.mostRecentBalanceUpdateTimestamp < oracleTimestamp,
-            "EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"
+            validatorInfo.status == VALIDATOR_STATUS.ACTIVE,
+            "EigenPod._verifyCheckpointProof: validator must be ACTIVE"
         );
 
-        // 2. Balance updates should only be performed on "ACTIVE" validators
+        // Ensure we aren't proving a validator twice for the same checkpoint. This will fail if:
+        // - validator submitted twice during this checkpoint
+        // - validator withdrawal credentials verified after checkpoint starts, then submitted
+        //   as a checkpoint proof
+        // TODO - we might want to "skip" and emit an event, rather than revert?
         require(
-            validatorInfo.status == VALIDATOR_STATUS.ACTIVE, 
-            "EigenPod.verifyBalanceUpdate: Validator not active"
+            validatorInfo.mostRecentBalanceUpdateTimestamp < beaconTimestamp,
+            "EigenPod._verifyCheckpointProof: validator already proven for this checkpoint"
         );
-
-        // 3. Balance updates should only be made before a validator is fully withdrawn. 
-        // -- A withdrawable validator may not have withdrawn yet, so we require their balance is nonzero
-        // -- A fully withdrawn validator should withdraw via verifyAndProcessWithdrawals
-        if (validatorFields.getWithdrawableEpoch() <= _timestampToEpoch(oracleTimestamp)) {
-            require(
-                validatorEffectiveBalanceGwei > 0,
-                "EigenPod.verifyBalanceUpdate: validator is withdrawable but has not withdrawn"
-            );
-        }
-
-        // Verify passed-in validatorFields against verified beaconStateRoot:
-        BeaconChainProofs.verifyValidatorFields({
-            beaconStateRoot: beaconStateRoot,
-            validatorFields: validatorFields,
-            validatorFieldsProof: validatorFieldsProof,
-            validatorIndex: validatorIndex
-        });
-
-        // Done with proofs! Now update the validator's balance and send to the EigenPodManager if needed
-
-        uint64 currentRestakedBalanceGwei = validatorInfo.restakedBalanceGwei;
-        uint64 newRestakedBalanceGwei;
-        if (validatorEffectiveBalanceGwei > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) {
-            newRestakedBalanceGwei = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-        } else {
-            newRestakedBalanceGwei = validatorEffectiveBalanceGwei;
-        }
         
-        // Update validator balance and timestamp, and save to state:
-        validatorInfo.restakedBalanceGwei = newRestakedBalanceGwei;
-        validatorInfo.mostRecentBalanceUpdateTimestamp = oracleTimestamp;
-        _validatorPubkeyHashToInfo[validatorPubkeyHash] = validatorInfo;
+        // Verify validator balance against beaconStateRoot
+        uint64 prevBalanceGwei = validatorInfo.restakedBalanceGwei;
+        uint64 newBalanceGwei = BeaconChainProofs.verifyValidatorBalance({
+            beaconStateRoot: beaconStateRoot,
+            validatorIndex: validatorInfo.validatorIndex,
+            proof: proof
+        });
+        
+        // Update validator state. If their new balance is 0, they are marked `WITHDRAWN`
+        validatorInfo.restakedBalanceGwei = newBalanceGwei;
+        validatorInfo.mostRecentBalanceUpdateTimestamp = beaconTimestamp;
+        if (newBalanceGwei == 0) {
+            activeValidatorCount--;
+            validatorInfo.status = VALIDATOR_STATUS.WITHDRAWN;
+        }
 
-        // If our new and old balances differ, calculate the delta and send to the EigenPodManager
-        if (newRestakedBalanceGwei != currentRestakedBalanceGwei) {
-            emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, newRestakedBalanceGwei);
+        _validatorPubkeyHashToInfo[proof.pubkeyHash] = validatorInfo;
 
-            sharesDeltaGwei = _calculateSharesDelta({
-                newAmountGwei: newRestakedBalanceGwei,
-                previousAmountGwei: currentRestakedBalanceGwei
+        // Calculate change in the validator's balance since the last proof
+        if (newBalanceGwei != prevBalanceGwei) {
+            emit ValidatorBalanceUpdated(validatorIndex, beaconTimestamp, newBalanceGwei);
+
+            balanceDeltaWei = _calcBalanceDeltaWei({
+                newAmountGwei: newBalanceGwei,
+                previousAmountGwei: prevBalanceGwei
             });
+        }
+
+        // If the validator was marked stale and this proof is younger than
+        // `TIME_TILL_STALE_BALANCE`, the validator is no longer stale.
+        if (
+            beaconTimestamp + TIME_TILL_STALE_BALANCE >= block.timestamp && 
+            isValidatorStale[proof.pubkeyHash]
+        ) {
+            isValidatorStale[proof.pubkeyHash] = false;
+            noLongerStale = true;
+        }
+
+        return (balanceDeltaWei, noLongerStale);
+    }
+
+    /**
+     * @dev Finish progress on a checkpoint and store it in state.
+     * @dev If the checkpoint has no proofs remaining, it is finalized:
+     * - a share delta is calculated and sent to the `EigenPodManager`
+     * - the checkpointed `podBalance` is added to `withdrawableRestakedExecutionLayerGwei`
+     * - `lastFinalizedCheckpoint` is updated
+     * - `currentCheckpoint` and `currentCheckpointTimestamp` are deleted
+     */
+    function _updateCheckpoint(Checkpoint memory checkpoint) internal {
+        if (checkpoint.proofsRemaining == 0) {
+            int256 totalShareDelta =
+                int256(checkpoint.podBalance) + checkpoint.balanceDeltas;
+
+            // Add any native ETH in the pod to `withdrawableRestakedExecutionLayerGwei`
+            // ... this amount can be withdrawn via the `DelegationManager` withdrawal queue
+            uint64 podBalanceGwei = checkpoint.podBalanceWei / GWEI_TO_WEI;
+            withdrawableRestakedExecutionLayerGwei += podBalanceGwei;
+
+            // Finalize the checkpoint
+            lastFinalizedCheckpoint = currentCheckpointTimestamp;
+            delete currentCheckpointTimestamp;
+            delete currentCheckpoint;
+
+            // Update pod owner's shares
+            eigenPodManager.recordBeaconChainETHBalanceUpdate(podOwner, totalShareDelta);
+        } else {
+            currentCheckpoint = checkpoint;
         }
     }
 
@@ -520,22 +668,10 @@ contract EigenPod is EigenPodStorage, Initializable, ReentrancyGuardUpgradeable,
         return sha256(abi.encodePacked(validatorPubkey, bytes16(0)));
     }
 
-    /**
-     * Calculates delta between two share amounts and returns as an int256
-     */
-    function _calculateSharesDelta(uint64 newAmountGwei, uint64 previousAmountGwei) internal pure returns (int256) {
+    /// @dev Calculates the delta between two Gwei amounts, converts to Wei, and returns as an int256
+    function _calcBalanceDeltaWei(uint64 newAmountGwei, uint64 previousAmountGwei) internal pure returns (int256) {
         return
-            int256(uint256(newAmountGwei)) - int256(uint256(previousAmountGwei));
-    }
-
-    /**
-     * @dev Converts a timestamp to a beacon chain epoch by calculating the number of
-     * seconds since genesis, and dividing by seconds per epoch.
-     * reference: https://github.com/ethereum/consensus-specs/blob/ce240ca795e257fc83059c4adfd591328c7a7f21/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
-     */
-    function _timestampToEpoch(uint64 timestamp) internal view returns (uint64) {
-        require(timestamp >= GENESIS_TIME, "EigenPod._timestampToEpoch: timestamp is before genesis");
-        return (timestamp - GENESIS_TIME) / BeaconChainProofs.SECONDS_PER_EPOCH;
+            (int256(uint256(newAmountGwei)) - int256(uint256(previousAmountGwei))) * int256(GWEI_TO_WEI);
     }
 
     /*******************************************************************************

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -236,7 +236,7 @@ contract EigenPod is
      * @dev Verify one or more validators have their withdrawal credentials pointed at this EigenPod, and award
      * shares based on their effective balance. Proven validators are marked `ACTIVE` within the EigenPod, and
      * future checkpoint proofs will need to include them.
-     * @dev Withdrawal credential proofs MUST NOT be older than the `lastFinalizedCheckpoint` OR `currentCheckpointTimestamp`.
+     * @dev Withdrawal credential proofs MUST NOT be older than the `lastCheckpointTimestamp` OR `currentCheckpointTimestamp`.
      * @dev Validators proven via this method MUST NOT have an exit epoch set already.
      * @param beaconTimestamp the beacon chain timestamp sent to the 4788 oracle contract. Corresponds
      * to the parent beacon block root against which the proof is verified.
@@ -265,7 +265,7 @@ contract EigenPod is
         );
         
         require(
-            beaconTimestamp > lastFinalizedCheckpoint && beaconTimestamp > currentCheckpointTimestamp,
+            beaconTimestamp > lastCheckpointTimestamp && beaconTimestamp > currentCheckpointTimestamp,
             "EigenPod.verifyWithdrawalCredentials: specified timestamp is too far in past"
         );
 
@@ -593,7 +593,7 @@ contract EigenPod is
      * @dev If the checkpoint has no proofs remaining, it is finalized:
      * - a share delta is calculated and sent to the `EigenPodManager`
      * - the checkpointed `podBalance` is added to `withdrawableRestakedExecutionLayerGwei`
-     * - `lastFinalizedCheckpoint` is updated
+     * - `lastCheckpointTimestamp` is updated
      * - `currentCheckpoint` and `currentCheckpointTimestamp` are deleted
      */
     function _updateCheckpoint(Checkpoint memory checkpoint) internal {
@@ -606,7 +606,7 @@ contract EigenPod is
             withdrawableRestakedExecutionLayerGwei += uint64(checkpoint.podBalanceGwei);
 
             // Finalize the checkpoint
-            lastFinalizedCheckpoint = currentCheckpointTimestamp;
+            lastCheckpointTimestamp = currentCheckpointTimestamp;
             delete currentCheckpointTimestamp;
             delete currentCheckpoint;
 

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -370,8 +370,11 @@ contract EigenPod is
 
     /**
      * @notice Called by the pod owner to activate restaking by withdrawing
-     * all existing ETH from the pod and preventing further withdrawals via
-     * "withdrawBeforeRestaking()"
+     * all existing ETH from the pod by starting a checkpoint. Once this is called,
+     * the pod owner can begin proving validator withdrawal credentials and checkpoints
+     * to receive shares for beacon chain ETH.
+     * Note: This method is only callable on pods that were deployed *before* the M2
+     * upgrade. After the M2 upgrade, restaking is enabled by default.
      */
     function activateRestaking()
         external

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -548,6 +548,7 @@ contract EigenPod is
         }
 
         _validatorPubkeyHashToInfo[proof.pubkeyHash] = validatorInfo;
+        emit ValidatorCheckpointed(beaconTimestamp, uint40(validatorInfo.validatorIndex));
 
         // Calculate change in the validator's balance since the last proof
         if (newBalanceGwei != prevBalanceGwei) {
@@ -586,6 +587,8 @@ contract EigenPod is
         // Place checkpoint in storage
         currentCheckpointTimestamp = uint64(block.timestamp);
         _updateCheckpoint(checkpoint);
+
+        emit CheckpointCreated(uint64(block.timestamp), checkpoint.beaconBlockRoot);
     }
 
     /**

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -307,7 +307,6 @@ contract EigenPod is
      * - `beaconTimestamp` MUST NOT fall within `STALENESS_GRACE_PERIOD` seconds of `block.timestamp`
      * - Validator's last balance update is older than `beaconTimestamp` by `TIME_TILL_STALE_BALANCE`
      * - Validator MUST be in `ACTIVE` status in the pod
-     * - Validator MUST NOT already be marked stale
      * - Validator MUST be slashed on the beacon chain
      */
     function verifyStaleBalance(
@@ -340,7 +339,7 @@ contract EigenPod is
 
         // Validator must be slashed on the beacon chain
         require(
-            proof.validatorFields.getSlashStatus() == true,
+            proof.validatorFields.isValidatorSlashed(),
             "EigenPod.verifyStaleBalance: validator must be slashed to be marked stale"
         );
 

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -139,6 +139,13 @@ contract EigenPodManager is
         emit PodSharesUpdated(podOwner, sharesDelta);
     }
 
+    /**
+     * @dev Changes the `podOwner's` stale validator count by `countDelta`. The stale validator
+     * count can be used as an additional weighting mechanism to determine a staker or operator's shares.
+     * @param podOwner the pod owner whose stale validator count is being updated
+     * @param countDelta the change in `podOwner's` stale validator count as a signed integer
+     * @dev Callable only by the `podOwner's` EigenPod contract
+     */
     function updateStaleValidatorCount(
         address podOwner,
         int256 countDelta

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -141,6 +141,27 @@ contract EigenPodManager is
         emit PodSharesUpdated(podOwner, sharesDelta);
     }
 
+    function updateStaleValidatorCount(
+        address podOwner,
+        int256 countDelta
+    ) external onlyEigenPod(podOwner) {
+        require(podOwner != address(0), "EigenPodManager.updateStaleValidatorCount: podOwner cannot be zero address");
+        require(countDelta != 0, "EigenPodManager.updateStaleValidatorCount: invalid countDelta");
+
+        uint256 currentCount = staleValidatorCount[podOwner];
+        uint256 deltaAbs = uint256(countDelta);
+
+        if (countDelta < 0) {
+            require(deltaAbs <= currentCount, "EigenPodManager.updateStaleValidatorCount: applying countDelta would make count negative");
+
+            staleValidatorCount[podOwner] -= deltaAbs;
+        } else {
+            staleValidatorCount[podOwner] += deltaAbs;
+        }
+
+        // TODO emit event
+    }
+
     /**
      * @notice Used by the DelegationManager to remove a pod owner's shares while they're in the withdrawal queue.
      * Simply decreases the `podOwner`'s shares by `shares`, down to a minimum of zero.

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -55,12 +55,10 @@ contract EigenPodManager is
     }
 
     function initialize(
-        IBeaconChainOracle _beaconChainOracle,
         address initialOwner,
         IPauserRegistry _pauserRegistry,
         uint256 _initPausedStatus
     ) external initializer {
-        _updateBeaconChainOracle(_beaconChainOracle);
         _transferOwnership(initialOwner);
         _initializePauser(_pauserRegistry, _initPausedStatus);
     }
@@ -243,15 +241,6 @@ contract EigenPodManager is
     }
 
     /**
-     * @notice Updates the oracle contract that provides the beacon chain state root
-     * @param newBeaconChainOracle is the new oracle contract being pointed to
-     * @dev Callable only by the owner of this contract (i.e. governance)
-     */
-    function updateBeaconChainOracle(IBeaconChainOracle newBeaconChainOracle) external onlyOwner {
-        _updateBeaconChainOracle(newBeaconChainOracle);
-    }
-
-    /**
      * @notice Sets the timestamp of the Deneb fork.
      * @param newDenebForkTimestamp is the new timestamp of the Deneb fork
      */
@@ -281,12 +270,6 @@ contract EigenPodManager is
         ownerToPod[msg.sender] = pod;
         emit PodDeployed(address(pod), msg.sender);
         return pod;
-    }
-
-    /// @notice Internal setter for `beaconChainOracle` that also emits an event
-    function _updateBeaconChainOracle(IBeaconChainOracle newBeaconChainOracle) internal {
-        beaconChainOracle = newBeaconChainOracle;
-        emit BeaconOracleUpdated(address(newBeaconChainOracle));
     }
 
     /**
@@ -335,14 +318,24 @@ contract EigenPodManager is
         return address(ownerToPod[podOwner]) != address(0);
     }
 
-    /// @notice Returns the Beacon block root at `timestamp`. Reverts if the Beacon block root at `timestamp` has not yet been finalized.
-    function getBlockRootAtTimestamp(uint64 timestamp) external view returns (bytes32) {
-        bytes32 stateRoot = beaconChainOracle.timestampToBlockRoot(timestamp);
+    /// @notice Query the 4788 oracle to get the parent block root of the slot with the given `timestamp`
+    /// @param timestamp of the block for which the parent block root will be returned. MUST correspond
+    /// to an existing slot within the last 24 hours. If the slot at `timestamp` was skipped, this method
+    /// will revert.
+    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32) {
         require(
-            stateRoot != bytes32(0),
-            "EigenPodManager.getBlockRootAtTimestamp: state root at timestamp not yet finalized"
+            block.timestamp - timestamp < BEACON_ROOTS_HISTORY_BUFFER_LENGTH * 12,
+            "EigenPodManager.getParentBlockRoot: timestamp out of range"
         );
-        return stateRoot;
+
+        (bool success, bytes memory result) =
+            BEACON_ROOTS_ADDRESS.staticcall(abi.encode(timestamp));
+
+        if (success && result.length > 0) {
+            return abi.decode(result, (bytes32));
+        } else {
+            revert("EigenPodManager.getParentBlockRoot: invalid block root returned");
+        }
     }
 
     /**

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -297,26 +297,6 @@ contract EigenPodManager is
         return address(ownerToPod[podOwner]) != address(0);
     }
 
-    /// @notice Query the 4788 oracle to get the parent block root of the slot with the given `timestamp`
-    /// @param timestamp of the block for which the parent block root will be returned. MUST correspond
-    /// to an existing slot within the last 24 hours. If the slot at `timestamp` was skipped, this method
-    /// will revert.
-    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32) {
-        require(
-            block.timestamp - timestamp < BEACON_ROOTS_HISTORY_BUFFER_LENGTH * 12,
-            "EigenPodManager.getParentBlockRoot: timestamp out of range"
-        );
-
-        (bool success, bytes memory result) =
-            BEACON_ROOTS_ADDRESS.staticcall(abi.encode(timestamp));
-
-        if (success && result.length > 0) {
-            return abi.decode(result, (bytes32));
-        } else {
-            revert("EigenPodManager.getParentBlockRoot: invalid block root returned");
-        }
-    }
-
     /**
      * @notice Wrapper around the `_denebForkTimestamp` storage variable that returns type(uint64).max if the storage variable is unset.
      * @dev This allows restricting the storage variable to be set once and only once.

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -140,34 +140,6 @@ contract EigenPodManager is
     }
 
     /**
-     * @dev Changes the `podOwner's` stale validator count by `countDelta`. The stale validator
-     * count can be used as an additional weighting mechanism to determine a staker or operator's shares.
-     * @param podOwner the pod owner whose stale validator count is being updated
-     * @param countDelta the change in `podOwner's` stale validator count as a signed integer
-     * @dev Callable only by the `podOwner's` EigenPod contract
-     */
-    function updateStaleValidatorCount(
-        address podOwner,
-        int256 countDelta
-    ) external onlyEigenPod(podOwner) {
-        require(podOwner != address(0), "EigenPodManager.updateStaleValidatorCount: podOwner cannot be zero address");
-        require(countDelta != 0, "EigenPodManager.updateStaleValidatorCount: invalid countDelta");
-
-        uint256 currentCount = staleValidatorCount[podOwner];
-        uint256 deltaAbs = uint256(countDelta);
-
-        if (countDelta < 0) {
-            require(deltaAbs <= currentCount, "EigenPodManager.updateStaleValidatorCount: applying countDelta would make count negative");
-
-            staleValidatorCount[podOwner] -= deltaAbs;
-        } else {
-            staleValidatorCount[podOwner] += deltaAbs;
-        }
-
-        // TODO emit event
-    }
-
-    /**
      * @notice Used by the DelegationManager to remove a pod owner's shares while they're in the withdrawal queue.
      * Simply decreases the `podOwner`'s shares by `shares`, down to a minimum of zero.
      * @dev This function reverts if it would result in `podOwnerShares[podOwner]` being less than zero, i.e. it is forbidden for this function to

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -83,9 +83,6 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     uint64 internal _denebForkTimestamp;
 
-    /// @dev Maps pod owner address -> number of validators with stale balances
-    mapping(address => uint256) public staleValidatorCount;
-
     constructor(
         IETHPOSDeposit _ethPOS,
         IBeacon _eigenPodBeacon,
@@ -105,5 +102,5 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[43] private __gap;
+    uint256[44] private __gap;
 }

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -11,6 +11,11 @@ import "../interfaces/IETHPOSDeposit.sol";
 import "../interfaces/IEigenPod.sol";
 
 abstract contract EigenPodManagerStorage is IEigenPodManager {
+
+    /*******************************************************************************
+                               CONSTANTS / IMMUTABLES
+    *******************************************************************************/
+
     /// @notice The ETH2 Deposit Contract
     IETHPOSDeposit public immutable ethPOS;
 
@@ -40,8 +45,19 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
-    /// @notice Oracle contract that provides updates to the beacon chain's state
-    IBeaconChainOracle public beaconChainOracle;
+    /// @notice The address of the EIP-4788 beacon block root oracle
+    /// (See https://eips.ethereum.org/EIPS/eip-4788)
+    address internal constant BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
+
+    /// @notice The length of the EIP-4799 beacon block root ring buffer
+    uint256 internal constant BEACON_ROOTS_HISTORY_BUFFER_LENGTH = 8191;
+
+    /*******************************************************************************
+                                   STATE VARIABLES
+    *******************************************************************************/
+
+    /// @notice [DEPRECATED] Previously used to query beacon block roots. We now use eip-4788 directly
+    IBeaconChainOracle internal __deprecated_beaconChainOracle;
 
     /// @notice Pod owner to deployed EigenPod address
     mapping(address => IEigenPod) public ownerToPod;
@@ -50,7 +66,7 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
     /// @notice The number of EigenPods that have been deployed
     uint256 public numPods;
 
-    /// @notice Deprecated from old mainnet release. Was initially used to limit growth early on but there is no longer
+    /// @notice [DEPRECATED] Was initially used to limit growth early on but there is no longer
     /// a maximum number of EigenPods that can be deployed.
     uint256 private __deprecated_maxPods;
 

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -45,13 +45,6 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
-    /// @notice The address of the EIP-4788 beacon block root oracle
-    /// (See https://eips.ethereum.org/EIPS/eip-4788)
-    address internal constant BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02;
-
-    /// @notice The length of the EIP-4799 beacon block root ring buffer
-    uint256 internal constant BEACON_ROOTS_HISTORY_BUFFER_LENGTH = 8191;
-
     /*******************************************************************************
                                    STATE VARIABLES
     *******************************************************************************/

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -67,6 +67,9 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     uint64 internal _denebForkTimestamp;
 
+    /// @dev Maps pod owner address -> number of validators with stale balances
+    mapping(address => uint256) public staleValidatorCount;
+
     constructor(
         IETHPOSDeposit _ethPOS,
         IBeacon _eigenPodBeacon,
@@ -86,5 +89,5 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[44] private __gap;
+    uint256[43] private __gap;
 }

--- a/src/contracts/pods/EigenPodPausingConstants.sol
+++ b/src/contracts/pods/EigenPodPausingConstants.sol
@@ -17,10 +17,17 @@ abstract contract EigenPodPausingConstants {
 
     /// @notice Index for flag that pauses the deposit related functions *of the EigenPods* when set. see EigenPod code for details.
     uint8 internal constant PAUSED_EIGENPODS_VERIFY_CREDENTIALS = 2;
-    /// @notice Index for flag that pauses the `verifyBalanceUpdate` function *of the EigenPods* when set. see EigenPod code for details.
-    uint8 internal constant PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE = 3;
-    /// @notice Index for flag that pauses the `verifyBeaconChainFullWithdrawal` function *of the EigenPods* when set. see EigenPod code for details.
-    uint8 internal constant PAUSED_EIGENPODS_VERIFY_WITHDRAWAL = 4;
+    
+    /// @notice Index for flag that pauses the `verifyCheckpointProofs` function *of the EigenPods* when set. see EigenPod code for details.
+    uint8 internal constant PAUSED_EIGENPODS_VERIFY_CHECKPOINT_PROOFS = 3;
+
+    // Deprecated
+    // uint8 internal constant PAUSED_EIGENPODS_VERIFY_WITHDRAWAL = 4;
+
     /// @notice Pausability for EigenPod's "accidental transfer" withdrawal methods
     uint8 internal constant PAUSED_NON_PROOF_WITHDRAWALS = 5;
+
+    uint8 internal constant PAUSED_START_CHECKPOINT = 6;
+
+    uint8 internal constant PAUSED_VERIFY_STALE_BALANCE = 7;
 }

--- a/src/contracts/pods/EigenPodPausingConstants.sol
+++ b/src/contracts/pods/EigenPodPausingConstants.sol
@@ -18,8 +18,8 @@ abstract contract EigenPodPausingConstants {
     /// @notice Index for flag that pauses the deposit related functions *of the EigenPods* when set. see EigenPod code for details.
     uint8 internal constant PAUSED_EIGENPODS_VERIFY_CREDENTIALS = 2;
     
-    /// @notice Index for flag that pauses the `verifyCheckpointProofs` function *of the EigenPods* when set. see EigenPod code for details.
-    uint8 internal constant PAUSED_EIGENPODS_VERIFY_CHECKPOINT_PROOFS = 3;
+    // Deprecated
+    // uint8 internal constant PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE = 3;
 
     // Deprecated
     // uint8 internal constant PAUSED_EIGENPODS_VERIFY_WITHDRAWAL = 4;
@@ -29,5 +29,8 @@ abstract contract EigenPodPausingConstants {
 
     uint8 internal constant PAUSED_START_CHECKPOINT = 6;
 
-    uint8 internal constant PAUSED_VERIFY_STALE_BALANCE = 7;
+    /// @notice Index for flag that pauses the `verifyCheckpointProofs` function *of the EigenPods* when set. see EigenPod code for details.
+    uint8 internal constant PAUSED_EIGENPODS_VERIFY_CHECKPOINT_PROOFS = 7;
+
+    uint8 internal constant PAUSED_VERIFY_STALE_BALANCE = 8;
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "../interfaces/IEigenPod.sol";
+
+abstract contract EigenPodStorage is IEigenPod {
+
+    /// @notice The owner of this EigenPod
+    address public podOwner;
+
+    /**
+     * @notice The latest timestamp at which the pod owner withdrew the balance of the pod, via calling `withdrawBeforeRestaking`.
+     * @dev This variable is only updated when the `withdrawBeforeRestaking` function is called, which can only occur before `hasRestaked` is set to true for this pod.
+     * Proofs for this pod are only valid against Beacon Chain state roots corresponding to timestamps after the stored `mostRecentWithdrawalTimestamp`.
+     */
+    uint64 public mostRecentWithdrawalTimestamp;
+
+    /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from the Beacon Chain but not from EigenLayer),
+    uint64 public withdrawableRestakedExecutionLayerGwei;
+
+    /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
+    bool public hasRestaked;
+
+    /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp
+    mapping(bytes32 => mapping(uint64 => bool)) public provenWithdrawal;
+
+    /// @notice This is a mapping that tracks a validator's information by their pubkey hash
+    mapping(bytes32 => ValidatorInfo) internal _validatorPubkeyHashToInfo;
+
+    /// @notice This variable tracks any ETH deposited into this contract via the `receive` fallback function
+    uint256 public nonBeaconChainETHBalanceWei;
+
+    /// @notice This variable tracks the total amount of partial withdrawals claimed via merkle proofs prior to a switch to ZK proofs for claiming partial withdrawals
+    uint64 public sumOfPartialWithdrawalsClaimedGwei;
+
+    /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
+    uint256 activeValidatorCount;
+
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[44] private __gap;
+}

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -22,7 +22,7 @@ abstract contract EigenPodStorage is IEigenPod {
     bool public hasRestaked;
 
     /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp
-    mapping(bytes32 => mapping(uint64 => bool)) public provenWithdrawal;
+    mapping(bytes32 => mapping(uint64 => bool)) public __deprecated_provenWithdrawal;
 
     /// @notice This is a mapping that tracks a validator's information by their pubkey hash
     mapping(bytes32 => ValidatorInfo) internal _validatorPubkeyHashToInfo;
@@ -31,15 +31,27 @@ abstract contract EigenPodStorage is IEigenPod {
     uint256 public nonBeaconChainETHBalanceWei;
 
     /// @notice This variable tracks the total amount of partial withdrawals claimed via merkle proofs prior to a switch to ZK proofs for claiming partial withdrawals
-    uint64 public sumOfPartialWithdrawalsClaimedGwei;
+    uint64 __deprecated_sumOfPartialWithdrawalsClaimedGwei;
 
     /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
-    uint256 activeValidatorCount;
+    uint256 public activeValidatorCount;
+
+    /// @notice The timestamp of the last checkpoint finalized
+    uint64 public lastFinalizedCheckpoint;
+
+    /// @notice The timestamp of the currently-active checkpoint. Will be 0 if there is not active checkpoint
+    uint64 public currentCheckpointTimestamp;
+
+    /// @notice The current checkpoint, if there is one active
+    Checkpoint public currentCheckpoint;
+
+    /// @notice Maps pubkey hash -> whether a validator has been marked "stale"
+    mapping(bytes32 => bool) public isValidatorStale;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[44] private __gap;
+    uint256[40] private __gap;
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -43,7 +43,7 @@ abstract contract EigenPodStorage is IEigenPod {
     uint64 public currentCheckpointTimestamp;
 
     /// @notice The current checkpoint, if there is one active
-    Checkpoint public currentCheckpoint;
+    Checkpoint internal _currentCheckpoint;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -37,7 +37,7 @@ abstract contract EigenPodStorage is IEigenPod {
     uint256 public activeValidatorCount;
 
     /// @notice The timestamp of the last checkpoint finalized
-    uint64 public lastFinalizedCheckpoint;
+    uint64 public lastCheckpointTimestamp;
 
     /// @notice The timestamp of the currently-active checkpoint. Will be 0 if there is not active checkpoint
     uint64 public currentCheckpointTimestamp;

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -53,5 +53,5 @@ abstract contract EigenPodStorage is IEigenPod {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[40] private __gap;
+    uint256[37] private __gap;
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -22,7 +22,7 @@ abstract contract EigenPodStorage is IEigenPod {
     bool public hasRestaked;
 
     /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp
-    mapping(bytes32 => mapping(uint64 => bool)) public __deprecated_provenWithdrawal;
+    mapping(bytes32 => mapping(uint64 => bool)) internal __deprecated_provenWithdrawal;
 
     /// @notice This is a mapping that tracks a validator's information by their pubkey hash
     mapping(bytes32 => ValidatorInfo) internal _validatorPubkeyHashToInfo;
@@ -45,13 +45,10 @@ abstract contract EigenPodStorage is IEigenPod {
     /// @notice The current checkpoint, if there is one active
     Checkpoint public currentCheckpoint;
 
-    /// @notice Maps pubkey hash -> whether a validator has been marked "stale"
-    mapping(bytes32 => bool) public isValidatorStale;
-
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[37] private __gap;
+    uint256[38] private __gap;
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -28,7 +28,7 @@ abstract contract EigenPodStorage is IEigenPod {
     mapping(bytes32 => ValidatorInfo) internal _validatorPubkeyHashToInfo;
 
     /// @notice This variable tracks any ETH deposited into this contract via the `receive` fallback function
-    uint256 public nonBeaconChainETHBalanceWei;
+    uint256 internal __deprecated_nonBeaconChainETHBalanceWei;
 
     /// @notice This variable tracks the total amount of partial withdrawals claimed via merkle proofs prior to a switch to ZK proofs for claiming partial withdrawals
     uint64 __deprecated_sumOfPartialWithdrawalsClaimedGwei;

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -367,7 +367,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
         );
 
         ethPOSDeposit = new ETHPOSDepositMock();
-        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, GOERLI_GENESIS_TIME);
+        pod = new EigenPod(ethPOSDeposit, delayedWithdrawalRouter, eigenPodManager, GOERLI_GENESIS_TIME);
 
         eigenPodBeacon = new UpgradeableBeacon(address(pod));
 
@@ -416,7 +416,6 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                beaconChainOracleAddress,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
                 0/*initialPausedStatus*/

--- a/src/test/EigenLayerDeployer.t.sol
+++ b/src/test/EigenLayerDeployer.t.sol
@@ -79,7 +79,6 @@ contract EigenLayerDeployer is Operators {
     uint32 PARTIAL_WITHDRAWAL_FRAUD_PROOF_PERIOD_BLOCKS = 7 days / 12 seconds;
     uint256 REQUIRED_BALANCE_WEI = 32 ether;
     uint64 MAX_PARTIAL_WTIHDRAWAL_AMOUNT_GWEI = 1 ether / 1e9;
-    uint64 MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
     uint64 GOERLI_GENESIS_TIME = 1616508000;
 
     address pauser;
@@ -170,7 +169,6 @@ contract EigenLayerDeployer is Operators {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -244,7 +242,6 @@ contract EigenLayerDeployer is Operators {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -303,7 +300,6 @@ contract EigenLayerDeployer is Operators {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                beaconChainOracleAddress,
                 eigenLayerReputedMultisig,
                 eigenLayerPauserReg,
                 0 /*initialPausedStatus*/

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -273,39 +273,39 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
-    function testWithdrawBeforeRestaking() public {
-        testStaking();
-        IEigenPod pod = eigenPodManager.getPod(podOwner);
+    // function testWithdrawBeforeRestaking() public {
+    //     testStaking();
+    //     IEigenPod pod = eigenPodManager.getPod(podOwner);
 
-        //simulate that hasRestaked is set to false, so that we can test withdrawBeforeRestaking for pods deployed before M2 activation
-        cheats.store(address(pod), bytes32(uint256(52)), bytes32(uint256(1)));
-        require(pod.hasRestaked() == false, "Pod should not be restaked");
+    //     //simulate that hasRestaked is set to false, so that we can test withdrawBeforeRestaking for pods deployed before M2 activation
+    //     cheats.store(address(pod), bytes32(uint256(52)), bytes32(uint256(1)));
+    //     require(pod.hasRestaked() == false, "Pod should not be restaked");
 
-        // simulate a withdrawal
-        cheats.deal(address(pod), stakeAmount);
-        cheats.startPrank(podOwner);
-        cheats.expectEmit(true, true, true, true, address(delayedWithdrawalRouter));
-        emit DelayedWithdrawalCreated(
-            podOwner,
-            podOwner,
-            stakeAmount,
-            delayedWithdrawalRouter.userWithdrawalsLength(podOwner)
-        );
+    //     // simulate a withdrawal
+    //     cheats.deal(address(pod), stakeAmount);
+    //     cheats.startPrank(podOwner);
+    //     cheats.expectEmit(true, true, true, true, address(delayedWithdrawalRouter));
+    //     emit DelayedWithdrawalCreated(
+    //         podOwner,
+    //         podOwner,
+    //         stakeAmount,
+    //         delayedWithdrawalRouter.userWithdrawalsLength(podOwner)
+    //     );
 
-        uint timestampBeforeTx = pod.mostRecentWithdrawalTimestamp();
+    //     uint timestampBeforeTx = pod.mostRecentWithdrawalTimestamp();
 
-        pod.withdrawBeforeRestaking();
+    //     pod.withdrawBeforeRestaking();
 
-        require(_getLatestDelayedWithdrawalAmount(podOwner) == stakeAmount, "Payment amount should be stake amount");
-        require(
-            pod.mostRecentWithdrawalTimestamp() == uint64(block.timestamp),
-            "Most recent withdrawal block number not updated"
-        );
-        require(
-            pod.mostRecentWithdrawalTimestamp() > timestampBeforeTx,
-            "Most recent withdrawal block number not updated"
-        );
-    }
+    //     require(_getLatestDelayedWithdrawalAmount(podOwner) == stakeAmount, "Payment amount should be stake amount");
+    //     require(
+    //         pod.mostRecentWithdrawalTimestamp() == uint64(block.timestamp),
+    //         "Most recent withdrawal block number not updated"
+    //     );
+    //     require(
+    //         pod.mostRecentWithdrawalTimestamp() > timestampBeforeTx,
+    //         "Most recent withdrawal block number not updated"
+    //     );
+    // }
 
     function testDeployEigenPodWithoutActivateRestaking() public {
         // ./solidityProofGen  -newBalance=32000115173 "ValidatorFieldsProof" 302913 true "data/withdrawal_proof_goerli/goerli_block_header_6399998.json"  "data/withdrawal_proof_goerli/goerli_slot_6399998.json" "withdrawal_credential_proof_302913.json"
@@ -344,69 +344,69 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
-    function testWithdrawNonBeaconChainETHBalanceWei() public {
-        IEigenPod pod = testDeployAndVerifyNewEigenPod();
+    // function testWithdrawNonBeaconChainETHBalanceWei() public {
+    //     IEigenPod pod = testDeployAndVerifyNewEigenPod();
 
-        cheats.deal(address(podOwner), 10 ether);
-        emit log_named_address("Pod:", address(pod));
+    //     cheats.deal(address(podOwner), 10 ether);
+    //     emit log_named_address("Pod:", address(pod));
 
-        uint256 balanceBeforeDeposit = pod.nonBeaconChainETHBalanceWei();
+    //     uint256 balanceBeforeDeposit = pod.nonBeaconChainETHBalanceWei();
 
-        (bool sent, ) = payable(address(pod)).call{value: 1 ether}("");
+    //     (bool sent, ) = payable(address(pod)).call{value: 1 ether}("");
 
-        require(sent == true, "not sent");
+    //     require(sent == true, "not sent");
 
-        uint256 balanceAfterDeposit = pod.nonBeaconChainETHBalanceWei();
+    //     uint256 balanceAfterDeposit = pod.nonBeaconChainETHBalanceWei();
 
-        require(
-            balanceBeforeDeposit < balanceAfterDeposit 
-            && (balanceAfterDeposit - balanceBeforeDeposit) == 1 ether, 
-            "increment checks"
-        );
+    //     require(
+    //         balanceBeforeDeposit < balanceAfterDeposit 
+    //         && (balanceAfterDeposit - balanceBeforeDeposit) == 1 ether, 
+    //         "increment checks"
+    //     );
 
-        cheats.startPrank(podOwner, podOwner);
-        cheats.expectEmit(true, true, true, true, address(pod));
-        emit NonBeaconChainETHWithdrawn(podOwner, 1 ether);
-        pod.withdrawNonBeaconChainETHBalanceWei(
-            podOwner,
-            1 ether
-        );
+    //     cheats.startPrank(podOwner, podOwner);
+    //     cheats.expectEmit(true, true, true, true, address(pod));
+    //     emit NonBeaconChainETHWithdrawn(podOwner, 1 ether);
+    //     pod.withdrawNonBeaconChainETHBalanceWei(
+    //         podOwner,
+    //         1 ether
+    //     );
 
-        uint256 balanceAfterWithdrawal = pod.nonBeaconChainETHBalanceWei();
+    //     uint256 balanceAfterWithdrawal = pod.nonBeaconChainETHBalanceWei();
 
-        require(
-            balanceAfterWithdrawal < balanceAfterDeposit 
-            && balanceAfterWithdrawal == balanceBeforeDeposit, 
-            "decrement checks"
-        );
+    //     require(
+    //         balanceAfterWithdrawal < balanceAfterDeposit 
+    //         && balanceAfterWithdrawal == balanceBeforeDeposit, 
+    //         "decrement checks"
+    //     );
 
-        cheats.stopPrank();
-    }
+    //     cheats.stopPrank();
+    // }
 
-    function testWithdrawFromPod() public {
-        IEigenPod pod = eigenPodManager.getPod(podOwner);
-        cheats.startPrank(podOwner);
+    // function testWithdrawFromPod() public {
+    //     IEigenPod pod = eigenPodManager.getPod(podOwner);
+    //     cheats.startPrank(podOwner);
 
-        cheats.expectEmit(true, true, true, true, address(pod));
-        emit EigenPodStaked(pubkey);
+    //     cheats.expectEmit(true, true, true, true, address(pod));
+    //     emit EigenPodStaked(pubkey);
 
-        eigenPodManager.stake{value: stakeAmount}(pubkey, signature, depositDataRoot);
-        cheats.stopPrank();
+    //     eigenPodManager.stake{value: stakeAmount}(pubkey, signature, depositDataRoot);
+    //     cheats.stopPrank();
 
-        cheats.deal(address(pod), stakeAmount);
+    //     cheats.deal(address(pod), stakeAmount);
 
-        // this is testing if pods deployed before M2 that do not have hasRestaked initialized to true, will revert
-        cheats.store(address(pod), bytes32(uint256(52)), bytes32(uint256(1)));
+    //     // this is testing if pods deployed before M2 that do not have hasRestaked initialized to true, will revert
+    //     cheats.store(address(pod), bytes32(uint256(52)), bytes32(uint256(1)));
 
-        cheats.startPrank(podOwner);
-        uint256 userWithdrawalsLength = delayedWithdrawalRouter.userWithdrawalsLength(podOwner);
-        // cheats.expectEmit(true, true, true, true, address(delayedWithdrawalRouter));
-        //cheats.expectEmit(true, true, true, true);
-        emit DelayedWithdrawalCreated(podOwner, podOwner, stakeAmount, userWithdrawalsLength);
-        pod.withdrawBeforeRestaking();
-        cheats.stopPrank();
-        require(address(pod).balance == 0, "Pod balance should be 0");
-    }
+    //     cheats.startPrank(podOwner);
+    //     uint256 userWithdrawalsLength = delayedWithdrawalRouter.userWithdrawalsLength(podOwner);
+    //     // cheats.expectEmit(true, true, true, true, address(delayedWithdrawalRouter));
+    //     //cheats.expectEmit(true, true, true, true);
+    //     emit DelayedWithdrawalCreated(podOwner, podOwner, stakeAmount, userWithdrawalsLength);
+    //     pod.withdrawBeforeRestaking();
+    //     cheats.stopPrank();
+    //     require(address(pod).balance == 0, "Pod balance should be 0");
+    // }
 
     // function testFullWithdrawalProof() public {
     //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
@@ -1059,20 +1059,20 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.stopPrank();
     }
 
-    function testCallWithdrawBeforeRestakingFromNonOwner(address nonPodOwner) external fuzzedAddress(nonPodOwner) {
-        cheats.assume(nonPodOwner != podOwner);
-        testStaking();
-        IEigenPod pod = eigenPodManager.getPod(podOwner);
+    // function testCallWithdrawBeforeRestakingFromNonOwner(address nonPodOwner) external fuzzedAddress(nonPodOwner) {
+    //     cheats.assume(nonPodOwner != podOwner);
+    //     testStaking();
+    //     IEigenPod pod = eigenPodManager.getPod(podOwner);
 
-        // this is testing if pods deployed before M2 that do not have hasRestaked initialized to true, will revert
-        cheats.store(address(pod), bytes32(uint256(52)), bytes32(0));
-        require(pod.hasRestaked() == false, "Pod should not be restaked");
+    //     // this is testing if pods deployed before M2 that do not have hasRestaked initialized to true, will revert
+    //     cheats.store(address(pod), bytes32(uint256(52)), bytes32(0));
+    //     require(pod.hasRestaked() == false, "Pod should not be restaked");
 
-        //simulate a withdrawal
-        cheats.startPrank(nonPodOwner);
-        cheats.expectRevert(bytes("EigenPod.onlyEigenPodOwner: not podOwner"));
-        pod.withdrawBeforeRestaking();
-    }
+    //     //simulate a withdrawal
+    //     cheats.startPrank(nonPodOwner);
+    //     cheats.expectRevert(bytes("EigenPod.onlyEigenPodOwner: not podOwner"));
+    //     pod.withdrawBeforeRestaking();
+    // }
 
     /* test deprecated since this is checked on the EigenPodManager level, rather than the EigenPod level
     TODO: @Sidu28 - check whether we have adequate coverage of the correct function

--- a/src/test/harnesses/EigenPodHarness.sol
+++ b/src/test/harnesses/EigenPodHarness.sol
@@ -10,13 +10,11 @@ contract EPInternalFunctions is EigenPod, Test {
         IETHPOSDeposit _ethPOS,
         IDelayedWithdrawalRouter _delayedWithdrawalRouter,
         IEigenPodManager _eigenPodManager,
-        uint64 _MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
         uint64 _GENESIS_TIME
     ) EigenPod(
         _ethPOS,
         _delayedWithdrawalRouter,
         _eigenPodManager,
-        _MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
         _GENESIS_TIME
     ) {}
 
@@ -40,75 +38,6 @@ contract EPInternalFunctions is EigenPod, Test {
             beaconStateRoot,
             validatorIndex,
             validatorFieldsProof,
-            validatorFields
-        );
-    }
-
-    function verifyAndProcessWithdrawal(
-        bytes32 beaconStateRoot,
-        BeaconChainProofs.WithdrawalProof calldata withdrawalProof,
-        bytes calldata validatorFieldsProof,
-        bytes32[] calldata validatorFields,
-        bytes32[] calldata withdrawalFields
-    ) public returns (IEigenPod.VerifiedWithdrawal memory) {
-        return _verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalProof,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
-    }
-
-    function processFullWithdrawal(
-        uint40 validatorIndex,
-        bytes32 validatorPubkeyHash,
-        uint64 withdrawalHappenedTimestamp,
-        address recipient,
-        uint64 withdrawalAmountGwei,
-        ValidatorInfo memory validatorInfo
-    ) public returns(IEigenPod.VerifiedWithdrawal memory) {
-        return _processFullWithdrawal(
-            validatorIndex,
-            validatorPubkeyHash,
-            withdrawalHappenedTimestamp,
-            recipient,
-            withdrawalAmountGwei,
-            validatorInfo
-        );
-    }
-
-    function processPartialWithdrawal(
-        uint40 validatorIndex,
-        uint64 withdrawalHappenedTimestamp,
-        address recipient,
-        uint64 withdrawalAmountGwei
-    ) public returns(IEigenPod.VerifiedWithdrawal memory) {
-        return _processPartialWithdrawal(
-            validatorIndex,
-            withdrawalHappenedTimestamp,
-            recipient,
-            withdrawalAmountGwei
-        );
-    }
-
-    function verifyBalanceUpdate(
-        uint64 oracleTimestamp,
-        uint40 validatorIndex,
-        bytes32 beaconStateRoot,
-        bytes calldata validatorFieldsProofs,
-        bytes32[] calldata validatorFields,
-        uint64 mostRecentBalanceUpdateTimestamp
-    )
-        public returns (int256)
-    {
-        bytes32 pkhash = validatorFields[0];
-        _validatorPubkeyHashToInfo[pkhash].mostRecentBalanceUpdateTimestamp = mostRecentBalanceUpdateTimestamp;
-        return _verifyBalanceUpdate(
-            oracleTimestamp,
-            validatorIndex,
-            beaconStateRoot,
-            validatorFieldsProofs,
             validatorFields
         );
     }

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -252,7 +252,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             0
         );
 
@@ -319,7 +318,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             address(eigenPodManagerImplementation),
             abi.encodeWithSelector(
                 EigenPodManager.initialize.selector,
-                address(beaconChainOracle),
                 eigenLayerReputedMultisig, // initialOwner
                 eigenLayerPauserReg,
                 0 // initialPausedStatus
@@ -387,7 +385,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             0
         );
         eigenPodBeacon.upgradeTo(address(eigenPodImplementation));
@@ -465,7 +462,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         eigenPodManager.unpause(0);
         strategyManager.unpause(0);
 
-        eigenPodManager.updateBeaconChainOracle(beaconChainOracle);
         timeMachine.setProofGenStartTime(0);
         beaconChain.setNextTimestamp(timeMachine.proofGenStartTime());
 
@@ -497,7 +493,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             ethPOSDeposit,
             delayedWithdrawalRouter,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             0
         );
         eigenPodBeacon.upgradeTo(address(eigenPodImplementation));
@@ -575,7 +570,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         eigenPodManager.unpause(0);
         strategyManager.unpause(0);
 
-        eigenPodManager.updateBeaconChainOracle(beaconChainOracle);
         timeMachine.setProofGenStartTime(0);
         beaconChain.setNextTimestamp(timeMachine.proofGenStartTime());
 
@@ -720,7 +714,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
                 ethPOSDeposit,
                 eigenPodImplementation.delayedWithdrawalRouter(),
                 eigenPodImplementation.eigenPodManager(),
-                eigenPodImplementation.MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR(),
                 0
             );
             // Create time machine and set block timestamp forward so we can create EigenPod proofs in the past
@@ -731,7 +724,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
 
             cheats.startPrank(executorMultisig);
             eigenPodBeacon.upgradeTo(address(eigenPodImplementation));
-            eigenPodManager.updateBeaconChainOracle(beaconChainOracle);
             cheats.stopPrank();
 
         } else {

--- a/src/test/integration/mocks/BeaconChainMock.t.sol
+++ b/src/test/integration/mocks/BeaconChainMock.t.sol
@@ -18,22 +18,22 @@ struct CredentialsProofs {
     bytes32[][] validatorFields;
 }
 
-struct BeaconWithdrawal {
-    uint64 oracleTimestamp;
-    BeaconChainProofs.StateRootProof stateRootProof;
-    BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
-    bytes[] validatorFieldsProofs;
-    bytes32[][] validatorFields;
-    bytes32[][] withdrawalFields;
-}
+// struct BeaconWithdrawal {
+//     uint64 oracleTimestamp;
+//     BeaconChainProofs.StateRootProof stateRootProof;
+//     BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
+//     bytes[] validatorFieldsProofs;
+//     bytes32[][] validatorFields;
+//     bytes32[][] withdrawalFields;
+// }
 
-struct BalanceUpdate {
-    uint64 oracleTimestamp;
-    BeaconChainProofs.StateRootProof stateRootProof;
-    uint40[] validatorIndices;
-    bytes[] validatorFieldsProofs;
-    bytes32[][] validatorFields;
-}
+// struct BalanceUpdate {
+//     uint64 oracleTimestamp;
+//     BeaconChainProofs.StateRootProof stateRootProof;
+//     uint40[] validatorIndices;
+//     bytes[] validatorFieldsProofs;
+//     bytes32[][] validatorFields;
+// }
 
 contract BeaconChainMock is Test {
 
@@ -116,49 +116,49 @@ contract BeaconChainMock is Test {
      * Additionally, it will send the withdrawal amount to the validator's withdrawal
      * destination.
      */
-    function exitValidator(uint40 validatorIndex) public returns (BeaconWithdrawal memory) {
-        emit log_named_uint("- BeaconChain.exitValidator: ", validatorIndex);
+    // function exitValidator(uint40 validatorIndex) public returns (BeaconWithdrawal memory) {
+    //     emit log_named_uint("- BeaconChain.exitValidator: ", validatorIndex);
 
-        Validator memory validator = validators[validatorIndex];
+    //     Validator memory validator = validators[validatorIndex];
 
-        // Get the withdrawal amount and destination
-        uint amountToWithdraw = validator.effectiveBalanceGwei * GWEI_TO_WEI;
-        address destination = _toAddress(validator.withdrawalCreds);
+    //     // Get the withdrawal amount and destination
+    //     uint amountToWithdraw = validator.effectiveBalanceGwei * GWEI_TO_WEI;
+    //     address destination = _toAddress(validator.withdrawalCreds);
 
-        // Generate exit proofs for a full exit
-        BeaconWithdrawal memory withdrawal = _genExitProof(validator);
+    //     // Generate exit proofs for a full exit
+    //     BeaconWithdrawal memory withdrawal = _genExitProof(validator);
 
-        // Update state - set validator balance to zero and send balance to withdrawal destination
-        validators[validatorIndex].effectiveBalanceGwei = 0;
-        cheats.deal(destination, destination.balance + amountToWithdraw);
+    //     // Update state - set validator balance to zero and send balance to withdrawal destination
+    //     validators[validatorIndex].effectiveBalanceGwei = 0;
+    //     cheats.deal(destination, destination.balance + amountToWithdraw);
 
-        return withdrawal;
-    }
+    //     return withdrawal;
+    // }
 
     /**
      * Note: `delta` is expected to be a raw token amount. This method will convert the delta to Gwei
      */
-    function updateBalance(uint40 validatorIndex, int delta) public returns (BalanceUpdate memory) {
-        delta /= int(GWEI_TO_WEI);
+    // function updateBalance(uint40 validatorIndex, int delta) public returns (BalanceUpdate memory) {
+    //     delta /= int(GWEI_TO_WEI);
         
-        emit log_named_uint("- BeaconChain.updateBalance for validator: ", validatorIndex);
-        emit log_named_int("- BeaconChain.updateBalance delta gwei: ", delta);
+    //     emit log_named_uint("- BeaconChain.updateBalance for validator: ", validatorIndex);
+    //     emit log_named_int("- BeaconChain.updateBalance delta gwei: ", delta);
         
-        // Apply delta and update validator balance in state
-        uint64 newBalance;
-        if (delta <= 0) {
-            newBalance = validators[validatorIndex].effectiveBalanceGwei - uint64(uint(-delta));
-        } else {
-            newBalance = validators[validatorIndex].effectiveBalanceGwei + uint64(uint(delta));
-        }
-        validators[validatorIndex].effectiveBalanceGwei = newBalance;
+    //     // Apply delta and update validator balance in state
+    //     uint64 newBalance;
+    //     if (delta <= 0) {
+    //         newBalance = validators[validatorIndex].effectiveBalanceGwei - uint64(uint(-delta));
+    //     } else {
+    //         newBalance = validators[validatorIndex].effectiveBalanceGwei + uint64(uint(delta));
+    //     }
+    //     validators[validatorIndex].effectiveBalanceGwei = newBalance;
         
-        // Generate balance update proof
-        Validator memory validator = validators[validatorIndex];
-        BalanceUpdate memory update = _genBalanceUpdateProof(validator);
+    //     // Generate balance update proof
+    //     Validator memory validator = validators[validatorIndex];
+    //     BalanceUpdate memory update = _genBalanceUpdateProof(validator);
 
-        return update;
-    }
+    //     return update;
+    // }
 
     function setNextTimestamp(uint64 timestamp) public {
         nextTimestamp = timestamp;
@@ -259,145 +259,145 @@ contract BeaconChainMock is Test {
      * roots are calculated and the final beaconBlockRoot can be calculated and sent to the
      * oracle.
      */
-    function _genExitProof(Validator memory validator) internal returns (BeaconWithdrawal memory) {
-        BeaconWithdrawal memory withdrawal;
-        uint64 withdrawalEpoch = uint64(block.timestamp);
+    // function _genExitProof(Validator memory validator) internal returns (BeaconWithdrawal memory) {
+    //     BeaconWithdrawal memory withdrawal;
+    //     uint64 withdrawalEpoch = uint64(block.timestamp);
 
-        // Get a new, unique timestamp for queries to the oracle
-        withdrawal.oracleTimestamp = uint64(nextTimestamp);
-        nextTimestamp++;
+    //     // Get a new, unique timestamp for queries to the oracle
+    //     withdrawal.oracleTimestamp = uint64(nextTimestamp);
+    //     nextTimestamp++;
 
-        // Initialize proof arrays
-        BeaconChainProofs.WithdrawalProof memory withdrawalProof = _initWithdrawalProof({
-            withdrawalEpoch: withdrawalEpoch,
-            withdrawalIndex: WITHDRAWAL_INDEX,
-            oracleTimestamp: withdrawal.oracleTimestamp
-        });
+    //     // Initialize proof arrays
+    //     BeaconChainProofs.WithdrawalProof memory withdrawalProof = _initWithdrawalProof({
+    //         withdrawalEpoch: withdrawalEpoch,
+    //         withdrawalIndex: WITHDRAWAL_INDEX,
+    //         oracleTimestamp: withdrawal.oracleTimestamp
+    //     });
 
-        // Calculate withdrawalFields and record the validator's index and withdrawal amount
-        withdrawal.withdrawalFields = new bytes32[][](1);
-        withdrawal.withdrawalFields[0] = new bytes32[](2 ** BeaconChainProofs.WITHDRAWAL_FIELD_TREE_HEIGHT);
-        withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_INDEX_INDEX] =
-            _toLittleEndianUint64(validator.validatorIndex);
-        withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX] =
-            _toLittleEndianUint64(validator.effectiveBalanceGwei);
+    //     // Calculate withdrawalFields and record the validator's index and withdrawal amount
+    //     withdrawal.withdrawalFields = new bytes32[][](1);
+    //     withdrawal.withdrawalFields[0] = new bytes32[](2 ** BeaconChainProofs.WITHDRAWAL_FIELD_TREE_HEIGHT);
+    //     withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_INDEX_INDEX] =
+    //         _toLittleEndianUint64(validator.validatorIndex);
+    //     withdrawal.withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX] =
+    //         _toLittleEndianUint64(validator.effectiveBalanceGwei);
 
-        {
-            /**
-             * Generate proofs then root for subtree:
-             * 
-             * executionPayloadRoot
-             * - timestampRoot         (withdrawalProof.timestampProof)
-             * - withdrawalFieldsRoot  (withdrawalProof.withdrawalProof)
-             */            
-            withdrawalProof.executionPayloadRoot = _genExecPayloadProofs({ 
-                withdrawalProof: withdrawalProof,
-                withdrawalRoot: Merkle.merkleizeSha256(withdrawal.withdrawalFields[0])
-            });
-        }
+    //     {
+    //         /**
+    //          * Generate proofs then root for subtree:
+    //          * 
+    //          * executionPayloadRoot
+    //          * - timestampRoot         (withdrawalProof.timestampProof)
+    //          * - withdrawalFieldsRoot  (withdrawalProof.withdrawalProof)
+    //          */            
+    //         withdrawalProof.executionPayloadRoot = _genExecPayloadProofs({ 
+    //             withdrawalProof: withdrawalProof,
+    //             withdrawalRoot: Merkle.merkleizeSha256(withdrawal.withdrawalFields[0])
+    //         });
+    //     }
 
-        {
-            /**
-             * Generate proofs then root for subtree:
-             * 
-             * blockRoot (historical summaries)
-             * - slotRoot             (withdrawalProof.slotProof)
-             * - executionPayloadRoot (withdrawalProof.executionPayloadProof)
-             */
-            withdrawalProof.blockRoot = _genBlockRootProofs({ 
-                withdrawalProof: withdrawalProof
-            });
-        }
+    //     {
+    //         /**
+    //          * Generate proofs then root for subtree:
+    //          * 
+    //          * blockRoot (historical summaries)
+    //          * - slotRoot             (withdrawalProof.slotProof)
+    //          * - executionPayloadRoot (withdrawalProof.executionPayloadProof)
+    //          */
+    //         withdrawalProof.blockRoot = _genBlockRootProofs({ 
+    //             withdrawalProof: withdrawalProof
+    //         });
+    //     }
 
-        // validatorFields
-        withdrawal.validatorFields = new bytes32[][](1);
-        withdrawal.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
-        withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
-        withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX] = 
-            _toLittleEndianUint64(withdrawalEpoch);
+    //     // validatorFields
+    //     withdrawal.validatorFields = new bytes32[][](1);
+    //     withdrawal.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
+    //     withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
+    //     withdrawal.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWABLE_EPOCH_INDEX] = 
+    //         _toLittleEndianUint64(withdrawalEpoch);
         
-        withdrawal.validatorFieldsProofs = new bytes[](1);
-        withdrawal.validatorFieldsProofs[0] = new bytes(VAL_FIELDS_PROOF_LEN);
+    //     withdrawal.validatorFieldsProofs = new bytes[](1);
+    //     withdrawal.validatorFieldsProofs[0] = new bytes(VAL_FIELDS_PROOF_LEN);
 
-        {
-            /**
-             * Generate proofs then root for subtree:
-             *
-             * beaconStateRoot
-             * - validatorFieldsRoot               (withdrawal.validatorFieldsProofs[0])
-             * - blockRoot (historical summaries)  (withdrawalProof.historicalSummaryBlockRootProof)
-             */
-            withdrawal.stateRootProof.beaconStateRoot = _genBeaconStateRootProofs({ 
-                withdrawalProof: withdrawalProof,
-                validatorFieldsProof: withdrawal.validatorFieldsProofs[0],
-                validatorIndex: validator.validatorIndex,
-                validatorRoot: Merkle.merkleizeSha256(withdrawal.validatorFields[0])
-            });
-        }
+    //     {
+    //         /**
+    //          * Generate proofs then root for subtree:
+    //          *
+    //          * beaconStateRoot
+    //          * - validatorFieldsRoot               (withdrawal.validatorFieldsProofs[0])
+    //          * - blockRoot (historical summaries)  (withdrawalProof.historicalSummaryBlockRootProof)
+    //          */
+    //         withdrawal.stateRootProof.beaconStateRoot = _genBeaconStateRootProofs({ 
+    //             withdrawalProof: withdrawalProof,
+    //             validatorFieldsProof: withdrawal.validatorFieldsProofs[0],
+    //             validatorIndex: validator.validatorIndex,
+    //             validatorRoot: Merkle.merkleizeSha256(withdrawal.validatorFields[0])
+    //         });
+    //     }
 
-        withdrawal.withdrawalProofs = new BeaconChainProofs.WithdrawalProof[](1);
-        withdrawal.withdrawalProofs[0] = withdrawalProof;
+    //     withdrawal.withdrawalProofs = new BeaconChainProofs.WithdrawalProof[](1);
+    //     withdrawal.withdrawalProofs[0] = withdrawalProof;
 
-        // Calculate beaconBlockRoot using beaconStateRoot and an empty proof:
-        withdrawal.stateRootProof.proof = new bytes(BLOCKROOT_PROOF_LEN);
-        bytes32 beaconBlockRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawal.stateRootProof.proof,
-            leaf: withdrawal.stateRootProof.beaconStateRoot,
-            index: BeaconChainProofs.STATE_ROOT_INDEX
-        });
+    //     // Calculate beaconBlockRoot using beaconStateRoot and an empty proof:
+    //     withdrawal.stateRootProof.proof = new bytes(BLOCKROOT_PROOF_LEN);
+    //     bytes32 beaconBlockRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawal.stateRootProof.proof,
+    //         leaf: withdrawal.stateRootProof.beaconStateRoot,
+    //         index: BeaconChainProofs.STATE_ROOT_INDEX
+    //     });
 
-        // Send the block root to the oracle
-        oracle.setBlockRoot(withdrawal.oracleTimestamp, beaconBlockRoot);
-        return withdrawal;
-    }
+    //     // Send the block root to the oracle
+    //     oracle.setBlockRoot(withdrawal.oracleTimestamp, beaconBlockRoot);
+    //     return withdrawal;
+    // }
 
-    function _genBalanceUpdateProof(Validator memory validator) internal returns (BalanceUpdate memory) {
-        BalanceUpdate memory update;
+    // function _genBalanceUpdateProof(Validator memory validator) internal returns (BalanceUpdate memory) {
+    //     BalanceUpdate memory update;
 
-        update.validatorIndices = new uint40[](1);
-        update.validatorIndices[0] = validator.validatorIndex;
+    //     update.validatorIndices = new uint40[](1);
+    //     update.validatorIndices[0] = validator.validatorIndex;
 
-        // Create validatorFields showing the balance update
-        update.validatorFields = new bytes32[][](1);
-        update.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
-        update.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
-        update.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWAL_CREDENTIALS_INDEX] = 
-            bytes32(validator.withdrawalCreds);
-        update.validatorFields[0][BeaconChainProofs.VALIDATOR_BALANCE_INDEX] = 
-            _toLittleEndianUint64(validator.effectiveBalanceGwei);
+    //     // Create validatorFields showing the balance update
+    //     update.validatorFields = new bytes32[][](1);
+    //     update.validatorFields[0] = new bytes32[](2 ** BeaconChainProofs.VALIDATOR_FIELD_TREE_HEIGHT);
+    //     update.validatorFields[0][BeaconChainProofs.VALIDATOR_PUBKEY_INDEX] = validator.pubkeyHash;
+    //     update.validatorFields[0][BeaconChainProofs.VALIDATOR_WITHDRAWAL_CREDENTIALS_INDEX] = 
+    //         bytes32(validator.withdrawalCreds);
+    //     update.validatorFields[0][BeaconChainProofs.VALIDATOR_BALANCE_INDEX] = 
+    //         _toLittleEndianUint64(validator.effectiveBalanceGwei);
 
-        // Calculate beaconStateRoot using validator index and an empty proof:
-        update.validatorFieldsProofs = new bytes[](1);
-        update.validatorFieldsProofs[0] = new bytes(VAL_FIELDS_PROOF_LEN);
-        bytes32 validatorRoot = Merkle.merkleizeSha256(update.validatorFields[0]);
-        uint index = _calcValProofIndex(validator.validatorIndex);
+    //     // Calculate beaconStateRoot using validator index and an empty proof:
+    //     update.validatorFieldsProofs = new bytes[](1);
+    //     update.validatorFieldsProofs[0] = new bytes(VAL_FIELDS_PROOF_LEN);
+    //     bytes32 validatorRoot = Merkle.merkleizeSha256(update.validatorFields[0]);
+    //     uint index = _calcValProofIndex(validator.validatorIndex);
 
-        bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
-            proof: update.validatorFieldsProofs[0],
-            leaf: validatorRoot,
-            index: index
-        });
+    //     bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
+    //         proof: update.validatorFieldsProofs[0],
+    //         leaf: validatorRoot,
+    //         index: index
+    //     });
 
-        // Calculate blockRoot using beaconStateRoot and an empty proof:
-        bytes memory blockRootProof = new bytes(BLOCKROOT_PROOF_LEN);
-        bytes32 blockRoot = Merkle.processInclusionProofSha256({
-            proof: blockRootProof,
-            leaf: beaconStateRoot,
-            index: BeaconChainProofs.STATE_ROOT_INDEX
-        });
+    //     // Calculate blockRoot using beaconStateRoot and an empty proof:
+    //     bytes memory blockRootProof = new bytes(BLOCKROOT_PROOF_LEN);
+    //     bytes32 blockRoot = Merkle.processInclusionProofSha256({
+    //         proof: blockRootProof,
+    //         leaf: beaconStateRoot,
+    //         index: BeaconChainProofs.STATE_ROOT_INDEX
+    //     });
 
-        update.stateRootProof = BeaconChainProofs.StateRootProof({
-            beaconStateRoot: beaconStateRoot,
-            proof: blockRootProof
-        });
+    //     update.stateRootProof = BeaconChainProofs.StateRootProof({
+    //         beaconStateRoot: beaconStateRoot,
+    //         proof: blockRootProof
+    //     });
 
-        // Send the block root to the oracle and increment timestamp:
-        update.oracleTimestamp = uint64(nextTimestamp);
-        oracle.setBlockRoot(nextTimestamp, blockRoot);
-        nextTimestamp++;
+    //     // Send the block root to the oracle and increment timestamp:
+    //     update.oracleTimestamp = uint64(nextTimestamp);
+    //     oracle.setBlockRoot(nextTimestamp, blockRoot);
+    //     nextTimestamp++;
         
-        return update;
-    }
+    //     return update;
+    // }
 
     /**
      * @dev Generates converging merkle proofs for timestampRoot and withdrawalRoot
@@ -408,49 +408,49 @@ contract BeaconChainMock is Test {
      *
      * @return executionPayloadRoot
      */
-    function _genExecPayloadProofs(
-        BeaconChainProofs.WithdrawalProof memory withdrawalProof,
-        bytes32 withdrawalRoot
-    ) internal view returns (bytes32) {
+    // function _genExecPayloadProofs(
+    //     BeaconChainProofs.WithdrawalProof memory withdrawalProof,
+    //     bytes32 withdrawalRoot
+    // ) internal view returns (bytes32) {
 
-        uint withdrawalProofIndex = 
-            (BeaconChainProofs.WITHDRAWALS_INDEX << (BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1)) |
-            uint(withdrawalProof.withdrawalIndex);
+    //     uint withdrawalProofIndex = 
+    //         (BeaconChainProofs.WITHDRAWALS_INDEX << (BeaconChainProofs.WITHDRAWALS_TREE_HEIGHT + 1)) |
+    //         uint(withdrawalProof.withdrawalIndex);
 
-        /**
-         * Generate merkle proofs for timestampRoot and withdrawalRoot
-         * that converge at or before executionPayloadRoot.
-         * 
-         * timestampProof length: 4
-         * withdrawalProof length: 9
-         */
-        _genConvergentProofs({
-            shortProof: withdrawalProof.timestampProof,
-            shortIndex: BeaconChainProofs.TIMESTAMP_INDEX,
-            shortLeaf: withdrawalProof.timestampRoot,
-            longProof: withdrawalProof.withdrawalProof,
-            longIndex: withdrawalProofIndex,
-            longLeaf: withdrawalRoot
-        });
+    //     /**
+    //      * Generate merkle proofs for timestampRoot and withdrawalRoot
+    //      * that converge at or before executionPayloadRoot.
+    //      * 
+    //      * timestampProof length: 4
+    //      * withdrawalProof length: 9
+    //      */
+    //     _genConvergentProofs({
+    //         shortProof: withdrawalProof.timestampProof,
+    //         shortIndex: BeaconChainProofs.TIMESTAMP_INDEX,
+    //         shortLeaf: withdrawalProof.timestampRoot,
+    //         longProof: withdrawalProof.withdrawalProof,
+    //         longIndex: withdrawalProofIndex,
+    //         longLeaf: withdrawalRoot
+    //     });
 
-        // Use generated proofs to calculate tree root and verify both proofs
-        // result in the same root:
-        bytes32 execPayloadRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawalProof.timestampProof,
-            leaf: withdrawalProof.timestampRoot,
-            index: BeaconChainProofs.TIMESTAMP_INDEX
-        });
+    //     // Use generated proofs to calculate tree root and verify both proofs
+    //     // result in the same root:
+    //     bytes32 execPayloadRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawalProof.timestampProof,
+    //         leaf: withdrawalProof.timestampRoot,
+    //         index: BeaconChainProofs.TIMESTAMP_INDEX
+    //     });
 
-        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawalProof.withdrawalProof,
-            leaf: withdrawalRoot,
-            index: withdrawalProofIndex
-        });
+    //     bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawalProof.withdrawalProof,
+    //         leaf: withdrawalRoot,
+    //         index: withdrawalProofIndex
+    //     });
 
-        require(execPayloadRoot == expectedRoot, "_genExecPayloadProofs: mismatched roots");
+    //     require(execPayloadRoot == expectedRoot, "_genExecPayloadProofs: mismatched roots");
         
-        return execPayloadRoot;
-    }
+    //     return execPayloadRoot;
+    // }
 
     /**
      * @dev Generates converging merkle proofs for slotRoot and executionPayloadRoot
@@ -461,49 +461,49 @@ contract BeaconChainMock is Test {
      *
      * @return historical summary block root
      */
-    function _genBlockRootProofs(
-        BeaconChainProofs.WithdrawalProof memory withdrawalProof
-    ) internal view returns (bytes32) {
+    // function _genBlockRootProofs(
+    //     BeaconChainProofs.WithdrawalProof memory withdrawalProof
+    // ) internal view returns (bytes32) {
 
-        uint slotRootIndex = BeaconChainProofs.SLOT_INDEX;
-        uint execPayloadIndex = 
-            (BeaconChainProofs.BODY_ROOT_INDEX << BeaconChainProofs.BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT) |
-            BeaconChainProofs.EXECUTION_PAYLOAD_INDEX;
+    //     uint slotRootIndex = BeaconChainProofs.SLOT_INDEX;
+    //     uint execPayloadIndex = 
+    //         (BeaconChainProofs.BODY_ROOT_INDEX << BeaconChainProofs.BEACON_BLOCK_BODY_FIELD_TREE_HEIGHT) |
+    //         BeaconChainProofs.EXECUTION_PAYLOAD_INDEX;
 
-        /**
-         * Generate merkle proofs for slotRoot and executionPayloadRoot
-         * that converge at or before block root.
-         * 
-         * slotProof length: 3
-         * executionPayloadProof length: 7
-         */
-        _genConvergentProofs({
-            shortProof: withdrawalProof.slotProof,
-            shortIndex: slotRootIndex,
-            shortLeaf: withdrawalProof.slotRoot,
-            longProof: withdrawalProof.executionPayloadProof,
-            longIndex: execPayloadIndex,
-            longLeaf: withdrawalProof.executionPayloadRoot
-        });
+    //     /**
+    //      * Generate merkle proofs for slotRoot and executionPayloadRoot
+    //      * that converge at or before block root.
+    //      * 
+    //      * slotProof length: 3
+    //      * executionPayloadProof length: 7
+    //      */
+    //     _genConvergentProofs({
+    //         shortProof: withdrawalProof.slotProof,
+    //         shortIndex: slotRootIndex,
+    //         shortLeaf: withdrawalProof.slotRoot,
+    //         longProof: withdrawalProof.executionPayloadProof,
+    //         longIndex: execPayloadIndex,
+    //         longLeaf: withdrawalProof.executionPayloadRoot
+    //     });
 
-        // Use generated proofs to calculate tree root and verify both proofs
-        // result in the same root:
-        bytes32 blockRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawalProof.slotProof,
-            leaf: withdrawalProof.slotRoot,
-            index: slotRootIndex
-        });
+    //     // Use generated proofs to calculate tree root and verify both proofs
+    //     // result in the same root:
+    //     bytes32 blockRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawalProof.slotProof,
+    //         leaf: withdrawalProof.slotRoot,
+    //         index: slotRootIndex
+    //     });
 
-        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawalProof.executionPayloadProof,
-            leaf: withdrawalProof.executionPayloadRoot,
-            index: execPayloadIndex
-        });
+    //     bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawalProof.executionPayloadProof,
+    //         leaf: withdrawalProof.executionPayloadRoot,
+    //         index: execPayloadIndex
+    //     });
 
-        require(blockRoot == expectedRoot, "_genBlockRootProofs: mismatched roots");
+    //     require(blockRoot == expectedRoot, "_genBlockRootProofs: mismatched roots");
         
-        return blockRoot;
-    }
+    //     return blockRoot;
+    // }
 
     /**
      * @dev Generates converging merkle proofs for block root and validatorRoot
@@ -514,49 +514,49 @@ contract BeaconChainMock is Test {
      *
      * @return beaconStateRoot
      */
-    function _genBeaconStateRootProofs(
-        BeaconChainProofs.WithdrawalProof memory withdrawalProof,
-        bytes memory validatorFieldsProof,
-        uint40 validatorIndex, 
-        bytes32 validatorRoot
-    ) internal view returns (bytes32) {
-        uint blockHeaderIndex = _calcBlockHeaderIndex(withdrawalProof);
-        uint validatorProofIndex = _calcValProofIndex(validatorIndex);
+    // function _genBeaconStateRootProofs(
+    //     BeaconChainProofs.WithdrawalProof memory withdrawalProof,
+    //     bytes memory validatorFieldsProof,
+    //     uint40 validatorIndex, 
+    //     bytes32 validatorRoot
+    // ) internal view returns (bytes32) {
+    //     uint blockHeaderIndex = _calcBlockHeaderIndex(withdrawalProof);
+    //     uint validatorProofIndex = _calcValProofIndex(validatorIndex);
 
-        /**
-         * Generate merkle proofs for validatorRoot and blockRoot
-         * that converge at or before beaconStateRoot.
-         * 
-         * historicalSummaryBlockRootProof length: 44
-         * validatorFieldsProof length: 46
-         */
-        _genConvergentProofs({
-            shortProof: withdrawalProof.historicalSummaryBlockRootProof,
-            shortIndex: blockHeaderIndex,
-            shortLeaf: withdrawalProof.blockRoot,
-            longProof: validatorFieldsProof,
-            longIndex: validatorProofIndex,
-            longLeaf: validatorRoot
-        });
+    //     /**
+    //      * Generate merkle proofs for validatorRoot and blockRoot
+    //      * that converge at or before beaconStateRoot.
+    //      * 
+    //      * historicalSummaryBlockRootProof length: 44
+    //      * validatorFieldsProof length: 46
+    //      */
+    //     _genConvergentProofs({
+    //         shortProof: withdrawalProof.historicalSummaryBlockRootProof,
+    //         shortIndex: blockHeaderIndex,
+    //         shortLeaf: withdrawalProof.blockRoot,
+    //         longProof: validatorFieldsProof,
+    //         longIndex: validatorProofIndex,
+    //         longLeaf: validatorRoot
+    //     });
 
-        // Use generated proofs to calculate tree root and verify both proofs
-        // result in the same root:
-        bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
-            proof: withdrawalProof.historicalSummaryBlockRootProof,
-            leaf: withdrawalProof.blockRoot,
-            index: blockHeaderIndex
-        });
+    //     // Use generated proofs to calculate tree root and verify both proofs
+    //     // result in the same root:
+    //     bytes32 beaconStateRoot = Merkle.processInclusionProofSha256({
+    //         proof: withdrawalProof.historicalSummaryBlockRootProof,
+    //         leaf: withdrawalProof.blockRoot,
+    //         index: blockHeaderIndex
+    //     });
 
-        bytes32 expectedRoot = Merkle.processInclusionProofSha256({
-            proof: validatorFieldsProof,
-            leaf: validatorRoot,
-            index: validatorProofIndex
-        });
+    //     bytes32 expectedRoot = Merkle.processInclusionProofSha256({
+    //         proof: validatorFieldsProof,
+    //         leaf: validatorRoot,
+    //         index: validatorProofIndex
+    //     });
 
-        require(beaconStateRoot == expectedRoot, "_genBeaconStateRootProofs: mismatched roots");
+    //     require(beaconStateRoot == expectedRoot, "_genBeaconStateRootProofs: mismatched roots");
         
-        return beaconStateRoot;
-    }
+    //     return beaconStateRoot;
+    // }
 
     /**
      * @dev Generates converging merkle proofs given two leaves and empty proofs. 
@@ -736,43 +736,43 @@ contract BeaconChainMock is Test {
         BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 1
     );
 
-    function _initWithdrawalProof(
-        uint64 withdrawalEpoch, 
-        uint64 withdrawalIndex,
-        uint64 oracleTimestamp
-    ) internal view returns (BeaconChainProofs.WithdrawalProof memory) {
-        uint256 withdrawalProofLength;
-        uint256 timestampProofLength;
-        if (block.timestamp > eigenPodManager.denebForkTimestamp()) {
-            withdrawalProofLength = WITHDRAWAL_PROOF_LEN_DENEB;
-            timestampProofLength = TIMESTAMP_PROOF_LEN_DENEB;
-        } else {
-            withdrawalProofLength = WITHDRAWAL_PROOF_LEN_CAPELLA;
-            timestampProofLength = TIMESTAMP_PROOF_LEN_CAPELLA;
-        }
-        return BeaconChainProofs.WithdrawalProof({
-            withdrawalProof: new bytes(withdrawalProofLength),
-            slotProof: new bytes(SLOT_PROOF_LEN),
-            executionPayloadProof: new bytes(EXECPAYLOAD_PROOF_LEN),
-            timestampProof: new bytes(timestampProofLength),
-            historicalSummaryBlockRootProof: new bytes(HISTSUMMARY_PROOF_LEN),
-            blockRootIndex: 0,
-            historicalSummaryIndex: 0,
-            withdrawalIndex: withdrawalIndex,
-            blockRoot: bytes32(0),
-            slotRoot: _toLittleEndianUint64(withdrawalEpoch * BeaconChainProofs.SLOTS_PER_EPOCH),
-            timestampRoot: _toLittleEndianUint64(oracleTimestamp),
-            executionPayloadRoot: bytes32(0)
-        });
-    }
+    // function _initWithdrawalProof(
+    //     uint64 withdrawalEpoch, 
+    //     uint64 withdrawalIndex,
+    //     uint64 oracleTimestamp
+    // ) internal view returns (BeaconChainProofs.WithdrawalProof memory) {
+    //     uint256 withdrawalProofLength;
+    //     uint256 timestampProofLength;
+    //     if (block.timestamp > eigenPodManager.denebForkTimestamp()) {
+    //         withdrawalProofLength = WITHDRAWAL_PROOF_LEN_DENEB;
+    //         timestampProofLength = TIMESTAMP_PROOF_LEN_DENEB;
+    //     } else {
+    //         withdrawalProofLength = WITHDRAWAL_PROOF_LEN_CAPELLA;
+    //         timestampProofLength = TIMESTAMP_PROOF_LEN_CAPELLA;
+    //     }
+    //     return BeaconChainProofs.WithdrawalProof({
+    //         withdrawalProof: new bytes(withdrawalProofLength),
+    //         slotProof: new bytes(SLOT_PROOF_LEN),
+    //         executionPayloadProof: new bytes(EXECPAYLOAD_PROOF_LEN),
+    //         timestampProof: new bytes(timestampProofLength),
+    //         historicalSummaryBlockRootProof: new bytes(HISTSUMMARY_PROOF_LEN),
+    //         blockRootIndex: 0,
+    //         historicalSummaryIndex: 0,
+    //         withdrawalIndex: withdrawalIndex,
+    //         blockRoot: bytes32(0),
+    //         slotRoot: _toLittleEndianUint64(withdrawalEpoch * BeaconChainProofs.SLOTS_PER_EPOCH),
+    //         timestampRoot: _toLittleEndianUint64(oracleTimestamp),
+    //         executionPayloadRoot: bytes32(0)
+    //     });
+    // }
 
-    function _calcBlockHeaderIndex(BeaconChainProofs.WithdrawalProof memory withdrawalProof) internal view returns (uint) {
-        return 
-            HIST_SUMMARIES_PROOF_INDEX |
-            (uint(withdrawalProof.historicalSummaryIndex) << (BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 1)) |
-            (BeaconChainProofs.BLOCK_SUMMARY_ROOT_INDEX << BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT) |
-            uint(withdrawalProof.blockRootIndex);
-    }
+    // function _calcBlockHeaderIndex(BeaconChainProofs.WithdrawalProof memory withdrawalProof) internal view returns (uint) {
+    //     return 
+    //         HIST_SUMMARIES_PROOF_INDEX |
+    //         (uint(withdrawalProof.historicalSummaryIndex) << (BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT + 1)) |
+    //         (BeaconChainProofs.BLOCK_SUMMARY_ROOT_INDEX << BeaconChainProofs.BLOCK_ROOTS_TREE_HEIGHT) |
+    //         uint(withdrawalProof.blockRootIndex);
+    // }
 
     function _calcValProofIndex(uint40 validatorIndex) internal pure returns (uint) {
         return 

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -114,7 +114,7 @@ contract User is Test {
                     validators.push(newValidatorIndex);
                     emit log_named_uint("oracle timestamp", proofs.oracleTimestamp);
                     pod.verifyWithdrawalCredentials({
-                        oracleTimestamp: proofs.oracleTimestamp,
+                        beaconTimestamp: proofs.oracleTimestamp,
                         stateRootProof: proofs.stateRootProof,
                         validatorIndices: proofs.validatorIndices,
                         validatorFieldsProofs: proofs.validatorFieldsProofs,
@@ -131,37 +131,38 @@ contract User is Test {
 
     function updateBalances(IStrategy[] memory strategies, int[] memory tokenDeltas) public createSnapshot virtual {
         emit log(_name(".updateBalances"));
+        revert("fail - placeholder");
 
-        for (uint i = 0; i < strategies.length; i++) {
-            IStrategy strat = strategies[i];
-            int delta = tokenDeltas[i];
+        // for (uint i = 0; i < strategies.length; i++) {
+        //     IStrategy strat = strategies[i];
+        //     int delta = tokenDeltas[i];
 
-            if (strat == BEACONCHAIN_ETH_STRAT) {
-                // TODO - right now, we just grab the first validator
-                uint40 validator = getUpdatableValidator();
-                BalanceUpdate memory update = beaconChain.updateBalance(validator, delta);
+        //     if (strat == BEACONCHAIN_ETH_STRAT) {
+        //         // TODO - right now, we just grab the first validator
+        //         uint40 validator = getUpdatableValidator();
+        //         BalanceUpdate memory update = beaconChain.updateBalance(validator, delta);
 
-                int sharesBefore = eigenPodManager.podOwnerShares(address(this));
+        //         int sharesBefore = eigenPodManager.podOwnerShares(address(this));
 
-                pod.verifyBalanceUpdates({
-                    oracleTimestamp: update.oracleTimestamp,
-                    validatorIndices: update.validatorIndices,
-                    stateRootProof: update.stateRootProof,
-                    validatorFieldsProofs: update.validatorFieldsProofs,
-                    validatorFields: update.validatorFields
-                });
+        //         pod.verifyBalanceUpdates({
+        //             oracleTimestamp: update.oracleTimestamp,
+        //             validatorIndices: update.validatorIndices,
+        //             stateRootProof: update.stateRootProof,
+        //             validatorFieldsProofs: update.validatorFieldsProofs,
+        //             validatorFields: update.validatorFields
+        //         });
 
-                int sharesAfter = eigenPodManager.podOwnerShares(address(this));
+        //         int sharesAfter = eigenPodManager.podOwnerShares(address(this));
 
-                emit log_named_int("pod owner shares before: ", sharesBefore);
-                emit log_named_int("pod owner shares after: ", sharesAfter);
-            } else {
-                uint tokens = uint(delta);
-                IERC20 underlyingToken = strat.underlyingToken();
-                underlyingToken.approve(address(strategyManager), tokens);
-                strategyManager.depositIntoStrategy(strat, underlyingToken, tokens);
-            }
-        }
+        //         emit log_named_int("pod owner shares before: ", sharesBefore);
+        //         emit log_named_int("pod owner shares after: ", sharesAfter);
+        //     } else {
+        //         uint tokens = uint(delta);
+        //         IERC20 underlyingToken = strat.underlyingToken();
+        //         underlyingToken.approve(address(strategyManager), tokens);
+        //         strategyManager.depositIntoStrategy(strat, underlyingToken, tokens);
+        //     }
+        // }
     }
 
     /// @dev Delegate to the operator without a signature
@@ -301,30 +302,31 @@ contract User is Test {
                 if (receiveAsTokens) {
                     
                     emit log("exiting validators and processing withdrawals...");
-                    
-                    uint numValidators = validators.length;
-                    for (uint j = 0; j < numValidators; j++) {
-                        emit log_named_uint("exiting validator ", j);
+                    revert("fail - placeholder");
 
-                        uint40 validatorIndex = validators[j];
-                        BeaconWithdrawal memory proofs = beaconChain.exitValidator(validatorIndex);
+                    // uint numValidators = validators.length;
+                    // for (uint j = 0; j < numValidators; j++) {
+                    //     emit log_named_uint("exiting validator ", j);
 
-                        uint64 withdrawableBefore = pod.withdrawableRestakedExecutionLayerGwei();
+                    //     uint40 validatorIndex = validators[j];
+                    //     BeaconWithdrawal memory proofs = beaconChain.exitValidator(validatorIndex);
 
-                        pod.verifyAndProcessWithdrawals({
-                            oracleTimestamp: proofs.oracleTimestamp,
-                            stateRootProof: proofs.stateRootProof,
-                            withdrawalProofs: proofs.withdrawalProofs,
-                            validatorFieldsProofs: proofs.validatorFieldsProofs,
-                            validatorFields: proofs.validatorFields,
-                            withdrawalFields: proofs.withdrawalFields
-                        });
+                    //     uint64 withdrawableBefore = pod.withdrawableRestakedExecutionLayerGwei();
 
-                        uint64 withdrawableAfter = pod.withdrawableRestakedExecutionLayerGwei();
+                    //     pod.verifyAndProcessWithdrawals({
+                    //         oracleTimestamp: proofs.oracleTimestamp,
+                    //         stateRootProof: proofs.stateRootProof,
+                    //         withdrawalProofs: proofs.withdrawalProofs,
+                    //         validatorFieldsProofs: proofs.validatorFieldsProofs,
+                    //         validatorFields: proofs.validatorFields,
+                    //         withdrawalFields: proofs.withdrawalFields
+                    //     });
 
-                        emit log_named_uint("pod withdrawable before: ", withdrawableBefore);
-                        emit log_named_uint("pod withdrawable after: ", withdrawableAfter);
-                    }
+                    //     uint64 withdrawableAfter = pod.withdrawableRestakedExecutionLayerGwei();
+
+                    //     emit log_named_uint("pod withdrawable before: ", withdrawableBefore);
+                    //     emit log_named_uint("pod withdrawable after: ", withdrawableAfter);
+                    // }
                 }
             } else {
                 tokens[i] = strat.underlyingToken();
@@ -438,7 +440,7 @@ contract User_AltMethods is User {
                     validators.push(newValidatorIndex);
 
                     pod.verifyWithdrawalCredentials({
-                        oracleTimestamp: proofs.oracleTimestamp,
+                        beaconTimestamp: proofs.oracleTimestamp,
                         stateRootProof: proofs.stateRootProof,
                         validatorIndices: proofs.validatorIndices,
                         validatorFieldsProofs: proofs.validatorFieldsProofs,

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -74,10 +74,6 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
 
     function numPods() external view returns (uint256) {}
 
-    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32) {
-        return bytes32(0);
-    }
-
     function updateStaleValidatorCount(address, int256) external {}
 
     function denebForkTimestamp() external pure returns (uint64) {

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -18,8 +18,6 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
     function stake(bytes calldata /*pubkey*/, bytes calldata /*signature*/, bytes32 /*depositDataRoot*/) external payable {}
 
     function recordBeaconChainETHBalanceUpdate(address /*podOwner*/, int256 /*sharesDelta*/) external pure {}
-    
-    function updateBeaconChainOracle(IBeaconChainOracle /*newBeaconChainOracle*/) external pure {}
 
     function ownerToPod(address /*podOwner*/) external pure returns(IEigenPod) {
         return IEigenPod(address(0));
@@ -27,14 +25,6 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
 
     function getPod(address podOwner) external pure returns(IEigenPod) {
         return IEigenPod(podOwner);
-    }
-
-    function beaconChainOracle() external pure returns(IBeaconChainOracle) {
-        return IBeaconChainOracle(address(0));
-    }   
-
-    function getBlockRootAtTimestamp(uint64 /*timestamp*/) external pure returns(bytes32) {
-        return bytes32(0);
     }
 
     function strategyManager() external pure returns(IStrategyManager) {
@@ -83,6 +73,12 @@ contract EigenPodManagerMock is IEigenPodManager, Test {
     function removeShares(address podOwner, uint256 shares) external {}
 
     function numPods() external view returns (uint256) {}
+
+    function getParentBlockRoot(uint64 timestamp) external view returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function updateStaleValidatorCount(address, int256) external {}
 
     function denebForkTimestamp() external pure returns (uint64) {
         return type(uint64).max;

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -5,8 +5,6 @@ import "forge-std/Test.sol";
 import "../../contracts/interfaces/IEigenPod.sol";
 
 contract EigenPodMock is IEigenPod, Test {
-    /// @notice The max amount of eth, in gwei, that can be restaked per validator
-    function MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR() external view returns(uint64) {}
 
     function nonBeaconChainETHBalanceWei() external view returns(uint256) {}
 
@@ -42,10 +40,6 @@ contract EigenPodMock is IEigenPod, Test {
     /// @notice Returns the validatorInfo struct for the provided pubkeyHash
     function validatorPubkeyHashToInfo(bytes32 validatorPubkeyHash) external view returns (ValidatorInfo memory) {}
 
-
-    ///@notice mapping that tracks proven withdrawals
-    function provenWithdrawal(bytes32 validatorPubkeyHash, uint64 slot) external view returns (bool) {}
-
     /// @notice This returns the status of a given validator
     function validatorStatus(bytes32 pubkeyHash) external view returns(VALIDATOR_STATUS) {}
 
@@ -56,24 +50,6 @@ contract EigenPodMock is IEigenPod, Test {
         uint40[] calldata validatorIndices,
         bytes[] calldata withdrawalCredentialProofs,
         bytes32[][] calldata validatorFields
-    ) external {}
-
-    
-    function verifyBalanceUpdates(
-        uint64 oracleTimestamp,
-        uint40[] calldata validatorIndices,
-        BeaconChainProofs.StateRootProof calldata stateRootProof,
-        bytes[] calldata validatorFieldsProofs,
-        bytes32[][] calldata validatorFields
-    ) external {}
-
-    function verifyAndProcessWithdrawals(
-        uint64 oracleTimestamp,
-        BeaconChainProofs.StateRootProof calldata stateRootProof,
-        BeaconChainProofs.WithdrawalProof[] calldata withdrawalProofs,
-        bytes[] calldata validatorFieldsProofs,
-        bytes32[][] calldata validatorFields,
-        bytes32[][] calldata withdrawalFields
     ) external {}
 
     /// @notice Called by the pod owner to withdraw the balance of the pod when `hasRestaked` is set to false

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -43,6 +43,15 @@ contract EigenPodMock is IEigenPod, Test {
     /// @notice This returns the status of a given validator
     function validatorStatus(bytes32 pubkeyHash) external view returns(VALIDATOR_STATUS) {}
 
+    /// @notice Number of validators with proven withdrawal credentials, who do not have proven full withdrawals
+    function activeValidatorCount() external view returns (uint256) {}
+
+    /// @notice The timestamp of the last checkpoint finalized
+    function lastCheckpointTimestamp() external view returns (uint64) {}
+
+    /// @notice The timestamp of the currently-active checkpoint. Will be 0 if there is not active checkpoint
+    function currentCheckpointTimestamp() external view returns (uint64) {}
+
     /// @notice Returns the currently-active checkpoint
     function currentCheckpoint() external view returns (Checkpoint memory) {}
 

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -43,6 +43,21 @@ contract EigenPodMock is IEigenPod, Test {
     /// @notice This returns the status of a given validator
     function validatorStatus(bytes32 pubkeyHash) external view returns(VALIDATOR_STATUS) {}
 
+    /// @notice Returns the currently-active checkpoint
+    function currentCheckpoint() external view returns (Checkpoint memory) {}
+
+    function startCheckpoint(bool revertIfNoBalance) external {}
+
+    function verifyCheckpointProofs(
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        BeaconChainProofs.BalanceProof[] calldata proofs
+    ) external {}
+
+    function verifyStaleBalance(
+        uint64 beaconTimestamp,
+        BeaconChainProofs.StateRootProof calldata stateRootProof,
+        BeaconChainProofs.ValidatorProof calldata proof
+    ) external {}
 
     function verifyWithdrawalCredentials(
         uint64 oracleTimestamp,

--- a/src/test/unit/EigenPod-PodManagerUnit.t.sol
+++ b/src/test/unit/EigenPod-PodManagerUnit.t.sol
@@ -65,7 +65,6 @@ contract EigenPod_PodManager_UnitTests is EigenLayerUnitTestSetup {
             ethPOSMock,
             delayedWithdrawalRouterMock,
             eigenPodManager,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -142,45 +141,45 @@ contract EigenPod_PodManager_UnitTests_EigenPodPausing is EigenPod_PodManager_Un
     /// @notice Index for flag that pauses the `verifyBeaconChainFullWithdrawal` function *of the EigenPods* when set. see EigenPod code for details.
     uint8 internal constant PAUSED_EIGENPODS_VERIFY_WITHDRAWAL = 4;
 
-    function test_verifyBalanceUpdates_revert_pausedEigenVerifyBalanceUpdate() public {
-        BeaconChainProofs.StateRootProof memory stateRootProofStruct;
+    // function test_verifyBalanceUpdates_revert_pausedEigenVerifyBalanceUpdate() public {
+    //     BeaconChainProofs.StateRootProof memory stateRootProofStruct;
 
-        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
-        bytes[] memory proofsArray = new bytes[](1);
-        uint40[] memory validatorIndices = new uint40[](1);
+    //     bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+    //     bytes[] memory proofsArray = new bytes[](1);
+    //     uint40[] memory validatorIndices = new uint40[](1);
 
-        // pause the contract
-        cheats.prank(address(pauser));
-        eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE);
+    //     // pause the contract
+    //     cheats.prank(address(pauser));
+    //     eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE);
 
-        cheats.prank(address(podOwner));
-        cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
-        eigenPod.verifyBalanceUpdates(0, validatorIndices, stateRootProofStruct, proofsArray, validatorFieldsArray);
-    }
+    //     cheats.prank(address(podOwner));
+    //     cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
+    //     eigenPod.verifyBalanceUpdates(0, validatorIndices, stateRootProofStruct, proofsArray, validatorFieldsArray);
+    // }
 
-    function test_verifyAndProcessWithdrawals_revert_pausedEigenVerifyWithdrawal() public {
-        BeaconChainProofs.StateRootProof memory stateRootProofStruct;
-        BeaconChainProofs.WithdrawalProof[] memory withdrawalProofsArray;
+    // function test_verifyAndProcessWithdrawals_revert_pausedEigenVerifyWithdrawal() public {
+    //     BeaconChainProofs.StateRootProof memory stateRootProofStruct;
+    //     BeaconChainProofs.WithdrawalProof[] memory withdrawalProofsArray;
 
-        bytes[] memory validatorFieldsProofArray = new bytes[](1);
-        bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
-        bytes32[][] memory withdrawalFieldsArray = new bytes32[][](1);
+    //     bytes[] memory validatorFieldsProofArray = new bytes[](1);
+    //     bytes32[][] memory validatorFieldsArray = new bytes32[][](1);
+    //     bytes32[][] memory withdrawalFieldsArray = new bytes32[][](1);
 
-        // pause the contract
-        cheats.prank(address(pauser));
-        eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_WITHDRAWAL);
+    //     // pause the contract
+    //     cheats.prank(address(pauser));
+    //     eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_WITHDRAWAL);
 
-        cheats.prank(address(podOwner));
-        cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
-        eigenPod.verifyAndProcessWithdrawals(
-            0,
-            stateRootProofStruct,
-            withdrawalProofsArray,
-            validatorFieldsProofArray,
-            validatorFieldsArray,
-            withdrawalFieldsArray
-        );
-    }
+    //     cheats.prank(address(podOwner));
+    //     cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
+    //     eigenPod.verifyAndProcessWithdrawals(
+    //         0,
+    //         stateRootProofStruct,
+    //         withdrawalProofsArray,
+    //         validatorFieldsProofArray,
+    //         validatorFieldsArray,
+    //         withdrawalFieldsArray
+    //     );
+    // }
 
     function test_verifyWithdrawalCredentials_revert_pausedEigenVerifyCredentials() public {
         BeaconChainProofs.StateRootProof memory stateRootProofStruct;
@@ -266,7 +265,7 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
     bytes[] validatorFieldsProofs;
     bytes32[][] validatorFields;
     // BeaconChainProofs.BalanceUpdateProof[] balanceUpdateProof;
-    BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
+    // BeaconChainProofs.WithdrawalProof[] withdrawalProofs;
     bytes32[][] withdrawalFields;
 
     function test_verifyWithdrawalCredentials() public {    
@@ -298,223 +297,223 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
         assertEq(updatedShares, 32e18, "Shares should be 32ETH in wei after verifying withdrawal credentials");
     }
 
-    function test_balanceUpdate_negativeSharesDelta() public {
-        // Verify withdrawal credentials
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
-        _verifyWithdrawalCredentials();
+    // function test_balanceUpdate_negativeSharesDelta() public {
+    //     // Verify withdrawal credentials
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+    //     _verifyWithdrawalCredentials();
 
-        // Set JSON
-        setJSON("src/test/test-data/balanceUpdateProof_balance28ETH_302913.json");
-        bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
+    //     // Set JSON
+    //     setJSON("src/test/test-data/balanceUpdateProof_balance28ETH_302913.json");
+    //     bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
 
-        // Set proof params, oracle block root, and warp time
-        _setBalanceUpdateParams();
-        _setOracleBlockRoot();
-        cheats.warp(GOERLI_GENESIS_TIME);
-        uint64 oracleTimestamp = uint64(block.timestamp);
+    //     // Set proof params, oracle block root, and warp time
+    //     _setBalanceUpdateParams();
+    //     _setOracleBlockRoot();
+    //     cheats.warp(GOERLI_GENESIS_TIME);
+    //     uint64 oracleTimestamp = uint64(block.timestamp);
 
-        // Save state for checks
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
-        uint64 newValidatorBalance = validatorFields[0].getEffectiveBalanceGwei();
+    //     // Save state for checks
+    //     int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
+    //     uint64 newValidatorBalance = validatorFields[0].getEffectiveBalanceGwei();
 
-        // Verify balance update
-        eigenPod.verifyBalanceUpdates(
-            oracleTimestamp,
-            validatorIndices,
-            stateRootProofStruct,
-            validatorFieldsProofs,
-            validatorFields
-        );
+    //     // Verify balance update
+    //     eigenPod.verifyBalanceUpdates(
+    //         oracleTimestamp,
+    //         validatorIndices,
+    //         stateRootProofStruct,
+    //         validatorFieldsProofs,
+    //         validatorFields
+    //     );
 
-        // Checks
-        int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
-        assertEq(validatorInfo.restakedBalanceGwei, newValidatorBalance, "Restaked balance gwei is incorrect");
-        assertLt(updatedShares - initialShares, 0, "Shares delta should be negative");
-        int256 expectedSharesDiff = (int256(uint256(newValidatorBalance)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))) * 1e9;
-        assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta should be equal to restaked balance");
-    }
+    //     // Checks
+    //     int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
+    //     assertEq(validatorInfo.restakedBalanceGwei, newValidatorBalance, "Restaked balance gwei is incorrect");
+    //     assertLt(updatedShares - initialShares, 0, "Shares delta should be negative");
+    //     int256 expectedSharesDiff = (int256(uint256(newValidatorBalance)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))) * 1e9;
+    //     assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta should be equal to restaked balance");
+    // }
 
-    function test_balanceUpdate_positiveSharesDelta() public {
-        // Verify withdrawal credentials
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
-        _verifyWithdrawalCredentials();
+    // function test_balanceUpdate_positiveSharesDelta() public {
+    //     // Verify withdrawal credentials
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
+    //     _verifyWithdrawalCredentials();
 
-        // Set JSON
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
-        bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
+    //     // Set JSON
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    //     bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
 
-        // Set proof params, oracle block root, and warp time
-        _setBalanceUpdateParams();
-        _setOracleBlockRoot();
-        cheats.warp(GOERLI_GENESIS_TIME);
-        uint64 oracleTimestamp = uint64(block.timestamp);
+    //     // Set proof params, oracle block root, and warp time
+    //     _setBalanceUpdateParams();
+    //     _setOracleBlockRoot();
+    //     cheats.warp(GOERLI_GENESIS_TIME);
+    //     uint64 oracleTimestamp = uint64(block.timestamp);
 
-        // Save state for checks
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
-        uint64 newValidatorBalance = validatorFields[0].getEffectiveBalanceGwei();
+    //     // Save state for checks
+    //     int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
+    //     uint64 newValidatorBalance = validatorFields[0].getEffectiveBalanceGwei();
 
-        // Verify balance update
-        eigenPod.verifyBalanceUpdates(
-            oracleTimestamp,
-            validatorIndices,
-            stateRootProofStruct,
-            validatorFieldsProofs,
-            validatorFields
-        );
+    //     // Verify balance update
+    //     eigenPod.verifyBalanceUpdates(
+    //         oracleTimestamp,
+    //         validatorIndices,
+    //         stateRootProofStruct,
+    //         validatorFieldsProofs,
+    //         validatorFields
+    //     );
 
-        // Checks
-        int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
-        assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
-        assertGt(updatedShares - initialShares, 0, "Shares delta should be positive");
-        assertEq(updatedShares, 32e18, "Shares should be 32ETH");
-        assertEq(newValidatorBalance, 32e9, "validator balance should be 32e9 Gwei");
-    }
+    //     // Checks
+    //     int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
+    //     assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
+    //     assertGt(updatedShares - initialShares, 0, "Shares delta should be positive");
+    //     assertEq(updatedShares, 32e18, "Shares should be 32ETH");
+    //     assertEq(newValidatorBalance, 32e9, "validator balance should be 32e9 Gwei");
+    // }
 
-    function test_fullWithdrawal_excess32ETH() public {
-        // Verify withdrawal credentials
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
-        _verifyWithdrawalCredentials();
+    // function test_fullWithdrawal_excess32ETH() public {
+    //     // Verify withdrawal credentials
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
+    //     _verifyWithdrawalCredentials();
 
-        // Set JSON
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
+    //     // Set JSON
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
 
-        // Set proof params, block root
-        _setWithdrawalProofParams();        
-        _setOracleBlockRoot();
+    //     // Set proof params, block root
+    //     _setWithdrawalProofParams();        
+    //     _setOracleBlockRoot();
 
-        // Save state for checks; deal EigenPod withdrawal router balance
-        uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
-            withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
-        );
-        uint64 leftOverBalanceWEI = uint64(withdrawalAmountGwei - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) * 1e9;
-        cheats.deal(address(eigenPod), leftOverBalanceWEI);
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
+    //     // Save state for checks; deal EigenPod withdrawal router balance
+    //     uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
+    //         withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
+    //     );
+    //     uint64 leftOverBalanceWEI = uint64(withdrawalAmountGwei - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) * 1e9;
+    //     cheats.deal(address(eigenPod), leftOverBalanceWEI);
+    //     int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
 
-        // Withdraw
-        eigenPod.verifyAndProcessWithdrawals(
-            0,
-            stateRootProofStruct,
-            withdrawalProofs,
-            validatorFieldsProofs,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Withdraw
+    //     eigenPod.verifyAndProcessWithdrawals(
+    //         0,
+    //         stateRootProofStruct,
+    //         withdrawalProofs,
+    //         validatorFieldsProofs,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Checks
-        int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
-        assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
-        assertGt(updatedShares - initialShares, 0, "Shares diff should be positive");
-        int256 expectedSharesDiff = (int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))*1e9) - initialShares;
-        assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta incorrect");
-        assertEq(updatedShares, 32e18, "Shares should be 32e18");
-        assertEq(address(delayedWithdrawalRouterMock).balance, leftOverBalanceWEI, "Incorrect amount sent to delayed withdrawal router");
-    }
+    //     // Checks
+    //     int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
+    //     assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
+    //     assertGt(updatedShares - initialShares, 0, "Shares diff should be positive");
+    //     int256 expectedSharesDiff = (int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))*1e9) - initialShares;
+    //     assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta incorrect");
+    //     assertEq(updatedShares, 32e18, "Shares should be 32e18");
+    //     assertEq(address(delayedWithdrawalRouterMock).balance, leftOverBalanceWEI, "Incorrect amount sent to delayed withdrawal router");
+    // }
 
-    function test_withdrawRestakedBeaconChainETH() public {
-        test_fullWithdrawal_excess32ETH();
+    // function test_withdrawRestakedBeaconChainETH() public {
+    //     test_fullWithdrawal_excess32ETH();
 
-        // Deal eigenPod balance - max restaked balance
-        cheats.deal(address(eigenPod), 32 ether);
+    //     // Deal eigenPod balance - max restaked balance
+    //     cheats.deal(address(eigenPod), 32 ether);
 
-        cheats.startPrank(address(delegationManagerMock));
-        vm.expectEmit(true, true, true, true);
-        emit RestakedBeaconChainETHWithdrawn(podOwner, 32 ether);
-        eigenPodManager.withdrawSharesAsTokens(
-            podOwner,
-            podOwner,
-            uint256(eigenPodManager.podOwnerShares(podOwner))
-        );
-        cheats.stopPrank();
+    //     cheats.startPrank(address(delegationManagerMock));
+    //     vm.expectEmit(true, true, true, true);
+    //     emit RestakedBeaconChainETHWithdrawn(podOwner, 32 ether);
+    //     eigenPodManager.withdrawSharesAsTokens(
+    //         podOwner,
+    //         podOwner,
+    //         uint256(eigenPodManager.podOwnerShares(podOwner))
+    //     );
+    //     cheats.stopPrank();
 
-        // Checks
-        assertEq(address(podOwner).balance, 32 ether, "EigenPod balance should be 0");
-        assertEq(address(eigenPod).balance, 0, "EigenPod balance should be 0");
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 0, "Restaked execution layer gwei should be 0");
-    }
+    //     // Checks
+    //     assertEq(address(podOwner).balance, 32 ether, "EigenPod balance should be 0");
+    //     assertEq(address(eigenPod).balance, 0, "EigenPod balance should be 0");
+    //     assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), 0, "Restaked execution layer gwei should be 0");
+    // }
 
-    function test_fullWithdrawal_less32ETH() public {
-        // Verify withdrawal credentials
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
-        _verifyWithdrawalCredentials();
+    // function test_fullWithdrawal_less32ETH() public {
+    //     // Verify withdrawal credentials
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+    //     _verifyWithdrawalCredentials();
 
-        // Set JSON
-        setJSON("src/test/test-data/fullWithdrawalProof_Latest_28ETH.json");
-        bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
+    //     // Set JSON
+    //     setJSON("src/test/test-data/fullWithdrawalProof_Latest_28ETH.json");
+    //     bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
 
-        // Set proof params, block root
-        _setWithdrawalProofParams();        
-        _setOracleBlockRoot();
+    //     // Set proof params, block root
+    //     _setWithdrawalProofParams();        
+    //     _setOracleBlockRoot();
 
-        // Save State
-        uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
-            withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
-        );
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
+    //     // Save State
+    //     uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
+    //         withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
+    //     );
+    //     int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
 
-        // Withdraw
-        eigenPod.verifyAndProcessWithdrawals(
-            0,
-            stateRootProofStruct,
-            withdrawalProofs,
-            validatorFieldsProofs,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Withdraw
+    //     eigenPod.verifyAndProcessWithdrawals(
+    //         0,
+    //         stateRootProofStruct,
+    //         withdrawalProofs,
+    //         validatorFieldsProofs,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Checks
-        int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
-        assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei is incorrect");
-        assertLt(updatedShares - initialShares, 0, "Shares delta should be negative");
-        int256 expectedSharesDiff = (int256(uint256(withdrawalAmountGwei)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))) * 1e9;
-        assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta incorrect");
-    }
+    //     // Checks
+    //     int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
+    //     assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei is incorrect");
+    //     assertLt(updatedShares - initialShares, 0, "Shares delta should be negative");
+    //     int256 expectedSharesDiff = (int256(uint256(withdrawalAmountGwei)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR))) * 1e9;
+    //     assertEq(updatedShares - initialShares, expectedSharesDiff, "Shares delta incorrect");
+    // }
 
-    function test_partialWithdrawal() public {
-        // Set JSON & params
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
-        _verifyWithdrawalCredentials();
+    // function test_partialWithdrawal() public {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+    //     _verifyWithdrawalCredentials();
         
-        // Set JSON
-        setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
-        bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
+    //     // Set JSON
+    //     setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
+    //     bytes32 validatorPubkeyHash = validatorFields[0].getPubkeyHash();
 
-        // Set proof params, block root
-        _setWithdrawalProofParams();        
-        _setOracleBlockRoot();
+    //     // Set proof params, block root
+    //     _setWithdrawalProofParams();        
+    //     _setOracleBlockRoot();
 
-        // Assert that partial withdrawal code path will be tested
-        assertLt(withdrawalProofs[0].getWithdrawalEpoch(), validatorFields[0].getWithdrawableEpoch(), "Withdrawal epoch should be less than the withdrawable epoch");
+    //     // Assert that partial withdrawal code path will be tested
+    //     assertLt(withdrawalProofs[0].getWithdrawalEpoch(), validatorFields[0].getWithdrawableEpoch(), "Withdrawal epoch should be less than the withdrawable epoch");
 
-        // Save state for checks; deal EigenPod withdrawal router balance
-        uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
-            withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
-        );
-        cheats.deal(address(eigenPod), withdrawalAmountGwei * 1e9); // deal full withdrawal amount since it's a partial withdrawal
-        uint64 initialRestakedBalance = (eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash)).restakedBalanceGwei;
-        int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
+    //     // Save state for checks; deal EigenPod withdrawal router balance
+    //     uint64 withdrawalAmountGwei = Endian.fromLittleEndianUint64(
+    //         withdrawalFields[0][BeaconChainProofs.WITHDRAWAL_VALIDATOR_AMOUNT_INDEX]
+    //     );
+    //     cheats.deal(address(eigenPod), withdrawalAmountGwei * 1e9); // deal full withdrawal amount since it's a partial withdrawal
+    //     uint64 initialRestakedBalance = (eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash)).restakedBalanceGwei;
+    //     int256 initialShares = eigenPodManager.podOwnerShares(podOwner);
 
-        // Withdraw
-        eigenPod.verifyAndProcessWithdrawals(
-            0,
-            stateRootProofStruct,
-            withdrawalProofs,
-            validatorFieldsProofs,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Withdraw
+    //     eigenPod.verifyAndProcessWithdrawals(
+    //         0,
+    //         stateRootProofStruct,
+    //         withdrawalProofs,
+    //         validatorFieldsProofs,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Checks
-        int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
-        assertEq(validatorInfo.restakedBalanceGwei, initialRestakedBalance, "Restaked balance gwei should be unchanged");
-        assertEq(updatedShares - initialShares, 0, "Shares diff should be 0");
-        assertEq(address(delayedWithdrawalRouterMock).balance, withdrawalAmountGwei * 1e9, "Incorrect amount sent to delayed withdrawal router");
-    }
+    //     // Checks
+    //     int256 updatedShares = eigenPodManager.podOwnerShares(podOwner);
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPod.validatorPubkeyHashToInfo(validatorPubkeyHash);
+    //     assertEq(validatorInfo.restakedBalanceGwei, initialRestakedBalance, "Restaked balance gwei should be unchanged");
+    //     assertEq(updatedShares - initialShares, 0, "Shares diff should be 0");
+    //     assertEq(address(delayedWithdrawalRouterMock).balance, withdrawalAmountGwei * 1e9, "Incorrect amount sent to delayed withdrawal router");
+    // }
 
     // Helper Functions
     function _getStateRootProof() internal returns (BeaconChainProofs.StateRootProof memory) {
@@ -566,48 +565,48 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
         validatorFieldsProofs.push(abi.encodePacked(getWithdrawalCredentialProof())); // Validator fields are proven here
     }
 
-    function _setBalanceUpdateParams() internal {
-        // Reset arrays
-        delete validatorIndices;
-        delete validatorFields;
-        delete validatorFieldsProofs;
+    // function _setBalanceUpdateParams() internal {
+    //     // Reset arrays
+    //     delete validatorIndices;
+    //     delete validatorFields;
+    //     delete validatorFieldsProofs;
         
-        // Set state proof struct
-        stateRootProofStruct = _getStateRootProof();
+    //     // Set state proof struct
+    //     stateRootProofStruct = _getStateRootProof();
 
-        // Set validator indices
-        uint40 validatorIndex = uint40(getValidatorIndex());
-        validatorIndices.push(validatorIndex);
+    //     // Set validator indices
+    //     uint40 validatorIndex = uint40(getValidatorIndex());
+    //     validatorIndices.push(validatorIndex);
 
-        // Set validatorFieldsArray
-        validatorFields.push(getValidatorFields());
+    //     // Set validatorFieldsArray
+    //     validatorFields.push(getValidatorFields());
 
-        // Set validator fields proof
-        validatorFieldsProofs.push(abi.encodePacked(getBalanceUpdateProof())); // Validator fields are proven here
-    }
+    //     // Set validator fields proof
+    //     validatorFieldsProofs.push(abi.encodePacked(getBalanceUpdateProof())); // Validator fields are proven here
+    // }
 
-    function _setWithdrawalProofParams() internal {
-        // Reset arrays
-        delete validatorFields;
-        delete validatorFieldsProofs;
-        delete withdrawalFields;
-        delete withdrawalProofs;
+    // function _setWithdrawalProofParams() internal {
+    //     // Reset arrays
+    //     delete validatorFields;
+    //     delete validatorFieldsProofs;
+    //     delete withdrawalFields;
+    //     delete withdrawalProofs;
 
-        // Set state proof struct
-        stateRootProofStruct = _getStateRootProof();
+    //     // Set state proof struct
+    //     stateRootProofStruct = _getStateRootProof();
     
-        // Set validatorFields
-        validatorFields.push(getValidatorFields());
+    //     // Set validatorFields
+    //     validatorFields.push(getValidatorFields());
 
-        // Set validator fields proof
-        validatorFieldsProofs.push(abi.encodePacked(getValidatorProof()));
+    //     // Set validator fields proof
+    //     validatorFieldsProofs.push(abi.encodePacked(getValidatorProof()));
 
-        // Set withdrawal fields
-        withdrawalFields.push(getWithdrawalFields());
+    //     // Set withdrawal fields
+    //     withdrawalFields.push(getWithdrawalFields());
 
-        // Set withdrawal proofs
-        withdrawalProofs.push(_getWithdrawalProof());
-    }
+    //     // Set withdrawal proofs
+    //     withdrawalProofs.push(_getWithdrawalProof());
+    // }
 
     // function _getBalanceUpdateProof() internal returns (BeaconChainProofs.BalanceUpdateProof memory) {
     //     bytes32 balanceRoot = getBalanceRoot();
@@ -620,29 +619,29 @@ contract EigenPod_PodManager_UnitTests_EigenPodManager is EigenPod_PodManager_Un
     // }
 
     /// @notice this function just generates a valid proof so that we can test other functionalities of the withdrawal flow
-    function _getWithdrawalProof() internal returns (BeaconChainProofs.WithdrawalProof memory) {
-        {
-            bytes32 blockRoot = getBlockRoot();
-            bytes32 slotRoot = getSlotRoot();
-            bytes32 timestampRoot = getTimestampRoot();
-            bytes32 executionPayloadRoot = getExecutionPayloadRoot();
+    // function _getWithdrawalProof() internal returns (BeaconChainProofs.WithdrawalProof memory) {
+    //     {
+    //         bytes32 blockRoot = getBlockRoot();
+    //         bytes32 slotRoot = getSlotRoot();
+    //         bytes32 timestampRoot = getTimestampRoot();
+    //         bytes32 executionPayloadRoot = getExecutionPayloadRoot();
 
-            return
-                BeaconChainProofs.WithdrawalProof(
-                    abi.encodePacked(getWithdrawalProofCapella()),
-                    abi.encodePacked(getSlotProof()),
-                    abi.encodePacked(getExecutionPayloadProof()),
-                    abi.encodePacked(getTimestampProofCapella()),
-                    abi.encodePacked(getHistoricalSummaryProof()),
-                    uint64(getBlockRootIndex()),
-                    uint64(getHistoricalSummaryIndex()),
-                    uint64(getWithdrawalIndex()),
-                    blockRoot,
-                    slotRoot,
-                    timestampRoot,
-                    executionPayloadRoot
-                );
-        }
-    }
+    //         return
+    //             BeaconChainProofs.WithdrawalProof(
+    //                 abi.encodePacked(getWithdrawalProofCapella()),
+    //                 abi.encodePacked(getSlotProof()),
+    //                 abi.encodePacked(getExecutionPayloadProof()),
+    //                 abi.encodePacked(getTimestampProofCapella()),
+    //                 abi.encodePacked(getHistoricalSummaryProof()),
+    //                 uint64(getBlockRootIndex()),
+    //                 uint64(getHistoricalSummaryIndex()),
+    //                 uint64(getWithdrawalIndex()),
+    //                 blockRoot,
+    //                 slotRoot,
+    //                 timestampRoot,
+    //                 executionPayloadRoot
+    //             );
+    //     }
+    // }
 }
 

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -53,7 +53,6 @@ contract EigenPodManagerUnitTests is EigenLayerUnitTestSetup {
                     address(eigenLayerProxyAdmin),
                     abi.encodeWithSelector(
                         EigenPodManager.initialize.selector,
-                        IBeaconChainOracle(address(0)) /*beaconChainOracle*/,
                         initialOwner,
                         pauserRegistry,
                         0 /*initialPausedStatus*/
@@ -110,7 +109,6 @@ contract EigenPodManagerUnitTests_Initialization_Setters is EigenPodManagerUnitT
 
     function test_initialization() public {
         // Check max pods, beacon chain, owner, and pauser
-        assertEq(address(eigenPodManager.beaconChainOracle()), address(IBeaconChainOracle(address(0))), "Initialization: beacon chain oracle incorrect");
         assertEq(eigenPodManager.owner(), initialOwner, "Initialization: owner incorrect");
         assertEq(address(eigenPodManager.pauserRegistry()), address(pauserRegistry), "Initialization: pauser registry incorrect");
         assertEq(eigenPodManager.paused(), 0, "Initialization: paused value not 0");
@@ -126,7 +124,6 @@ contract EigenPodManagerUnitTests_Initialization_Setters is EigenPodManagerUnitT
     function test_initialize_revert_alreadyInitialized() public {
         cheats.expectRevert("Initializable: contract is already initialized");
         eigenPodManager.initialize(
-            IBeaconChainOracle(address(0)) /*beaconChainOracle*/,
             initialOwner,
             pauserRegistry,
             0 /*initialPausedStatus*/);
@@ -136,24 +133,24 @@ contract EigenPodManagerUnitTests_Initialization_Setters is EigenPodManagerUnitT
                                      Setters
     *******************************************************************************/
 
-    function testFuzz_updateBeaconChainOracle_revert_notOwner(address notOwner) public filterFuzzedAddressInputs(notOwner) {
-        cheats.assume(notOwner != initialOwner);
-        cheats.prank(notOwner);
-        cheats.expectRevert("Ownable: caller is not the owner");
-        eigenPodManager.updateBeaconChainOracle(IBeaconChainOracle(address(1)));
-    }
+    // function testFuzz_updateBeaconChainOracle_revert_notOwner(address notOwner) public filterFuzzedAddressInputs(notOwner) {
+    //     cheats.assume(notOwner != initialOwner);
+    //     cheats.prank(notOwner);
+    //     cheats.expectRevert("Ownable: caller is not the owner");
+    //     eigenPodManager.updateBeaconChainOracle(IBeaconChainOracle(address(1)));
+    // }
 
-    function test_updateBeaconChainOracle() public {
-        // Set new beacon chain oracle
-        IBeaconChainOracle newBeaconChainOracle = IBeaconChainOracle(address(1));
-        cheats.prank(initialOwner);
-        cheats.expectEmit(true, true, true, true);
-        emit BeaconOracleUpdated(address(newBeaconChainOracle));
-        eigenPodManager.updateBeaconChainOracle(newBeaconChainOracle);
+    // function test_updateBeaconChainOracle() public {
+    //     // Set new beacon chain oracle
+    //     IBeaconChainOracle newBeaconChainOracle = IBeaconChainOracle(address(1));
+    //     cheats.prank(initialOwner);
+    //     cheats.expectEmit(true, true, true, true);
+    //     emit BeaconOracleUpdated(address(newBeaconChainOracle));
+    //     eigenPodManager.updateBeaconChainOracle(newBeaconChainOracle);
 
-        // Check storage update
-        assertEq(address(eigenPodManager.beaconChainOracle()), address(newBeaconChainOracle), "Beacon chain oracle not updated");
-    }
+    //     // Check storage update
+    //     assertEq(address(eigenPodManager.beaconChainOracle()), address(newBeaconChainOracle), "Beacon chain oracle not updated");
+    // }
 
     function test_setDenebForkTimestamp(uint64 denebForkTimestamp) public {
         cheats.assume(denebForkTimestamp != 0);

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -31,8 +31,6 @@ contract EigenPodUnitTests is EigenLayerUnitTestSetup {
     bool IS_DENEB = false;
     
     // Constants
-    // uint32 public constant WITHDRAWAL_DELAY_BLOCKS = 7 days / 12 seconds;
-    uint64 public constant MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR = 32e9;
     // uint64 public constant RESTAKED_BALANCE_OFFSET_GWEI = 75e7;
     uint64 public constant GOERLI_GENESIS_TIME = 1616508000;
     // uint64 public constant SECONDS_PER_SLOT = 12;
@@ -54,7 +52,6 @@ contract EigenPodUnitTests is EigenLayerUnitTestSetup {
             ethPOSDepositMock,
             delayedWithdrawalRouterMock,
             eigenPodManagerMock,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -104,7 +101,6 @@ contract EigenPodUnitTests_Initialization is EigenPodUnitTests, IEigenPodEvents 
         assertEq(address(eigenPod.ethPOS()), address(ethPOSDepositMock), "EthPOS incorrectly set");
         assertEq(address(eigenPod.delayedWithdrawalRouter()), address(delayedWithdrawalRouterMock), "DelayedWithdrawalRouter incorrectly set");
         assertEq(address(eigenPod.eigenPodManager()), address(eigenPodManagerMock), "EigenPodManager incorrectly set");
-        assertEq(eigenPod.MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR(), MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Max restaked balance incorrectly set");
         assertEq(eigenPod.GENESIS_TIME(), GOERLI_GENESIS_TIME, "Goerli genesis time incorrectly set");
     }
 
@@ -380,7 +376,6 @@ contract EigenPodHarnessSetup is EigenPodUnitTests {
             ethPOSDepositMock,
             delayedWithdrawalRouterMock,
             eigenPodManagerMock,
-            MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR,
             GOERLI_GENESIS_TIME
         );
 
@@ -444,67 +439,67 @@ contract EigenPodUnitTests_VerifyWithdrawalCredentialsTests is EigenPodHarnessSe
         );
     }
 
-    function test_effectiveBalanceGreaterThan32ETH() public {
-        // Set JSON and params
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
-        _setWithdrawalCredentialParams();
+    // function test_effectiveBalanceGreaterThan32ETH() public {
+    //     // Set JSON and params
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913.json");
+    //     _setWithdrawalCredentialParams();
         
-        // Check that restaked balance greater than 32 ETH
-        uint64 effectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
-        assertGt(effectiveBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Proof file has an effective balance less than 32 ETH");
+    //     // Check that restaked balance greater than 32 ETH
+    //     uint64 effectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
+    //     assertGt(effectiveBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Proof file has an effective balance less than 32 ETH");
 
-        uint activeValidatorCountBefore = eigenPodHarness.getActiveValidatorCount();
+    //     uint activeValidatorCountBefore = eigenPodHarness.getActiveValidatorCount();
 
-        // Verify withdrawal credentials
-        vm.expectEmit(true, true, true, true);
-        emit ValidatorRestaked(validatorIndex);
-        vm.expectEmit(true, true, true, true);
-        emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
-        uint256 restakedBalanceWei = eigenPodHarness.verifyWithdrawalCredentials(
-            oracleTimestamp,
-            beaconStateRoot,
-            validatorIndex,
-            validatorFieldsProof,
-            validatorFields
-        );
+    //     // Verify withdrawal credentials
+    //     vm.expectEmit(true, true, true, true);
+    //     emit ValidatorRestaked(validatorIndex);
+    //     vm.expectEmit(true, true, true, true);
+    //     emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
+    //     uint256 restakedBalanceWei = eigenPodHarness.verifyWithdrawalCredentials(
+    //         oracleTimestamp,
+    //         beaconStateRoot,
+    //         validatorIndex,
+    //         validatorFieldsProof,
+    //         validatorFields
+    //     );
 
-        // Checks
-        uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
-        assertEq(activeValidatorCountAfter, activeValidatorCountBefore + 1, "active validator count should increase when proving withdrawal credentials");
-        assertEq(restakedBalanceWei, uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) * uint256(1e9), "Returned restaked balance gwei should be max");
-        _assertWithdrawalCredentialsSet(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
-    }
+    //     // Checks
+    //     uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
+    //     assertEq(activeValidatorCountAfter, activeValidatorCountBefore + 1, "active validator count should increase when proving withdrawal credentials");
+    //     assertEq(restakedBalanceWei, uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR) * uint256(1e9), "Returned restaked balance gwei should be max");
+    //     _assertWithdrawalCredentialsSet(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
+    // }
 
-    function test_effectiveBalanceLessThan32ETH() public {
-        // Set JSON and params
-        setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
-        _setWithdrawalCredentialParams();
+    // function test_effectiveBalanceLessThan32ETH() public {
+    //     // Set JSON and params
+    //     setJSON("./src/test/test-data/withdrawal_credential_proof_302913_30ETHBalance.json");
+    //     _setWithdrawalCredentialParams();
         
-        // Check that restaked balance less than 32 ETH
-        uint64 effectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
-        assertLt(effectiveBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Proof file has an effective balance greater than 32 ETH");
+    //     // Check that restaked balance less than 32 ETH
+    //     uint64 effectiveBalanceGwei = validatorFields.getEffectiveBalanceGwei();
+    //     assertLt(effectiveBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Proof file has an effective balance greater than 32 ETH");
 
-        uint activeValidatorCountBefore = eigenPodHarness.getActiveValidatorCount();
+    //     uint activeValidatorCountBefore = eigenPodHarness.getActiveValidatorCount();
 
-        // Verify withdrawal credentials
-        vm.expectEmit(true, true, true, true);
-        emit ValidatorRestaked(validatorIndex);
-        vm.expectEmit(true, true, true, true);
-        emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, effectiveBalanceGwei);
-        uint256 restakedBalanceWei = eigenPodHarness.verifyWithdrawalCredentials(
-            oracleTimestamp,
-            beaconStateRoot,
-            validatorIndex,
-            validatorFieldsProof,
-            validatorFields
-        );
+    //     // Verify withdrawal credentials
+    //     vm.expectEmit(true, true, true, true);
+    //     emit ValidatorRestaked(validatorIndex);
+    //     vm.expectEmit(true, true, true, true);
+    //     emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, effectiveBalanceGwei);
+    //     uint256 restakedBalanceWei = eigenPodHarness.verifyWithdrawalCredentials(
+    //         oracleTimestamp,
+    //         beaconStateRoot,
+    //         validatorIndex,
+    //         validatorFieldsProof,
+    //         validatorFields
+    //     );
 
-        // Checks
-        uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
-        assertEq(activeValidatorCountAfter, activeValidatorCountBefore + 1, "active validator count should increase when proving withdrawal credentials");
-        assertEq(restakedBalanceWei, uint256(effectiveBalanceGwei) * uint256(1e9), "Returned restaked balance gwei incorrect");
-        _assertWithdrawalCredentialsSet(effectiveBalanceGwei);
-    }
+    //     // Checks
+    //     uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
+    //     assertEq(activeValidatorCountAfter, activeValidatorCountBefore + 1, "active validator count should increase when proving withdrawal credentials");
+    //     assertEq(restakedBalanceWei, uint256(effectiveBalanceGwei) * uint256(1e9), "Returned restaked balance gwei incorrect");
+    //     _assertWithdrawalCredentialsSet(effectiveBalanceGwei);
+    // }
 
     function _assertWithdrawalCredentialsSet(uint256 restakedBalanceGwei) internal {
         IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
@@ -539,171 +534,171 @@ contract EigenPodUnitTests_VerifyBalanceUpdateTests is EigenPodHarnessSetup, Pro
     bytes validatorFieldsProof;
     bytes32[] validatorFields;
 
-    function testFuzz_revert_oracleTimestampStale(uint64 oracleFuzzTimestamp, uint64 mostRecentBalanceUpdateTimestamp) public {
-        // Constain inputs and set proof file
-        cheats.assume(oracleFuzzTimestamp < mostRecentBalanceUpdateTimestamp);
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    // function testFuzz_revert_oracleTimestampStale(uint64 oracleFuzzTimestamp, uint64 mostRecentBalanceUpdateTimestamp) public {
+    //     // Constain inputs and set proof file
+    //     cheats.assume(oracleFuzzTimestamp < mostRecentBalanceUpdateTimestamp);
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
         
-        // Get validator fields and balance update root
-        validatorFields = getValidatorFields();
-        validatorFieldsProof = abi.encodePacked(getBalanceUpdateProof());
+    //     // Get validator fields and balance update root
+    //     validatorFields = getValidatorFields();
+    //     validatorFieldsProof = abi.encodePacked(getBalanceUpdateProof());
 
-        // Balance update reversion
-        cheats.expectRevert(
-            "EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"
-        );
-        eigenPodHarness.verifyBalanceUpdate(
-            oracleFuzzTimestamp,
-            0,
-            bytes32(0),
-            validatorFieldsProof,
-            validatorFields,
-            mostRecentBalanceUpdateTimestamp
-        );
-    }
+    //     // Balance update reversion
+    //     cheats.expectRevert(
+    //         "EigenPod.verifyBalanceUpdate: Validators balance has already been updated for this timestamp"
+    //     );
+    //     eigenPodHarness.verifyBalanceUpdate(
+    //         oracleFuzzTimestamp,
+    //         0,
+    //         bytes32(0),
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         mostRecentBalanceUpdateTimestamp
+    //     );
+    // }
 
-    function test_revert_validatorInactive() public {
-        // Set proof file
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    // function test_revert_validatorInactive() public {
+    //     // Set proof file
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
 
-        // Set proof params
-        _setBalanceUpdateParams();
+    //     // Set proof params
+    //     _setBalanceUpdateParams();
 
-        // Set validator status to inactive
-        eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.INACTIVE);
+    //     // Set validator status to inactive
+    //     eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.INACTIVE);
 
-        // Balance update reversion
-        cheats.expectRevert(
-            "EigenPod.verifyBalanceUpdate: Validator not active"
-        );
-        eigenPodHarness.verifyBalanceUpdate(
-            oracleTimestamp,
-            validatorIndex,
-            beaconStateRoot,
-            validatorFieldsProof,
-            validatorFields,
-            0 // Most recent balance update timestamp set to 0
-        );
-    }
+    //     // Balance update reversion
+    //     cheats.expectRevert(
+    //         "EigenPod.verifyBalanceUpdate: Validator not active"
+    //     );
+    //     eigenPodHarness.verifyBalanceUpdate(
+    //         oracleTimestamp,
+    //         validatorIndex,
+    //         beaconStateRoot,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         0 // Most recent balance update timestamp set to 0
+    //     );
+    // }
 
     /**
      * Regression test for a bug that allowed balance updates to be made for withdrawn validators. Thus
      * the validator's balance could be maliciously proven to be 0 before the validator themselves are
      * able to prove their withdrawal.
      */
-    function test_revert_balanceUpdateAfterWithdrawableEpoch() external {
-        // Set Json proof
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    // function test_revert_balanceUpdateAfterWithdrawableEpoch() external {
+    //     // Set Json proof
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
         
-        // Set proof params
-        _setBalanceUpdateParams();
+    //     // Set proof params
+    //     _setBalanceUpdateParams();
         
-        // Set effective balance and  withdrawable epoch
-        validatorFields[2] = bytes32(uint256(0)); // per consensus spec, slot 2 is effective balance
-        validatorFields[7] = bytes32(uint256(0)); // per consensus spec, slot 7 is withdrawable epoch == 0
+    //     // Set effective balance and  withdrawable epoch
+    //     validatorFields[2] = bytes32(uint256(0)); // per consensus spec, slot 2 is effective balance
+    //     validatorFields[7] = bytes32(uint256(0)); // per consensus spec, slot 7 is withdrawable epoch == 0
         
-        console.log("withdrawable epoch: ", validatorFields.getWithdrawableEpoch());
-        // Expect revert on balance update 
-        cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: validator is withdrawable but has not withdrawn"));
-        eigenPodHarness.verifyBalanceUpdate(oracleTimestamp, validatorIndex, beaconStateRoot, validatorFieldsProof, validatorFields, 0);
-    }
+    //     console.log("withdrawable epoch: ", validatorFields.getWithdrawableEpoch());
+    //     // Expect revert on balance update 
+    //     cheats.expectRevert(bytes("EigenPod.verifyBalanceUpdate: validator is withdrawable but has not withdrawn"));
+    //     eigenPodHarness.verifyBalanceUpdate(oracleTimestamp, validatorIndex, beaconStateRoot, validatorFieldsProof, validatorFields, 0);
+    // }
 
     /// @notice Rest of tests assume beacon chain proofs are correct; Now we update the validator's balance
 
     ///@notice Balance of validator is >= 32e9
-    function test_positiveSharesDelta() public {
-        // Set JSON
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    // function test_positiveSharesDelta() public {
+    //     // Set JSON
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
 
-        // Set proof params
-        _setBalanceUpdateParams();
+    //     // Set proof params
+    //     _setBalanceUpdateParams();
 
-        // Verify balance update
-        vm.expectEmit(true, true, true, true);
-        emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
-        int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
-            oracleTimestamp,
-            validatorIndex,
-            beaconStateRoot,
-            validatorFieldsProof,
-            validatorFields,
-            0 // Most recent balance update timestamp set to 0
-        );
+    //     // Verify balance update
+    //     vm.expectEmit(true, true, true, true);
+    //     emit ValidatorBalanceUpdated(validatorIndex, oracleTimestamp, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
+    //     int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
+    //         oracleTimestamp,
+    //         validatorIndex,
+    //         beaconStateRoot,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         0 // Most recent balance update timestamp set to 0
+    //     );
 
-        // Checks
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
-        assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
-        assertGt(sharesDeltaGwei, 0, "Shares delta should be positive");
-        assertEq(sharesDeltaGwei, int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR)), "Shares delta should be equal to restaked balance");
-    }
+    //     // Checks
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
+    //     assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
+    //     assertGt(sharesDeltaGwei, 0, "Shares delta should be positive");
+    //     assertEq(sharesDeltaGwei, int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR)), "Shares delta should be equal to restaked balance");
+    // }
     
-    function test_negativeSharesDelta() public {
-        // Set JSON
-        setJSON("src/test/test-data/balanceUpdateProof_balance28ETH_302913.json");
+    // function test_negativeSharesDelta() public {
+    //     // Set JSON
+    //     setJSON("src/test/test-data/balanceUpdateProof_balance28ETH_302913.json");
 
-        // Set proof params
-        _setBalanceUpdateParams();
-        uint64 newValidatorBalance = validatorFields.getEffectiveBalanceGwei();
+    //     // Set proof params
+    //     _setBalanceUpdateParams();
+    //     uint64 newValidatorBalance = validatorFields.getEffectiveBalanceGwei();
 
-        // Set balance of validator to max ETH
-        eigenPodHarness.setValidatorRestakedBalance(validatorFields[0], MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
+    //     // Set balance of validator to max ETH
+    //     eigenPodHarness.setValidatorRestakedBalance(validatorFields[0], MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
 
-        // Verify balance update
-        int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
-            oracleTimestamp,
-            validatorIndex,
-            beaconStateRoot,
-            validatorFieldsProof,
-            validatorFields,
-            0 // Most recent balance update timestamp set to 0
-        );
+    //     // Verify balance update
+    //     int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
+    //         oracleTimestamp,
+    //         validatorIndex,
+    //         beaconStateRoot,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         0 // Most recent balance update timestamp set to 0
+    //     );
 
-        // Checks
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
-        assertEq(validatorInfo.restakedBalanceGwei, newValidatorBalance, "Restaked balance gwei should be max");
-        assertLt(sharesDeltaGwei, 0, "Shares delta should be negative");
-        int256 expectedSharesDiff = int256(uint256(newValidatorBalance)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
-        assertEq(sharesDeltaGwei, expectedSharesDiff, "Shares delta should be equal to restaked balance");
-    }
+    //     // Checks
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
+    //     assertEq(validatorInfo.restakedBalanceGwei, newValidatorBalance, "Restaked balance gwei should be max");
+    //     assertLt(sharesDeltaGwei, 0, "Shares delta should be negative");
+    //     int256 expectedSharesDiff = int256(uint256(newValidatorBalance)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
+    //     assertEq(sharesDeltaGwei, expectedSharesDiff, "Shares delta should be equal to restaked balance");
+    // }
 
-    function test_zeroSharesDelta() public {
-        // Set JSON
-        setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
+    // function test_zeroSharesDelta() public {
+    //     // Set JSON
+    //     setJSON("src/test/test-data/balanceUpdateProof_notOverCommitted_302913.json");
 
-        // Set proof params
-        _setBalanceUpdateParams();
+    //     // Set proof params
+    //     _setBalanceUpdateParams();
 
-        // Set previous restaked balance to max restaked balance
-        eigenPodHarness.setValidatorRestakedBalance(validatorFields[0], MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
+    //     // Set previous restaked balance to max restaked balance
+    //     eigenPodHarness.setValidatorRestakedBalance(validatorFields[0], MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR);
 
-        // Verify balance update
-        int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
-            oracleTimestamp,
-            validatorIndex,
-            beaconStateRoot,
-            validatorFieldsProof,
-            validatorFields,
-            0 // Most recent balance update timestamp set to 0
-        );
+    //     // Verify balance update
+    //     int256 sharesDeltaGwei = eigenPodHarness.verifyBalanceUpdate(
+    //         oracleTimestamp,
+    //         validatorIndex,
+    //         beaconStateRoot,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         0 // Most recent balance update timestamp set to 0
+    //     );
 
-        // Checks
-        assertEq(sharesDeltaGwei, 0, "Shares delta should be 0");
-    }
+    //     // Checks
+    //     assertEq(sharesDeltaGwei, 0, "Shares delta should be 0");
+    // }
 
-    function _setBalanceUpdateParams() internal {
-        // Set validator index, beacon state root, balance update proof, and validator fields
-        validatorIndex = uint40(getValidatorIndex());
-        beaconStateRoot = getBeaconStateRoot();
-        validatorFieldsProof = abi.encodePacked(getBalanceUpdateProof());
-        validatorFields = getValidatorFields();
+    // function _setBalanceUpdateParams() internal {
+    //     // Set validator index, beacon state root, balance update proof, and validator fields
+    //     validatorIndex = uint40(getValidatorIndex());
+    //     beaconStateRoot = getBeaconStateRoot();
+    //     validatorFieldsProof = abi.encodePacked(getBalanceUpdateProof());
+    //     validatorFields = getValidatorFields();
 
-        // Get an oracle timestamp
-        cheats.warp(GOERLI_GENESIS_TIME + 1 days);
-        oracleTimestamp = uint64(block.timestamp);
+    //     // Get an oracle timestamp
+    //     cheats.warp(GOERLI_GENESIS_TIME + 1 days);
+    //     oracleTimestamp = uint64(block.timestamp);
 
-        // Set validator status to active
-        eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.ACTIVE);
-    }
+    //     // Set validator status to active
+    //     eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.ACTIVE);
+    // }
 }
 
 contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing, IEigenPodEvents {
@@ -711,362 +706,362 @@ contract EigenPodUnitTests_WithdrawalTests is EigenPodHarnessSetup, ProofParsing
 
     // Params to process withdrawal 
     bytes32 beaconStateRoot;
-    BeaconChainProofs.WithdrawalProof withdrawalToProve;
+    // BeaconChainProofs.WithdrawalProof withdrawalToProve;
     bytes validatorFieldsProof;
     bytes32[] validatorFields;
     bytes32[] withdrawalFields;
 
     // Most recent withdrawal timestamp incremented when withdrawal processed before restaking OR when staking activated
-    function test_verifyAndProcessWithdrawal_revert_staleProof() public hasNotRestaked {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_verifyAndProcessWithdrawal_revert_staleProof() public hasNotRestaked {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Set timestamp to after withdrawal timestamp
-        uint64 timestampOfWithdrawal = Endian.fromLittleEndianUint64(withdrawalToProve.timestampRoot);
-        uint256 newTimestamp = timestampOfWithdrawal + 2500;
-        cheats.warp(newTimestamp);
+    //     // Set timestamp to after withdrawal timestamp
+    //     uint64 timestampOfWithdrawal = Endian.fromLittleEndianUint64(withdrawalToProve.timestampRoot);
+    //     uint256 newTimestamp = timestampOfWithdrawal + 2500;
+    //     cheats.warp(newTimestamp);
 
-        // Activate restaking, setting `mostRecentWithdrawalTimestamp` 
-        eigenPodHarness.activateRestaking();
+    //     // Activate restaking, setting `mostRecentWithdrawalTimestamp` 
+    //     eigenPodHarness.activateRestaking();
 
-        // Expect revert
-        cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
-    }
+    //     // Expect revert
+    //     cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
+    // }
 
-    function test_verifyAndProcessWithdrawal_revert_statusInactive() public {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_verifyAndProcessWithdrawal_revert_statusInactive() public {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Set status to inactive
-        eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.INACTIVE);
+    //     // Set status to inactive
+    //     eigenPodHarness.setValidatorStatus(validatorFields[0], IEigenPod.VALIDATOR_STATUS.INACTIVE);
 
-        // Expect revert
-        cheats.expectRevert("EigenPod._verifyAndProcessWithdrawal: Validator never proven to have withdrawal credentials pointed to this contract");
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
-    }
+    //     // Expect revert
+    //     cheats.expectRevert("EigenPod._verifyAndProcessWithdrawal: Validator never proven to have withdrawal credentials pointed to this contract");
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
+    // }
 
-    function test_verifyAndProcessWithdrawal_withdrawalAlreadyProcessed() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_verifyAndProcessWithdrawal_withdrawalAlreadyProcessed() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Process withdrawal
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process withdrawal
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Attempt to process again
-        cheats.expectRevert("EigenPod._verifyAndProcessWithdrawal: withdrawal has already been proven for this timestamp");
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
-    }
+    //     // Attempt to process again
+    //     cheats.expectRevert("EigenPod._verifyAndProcessWithdrawal: withdrawal has already been proven for this timestamp");
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
+    // }
 
-    function test_verifyAndProcessWithdrawal_excess() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_verifyAndProcessWithdrawal_excess() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Process withdrawal
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process withdrawal
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Verify storage
-        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
-    }
+    //     // Verify storage
+    //     bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    // }
 
     // regression test for off-by-one error
-    function test_verifyAndProcessWithdrawal_atLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_verifyAndProcessWithdrawal_atLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        // set the `mostRecentWithdrawalTimestamp` to be equal to the withdrawal timestamp
-        eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp);
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     // set the `mostRecentWithdrawalTimestamp` to be equal to the withdrawal timestamp
+    //     eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp);
 
-        // Process withdrawal
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process withdrawal
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Verify storage
-        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
-    }
+    //     // Verify storage
+    //     bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+    //     assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    // }
 
-    function test_revert_verifyAndProcessWithdrawal_beforeLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_revert_verifyAndProcessWithdrawal_beforeLatestWithdrawalTimestamp() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        // set the `mostRecentWithdrawalTimestamp` to just after the withdrawal timestamp
-        eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp + 1);
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     // set the `mostRecentWithdrawalTimestamp` to just after the withdrawal timestamp
+    //     eigenPodHarness.setMostRecentWithdrawalTimestamp(withdrawalTimestamp + 1);
 
-        // Process withdrawal, expect revert
-        cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
-        eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
-    }
+    //     // Process withdrawal, expect revert
+    //     cheats.expectRevert("EigenPod.proofIsForValidTimestamp: beacon chain proof must be at or after mostRecentWithdrawalTimestamp");
+    //     eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
+    // }
 
     /// @notice Tests processing a full withdrawal > MAX_RESTAKED_GWEI_PER_VALIDATOR
-    function test_processFullWithdrawal_excess32ETH() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_processFullWithdrawal_excess32ETH() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/fullWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Get params to check against
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        uint40 validatorIndex = uint40(getValidatorIndex());
-        uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
-        assertGt(withdrawalAmountGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Withdrawal amount should be greater than max restaked balance for this test");
+    //     // Get params to check against
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     uint40 validatorIndex = uint40(getValidatorIndex());
+    //     uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
+    //     assertGt(withdrawalAmountGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Withdrawal amount should be greater than max restaked balance for this test");
 
-        // Process full withdrawal
-        vm.expectEmit(true, true, true, true);
-        emit FullWithdrawalRedeemed(validatorIndex, withdrawalTimestamp, podOwner, withdrawalAmountGwei);
-        IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process full withdrawal
+    //     vm.expectEmit(true, true, true, true);
+    //     emit FullWithdrawalRedeemed(validatorIndex, withdrawalTimestamp, podOwner, withdrawalAmountGwei);
+    //     IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Storage checks in _verifyAndProcessWithdrawal
-        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    //     // Storage checks in _verifyAndProcessWithdrawal
+    //     bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+    //     assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
 
-        // Checks from  _processFullWithdrawal
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Incorrect withdrawable restaked execution layer gwei");
-        // Excess withdrawal amount is diff between restaked balance and total withdrawal amount
-        uint64 excessWithdrawalAmount = withdrawalAmountGwei - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-        assertEq(vw.amountToSendGwei, excessWithdrawalAmount, "Amount to send via router is not correct");
-        assertEq(vw.sharesDeltaGwei, 0, "Shares delta not correct"); // Shares delta is 0 since restaked balance and amount to withdraw were max
+    //     // Checks from  _processFullWithdrawal
+    //     assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Incorrect withdrawable restaked execution layer gwei");
+    //     // Excess withdrawal amount is diff between restaked balance and total withdrawal amount
+    //     uint64 excessWithdrawalAmount = withdrawalAmountGwei - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
+    //     assertEq(vw.amountToSendGwei, excessWithdrawalAmount, "Amount to send via router is not correct");
+    //     assertEq(vw.sharesDeltaGwei, 0, "Shares delta not correct"); // Shares delta is 0 since restaked balance and amount to withdraw were max
         
-        // ValidatorInfo storage update checks
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
-        assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
-        assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
-    }
+    //     // ValidatorInfo storage update checks
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
+    //     assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
+    //     assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
+    // }
 
-    function test_processFullWithdrawal_lessThan32ETH() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("src/test/test-data/fullWithdrawalProof_Latest_28ETH.json");
-        _setWithdrawalProofParams();
+    // function test_processFullWithdrawal_lessThan32ETH() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("src/test/test-data/fullWithdrawalProof_Latest_28ETH.json");
+    //     _setWithdrawalProofParams();
 
-        // Get params to check against
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
-        assertLt(withdrawalAmountGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Withdrawal amount should be greater than max restaked balance for this test");
+    //     // Get params to check against
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
+    //     assertLt(withdrawalAmountGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Withdrawal amount should be greater than max restaked balance for this test");
 
-        // Process full withdrawal
-        IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process full withdrawal
+    //     IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Storage checks in _verifyAndProcessWithdrawal
-        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    //     // Storage checks in _verifyAndProcessWithdrawal
+    //     bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+    //     assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
 
-        // Checks from  _processFullWithdrawal
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), withdrawalAmountGwei, "Incorrect withdrawable restaked execution layer gwei");
-        // Excess withdrawal amount should be 0 since balance is < MAX
-        assertEq(vw.amountToSendGwei, 0, "Amount to send via router is not correct");
-        int256 expectedSharesDiff = int256(uint256(withdrawalAmountGwei)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
-        assertEq(vw.sharesDeltaGwei, expectedSharesDiff, "Shares delta not correct"); // Shares delta is 0 since restaked balance and amount to withdraw were max
+    //     // Checks from  _processFullWithdrawal
+    //     assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), withdrawalAmountGwei, "Incorrect withdrawable restaked execution layer gwei");
+    //     // Excess withdrawal amount should be 0 since balance is < MAX
+    //     assertEq(vw.amountToSendGwei, 0, "Amount to send via router is not correct");
+    //     int256 expectedSharesDiff = int256(uint256(withdrawalAmountGwei)) - int256(uint256(MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
+    //     assertEq(vw.sharesDeltaGwei, expectedSharesDiff, "Shares delta not correct"); // Shares delta is 0 since restaked balance and amount to withdraw were max
         
-        // ValidatorInfo storage update checks
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
-        assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
-        assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
-    }
+    //     // ValidatorInfo storage update checks
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
+    //     assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
+    //     assertEq(validatorInfo.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
+    // }
 
-    function test_processPartialWithdrawal() public setWithdrawalCredentialsExcess {
-        // Set JSON & params
-        setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
-        _setWithdrawalProofParams();
+    // function test_processPartialWithdrawal() public setWithdrawalCredentialsExcess {
+    //     // Set JSON & params
+    //     setJSON("./src/test/test-data/partialWithdrawalProof_Latest.json");
+    //     _setWithdrawalProofParams();
 
-        // Get params to check against
-        uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
-        uint40 validatorIndex = uint40(getValidatorIndex());
-        uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
+    //     // Get params to check against
+    //     uint64 withdrawalTimestamp = withdrawalToProve.getWithdrawalTimestamp();
+    //     uint40 validatorIndex = uint40(getValidatorIndex());
+    //     uint64 withdrawalAmountGwei = withdrawalFields.getWithdrawalAmountGwei();
         
-        // Assert that partial withdrawal code path will be tested
-        assertLt(withdrawalToProve.getWithdrawalEpoch(), validatorFields.getWithdrawableEpoch(), "Withdrawal epoch should be less than the withdrawable epoch");
+    //     // Assert that partial withdrawal code path will be tested
+    //     assertLt(withdrawalToProve.getWithdrawalEpoch(), validatorFields.getWithdrawableEpoch(), "Withdrawal epoch should be less than the withdrawable epoch");
 
-        // Process partial withdrawal
-        vm.expectEmit(true, true, true, true);
-        emit PartialWithdrawalRedeemed(validatorIndex, withdrawalTimestamp, podOwner, withdrawalAmountGwei);
-        IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
-            beaconStateRoot,
-            withdrawalToProve,
-            validatorFieldsProof,
-            validatorFields,
-            withdrawalFields
-        );
+    //     // Process partial withdrawal
+    //     vm.expectEmit(true, true, true, true);
+    //     emit PartialWithdrawalRedeemed(validatorIndex, withdrawalTimestamp, podOwner, withdrawalAmountGwei);
+    //     IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.verifyAndProcessWithdrawal(
+    //         beaconStateRoot,
+    //         withdrawalToProve,
+    //         validatorFieldsProof,
+    //         validatorFields,
+    //         withdrawalFields
+    //     );
 
-        // Storage checks in _verifyAndProcessWithdrawal
-        bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
-        assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
+    //     // Storage checks in _verifyAndProcessWithdrawal
+    //     bytes32 validatorPubKeyHash = validatorFields.getPubkeyHash();
+    //     assertTrue(eigenPodHarness.provenWithdrawal(validatorPubKeyHash, withdrawalTimestamp), "Withdrawal not set to proven");
 
-        // Checks from  _processPartialWithdrawal
-        assertEq(eigenPod.sumOfPartialWithdrawalsClaimedGwei(), withdrawalAmountGwei, "Incorrect partial withdrawal amount");
-        assertEq(vw.amountToSendGwei, withdrawalAmountGwei, "Amount to send via router is not correct");
-        assertEq(vw.sharesDeltaGwei, 0, "Shares delta should be 0");
+    //     // Checks from  _processPartialWithdrawal
+    //     assertEq(eigenPod.sumOfPartialWithdrawalsClaimedGwei(), withdrawalAmountGwei, "Incorrect partial withdrawal amount");
+    //     assertEq(vw.amountToSendGwei, withdrawalAmountGwei, "Amount to send via router is not correct");
+    //     assertEq(vw.sharesDeltaGwei, 0, "Shares delta should be 0");
 
-        // Assert validator still has same restaked balance and status
-        IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
-        assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.ACTIVE), "Validator status should be active");
-        assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
-    }
+    //     // Assert validator still has same restaked balance and status
+    //     IEigenPod.ValidatorInfo memory validatorInfo = eigenPodHarness.validatorPubkeyHashToInfo(validatorFields[0]);
+    //     assertEq(uint8(validatorInfo.status), uint8(IEigenPod.VALIDATOR_STATUS.ACTIVE), "Validator status should be active");
+    //     assertEq(validatorInfo.restakedBalanceGwei, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR, "Restaked balance gwei should be max");
+    // }
 
-    function testFuzz_processFullWithdrawal(bytes32 pubkeyHash, uint64 restakedAmount, uint64 withdrawalAmount) public {
-        // Format validatorInfo struct
-        IEigenPod.ValidatorInfo memory validatorInfo = IEigenPod.ValidatorInfo({
-            validatorIndex: 0,
-            restakedBalanceGwei: restakedAmount,
-            mostRecentBalanceUpdateTimestamp: 0,
-            status: IEigenPod.VALIDATOR_STATUS.ACTIVE
-        });
+    // function testFuzz_processFullWithdrawal(bytes32 pubkeyHash, uint64 restakedAmount, uint64 withdrawalAmount) public {
+    //     // Format validatorInfo struct
+    //     IEigenPod.ValidatorInfo memory validatorInfo = IEigenPod.ValidatorInfo({
+    //         validatorIndex: 0,
+    //         restakedBalanceGwei: restakedAmount,
+    //         mostRecentBalanceUpdateTimestamp: 0,
+    //         status: IEigenPod.VALIDATOR_STATUS.ACTIVE
+    //     });
 
-        // Since we're withdrawing using an ACTIVE validator, ensure we have
-        // a validator count to decrement
-        uint activeValidatorCountBefore = 1 + eigenPodHarness.getActiveValidatorCount();
-        eigenPodHarness.setActiveValidatorCount(activeValidatorCountBefore);
+    //     // Since we're withdrawing using an ACTIVE validator, ensure we have
+    //     // a validator count to decrement
+    //     uint activeValidatorCountBefore = 1 + eigenPodHarness.getActiveValidatorCount();
+    //     eigenPodHarness.setActiveValidatorCount(activeValidatorCountBefore);
         
-        // Process full withdrawal.
-        IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.processFullWithdrawal(0, pubkeyHash, 0, podOwner, withdrawalAmount, validatorInfo);
+    //     // Process full withdrawal.
+    //     IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.processFullWithdrawal(0, pubkeyHash, 0, podOwner, withdrawalAmount, validatorInfo);
 
-        // Validate that our activeValidatorCount decreased
-        uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
-        assertEq(activeValidatorCountAfter, activeValidatorCountBefore - 1, "active validator count should decrease when withdrawing active validator");
+    //     // Validate that our activeValidatorCount decreased
+    //     uint activeValidatorCountAfter = eigenPodHarness.getActiveValidatorCount();
+    //     assertEq(activeValidatorCountAfter, activeValidatorCountBefore - 1, "active validator count should decrease when withdrawing active validator");
 
-        // Get expected amounts based on withdrawalAmount
-        uint64 amountETHToQueue;
-        uint64 amountETHToSend;
-        if (withdrawalAmount > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR){
-            amountETHToQueue = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-            amountETHToSend = withdrawalAmount - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
-        } else {
-            amountETHToQueue = withdrawalAmount;
-            amountETHToSend = 0;
-        }
+    //     // Get expected amounts based on withdrawalAmount
+    //     uint64 amountETHToQueue;
+    //     uint64 amountETHToSend;
+    //     if (withdrawalAmount > MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR){
+    //         amountETHToQueue = MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
+    //         amountETHToSend = withdrawalAmount - MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR;
+    //     } else {
+    //         amountETHToQueue = withdrawalAmount;
+    //         amountETHToSend = 0;
+    //     }
 
-        // Check invariant-> amountToQueue + amountToSend = withdrawalAmount
-        assertEq(vw.amountToSendGwei + eigenPod.withdrawableRestakedExecutionLayerGwei(), withdrawalAmount, "Amount to queue and send must add up to total withdrawal amount");
+    //     // Check invariant-> amountToQueue + amountToSend = withdrawalAmount
+    //     assertEq(vw.amountToSendGwei + eigenPod.withdrawableRestakedExecutionLayerGwei(), withdrawalAmount, "Amount to queue and send must add up to total withdrawal amount");
 
-        // Check amount to queue and send
-        assertEq(vw.amountToSendGwei, amountETHToSend, "Amount to queue is not correct");
-        assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), amountETHToQueue, "Incorrect withdrawable restaked execution layer gwei");
+    //     // Check amount to queue and send
+    //     assertEq(vw.amountToSendGwei, amountETHToSend, "Amount to queue is not correct");
+    //     assertEq(eigenPod.withdrawableRestakedExecutionLayerGwei(), amountETHToQueue, "Incorrect withdrawable restaked execution layer gwei");
 
-        // Check shares delta
-        int256 expectedSharesDelta = int256(uint256(amountETHToQueue)) - int256(uint256(restakedAmount));
-        assertEq(vw.sharesDeltaGwei, expectedSharesDelta, "Shares delta not correct");
+    //     // Check shares delta
+    //     int256 expectedSharesDelta = int256(uint256(amountETHToQueue)) - int256(uint256(restakedAmount));
+    //     assertEq(vw.sharesDeltaGwei, expectedSharesDelta, "Shares delta not correct");
 
-        // Storage checks
-        IEigenPod.ValidatorInfo memory validatorInfoAfter = eigenPodHarness.validatorPubkeyHashToInfo(pubkeyHash);
-        assertEq(uint8(validatorInfoAfter.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
-        assertEq(validatorInfoAfter.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
-    }
+    //     // Storage checks
+    //     IEigenPod.ValidatorInfo memory validatorInfoAfter = eigenPodHarness.validatorPubkeyHashToInfo(pubkeyHash);
+    //     assertEq(uint8(validatorInfoAfter.status), uint8(IEigenPod.VALIDATOR_STATUS.WITHDRAWN), "Validator status should be withdrawn");
+    //     assertEq(validatorInfoAfter.restakedBalanceGwei, 0, "Restaked balance gwei should be 0");
+    // }
 
-    function testFuzz_processFullWithdrawal_lessMaxRestakedBalance(bytes32 pubkeyHash, uint64 restakedAmount, uint64 withdrawalAmount) public {
-        withdrawalAmount = uint64(bound(withdrawalAmount, 0, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
-        testFuzz_processFullWithdrawal(pubkeyHash, restakedAmount, withdrawalAmount);
-    }
+    // function testFuzz_processFullWithdrawal_lessMaxRestakedBalance(bytes32 pubkeyHash, uint64 restakedAmount, uint64 withdrawalAmount) public {
+    //     withdrawalAmount = uint64(bound(withdrawalAmount, 0, MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR));
+    //     testFuzz_processFullWithdrawal(pubkeyHash, restakedAmount, withdrawalAmount);
+    // }
     
-    function testFuzz_processPartialWithdrawal(        
-        uint40 validatorIndex,
-        uint64 withdrawalTimestamp,
-        address recipient,
-        uint64 partialWithdrawalAmountGwei
-    ) public {
-        IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.processPartialWithdrawal(validatorIndex, withdrawalTimestamp, recipient, partialWithdrawalAmountGwei);
+    // function testFuzz_processPartialWithdrawal(        
+    //     uint40 validatorIndex,
+    //     uint64 withdrawalTimestamp,
+    //     address recipient,
+    //     uint64 partialWithdrawalAmountGwei
+    // ) public {
+    //     IEigenPod.VerifiedWithdrawal memory vw = eigenPodHarness.processPartialWithdrawal(validatorIndex, withdrawalTimestamp, recipient, partialWithdrawalAmountGwei);
 
-        // Checks
-        assertEq(eigenPod.sumOfPartialWithdrawalsClaimedGwei(), partialWithdrawalAmountGwei, "Incorrect partial withdrawal amount");
-        assertEq(vw.amountToSendGwei, partialWithdrawalAmountGwei, "Amount to send via router is not correct");
-        assertEq(vw.sharesDeltaGwei, 0, "Shares delta should be 0");
-    }
+    //     // Checks
+    //     assertEq(eigenPod.sumOfPartialWithdrawalsClaimedGwei(), partialWithdrawalAmountGwei, "Incorrect partial withdrawal amount");
+    //     assertEq(vw.amountToSendGwei, partialWithdrawalAmountGwei, "Amount to send via router is not correct");
+    //     assertEq(vw.sharesDeltaGwei, 0, "Shares delta should be 0");
+    // }
 
-    function _setWithdrawalProofParams() internal {
-        // Set validator index, beacon state root, balance update proof, and validator fields
-        beaconStateRoot = getBeaconStateRoot();
-        validatorFields = getValidatorFields();
-        validatorFieldsProof = abi.encodePacked(getValidatorProof());
-        withdrawalToProve = _getWithdrawalProof();  
-        withdrawalFields = getWithdrawalFields();
-    }
+    // function _setWithdrawalProofParams() internal {
+    //     // Set validator index, beacon state root, balance update proof, and validator fields
+    //     beaconStateRoot = getBeaconStateRoot();
+    //     validatorFields = getValidatorFields();
+    //     validatorFieldsProof = abi.encodePacked(getValidatorProof());
+    //     withdrawalToProve = _getWithdrawalProof();  
+    //     withdrawalFields = getWithdrawalFields();
+    // }
 
     /// @notice this function just generates a valid proof so that we can test other functionalities of the withdrawal flow
-    function _getWithdrawalProof() internal returns (BeaconChainProofs.WithdrawalProof memory) {
-        {
-            bytes32 blockRoot = getBlockRoot();
-            bytes32 slotRoot = getSlotRoot();
-            bytes32 timestampRoot = getTimestampRoot();
-            bytes32 executionPayloadRoot = getExecutionPayloadRoot();
-            bytes memory withdrawalProof = IS_DENEB ? abi.encodePacked(getWithdrawalProofDeneb()) : abi.encodePacked(getWithdrawalProofCapella());
-            bytes memory timestampProof = IS_DENEB ? abi.encodePacked(getTimestampProofDeneb()) : abi.encodePacked(getTimestampProofCapella());
-            return
-                BeaconChainProofs.WithdrawalProof(
-                    abi.encodePacked(withdrawalProof),
-                    abi.encodePacked(getSlotProof()),
-                    abi.encodePacked(getExecutionPayloadProof()),
-                    abi.encodePacked(timestampProof),
-                    abi.encodePacked(getHistoricalSummaryProof()),
-                    uint64(getBlockRootIndex()),
-                    uint64(getHistoricalSummaryIndex()),
-                    uint64(getWithdrawalIndex()),
-                    blockRoot,
-                    slotRoot,
-                    timestampRoot,
-                    executionPayloadRoot
-                );
-        }
-    }
+    // function _getWithdrawalProof() internal returns (BeaconChainProofs.WithdrawalProof memory) {
+    //     {
+    //         bytes32 blockRoot = getBlockRoot();
+    //         bytes32 slotRoot = getSlotRoot();
+    //         bytes32 timestampRoot = getTimestampRoot();
+    //         bytes32 executionPayloadRoot = getExecutionPayloadRoot();
+    //         bytes memory withdrawalProof = IS_DENEB ? abi.encodePacked(getWithdrawalProofDeneb()) : abi.encodePacked(getWithdrawalProofCapella());
+    //         bytes memory timestampProof = IS_DENEB ? abi.encodePacked(getTimestampProofDeneb()) : abi.encodePacked(getTimestampProofCapella());
+    //         return
+    //             BeaconChainProofs.WithdrawalProof(
+    //                 abi.encodePacked(withdrawalProof),
+    //                 abi.encodePacked(getSlotProof()),
+    //                 abi.encodePacked(getExecutionPayloadProof()),
+    //                 abi.encodePacked(timestampProof),
+    //                 abi.encodePacked(getHistoricalSummaryProof()),
+    //                 uint64(getBlockRootIndex()),
+    //                 uint64(getHistoricalSummaryIndex()),
+    //                 uint64(getWithdrawalIndex()),
+    //                 blockRoot,
+    //                 slotRoot,
+    //                 timestampRoot,
+    //                 executionPayloadRoot
+    //             );
+    //     }
+    // }
 
     ///@notice Effective balance is > 32 ETH
     modifier setWithdrawalCredentialsExcess() {

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -177,35 +177,35 @@ contract EigenPodUnitTests_PodOwnerFunctions is EigenPodUnitTests, IEigenPodEven
                             Withdraw Non Beacon Chain ETH Tests
     *******************************************************************************/
 
-    function testFuzz_withdrawNonBeaconChainETH_revert_notPodOwner(address invalidCaller) public {
-        cheats.assume(invalidCaller != podOwner);
+    // function testFuzz_withdrawNonBeaconChainETH_revert_notPodOwner(address invalidCaller) public {
+    //     cheats.assume(invalidCaller != podOwner);
 
-        cheats.prank(invalidCaller);
-        cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
-        eigenPod.withdrawNonBeaconChainETHBalanceWei(invalidCaller, 1 ether);
-    }
+    //     cheats.prank(invalidCaller);
+    //     cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
+    //     eigenPod.withdrawNonBeaconChainETHBalanceWei(invalidCaller, 1 ether);
+    // }
 
-    function test_withdrawNonBeaconChainETH_revert_tooMuchWithdrawn() public {
-        // Send EigenPod 0.9 ether
-        _seedPodWithETH(0.9 ether);
+    // function test_withdrawNonBeaconChainETH_revert_tooMuchWithdrawn() public {
+    //     // Send EigenPod 0.9 ether
+    //     _seedPodWithETH(0.9 ether);
 
-        // Withdraw 1 ether
-        cheats.expectRevert("EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
-        eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, 1 ether);
-    }
+    //     // Withdraw 1 ether
+    //     cheats.expectRevert("EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
+    //     eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, 1 ether);
+    // }
 
-    function testFuzz_withdrawNonBeaconChainETH(uint256 ethAmount) public {
-        _seedPodWithETH(ethAmount);
-        assertEq(eigenPod.nonBeaconChainETHBalanceWei(), ethAmount, "Incorrect amount incremented in receive function");
+    // function testFuzz_withdrawNonBeaconChainETH(uint256 ethAmount) public {
+    //     _seedPodWithETH(ethAmount);
+    //     assertEq(eigenPod.nonBeaconChainETHBalanceWei(), ethAmount, "Incorrect amount incremented in receive function");
 
-        cheats.expectEmit(true, true, true, true);
-        emit NonBeaconChainETHWithdrawn(podOwner, ethAmount);
-        eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, ethAmount);
+    //     cheats.expectEmit(true, true, true, true);
+    //     emit NonBeaconChainETHWithdrawn(podOwner, ethAmount);
+    //     eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, ethAmount);
 
-        // Checks
-        assertEq(address(eigenPod).balance, 0, "Incorrect amount withdrawn from eigenPod");
-        assertEq(address(delayedWithdrawalRouterMock).balance, ethAmount, "Incorrect amount set to delayed withdrawal router");
-    }
+    //     // Checks
+    //     assertEq(address(eigenPod).balance, 0, "Incorrect amount withdrawn from eigenPod");
+    //     assertEq(address(delayedWithdrawalRouterMock).balance, ethAmount, "Incorrect amount set to delayed withdrawal router");
+    // }
 
     /*******************************************************************************
                                   Recover Tokens Tests
@@ -270,19 +270,19 @@ contract EigenPodUnitTests_PodOwnerFunctions is EigenPodUnitTests, IEigenPodEven
         eigenPod.activateRestaking();
     }
 
-    function testFuzz_activateRestaking(uint256 ethAmount) public hasNotRestaked {
-        // Seed some ETH
-        _seedPodWithETH(ethAmount);
+    // function testFuzz_activateRestaking(uint256 ethAmount) public hasNotRestaked {
+    //     // Seed some ETH
+    //     _seedPodWithETH(ethAmount);
 
-        // Activate restaking
-        vm.expectEmit(true, true, true, true);
-        emit RestakingActivated(podOwner);
-        eigenPod.activateRestaking();
+    //     // Activate restaking
+    //     vm.expectEmit(true, true, true, true);
+    //     emit RestakingActivated(podOwner);
+    //     eigenPod.activateRestaking();
 
-        // Checks
-        assertTrue(eigenPod.hasRestaked(), "hasRestaked incorrectly set");
-        _assertWithdrawalProcessed(ethAmount);
-    }
+    //     // Checks
+    //     assertTrue(eigenPod.hasRestaked(), "hasRestaked incorrectly set");
+    //     _assertWithdrawalProcessed(ethAmount);
+    // }
 
     /**
      * This is a regression test for a bug (EIG-14) found by Hexens.  Lets say podOwner sends 32 ETH to the EigenPod, 
@@ -293,67 +293,67 @@ contract EigenPodUnitTests_PodOwnerFunctions is EigenPodUnitTests, IEigenPodEven
      * And simply withdraw the 32ETH because nonBeaconChainETHBalanceWei is 32ETH.  This was an issue because 
      * nonBeaconChainETHBalanceWei was never zeroed out in _processWithdrawalBeforeRestaking
      */
-    function test_regression_validatorBalance_cannotBeRemoved_viaNonBeaconChainETHBalanceWei() external hasNotRestaked {
-        // Assert that the pod has not restaked
-        assertFalse(eigenPod.hasRestaked(), "hasRestaked should be false");
+    // function test_regression_validatorBalance_cannotBeRemoved_viaNonBeaconChainETHBalanceWei() external hasNotRestaked {
+    //     // Assert that the pod has not restaked
+    //     assertFalse(eigenPod.hasRestaked(), "hasRestaked should be false");
 
-        // Simulate podOwner sending 32 ETH to eigenPod
-        _seedPodWithETH(32 ether);
-        assertEq(eigenPod.nonBeaconChainETHBalanceWei(), 32 ether, "nonBeaconChainETHBalanceWei should be 32 ETH");
+    //     // Simulate podOwner sending 32 ETH to eigenPod
+    //     _seedPodWithETH(32 ether);
+    //     assertEq(eigenPod.nonBeaconChainETHBalanceWei(), 32 ether, "nonBeaconChainETHBalanceWei should be 32 ETH");
 
-        // Pod owner calls withdrawBeforeRestaking, sending 32 ETH to owner
-        eigenPod.withdrawBeforeRestaking();
-        assertEq(address(eigenPod).balance, 0, "eigenPod balance should be 0");
-        assertEq(address(delayedWithdrawalRouterMock).balance, 32 ether, "withdrawal router balance should be 32 ETH");
+    //     // Pod owner calls withdrawBeforeRestaking, sending 32 ETH to owner
+    //     eigenPod.withdrawBeforeRestaking();
+    //     assertEq(address(eigenPod).balance, 0, "eigenPod balance should be 0");
+    //     assertEq(address(delayedWithdrawalRouterMock).balance, 32 ether, "withdrawal router balance should be 32 ETH");
 
-        // Upgrade from m1 to m2
+    //     // Upgrade from m1 to m2
 
-        // Activate restaking on the pod
-        eigenPod.activateRestaking();
+    //     // Activate restaking on the pod
+    //     eigenPod.activateRestaking();
 
-        // Simulate a withdrawal by increasing eth balance without code execution
-        cheats.deal(address(eigenPod), 32 ether);
+    //     // Simulate a withdrawal by increasing eth balance without code execution
+    //     cheats.deal(address(eigenPod), 32 ether);
 
-        // Try calling withdrawNonBeaconChainETHBalanceWei, should fail since `nonBeaconChainETHBalanceWei` 
-        // was set to 0 when calling `_processWithdrawalBeforeRestaking` from `activateRestaking` 
-        cheats.expectRevert("EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
-        eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, 32 ether);
-    }
+    //     // Try calling withdrawNonBeaconChainETHBalanceWei, should fail since `nonBeaconChainETHBalanceWei` 
+    //     // was set to 0 when calling `_processWithdrawalBeforeRestaking` from `activateRestaking` 
+    //     cheats.expectRevert("EigenPod.withdrawnonBeaconChainETHBalanceWei: amountToWithdraw is greater than nonBeaconChainETHBalanceWei");
+    //     eigenPod.withdrawNonBeaconChainETHBalanceWei(podOwner, 32 ether);
+    // }
     
     /*******************************************************************************
                         Withdraw Before Restaking Tests
     *******************************************************************************/
 
-    function testFuzz_withdrawBeforeRestaking_revert_notPodOwner(address invalidCaller) public filterFuzzedAddressInputs(invalidCaller) {
-        cheats.assume(invalidCaller != podOwner);
+    // function testFuzz_withdrawBeforeRestaking_revert_notPodOwner(address invalidCaller) public filterFuzzedAddressInputs(invalidCaller) {
+    //     cheats.assume(invalidCaller != podOwner);
 
-        cheats.prank(invalidCaller);
-        cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
-        eigenPod.withdrawBeforeRestaking();
-    }
+    //     cheats.prank(invalidCaller);
+    //     cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
+    //     eigenPod.withdrawBeforeRestaking();
+    // }
 
-    function test_withdrawBeforeRestaking_revert_alreadyRestaked() public {
-        cheats.expectRevert("EigenPod.hasNeverRestaked: restaking is enabled");
-        eigenPod.withdrawBeforeRestaking();
-    }
+    // function test_withdrawBeforeRestaking_revert_alreadyRestaked() public {
+    //     cheats.expectRevert("EigenPod.hasNeverRestaked: restaking is enabled");
+    //     eigenPod.withdrawBeforeRestaking();
+    // }
 
-    function testFuzz_withdrawBeforeRestaking(uint256 ethAmount) public hasNotRestaked {
-        // Seed some ETH
-        _seedPodWithETH(ethAmount);
+    // function testFuzz_withdrawBeforeRestaking(uint256 ethAmount) public hasNotRestaked {
+    //     // Seed some ETH
+    //     _seedPodWithETH(ethAmount);
 
-        // Withdraw
-        eigenPod.withdrawBeforeRestaking();
+    //     // Withdraw
+    //     eigenPod.withdrawBeforeRestaking();
 
-        // Checks
-        _assertWithdrawalProcessed(ethAmount);
-    }
+    //     // Checks
+    //     _assertWithdrawalProcessed(ethAmount);
+    // }
 
     // Helpers
-    function _assertWithdrawalProcessed(uint256 amount) internal {
-        assertEq(eigenPod.mostRecentWithdrawalTimestamp(), uint32(block.timestamp), "Incorrect mostRecentWithdrawalTimestamp");
-        assertEq(eigenPod.nonBeaconChainETHBalanceWei(), 0, "Incorrect nonBeaconChainETHBalanceWei");
-        assertEq(address(delayedWithdrawalRouterMock).balance, amount, "Incorrect amount sent to delayed withdrawal router");
-    }
+    // function _assertWithdrawalProcessed(uint256 amount) internal {
+    //     assertEq(eigenPod.mostRecentWithdrawalTimestamp(), uint32(block.timestamp), "Incorrect mostRecentWithdrawalTimestamp");
+    //     assertEq(eigenPod.nonBeaconChainETHBalanceWei(), 0, "Incorrect nonBeaconChainETHBalanceWei");
+    //     assertEq(address(delayedWithdrawalRouterMock).balance, amount, "Incorrect amount sent to delayed withdrawal router");
+    // }
 
     function _seedPodWithETH(uint256 ethAmount) internal {
         cheats.deal(address(this), ethAmount);


### PR DESCRIPTION
This PR shows an example of how we can track the amount of exited validator balance in a checkpoint.

The problem for LRTs is that they need to track ETH exiting the EigenPod and treat rewards generated from staking vs exited validators differently from the protocol contracts.  For example, many LRTs take a protocol fee (e.g. 10%) from the rewards generated from staking and should NOT take this same fee from ETH leaving the EigenPod due to a validator exit.

This is just a quick example of how we could track it:
* Do not delete the last checkpoint when it is finished.  This allows the EigenPod owner to ensure that they have captured the expected amount of ETH from the previous checkpoint before starting a new one.
* In `_verifyCheckpointProof()`, if the validator is marked as exited, return the balance delta
* In the `CheckPoint` struct, track the exited balance delta in addition to the total