### PR TITLE
fix: defend against checkpoint proof griefing

### DIFF
--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -175,7 +175,7 @@ contract EigenPod is
 
     /**
      * @dev Progress the current checkpoint towards completion by submitting one or more validator
-     * checkpoint proofs. Anyone can call this method to submit proofs towards the current checkpoint.
+     * checkpoint proofs. Only the pod owner can call this method to submit proofs towards the current checkpoint.
      * For each validator proven, the current checkpoint's `proofsRemaining` decreases.
      * @dev If the checkpoint's `proofsRemaining` reaches 0, the checkpoint is finalized.
      * (see `_updateCheckpoint` for more details)
@@ -188,6 +188,7 @@ contract EigenPod is
         BeaconChainProofs.BalanceProof[] calldata proofs
     ) 
         external 
+        onlyEigenPodOwner() 
         onlyWhenNotPaused(PAUSED_EIGENPODS_VERIFY_CHECKPOINT_PROOFS) 
     {
         uint64 beaconTimestamp = currentCheckpointTimestamp;


### PR DESCRIPTION
Currently `EigenPod::verifyCheckpointProofs` is a function used to batch checkpoint proof submissions.

It is important to note that anyone can submit proofs directly to EigenPod for proof verification. If a validator balance update has already been verified in a started checkpoint, any subsequent call for re-verification will revert.

Because of this an attacker might construct a griefing attack that effectively DOS'es an LRT protocol's attempt to verify proofs for a batch of validators.

All the attacker has to do is to keep watching the mempool & simply front-run the batch verification transaction by submitting a proof for just one single validator in the batch.

When the actual transaction comes for execution, entire batch fails as one of the  proofs is already verified.

To prevent this, I am proposing modifying `EigenPod::verifyCheckpointProofs` so that only the pod owner can make checkpoint proof submissions.