### PR TITLE
feat: clean up slashing withdrawal completion

### DIFF
--- a/src/contracts/interfaces/ISlasher.sol
+++ b/src/contracts/interfaces/ISlasher.sol
@@ -148,19 +148,15 @@ interface ISlasher {
 		uint32 epoch
 	) external view returns (uint32);
 
-	/**
-     * @notice gets whether withdrawals of the given strategy delegated to the given operator can be withdrawn and the scaling factor
-     * @param operator the operator the withdrawal is delegated to
-     * @param strategy the strategy the withdrawal is from
-     * @param epoch the last epoch the withdrawal was slashable until
-     * @return whether the withdrawal can be executed
-     * @return whether there was a slashing request for the given operator and strategy at the given epoch
-     */
-    function getWithdrawabilityAndScalingFactorAtEpoch(
-        address operator,
-        IStrategy strategy,
-        uint32 epoch
-    ) external view returns (bool, uint64);
+	struct WithdrawableAmounts {
+		uint256 withdrawAmount;
+		uint256 redepositAmount;
+	}
+
+	function getWithdrawableAmounts(
+        IDelegationManager.Withdrawal calldata withdrawal,
+        address currentOperator
+    ) external view returns (WithdrawableAmounts[] memory amounts);
 
 	/**
      * @notice gets whether withdrawals of the given strategy delegated to the given operator can be withdrawn

--- a/src/contracts/libraries/EpochUtils.sol
+++ b/src/contracts/libraries/EpochUtils.sol
@@ -14,6 +14,11 @@ library EpochUtils {
     // TODO: define appropriately
     uint256 internal constant EPOCH_LENGTH_SECONDS = 1 weeks;
 
+    function slashingEndEpoch(uint64 startBlock) internal pure returns (uint32) {
+        // TODO idk convert to timestamp, then epoch, then add slashability
+        return 0;
+    }
+
     function getEpochFromTimestamp(uint256 timestamp) internal pure returns (uint32) {
         require(timestamp >= EPOCH_GENESIS_TIMESTAMP, "EpochUtils.getEpochFromTimestamp: timestamp is before genesis");
         return uint32((timestamp - EPOCH_GENESIS_TIMESTAMP) / EPOCH_LENGTH_SECONDS);
@@ -31,7 +36,7 @@ library EpochUtils {
         return requestEpoch + 2;
     }
 
-    function getEndOfSlashabilityEpoch(uint32 queuedEpoch) internal view returns (uint32) {
-        return queuedEpoch + 1;
+    function isSlashable(uint32 queuedEpoch) internal view returns (bool) {
+        return currentEpoch() > queuedEpoch + 1;
     }
 }

--- a/src/test/mocks/SlasherMock.sol
+++ b/src/test/mocks/SlasherMock.sol
@@ -121,19 +121,10 @@ contract SlasherMock is ISlasher, Test {
 		uint32 epoch
 	) external view returns (uint32) {}
 
-	/**
-     * @notice gets whether withdrawals of the given strategy delegated to the given operator can be withdrawn and the scaling factor
-     * @param operator the operator the withdrawal is delegated to
-     * @param strategy the strategy the withdrawal is from
-     * @param epoch the last epoch the withdrawal was slashable until
-     * @return whether the withdrawal can be executed
-     * @return whether there was a slashing request for the given operator and strategy at the given epoch
-     */
-    function getWithdrawabilityAndScalingFactorAtEpoch(
-        address operator,
-        IStrategy strategy,
-        uint32 epoch
-    ) external view returns (bool, uint64) {}
+	function getWithdrawableAmounts(
+        IDelegationManager.Withdrawal calldata withdrawal,
+        address currentOperator
+    ) external view returns (WithdrawableAmounts[] memory) {}
 
 	/**
      * @notice gets whether withdrawals of the given strategy delegated to the given operator can be withdrawn


### PR DESCRIPTION
* addresses a handful of my comments on the main slashing PR
* cleans up withdrawal completion logic to use fewer external calls and be less confusing
* TODO: EpochUtils.slashingEndEpoch calculation