### PR TITLE
fix: undelegating staker from operator on a full withdrawl

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -737,6 +737,13 @@ contract DelegationManager is Initializable, OwnableUpgradeable, Pausable, Deleg
 
         // Place withdrawal in queue
         pendingWithdrawals[withdrawalRoot] = true;
+        
+        // if the staker has no more shares, undelegate them from the operator
+        if (strategyManager.stakerStrategyListLength(staker) == 0) {
+            // undelegate the staker
+            emit StakerUndelegated(staker, operator);
+            delegatedTo[staker] = address(0);
+        }
 
         emit WithdrawalQueued(withdrawalRoot, withdrawal);
         return withdrawalRoot;


### PR DESCRIPTION
Complementary PR to #557 , undelegates a staker from the operator in the case of a full withdrawal 

@samlaf 