### PR TITLE
fix: disallow null stake delegations

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -536,7 +536,8 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         (IStrategy[] memory strategies, uint256[] memory shares)
             = getDelegatableShares(staker);
-
+        // check if the staker has any shares to delegate
+        require(strategies.length == 0, "DelegationManager._delegate: staker has no shares");
         for (uint256 i = 0; i < strategies.length;) {
             _increaseOperatorShares({
                 operator: operator,


### PR DESCRIPTION
This check will prevent stakers from delegating if they don't have any stake, in unity with the Eigenlayer frontend. 
This will prevent unintended behavior of users and downstream edge case handling for payments (eg: not giving rewards to stakers who have 0 stake from the operator's earnings reciever address.) 


@samlaf