### PR TITLE
Rename get staker delegateable shares to get staker delegatable shares for clarity

### DIFF
--- a/certora/harnesses/DelegationManagerHarness.sol
+++ b/certora/harnesses/DelegationManagerHarness.sol
@@ -27,3 +27,4 @@ contract DelegationManagerHarness is DelegationManager {
     }
 }
 
+

--- a/certora/harnesses/DelegationManagerHarness.sol
+++ b/certora/harnesses/DelegationManagerHarness.sol
@@ -12,7 +12,7 @@ contract DelegationManagerHarness is DelegationManager {
         return operatorShares[operator][strategy];
     }
 
-    function get_stakerDelegateableShares(address staker, IStrategy strategy) public view returns (uint256) {
+    function get_stakerDelegatableShares(address staker, IStrategy strategy) public view returns (uint256) {
         // this is the address of the virtual 'beaconChainETH' strategy
         if (address(strategy) == 0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0) {
             int256 beaconChainETHShares = eigenPodManager.podOwnerShares(staker);
@@ -26,3 +26,4 @@ contract DelegationManagerHarness is DelegationManager {
         }
     }
 }
+


### PR DESCRIPTION
Title: Rename get_stakerDelegateableShares to get_stakerDelegatableShares for clarity

Description:

This PR renames the function get_stakerDelegateableShares to get_stakerDelegatableShares in the DelegationManagerHarness contract. The new name better reflects the purpose of the function, enhancing code readability and maintainability.

Justification:

Clarity: The term "Delegatable" is the correct form, making the function name more intuitive and easier to understand.
Maintainability: Clearer function names contribute to better code maintainability, especially for new developers or contributors.
Impact: This change is non-breaking as it only involves renaming a function within the harness contract, which is typically used for testing or additional functionality layers. No core logic is altered.

Steps to Implement:
Open the file containing the DelegationManagerHarness contract.
Locate the get_stakerDelegateableShares function.
Rename it to get_stakerDelegatableShares.
Update any references to this function within the contract or associated test files.
By making this small change, the contract becomes more intuitive and user-friendly.