### PR TITLE
Docs rectify typographical inaccuracies

### DIFF
--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -10,7 +10,7 @@ labels: design
 Add a summary and description. What are we trying to do and why?
 
 ### Action Items
-- [ ] Come up with scheme for...
+- [ ] Come up with a scheme for...
 - [ ] Spec it in a HackMD or Google Doc that is linked here
 - [ ] Get @ to review design
 - [ ] Discuss design and tradeoffs with @

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -7,7 +7,7 @@ labels: research
 ---
 
 ## Description
-Add a summary and description. What do we need any why? Any preliminary notion of options + what we want out of them?
+Add a summary and description. What do we need and why? Any preliminary notion of options + what we want out of them?
 
 ### Action Items
 - [ ] Create a list of options to evaluate

--- a/.github/workflows/run-deploy-scripts.yml
+++ b/.github/workflows/run-deploy-scripts.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: true
 
-      # install foundry to run forge script. Should we run forge script in a container instead?
+      # install foundry to run forge script. Should we run the forge script in a container instead?
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -34,7 +34,7 @@ This document organizes methods according to the following themes (click each to
     * For all strategies including native beacon chain ETH, Stakers at minimum must wait this amount of time before a withdrawal can be completed.
     To withdraw a specific strategy, it may require additional time depending on the strategy's withdrawal delay. See `strategyWithdrawalDelayBlocks` below.
 * `mapping(IStrategy => uint256) public strategyWithdrawalDelayBlocks`:
-    * This mapping tracks the withdrawal delay for each strategy. This mapping value only comes into affect
+    * This mapping tracks the withdrawal delay for each strategy. This mapping value only comes into effect
     if `strategyWithdrawalDelayBlocks[strategy] > minWithdrawalDelayBlocks`. Otherwise, `minWithdrawalDelayBlocks` is used.
 * `mapping(bytes32 => bool) public pendingWithdrawals;`:
     * `Withdrawals` are hashed and set to `true` in this mapping when a withdrawal is initiated. The hash is set to false again when the withdrawal is completed. A per-staker nonce provides a way to distinguish multiple otherwise-identical withdrawals.

--- a/docs/core/EigenPodManager.md
+++ b/docs/core/EigenPodManager.md
@@ -396,7 +396,7 @@ function withdrawRestakedBeaconChainETH(
 The `EigenPodManager` calls this method when withdrawing a Pod Owner's shares as tokens (native ETH). The input `amountWei` is converted to Gwei and subtracted from `withdrawableRestakedExecutionLayerGwei`, which tracks Gwei that has been provably withdrawn (via `EigenPod.verifyAndProcessWithdrawals`).
 
 As such:
-* If a withdrawal has not been proven that sufficiently raises `withdrawableRestakedExecutionLayerGwei`, this method will revert.
+* If a withdrawal has not been proven that sufficiently raise `withdrawableRestakedExecutionLayerGwei`, this method will revert.
 * If the `EigenPod` does not have `amountWei` available to transfer, this method will revert
 
 *Effects*:

--- a/docs/core/RewardsCoordinator.md
+++ b/docs/core/RewardsCoordinator.md
@@ -38,7 +38,7 @@ This document is organized according to the following themes (click each to be t
     * Stakers and Operators can designate a "claimer" who can claim rewards via on their behalf via `processClaim`. If a claimer is not set in `claimerFor`, the earner will have to call `processClaim` themselves.
     * Note that the claimer isn't necessarily the reward recipient, but they do have the authority to specify the recipient when calling `processClaim` on the earner's behalf.
 * `mapping(address => mapping(IERC20 => uint256)) public cumulativeClaimed`: earner => token => total amount claimed to date
-    * Mapping for earners(Stakers/Operators) to track their total claimed earnings per reward token. This mapping is used to calculate the difference between the cumulativeEarnings stored in the merkle tree and the previous total claimed amount. This difference is then transfered to the specified destination address.
+    * Mapping for earners(Stakers/Operators) to track their total claimed earnings per reward token. This mapping is used to calculate the difference between the cumulativeEarnings stored in the merkle tree and the previous total claimed amount. This difference is then transferred to the specified destination address.
 * `uint16 public globalOperatorCommissionBips`: *Used off-chain* by the rewards updater to calculate an Operator's commission for a specific reward.
     * This is expected to be a flat 10% rate for the initial rewards release. Expressed in basis points, this is `1000`.
 


### PR DESCRIPTION
This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.

Hope it helps.

