### PR TITLE
feat: remove activateRestaking in favor of startCheckpoint

### DIFF
--- a/script/deploy/mainnet/M2Deploy.s.sol
+++ b/script/deploy/mainnet/M2Deploy.s.sol
@@ -425,10 +425,6 @@ contract M2Deploy is Script, Test {
         );
         require(eigenPodManager.hasPod(eigenPodDepositor) == hasPod, "eigenPodManager.hasPod incorrect");
         require(eigenPod.podOwner() == eigenPodOwner, "eigenPod.podOwner incorrect");
-        require(
-            eigenPod.mostRecentWithdrawalTimestamp() == mostRecentWithdrawalBlock,
-            "eigenPod.mostRecentWithdrawalTimestamp incorrect"
-        ); // Timestmap replace by block number in storage
         require(!eigenPod.hasRestaked(), "eigenPod.hasRestaked incorrect");
 
         // Unpause eigenpods verify credentials
@@ -444,19 +440,11 @@ contract M2Deploy is Script, Test {
         cheats.prank(eigenPodOwner);
         cheats.expectEmit(true, true, true, true);
         emit RestakingActivated(eigenPodOwner);
-        eigenPod.activateRestaking();
+        eigenPod.startCheckpoint(false);
 
         // Check updated storage values
         require(eigenPod.hasRestaked(), "eigenPod.hasRestaked not set to true");
         require(address(eigenPod).balance == 0, "eigenPod balance not 0 after activating restaking");
-        require(
-            eigenPod.mostRecentWithdrawalTimestamp() == block.timestamp,
-            "eigenPod.mostRecentWithdrawalTimestamp not updated"
-        );
-        require(
-            eigenPod.mostRecentWithdrawalTimestamp() > mostRecentWithdrawalBlock,
-            "eigenPod.mostRecentWithdrawalTimestamp not updated"
-        );
 
         // Check that delayed withdrawal has been created
         require(
@@ -501,13 +489,11 @@ contract M2Deploy is Script, Test {
     // Existing EigenPod owner – EigenPodManager.ownerToPod remains the same
     // Existing EigenPod owner –  EigenPodManager.hasPod remains the same
     // Existing EigenPod owner –  EigenPod.podOwner remains the same
-    // Existing EigenPod owner –  EigenPod.mostRecentWithdrawalTimestamp (after upgrade) == EigenPod.mostRecentWithdrawalBlock (before upgrade)
     // Existing EigenPod owner – EigenPod.hasRestaked remains false
     // Can call EigenPod.activateRestaking and it correctly:
     // Sends all funds in EigenPod (need to make sure it has nonzero balance beforehand)
     // Sets `hasRestaked` to ‘true’
     // Emits a ‘RestakingActivated’ event
-    // EigenPod.mostRecentWithdrawalTimestamp updates correctly
     // EigenPod: ethPOS, delayedWithdrawalRouter, eigenPodManager
     event RestakingActivated(address indexed podOwner);
 }

--- a/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
+++ b/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
@@ -322,7 +322,7 @@ contract Queue_M2_Upgrade is M2_Mainnet_Upgrade, TimelockEncoding {
         bytes[] memory validatorFieldsProofs;
         bytes32[][] memory validatorFields;
         cheats.startPrank(existingEigenPod.podOwner());
-        existingEigenPod.activateRestaking();
+        existingEigenPod.startCheckpoint(false);
         cheats.expectRevert("EigenPodManager.getBlockRootAtTimestamp: state root at timestamp not yet finalized");
         existingEigenPod.verifyWithdrawalCredentials(
             uint64(block.timestamp),

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -102,14 +102,8 @@ interface IEigenPod {
     function podOwner() external view returns (address);
 
     /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
+    /// TODO
     function hasRestaked() external view returns (bool);
-
-    /**
-     * @notice The latest timestamp at which the pod owner withdrew the balance of the pod, via calling `withdrawBeforeRestaking`.
-     * @dev This variable is only updated when the `withdrawBeforeRestaking` function is called, which can only occur before `hasRestaked` is set to true for this pod.
-     * Proofs for this pod are only valid against Beacon Chain state roots corresponding to timestamps after the stored `mostRecentWithdrawalTimestamp`.
-     */
-    function mostRecentWithdrawalTimestamp() external view returns (uint64);
 
     /// @notice Returns the validatorInfo struct for the provided pubkeyHash
     function validatorPubkeyHashToInfo(bytes32 validatorPubkeyHash) external view returns (ValidatorInfo memory);
@@ -211,13 +205,6 @@ interface IEigenPod {
         BeaconChainProofs.ValidatorProof calldata proof
     )
         external;
-
-    /**
-     * @notice Called by the pod owner to activate restaking by withdrawing
-     * all existing ETH from the pod and preventing further withdrawals via
-     * "withdrawBeforeRestaking()"
-     */
-    function activateRestaking() external;
 
     /// @notice called by owner of a pod to remove any ERC20s deposited in the pod
     function recoverTokens(IERC20[] memory tokenList, uint256[] memory amountsToWithdraw, address recipient) external;

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -102,7 +102,6 @@ interface IEigenPod {
     function podOwner() external view returns (address);
 
     /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
-    /// TODO
     function hasRestaked() external view returns (bool);
 
     /// @notice Returns the validatorInfo struct for the provided pubkeyHash

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -113,13 +113,7 @@ contract EigenPod is
     function initialize(address _podOwner) external initializer {
         require(_podOwner != address(0), "EigenPod.initialize: podOwner cannot be zero address");
         podOwner = _podOwner;
-        /**
-         * From the M2 deployment onwards, we are requiring that pods deployed are by default enabled with restaking
-         * In prior deployments without proofs, EigenPods could be deployed with restaking disabled so as to allow
-         * simple (proof-free) withdrawals.  However, this is no longer the case.  Thus going forward, all pods are
-         * initialized with hasRestaked set to true.
-         */
-        
+
         /// Pods deployed prior to the M2 release have this variable set to `false`, as before M2, pod owners
         /// did not need to engage with the proof system and were able to withdraw ETH from their pod on demand.
         hasRestaked = true;

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -13,14 +13,12 @@ abstract contract EigenPodStorage is IEigenPod {
      * @dev This variable is only updated when the `withdrawBeforeRestaking` function is called, which can only occur before `hasRestaked` is set to true for this pod.
      * Proofs for this pod are only valid against Beacon Chain state roots corresponding to timestamps after the stored `mostRecentWithdrawalTimestamp`.
      */
-    // TODO
     uint64 internal __deprecated_mostRecentWithdrawalTimestamp;
 
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from the Beacon Chain but not from EigenLayer),
     uint64 public withdrawableRestakedExecutionLayerGwei;
 
     /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
-    /// TODO
     bool public hasRestaked;
 
     /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -13,12 +13,14 @@ abstract contract EigenPodStorage is IEigenPod {
      * @dev This variable is only updated when the `withdrawBeforeRestaking` function is called, which can only occur before `hasRestaked` is set to true for this pod.
      * Proofs for this pod are only valid against Beacon Chain state roots corresponding to timestamps after the stored `mostRecentWithdrawalTimestamp`.
      */
-    uint64 public mostRecentWithdrawalTimestamp;
+    // TODO
+    uint64 internal __deprecated_mostRecentWithdrawalTimestamp;
 
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from the Beacon Chain but not from EigenLayer),
     uint64 public withdrawableRestakedExecutionLayerGwei;
 
     /// @notice an indicator of whether or not the podOwner has ever "fully restaked" by successfully calling `verifyCorrectWithdrawalCredentials`.
+    /// TODO
     bool public hasRestaked;
 
     /// @notice This is a mapping of validatorPubkeyHash to timestamp to whether or not they have proven a withdrawal for that timestamp

--- a/src/test/EigenPod.t.sol
+++ b/src/test/EigenPod.t.sol
@@ -377,7 +377,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
         // activate restaking
         cheats.startPrank(podOwner);
-        newPod.activateRestaking();
+        newPod.startCheckpoint(false);
 
         // Ensure verifyWC fails for each slot remaining in the epoch
         for (uint i = 0; i < 32; i++) {
@@ -945,7 +945,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
         cheats.startPrank(podOwner);
         if (!newPod.hasRestaked()) {
-            newPod.activateRestaking();
+            newPod.startCheckpoint(false);
         }
         // set oracle block root
         _setOracleBlockRoot();
@@ -1680,7 +1680,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
         cheats.startPrank(_podOwner);
         cheats.warp(timestamp);
         if (newPod.hasRestaked() == false) {
-            newPod.activateRestaking();
+            newPod.startCheckpoint(false);
         }
         //set the oracle block root
         _setOracleBlockRoot();
@@ -1728,7 +1728,7 @@ contract EigenPodTests is ProofParsing, EigenPodPausingConstants {
 
     function _verifyWCStartTimestamp(IEigenPod pod) internal  returns (uint64) {
         uint64 genesis = EigenPod(payable(address(pod))).GENESIS_TIME();
-        uint64 activateRestakingTimestamp = pod.mostRecentWithdrawalTimestamp();
+        uint64 activateRestakingTimestamp;
 
         // For pods deployed after M2, `mostRecentWithdrawalTimestamp` will always be 0
         // In order to give our `_nextEpochStartTimestamp` a sane calculation, we set it

--- a/src/test/harnesses/EigenPodHarness.sol
+++ b/src/test/harnesses/EigenPodHarness.sol
@@ -47,8 +47,4 @@ contract EPInternalFunctions is EigenPod, Test {
     function setValidatorRestakedBalance(bytes32 pkhash, uint64 restakedBalanceGwei) public {
         _validatorPubkeyHashToInfo[pkhash].restakedBalanceGwei = restakedBalanceGwei;
     }
-
-    function setMostRecentWithdrawalTimestamp(uint64 _mostRecentWithdrawalTimestamp) public {
-        mostRecentWithdrawalTimestamp = _mostRecentWithdrawalTimestamp;
-    }
- }
+}

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -116,7 +116,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
             // Enable restaking for stakers' pods
             for (uint i = 0; i < stakersToMigrate.length; i++) {
-                stakersToMigrate[i].activateRestaking();
+                stakersToMigrate[i].startCheckpoint();
             }
 
             // Register operators with DelegationManager

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -315,19 +315,6 @@ contract User is PrintUtils {
         });
     }
 
-    /// @notice We set the proof generation start time to be after the timestamp that pod restaking is activated
-    /// We do this to prevent proofIsForValidTimestamp modifier from reverting
-    /// TODO remove
-    function activateRestaking() public createSnapshot {
-        _logM("activateRestaking");
-        
-        // _log("pre-activation, most recent wd timestamp", uint(pod.mostRecentWithdrawalTimestamp()));
-
-        pod.activateRestaking();
-
-        // _log("post-activation, most recent wd timestamp", pod.mostRecentWithdrawalTimestamp());
-    }
-
     /*******************************************************************************
                               STRATEGYMANAGER METHODS
     *******************************************************************************/

--- a/src/test/unit/EigenPod-PodManagerUnit.t.sol
+++ b/src/test/unit/EigenPod-PodManagerUnit.t.sol
@@ -125,7 +125,6 @@ contract EigenPod_PodManager_UnitTests_EigenPodPausing is EigenPod_PodManager_Un
      * 1. verifyBalanceUpdates revert when PAUSED_EIGENPODS_VERIFY_BALANCE_UPDATE set
      * 2. verifyAndProcessWithdrawals revert when PAUSED_EIGENPODS_VERIFY_WITHDRAWAL set
      * 3. verifyWithdrawalCredentials revert when PAUSED_EIGENPODS_VERIFY_CREDENTIALS set
-     * 4. activateRestaking revert when PAUSED_EIGENPODS_VERIFY_CREDENTIALS set
      */
 
     /// @notice Index for flag that pauses creation of new EigenPods when set. See EigenPodManager code for details.
@@ -202,15 +201,15 @@ contract EigenPod_PodManager_UnitTests_EigenPodPausing is EigenPod_PodManager_Un
         );
     }
 
-    function test_activateRestaking_revert_pausedEigenVerifyCredentials() public {
-        // pause the contract
-        cheats.prank(address(pauser));
-        eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_CREDENTIALS);
+    // function test_activateRestaking_revert_pausedEigenVerifyCredentials() public {
+    //     // pause the contract
+    //     cheats.prank(address(pauser));
+    //     eigenPodManager.pause(2 ** PAUSED_EIGENPODS_VERIFY_CREDENTIALS);
 
-        cheats.prank(address(podOwner));
-        cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
-        eigenPod.activateRestaking();
-    }
+    //     cheats.prank(address(podOwner));
+    //     cheats.expectRevert(bytes("EigenPod.onlyWhenNotPaused: index is paused in EigenPodManager"));
+    //     eigenPod.activateRestaking();
+    // }
 }
 
 contract EigenPod_PodManager_UnitTests_EigenPod is EigenPod_PodManager_UnitTests {

--- a/src/test/unit/EigenPodUnit.t.sol
+++ b/src/test/unit/EigenPodUnit.t.sol
@@ -255,18 +255,18 @@ contract EigenPodUnitTests_PodOwnerFunctions is EigenPodUnitTests, IEigenPodEven
                              Activate Restaking Tests
     *******************************************************************************/
 
-    function testFuzz_activateRestaking_revert_notPodOwner(address invalidCaller) public {
-        cheats.assume(invalidCaller != podOwner);
+    // function testFuzz_activateRestaking_revert_notPodOwner(address invalidCaller) public {
+    //     cheats.assume(invalidCaller != podOwner);
 
-        cheats.prank(invalidCaller);
-        cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
-        eigenPod.activateRestaking();
-    }
+    //     cheats.prank(invalidCaller);
+    //     cheats.expectRevert("EigenPod.onlyEigenPodOwner: not podOwner");
+    //     eigenPod.activateRestaking();
+    // }
 
-    function test_activateRestaking_revert_alreadyRestaked() public {
-        cheats.expectRevert("EigenPod.hasNeverRestaked: restaking is enabled");
-        eigenPod.activateRestaking();
-    }
+    // function test_activateRestaking_revert_alreadyRestaked() public {
+    //     cheats.expectRevert("EigenPod.hasNeverRestaked: restaking is enabled");
+    //     eigenPod.activateRestaking();
+    // }
 
     // function testFuzz_activateRestaking(uint256 ethAmount) public hasNotRestaked {
     //     // Seed some ETH


### PR DESCRIPTION
This PR:
*  removes `EigenPod.activateRestaking` in favor of having the pod owner call `EigenPod.startCheckpoint`
* deprecates `EigenPod.mostRecentWithdrawalTimestamp`

Rationale:
* Removes a method from the interface, simplifying frontend support for Pre-M2 pods

Notes:

This changes `verifyWithdrawalCredentials` to no longer use `mostRecentWithdrawalTimestamp` to determine whether a proof timestamp is valid. This is the riskiest change in this PR and needs some thinking to ensure this doesn't miss any edge cases.

Comparing with the M2 usage of `mostRecentWithdrawalTimestamp`:
1. `verifyAndProcessWithdrawals` makes some requirements on `mostRecentWithdrawalTimestamp`, but this method has been removed entirely in the checkpoint system.
2. `verifyWithdrawalCredentials` requires that `mostRecentWithdrawalTimestamp == 0` OR that `oracleTimestamp >= _nextEpochStartTimestamp(mostRecentWithdrawalTimestamp)`

`mostRecentWithdrawalTimestamp` will always be 0 for post-M2 pods. For pre-M2 pods, `mostRecentWithdrawalTimestamp` matches the block timestamp when `activateRestaking` is called. We want `oracleTimestamp` to be greater than this value to ensure that withdrawal credentials cannot be verified if the validator has already exited.

However, since the checkpoint proofs version of `verifyWithdrawalCredentials`:
* requires that the validator in question does NOT have an exit epoch set
* uses EIP-4788 oracle to only allow proofs from the last 24 hours of blocks

... and because the minimum withdrawal delay is 256 epochs (~27 hours), we know that if `verifyWithdrawalCredentials` succeeds for a validator, then that validator must still be on the beacon chain.