### PR TITLE
Chore: Turn on code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,85 @@
+name: Run Coverage
+
+on:
+  push:
+  workflow_dispatch: {}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+  run-tests:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Load issue number
+      uses: actions/github-script@v6
+      id: get_issue_number
+      with:
+        script: |
+          if (context.issue.number) {
+            // Return issue number if present
+            return context.issue.number;
+          } else {
+            // Otherwise return issue number from commit
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0].number;
+          }
+        result-encoding: string
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install lcov
+      run: |
+        sudo apt-get install lcov
+      id: lcov
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
+    - name: Run coverage
+      run: forge coverage --report lcov
+    - name: Prune coverage report
+      run: lcov --remove ./lcov.info -o ./lcov.info.pruned 'src/test/*' 'script/*' --ignore-errors inconsistent
+    - name: Generate reports
+      run: genhtml -o report ./lcov.info.pruned
+    - name: Upload coverage results (s3 link here)
+      uses: actions/upload-artifact@v4
+      with:
+        name: code-coverage-report
+        path: report/*
+    - name: View Coverage (text here)
+      id: print_coverage
+      run: |
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "comment_contents<<$EOF" >> $GITHUB_OUTPUT
+        echo "$(lcov --list ./lcov.info.pruned --ignore-errors inconsistent)" >> $GITHUB_OUTPUT
+        echo "$EOF" >> $GITHUB_OUTPUT
+    - name: Comment the full report
+      uses: actions/github-script@v7
+      with:
+        script: |
+          let body = `${{ steps.print_coverage.outputs.comment_contents }}`;
+          github.rest.issues.createComment({
+            issue_number: ${{ steps.get_issue_number.outputs.result }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `
+            \`\`\`
+            ${body}
+            \`\`\`
+            `
+          })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "chalk": "^4.1.0",
         "dotenv": "^16.3.1",
         "fs": "^0.0.1-security",
-        "hardhat": "^2.12.4",
+        "hardhat": "^2.22.4",
         "hardhat-preprocessor": "^0.1.5",
         "husky": "^8.0.3",
         "ts-node": "^10.9.1",
@@ -977,270 +977,118 @@
         }
       ]
     },
-    "node_modules/@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+    "node_modules/@nomicfoundation/edr": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.0.tgz",
+      "integrity": "sha512-T96DMSogO8TCdbKKctvxfsDljbhFOUKWc9fHJhSeUh71EEho2qR4951LKQF7t7UWEzguVYh/idQr5L/E3QeaMw==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
+        "@nomicfoundation/edr-darwin-arm64": "0.4.0",
+        "@nomicfoundation/edr-darwin-x64": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-musl": "0.4.0",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.4.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "abstract-level": "^1.0.3",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "level": "^8.0.0",
-        "lru-cache": "^5.1.1",
-        "memory-level": "^1.0.0"
-      },
+    "node_modules/@nomicfoundation/edr-darwin-arm64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-7+rraFk9tCqvfemv9Ita5vTlSBAeO/S5aDKOgGRgYt0JEKZlrX161nDW6UfzMPxWl9GOLEDUzCEaYuNmXseUlg==",
       "engines": {
-        "node": ">=14"
+        "node": ">= 18"
       }
     },
-    "node_modules/@nomicfoundation/ethereumjs-blockchain/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+    "node_modules/@nomicfoundation/edr-darwin-x64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-+Hrc0mP9L6vhICJSfyGo/2taOToy1AIzVZawO3lU8Lf7oDQXfhQ4UkZnkWAs9SVu1eUwHUGGGE0qB8644piYgg==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-4HUDMchNClQrVRfVTqBeSX92hM/3khCgpZkXP52qrnJPqgbdCxosOehlQYZ65wu0b/kaaZSyvACgvCLSQ5oSzQ==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-D4J935ZRL8xfnP3zIFlCI9jXInJ0loDUkCTLeCEbOf2uuDumWDghKNQlF1itUS+EHaR1pFVBbuwqq8hVK0dASg==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-6x7HPy+uN5Cb9N77e2XMmT6+QSJ+7mRbHnhkGJ8jm4cZvWuj2Io7npOaeHQ3YHK+TiQpTnlbkjoOIpEwpY3XZA==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-linux-x64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-3HFIJSXgyubOiaN4MWGXx2xhTnhwlJk0PiSYNf9+L/fjBtcRkb2nM910ZJHTvqCb6OT98cUnaKuAYdXIW2amgw==",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-CP4GsllEfXEz+lidcGYxKe5rDJ60TM5/blB5z/04ELVvw6/CK9eLcYeku7HV0jvV7VE6dADYKSdQyUkvd0El+A==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz",
+      "integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "crc-32": "^1.2.0"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "abstract-level": "^1.0.3",
-        "bigint-crypto-utils": "^3.0.23",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-ethash/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "mcl-wasm": "^0.7.1",
-        "rustbn.js": "~0.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-evm/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+        "@nomicfoundation/ethereumjs-util": "9.0.4"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
+      "integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw==",
       "bin": {
-        "rlp": "bin/rlp"
+        "rlp": "bin/rlp.cjs"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-trie/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+        "node": ">=18"
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz",
+      "integrity": "sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.4",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
+        "@nomicfoundation/ethereumjs-util": "9.0.4",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "c-kzg": "^2.1.2"
+      },
+      "peerDependenciesMeta": {
+        "c-kzg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-tx/node_modules/ethereum-cryptography": {
@@ -1266,66 +1114,26 @@
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
+      "integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
       "dependencies": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
         "ethereum-cryptography": "0.1.3"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "c-kzg": "^2.1.2"
+      },
+      "peerDependenciesMeta": {
+        "c-kzg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nomicfoundation/ethereumjs-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
-      "dependencies": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "rustbn.js": "~0.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@nomicfoundation/ethereumjs-vm/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
@@ -1678,11 +1486,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "devOptional": true
     },
-    "node_modules/@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg=="
-    },
     "node_modules/@types/bn.js": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
@@ -1743,34 +1546,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
       "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
-    "node_modules/abstract-level": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "catering": "^2.1.0",
-        "is-buffer": "^2.0.5",
-        "level-supports": "^4.0.0",
-        "level-transcoder": "^1.0.1",
-        "module-error": "^1.0.1",
-        "queue-microtask": "^1.2.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/acorn": {
       "version": "8.8.1",
@@ -1838,6 +1613,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dependencies": {
+        "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -1919,22 +1702,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/async-eventemitter": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-      "dependencies": {
-        "async": "^2.4.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1946,44 +1713,6 @@
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bigint-crypto-utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.8.tgz",
-      "integrity": "sha512-+VMV9Laq8pXLBKKKK49nOoq9bfR3j7NNQAtbA617a4nw9bVLo8rsqkKMBgM2AJWlNX9fEIyYaYX+d0laqYV4tw==",
-      "dependencies": {
-        "bigint-mod-arith": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
-      "engines": {
-        "node": ">=10.4.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -2003,6 +1732,38 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "node_modules/boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "dependencies": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2028,17 +1789,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "node_modules/browser-level": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-      "dependencies": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.1",
-        "module-error": "^1.0.2",
-        "run-parallel-limit": "^1.1.0"
-      }
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -2076,29 +1826,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2126,18 +1853,6 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2182,14 +1897,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/catering": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
       "engines": {
         "node": ">=6"
       }
@@ -2298,28 +2005,23 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.0",
-        "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cliui": {
@@ -2422,17 +2124,6 @@
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-hash": {
@@ -2751,14 +2442,6 @@
         "npm": ">=3"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -2901,14 +2584,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2916,19 +2595,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-stream": {
@@ -3085,30 +2751,24 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.4.tgz",
-      "integrity": "sha512-rc9S2U/4M+77LxW1Kg7oqMMmjl81tzn5rNFARhbXKUA1am/nhfMJEujOjuKvt+ZGMiZ11PYSe8gyIpB/aRNDgw==",
+      "version": "2.22.5",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.5.tgz",
+      "integrity": "sha512-9Zq+HonbXCSy6/a13GY1cgHglQRfh4qkzmj1tpPlhxJDwNVnhxlReV6K7hCWFKlOrV13EQwsdcD0rjcaQKWRZw==",
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/edr": "^0.4.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.4",
+        "@nomicfoundation/ethereumjs-tx": "5.0.4",
+        "@nomicfoundation/ethereumjs-util": "9.0.4",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
+        "boxen": "^5.1.2",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
         "ci-info": "^2.0.0",
@@ -3128,7 +2788,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -3136,15 +2795,12 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
       "bin": {
-        "hardhat": "internal/cli/cli.js"
-      },
-      "engines": {
-        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+        "hardhat": "internal/cli/bootstrap.js"
       },
       "peerDependencies": {
         "ts-node": "*",
@@ -3184,34 +2840,12 @@
         "node": ">=4"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hash-base": {
@@ -3358,25 +2992,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/immutable": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.0.tgz",
@@ -3467,28 +3082,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-core-module": {
@@ -3712,42 +3305,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "node_modules/level": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-      "dependencies": {
-        "browser-level": "^1.0.1",
-        "classic-level": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/level"
-      }
-    },
-    "node_modules/level-supports": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/level-transcoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "module-error": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3851,14 +3408,6 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -3877,14 +3426,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mcl-wasm": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
-      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -3893,19 +3434,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/memory-level": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
-      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
-      "dependencies": {
-        "abstract-level": "^1.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "module-error": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/memorystream": {
@@ -4208,14 +3736,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/module-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4242,11 +3762,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -4334,14 +3849,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obliterator": {
@@ -4527,39 +4034,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/quick-lru": {
       "version": "4.0.1",
@@ -4855,33 +4329,6 @@
         "rlp": "bin/rlp"
       }
     },
-    "node_modules/run-parallel-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/rustbn.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4982,19 +4429,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -5504,6 +4938,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "dependencies": {
+        "string-width": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -5592,11 +5037,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -6289,257 +5729,76 @@
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
       "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
     },
-    "@nomicfoundation/ethereumjs-block": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
-      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+    "@nomicfoundation/edr": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.4.0.tgz",
+      "integrity": "sha512-T96DMSogO8TCdbKKctvxfsDljbhFOUKWc9fHJhSeUh71EEho2qR4951LKQF7t7UWEzguVYh/idQr5L/E3QeaMw==",
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
+        "@nomicfoundation/edr-darwin-arm64": "0.4.0",
+        "@nomicfoundation/edr-darwin-x64": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.4.0",
+        "@nomicfoundation/edr-linux-x64-musl": "0.4.0",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.4.0"
       }
     },
-    "@nomicfoundation/ethereumjs-blockchain": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
-      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "abstract-level": "^1.0.3",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "level": "^8.0.0",
-        "lru-cache": "^5.1.1",
-        "memory-level": "^1.0.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
+    "@nomicfoundation/edr-darwin-arm64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.4.0.tgz",
+      "integrity": "sha512-7+rraFk9tCqvfemv9Ita5vTlSBAeO/S5aDKOgGRgYt0JEKZlrX161nDW6UfzMPxWl9GOLEDUzCEaYuNmXseUlg=="
+    },
+    "@nomicfoundation/edr-darwin-x64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.4.0.tgz",
+      "integrity": "sha512-+Hrc0mP9L6vhICJSfyGo/2taOToy1AIzVZawO3lU8Lf7oDQXfhQ4UkZnkWAs9SVu1eUwHUGGGE0qB8644piYgg=="
+    },
+    "@nomicfoundation/edr-linux-arm64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.4.0.tgz",
+      "integrity": "sha512-4HUDMchNClQrVRfVTqBeSX92hM/3khCgpZkXP52qrnJPqgbdCxosOehlQYZ65wu0b/kaaZSyvACgvCLSQ5oSzQ=="
+    },
+    "@nomicfoundation/edr-linux-arm64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.4.0.tgz",
+      "integrity": "sha512-D4J935ZRL8xfnP3zIFlCI9jXInJ0loDUkCTLeCEbOf2uuDumWDghKNQlF1itUS+EHaR1pFVBbuwqq8hVK0dASg=="
+    },
+    "@nomicfoundation/edr-linux-x64-gnu": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.4.0.tgz",
+      "integrity": "sha512-6x7HPy+uN5Cb9N77e2XMmT6+QSJ+7mRbHnhkGJ8jm4cZvWuj2Io7npOaeHQ3YHK+TiQpTnlbkjoOIpEwpY3XZA=="
+    },
+    "@nomicfoundation/edr-linux-x64-musl": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.4.0.tgz",
+      "integrity": "sha512-3HFIJSXgyubOiaN4MWGXx2xhTnhwlJk0PiSYNf9+L/fjBtcRkb2nM910ZJHTvqCb6OT98cUnaKuAYdXIW2amgw=="
+    },
+    "@nomicfoundation/edr-win32-x64-msvc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.4.0.tgz",
+      "integrity": "sha512-CP4GsllEfXEz+lidcGYxKe5rDJ60TM5/blB5z/04ELVvw6/CK9eLcYeku7HV0jvV7VE6dADYKSdQyUkvd0El+A=="
     },
     "@nomicfoundation/ethereumjs-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
-      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-4.0.4.tgz",
+      "integrity": "sha512-9Rgb658lcWsjiicr5GzNCjI1llow/7r0k50dLL95OJ+6iZJcVbi15r3Y0xh2cIO+zgX0WIHcbzIu6FeQf9KPrg==",
       "requires": {
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "crc-32": "^1.2.0"
-      }
-    },
-    "@nomicfoundation/ethereumjs-ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
-      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "abstract-level": "^1.0.3",
-        "bigint-crypto-utils": "^3.0.23",
-        "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-evm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
-      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "mcl-wasm": "^0.7.1",
-        "rustbn.js": "~0.2.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
+        "@nomicfoundation/ethereumjs-util": "9.0.4"
       }
     },
     "@nomicfoundation/ethereumjs-rlp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
-      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw=="
-    },
-    "@nomicfoundation/ethereumjs-statemanager": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
-      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-trie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
-      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "ethereum-cryptography": "0.1.3",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-5.0.4.tgz",
+      "integrity": "sha512-8H1S3s8F6QueOc/X92SdrA4RDenpiAEqMg5vJH99kcQaCy/a3Q6fgseo75mgWlbanGJXSlAPtnCeG9jvfTYXlw=="
     },
     "@nomicfoundation/ethereumjs-tx": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
-      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-5.0.4.tgz",
+      "integrity": "sha512-Xjv8wAKJGMrP1f0n2PeyfFCCojHd7iS3s/Ab7qzF1S64kxZ8Z22LCMynArYsVqiFx6rzYy548HNVEyI+AYN/kw==",
       "requires": {
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.4",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
+        "@nomicfoundation/ethereumjs-util": "9.0.4",
         "ethereum-cryptography": "0.1.3"
       },
       "dependencies": {
@@ -6568,59 +5827,12 @@
       }
     },
     "@nomicfoundation/ethereumjs-util": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
-      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-9.0.4.tgz",
+      "integrity": "sha512-sLOzjnSrlx9Bb9EFNtHzK/FJFsfg2re6bsGqinFinH1gCqVfz9YYlXiMWwDM4C/L4ywuHFCYwfKTVr/QHQcU0Q==",
       "requires": {
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "@nomicfoundation/ethereumjs-rlp": "5.0.4",
         "ethereum-cryptography": "0.1.3"
-      },
-      "dependencies": {
-        "ethereum-cryptography": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-          "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-          "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
-          }
-        }
-      }
-    },
-    "@nomicfoundation/ethereumjs-vm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
-      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
-      "requires": {
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@types/async-eventemitter": "^0.2.1",
-        "async-eventemitter": "^0.2.4",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "0.1.3",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "rustbn.js": "~0.2.0"
       },
       "dependencies": {
         "ethereum-cryptography": {
@@ -6846,11 +6058,6 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "devOptional": true
     },
-    "@types/async-eventemitter": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
-      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg=="
-    },
     "@types/bn.js": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
@@ -6912,28 +6119,6 @@
       "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
       "dev": true
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
-    "abstract-level": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
-      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
-      "requires": {
-        "buffer": "^6.0.3",
-        "catering": "^2.1.0",
-        "is-buffer": "^2.0.5",
-        "level-supports": "^4.0.0",
-        "level-transcoder": "^1.0.1",
-        "module-error": "^1.0.1",
-        "queue-microtask": "^1.2.3"
-      }
-    },
     "acorn": {
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
@@ -6978,6 +6163,14 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "requires": {
+        "string-width": "^4.1.0"
       }
     },
     "ansi-colors": {
@@ -7038,22 +6231,6 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
-    "async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "async-eventemitter": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
-      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
-      "requires": {
-        "async": "^2.4.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -7066,24 +6243,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "bigint-crypto-utils": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.8.tgz",
-      "integrity": "sha512-+VMV9Laq8pXLBKKKK49nOoq9bfR3j7NNQAtbA617a4nw9bVLo8rsqkKMBgM2AJWlNX9fEIyYaYX+d0laqYV4tw==",
-      "requires": {
-        "bigint-mod-arith": "^3.1.0"
-      }
-    },
-    "bigint-mod-arith": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
-      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -7099,6 +6258,28 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
+    "boxen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
+      "integrity": "sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==",
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.1.0",
+        "cli-boxes": "^2.2.1",
+        "string-width": "^4.2.2",
+        "type-fest": "^0.20.2",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7121,17 +6302,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "browser-level": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
-      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
-      "requires": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.1",
-        "module-error": "^1.0.2",
-        "run-parallel-limit": "^1.1.0"
-      }
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -7169,15 +6339,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7200,15 +6361,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -7239,11 +6391,6 @@
           "dev": true
         }
       }
-    },
-    "catering": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
-      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -7319,22 +6466,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "classic-level": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
-      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
-      "requires": {
-        "abstract-level": "^1.0.2",
-        "catering": "^2.1.0",
-        "module-error": "^1.0.1",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "^4.3.0"
-      }
-    },
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+    },
+    "cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
     "cliui": {
       "version": "8.0.1",
@@ -7419,11 +6559,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
-    },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
     "create-hash": {
       "version": "1.2.0",
@@ -7686,11 +6821,6 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -7793,27 +6923,13 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
-      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -7924,30 +7040,24 @@
       "dev": true
     },
     "hardhat": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.4.tgz",
-      "integrity": "sha512-rc9S2U/4M+77LxW1Kg7oqMMmjl81tzn5rNFARhbXKUA1am/nhfMJEujOjuKvt+ZGMiZ11PYSe8gyIpB/aRNDgw==",
+      "version": "2.22.5",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.5.tgz",
+      "integrity": "sha512-9Zq+HonbXCSy6/a13GY1cgHglQRfh4qkzmj1tpPlhxJDwNVnhxlReV6K7hCWFKlOrV13EQwsdcD0rjcaQKWRZw==",
       "requires": {
         "@ethersproject/abi": "^5.1.2",
         "@metamask/eth-sig-util": "^4.0.0",
-        "@nomicfoundation/ethereumjs-block": "^4.0.0",
-        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
-        "@nomicfoundation/ethereumjs-common": "^3.0.0",
-        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
-        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
-        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
-        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
-        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
-        "@nomicfoundation/ethereumjs-util": "^8.0.0",
-        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/edr": "^0.4.0",
+        "@nomicfoundation/ethereumjs-common": "4.0.4",
+        "@nomicfoundation/ethereumjs-tx": "5.0.4",
+        "@nomicfoundation/ethereumjs-util": "9.0.4",
         "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
         "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
+        "boxen": "^5.1.2",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
         "ci-info": "^2.0.0",
@@ -7967,7 +7077,6 @@
         "mnemonist": "^0.38.0",
         "mocha": "^10.0.0",
         "p-map": "^4.0.0",
-        "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
@@ -7975,7 +7084,7 @@
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
         "tsort": "0.0.1",
-        "undici": "^5.4.0",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -8001,23 +7110,10 @@
         "murmur-128": "^0.2.1"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
     "hash-base": {
       "version": "3.1.0",
@@ -8129,11 +7225,6 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
     "immutable": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.0.tgz",
@@ -8209,11 +7300,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
     },
     "is-core-module": {
       "version": "2.13.1",
@@ -8374,29 +7460,6 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "level": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
-      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
-      "requires": {
-        "browser-level": "^1.0.1",
-        "classic-level": "^1.2.0"
-      }
-    },
-    "level-supports": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
-      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA=="
-    },
-    "level-transcoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
-      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
-      "requires": {
-        "buffer": "^6.0.3",
-        "module-error": "^1.0.1"
-      }
-    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -8491,14 +7554,6 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "requires": {
-        "yallist": "^3.0.2"
-      }
-    },
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -8511,11 +7566,6 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
-    "mcl-wasm": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
-      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ=="
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -8524,16 +7574,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "memory-level": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
-      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
-      "requires": {
-        "abstract-level": "^1.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "module-error": "^1.0.1"
       }
     },
     "memorystream": {
@@ -8751,11 +7791,6 @@
         }
       }
     },
-    "module-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
-      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8776,11 +7811,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w=="
-    },
-    "napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -8848,11 +7878,6 @@
       "requires": {
         "path-key": "^3.0.0"
       }
-    },
-    "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
     "obliterator": {
       "version": "2.0.4",
@@ -8980,19 +8005,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
-    },
-    "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "requires": {
-        "side-channel": "^1.0.4"
-      }
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "4.0.1",
@@ -9217,19 +8229,6 @@
         "bn.js": "^5.2.0"
       }
     },
-    "run-parallel-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
-      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "rustbn.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
-    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9301,16 +8300,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -9690,6 +8679,14 @@
         "isexe": "^2.0.0"
       }
     },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+      "requires": {
+        "string-width": "^4.0.0"
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -9748,11 +8745,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chalk": "^4.1.0",
     "dotenv": "^16.3.1",
     "fs": "^0.0.1-security",
-    "hardhat": "^2.12.4",
+    "hardhat": "^2.22.4",
     "hardhat-preprocessor": "^0.1.5",
     "husky": "^8.0.3",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
**Summary**:
This is a simple PR that enables code coverage using `forge coverage`. The only non-trivial piece is that forge coverage includes tests, scripts and other non-functional code as part of its coverage, so there's logic to strip these files out. Once the coverage site is generated, it's uploaded to S3 using an artifact action.

**How to view**:
- The bot will automatically post the coverage on your PR. You can look through the associated Github Action if you want the HTML report.

**Changelog**:
- bump hardhat version
- introduce a `coverage` job for GHA
- coverage job automatically computes coverage percentages, filtering out unnecessary files.
- coverage job then uploads report to s3 for review. 
- bot then posts the status on the PR.
