### PR TITLE
feat: time delay operator dereg

### DIFF
--- a/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/devnet/M2_Deploy_From_Scratch.s.sol
@@ -196,7 +196,7 @@ contract Deployer_M2 is Script, Test {
         // Second, deploy the *implementation* contracts, using the *proxy contracts* as inputs
         delegationImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
         strategyManagerImplementation = new StrategyManager(delegation, eigenPodManager, slasher);
-        avsDirectoryImplementation = new AVSDirectory(delegation);
+        avsDirectoryImplementation = new AVSDirectory(delegation, strategyManager);
         slasherImplementation = new Slasher(strategyManager, delegation);
         eigenPodManagerImplementation = new EigenPodManager(
             ethPOSDeposit,

--- a/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
@@ -81,7 +81,7 @@ contract M2_Deploy_Holesky_From_Scratch is ExistingDeploymentParser {
         );
 
         eigenPodBeacon = new UpgradeableBeacon(address(eigenPodImplementation));
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, strategyManager);
         delegationManagerImplementation = new DelegationManager(strategyManager, slasher, eigenPodManager);
         strategyManagerImplementation = new StrategyManager(delegationManager, eigenPodManager, slasher);
         slasherImplementation = new Slasher(strategyManager, delegationManager);

--- a/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
+++ b/script/deploy/mainnet/M2_Mainnet_Upgrade.s.sol
@@ -45,7 +45,7 @@ contract M2_Mainnet_Upgrade is ExistingDeploymentParser {
      */
     function _deployImplementationContracts() internal {
         // 1. Deploy New TUPS
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, strategyManager);
         avsDirectory = AVSDirectory(
             address(
                 new TransparentUpgradeableProxy(

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -15,21 +15,29 @@ contract AVSDirectory is
     AVSDirectoryStorage,
     ReentrancyGuardUpgradeable
 {
-    // @dev Index for flag that pauses operator register/deregister to avs when set.
+    /// @dev Index for flag that pauses operator register/deregister to avs when set.
     uint8 internal constant PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS = 0;
 
-    // @dev Chain ID at the time of contract deployment
+    /// @dev Chain ID at the time of contract deployment
     uint256 internal immutable ORIGINAL_CHAIN_ID;
 
-    /*******************************************************************************
-                            INITIALIZING FUNCTIONS
-    *******************************************************************************/
+    /// @notice Canonical, virtual beacon chain ETH strategy
+    IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
     /**
-     * @dev Initializes the immutable addresses of the strategy mananger, delegationManager, slasher, 
+     *
+     *                         INITIALIZING FUNCTIONS
+     *
+     */
+
+    /**
+     * @dev Initializes the immutable addresses of the strategy mananger, delegationManager, slasher,
      * and eigenpodManager contracts
      */
-    constructor(IDelegationManager _delegation) AVSDirectoryStorage(_delegation) {
+    constructor(
+        IDelegationManager _delegation,
+        IStrategyManager _strategyManager
+    ) AVSDirectoryStorage(_delegation, _strategyManager) {
         _disableInitializers();
         ORIGINAL_CHAIN_ID = block.chainid;
     }
@@ -48,21 +56,200 @@ contract AVSDirectory is
         _transferOwnership(initialOwner);
     }
 
-    /*******************************************************************************
-                            EXTERNAL FUNCTIONS 
-    *******************************************************************************/
-
+    /**
+     *
+     *                         EXTERNAL FUNCTIONS
+     *
+     */
 
     /**
-     * @notice Called by the AVS's service manager contract to register an operator with the avs.
-     * @param operator The address of the operator to register.
-     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     * @notice Updates the standby parameters for an operator across multiple operator sets.
+     * Allows the AVS to add the operator to a given operator set if they are not already registered.
+     *
+     * @param operator The address of the operator for which the standby parameters are being updated.
+     * @param standbyParams The new standby parameters for the operator.
+     * @param operatorSignature If non-empty, the signature of the operator authorizing the modification.
+     *                  If empty, the `msg.sender` must be the operator.
+     */
+    function updateStandbyParams(
+        address operator,
+        StandbyParam[] calldata standbyParams,
+        SignatureWithSaltAndExpiry calldata operatorSignature
+    ) external {
+        if (operatorSignature.signature.length == 0) {
+            // Assert caller is `operator` if signature length is zero.
+            require(msg.sender == operator, "AVSDirectory.updateStandbyParams: invalid signature");
+        } else {
+            // Assert operator's signature has not expired.
+            require(
+                operatorSignature.expiry >= block.timestamp,
+                "AVSDirectory.updateStandbyParams: operator signature expired"
+            );
+            // Assert operator's signature cannot be replayed.
+            require(
+                !operatorSaltIsSpent[operator][operatorSignature.salt], "AVSDirectory.updateStandbyParams: salt spent"
+            );
+            // Assert operator's signature is valid.
+            EIP1271SignatureUtils.checkSignature_EIP1271(
+                operator,
+                calculateUpdateStandbyDigestHash(standbyParams, operatorSignature.salt, operatorSignature.expiry),
+                operatorSignature.signature
+            );
+            // Spend salt.
+            operatorSaltIsSpent[operator][operatorSignature.salt] = true;
+        }
+
+        for (uint256 i; i < standbyParams.length; ++i) {
+            onStandby[standbyParams[i].operatorSet.avs][operator][standbyParams[i].operatorSet.id] =
+                standbyParams[i].onStandby;
+
+            emit StandbyParamUpdated(operator, standbyParams[i].operatorSet, standbyParams[i].onStandby);
+        }
+    }
+
+    /**
+     *  @notice Called by AVSs to add an operator to an operator set.
+     *
+     *  @param operator The address of the operator to be added to the operator set.
+     *  @param operatorSetIds The IDs of the operator sets.
+     *  @param operatorSignature The signature of the operator on their intent to register.
+     *
+     *  @dev msg.sender is used as the AVS.
+     *  @dev The operator must not have a pending deregistration from the operator set.
+     *  @dev If this is the first operator set in the AVS that the operator is
+     *  registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
+     *  a REGISTERED status.
+     */
+    function registerOperatorToOperatorSets(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+        // Assert `operator` is actually an operator.
+        require(
+            delegation.isOperator(operator),
+            "AVSDirectory.registerOperatorToOperatorSets: operator not registered to EigenLayer yet"
+        );
+        // Assert operator's signature has not expired.
+        require(
+            operatorSignature.expiry >= block.timestamp,
+            "AVSDirectory.registerOperatorToOperatorSets: operator signature expired"
+        );
+        // Assert operator's signature `salt` has not already been spent.
+        require(
+            !operatorSaltIsSpent[operator][operatorSignature.salt],
+            "AVSDirectory.registerOperatorToOperatorSets: salt already spent"
+        );
+
+        if (operatorSignature.signature.length != 0) {
+            // Assert signature provided by `operator` is valid.
+            EIP1271SignatureUtils.checkSignature_EIP1271(
+                operator,
+                calculateOperatorSetRegistrationDigestHash({
+                    avs: msg.sender,
+                    operatorSetIds: operatorSetIds,
+                    salt: operatorSignature.salt,
+                    expiry: operatorSignature.expiry
+                }),
+                operatorSignature.signature
+            );
+        }
+
+        // Mutate `operatorSaltIsSpent` to `true` to prevent future respending.
+        operatorSaltIsSpent[operator][operatorSignature.salt] = true;
+
+        // Register `operator` if not already registered.
+        if (avsOperatorStatus[msg.sender][operator] != OperatorAVSRegistrationStatus.REGISTERED) {
+            avsOperatorStatus[msg.sender][operator] = OperatorAVSRegistrationStatus.REGISTERED;
+            emit OperatorAVSRegistrationStatusUpdated(operator, msg.sender, OperatorAVSRegistrationStatus.REGISTERED);
+        }
+
+        // Mutate calling AVS to operator set AVS status, preventing further legacy registrations.
+        if (!isOperatorSetAVS[msg.sender]) isOperatorSetAVS[msg.sender] = true;
+
+        // Loop over `operatorSetIds` array and register `operator` for each item.
+        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
+            // Assert avs is on standby mode for the given `operator` and `operatorSetIds[i]`.
+            if (operatorSignature.signature.length == 0) {
+                require(
+                    onStandby[msg.sender][operator][operatorSetIds[i]],
+                    "AVSDirectory.registerOperatorToOperatorSets: avs not on standby"
+                );
+            }
+
+            // Assert `operator` has not already been registered to `operatorSetIds[i]`.
+            require(
+                !isOperatorInOperatorSet[msg.sender][operator][operatorSetIds[i]],
+                "AVSDirectory.registerOperatorToOperatorSets: operator already registered to operator set"
+            );
+
+            // Mutate `isOperatorInOperatorSet` to `true` for `operatorSetIds[i]`.
+            isOperatorInOperatorSet[msg.sender][operator][operatorSetIds[i]] = true;
+
+            emit OperatorAddedToOperatorSet(operator, OperatorSet({avs: msg.sender, id: operatorSetIds[i]}));
+        }
+
+        // Increase `operatorAVSOperatorSetCount` by `operatorSetIds.length`.
+        // You would have to add the operator to 2**256-2 operator sets before overflow is possible here.
+        unchecked {
+            operatorAVSOperatorSetCount[msg.sender][operator] += operatorSetIds.length;
+        }
+    }
+
+    /**
+     *  @notice Called by AVSs or operators to remove an operator from an operator set.
+     *
+     *  @param operator The address of the operator to be removed from the operator set.
+     *  @param operatorSetIds The IDs of the operator sets.
+     *
+     *  @dev msg.sender is used as the AVS.
+     *  @dev The operator must be registered for the msg.sender AVS and the given operator set.
+     *  @dev If this call removes the operator from all operator sets for the msg.sender AVS,
+     *  then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED status.
+     */
+    function deregisterOperatorFromOperatorSets(
+        address operator,
+        uint32[] calldata operatorSetIds
+    ) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+        // Loop over `operatorSetIds` array and deregister `operator` for each item.
+        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
+            // Assert `operator` is registered for this iterations operator set.
+            require(
+                isOperatorInOperatorSet[msg.sender][operator][operatorSetIds[i]],
+                "AVSDirectory.deregisterOperatorFromOperatorSet: operator not registered for operator set"
+            );
+
+            // Mutate `isOperatorInOperatorSet` to `false` for `operatorSetIds[i]`.
+            isOperatorInOperatorSet[msg.sender][operator][operatorSetIds[i]] = false;
+
+            emit OperatorRemovedFromOperatorSet(operator, OperatorSet({avs: msg.sender, id: operatorSetIds[i]}));
+        }
+
+        // The above assertion makes underflow logically impossible here.
+        unchecked {
+            operatorAVSOperatorSetCount[msg.sender][operator] -= operatorSetIds.length;
+        }
+
+        // Set the operator as deregistered if no longer registered for any operator sets
+        if (operatorAVSOperatorSetCount[msg.sender][operator] == 0) {
+            avsOperatorStatus[msg.sender][operator] = OperatorAVSRegistrationStatus.UNREGISTERED;
+            emit OperatorAVSRegistrationStatusUpdated(operator, msg.sender, OperatorAVSRegistrationStatus.UNREGISTERED);
+        }
+    }
+
+    /**
+     *  @notice Called by the AVS's service manager contract to register an operator with the AVS.
+     *
+     *  @param operator The address of the operator to register.
+     *  @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     *
+     *  @dev msg.sender must be the AVS.
+     *  @dev Only used by legacy M2 AVSs that have not integrated with operator sets.
      */
     function registerOperatorToAVS(
         address operator,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
-
         require(
             operatorSignature.expiry >= block.timestamp,
             "AVSDirectory.registerOperatorToAVS: operator signature expired"
@@ -77,7 +264,12 @@ contract AVSDirectory is
         );
         require(
             delegation.isOperator(operator),
-            "AVSDirectory.registerOperatorToAVS: operator not registered to EigenLayer yet");
+            "AVSDirectory.registerOperatorToAVS: operator not registered to EigenLayer yet"
+        );
+        require(
+            !isOperatorSetAVS[msg.sender],
+            "AVSDirectory.registerOperatorToAVS: operator set AVS cannot register operators with legacy method"
+        );
 
         // Calculate the digest hash
         bytes32 operatorRegistrationDigestHash = calculateOperatorAVSRegistrationDigestHash({
@@ -89,9 +281,7 @@ contract AVSDirectory is
 
         // Check that the signature is valid
         EIP1271SignatureUtils.checkSignature_EIP1271(
-            operator,
-            operatorRegistrationDigestHash,
-            operatorSignature.signature
+            operator, operatorRegistrationDigestHash, operatorSignature.signature
         );
 
         // Set the operator as registered
@@ -104,10 +294,16 @@ contract AVSDirectory is
     }
 
     /**
-     * @notice Called by an avs to deregister an operator with the avs.
-     * @param operator The address of the operator to deregister.
+     *  @notice Called by an AVS to deregister an operator from the AVS.
+     *
+     *  @param operator The address of the operator to deregister.
+     *
+     *  @dev Only used by legacy M2 AVSs that have not integrated with operator sets.
      */
-    function deregisterOperatorFromAVS(address operator) external onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+    function deregisterOperatorFromAVS(address operator)
+        external
+        onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS)
+    {
         require(
             avsOperatorStatus[msg.sender][operator] == OperatorAVSRegistrationStatus.REGISTERED,
             "AVSDirectory.deregisterOperatorFromAVS: operator not registered"
@@ -120,8 +316,11 @@ contract AVSDirectory is
     }
 
     /**
-     * @notice Called by an avs to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
-     * @param metadataURI The URI for metadata associated with an avs
+     *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     *
+     *  @param metadataURI The URI for metadata associated with an AVS.
+     *
+     *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
      */
     function updateAVSMetadataURI(string calldata metadataURI) external {
         emit AVSMetadataURIUpdated(msg.sender, metadataURI);
@@ -129,23 +328,41 @@ contract AVSDirectory is
 
     /**
      * @notice Called by an operator to cancel a salt that has been used to register with an AVS.
+     *
      * @param salt A unique and single use value associated with the approver signature.
      */
     function cancelSalt(bytes32 salt) external {
-        require(!operatorSaltIsSpent[msg.sender][salt], "AVSDirectory.cancelSalt: cannot cancel spent salt");
         operatorSaltIsSpent[msg.sender][salt] = true;
     }
 
-    /*******************************************************************************
-                            VIEW FUNCTIONS
-    *******************************************************************************/
+    /**
+     *
+     *                         VIEW FUNCTIONS
+     *
+     */
 
     /**
-     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
-     * @param operator The account registering as an operator
-     * @param avs The address of the service manager contract for the AVS that the operator is registering to
-     * @param salt A unique and single use value associated with the approver signature.
-     * @param expiry Time after which the approver's signature becomes invalid
+     *  @notice Calculates the digest hash to be signed by an operator to register with an AVS.
+     *
+     *  @param standbyParams The newly updated standby mode parameters.
+     *  @param salt A unique and single-use value associated with the approver's signature.
+     *  @param expiry The time after which the approver's signature becomes invalid.
+     */
+    function calculateUpdateStandbyDigestHash(
+        StandbyParam[] calldata standbyParams,
+        bytes32 salt,
+        uint256 expiry
+    ) public view returns (bytes32) {
+        return _calculateDigestHash(keccak256(abi.encode(OPERATOR_STANDBY_UPDATE, standbyParams, salt, expiry)));
+    }
+
+    /**
+     *  @notice Calculates the digest hash to be signed by an operator to register with an AVS.
+     *
+     *  @param operator The account registering as an operator.
+     *  @param avs The AVS the operator is registering with.
+     *  @param salt A unique and single-use value associated with the approver's signature.
+     *  @param expiry The time after which the approver's signature becomes invalid.
      */
     function calculateOperatorAVSRegistrationDigestHash(
         address operator,
@@ -153,31 +370,45 @@ contract AVSDirectory is
         bytes32 salt,
         uint256 expiry
     ) public view returns (bytes32) {
-        // calculate the struct hash
-        bytes32 structHash = keccak256(
-            abi.encode(OPERATOR_AVS_REGISTRATION_TYPEHASH, operator, avs, salt, expiry)
-        );
-        // calculate the digest hash
-        bytes32 digestHash = keccak256(
-            abi.encodePacked("\x19\x01", domainSeparator(), structHash)
-        );
-        return digestHash;
+        return
+            _calculateDigestHash(keccak256(abi.encode(OPERATOR_AVS_REGISTRATION_TYPEHASH, operator, avs, salt, expiry)));
     }
 
     /**
-     * @notice Getter function for the current EIP-712 domain separator for this contract.
-     * @dev The domain separator will change in the event of a fork that changes the ChainID.
+     * @notice Calculates the digest hash to be signed by an operator to register with an operator set.
+     *
+     * @param avs The AVS that operator is registering to operator sets for.
+     * @param operatorSetIds An array of operator set IDs the operator is registering to.
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid.
      */
+    function calculateOperatorSetRegistrationDigestHash(
+        address avs,
+        uint32[] calldata operatorSetIds,
+        bytes32 salt,
+        uint256 expiry
+    ) public view returns (bytes32) {
+        return _calculateDigestHash(
+            keccak256(abi.encode(OPERATOR_SET_REGISTRATION_TYPEHASH, avs, operatorSetIds, salt, expiry))
+        );
+    }
+
+    /// @notice Getter function for the current EIP-712 domain separator for this contract.
+    /// @dev The domain separator will change in the event of a fork that changes the ChainID.
     function domainSeparator() public view returns (bytes32) {
+        return _calculateDomainSeparator();
+    }
+
+    /// @notice Internal function for calculating the current domain separator of this contract
+    function _calculateDomainSeparator() internal view returns (bytes32) {
         if (block.chainid == ORIGINAL_CHAIN_ID) {
             return _DOMAIN_SEPARATOR;
         } else {
-            return _calculateDomainSeparator();
+            return keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes("EigenLayer")), block.chainid, address(this)));
         }
     }
 
-    // @notice Internal function for calculating the current domain separator of this contract
-    function _calculateDomainSeparator() internal view returns (bytes32) {
-        return keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes("EigenLayer")), block.chainid, address(this)));
+    function _calculateDigestHash(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", _calculateDomainSeparator(), structHash));
     }
 }

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -100,8 +100,8 @@ contract AVSDirectory is
         }
 
         for (uint256 i; i < standbyParams.length; ++i) {
-            operatorRegistrationInfo[standbyParams[i].operatorSet.avs][operator][standbyParams[i].operatorSet.id].onStandby =
-                standbyParams[i].onStandby;
+            operatorRegistrationInfo[standbyParams[i].operatorSet.avs][operator][standbyParams[i].operatorSet.id]
+                .onStandby = standbyParams[i].onStandby;
 
             emit StandbyParamUpdated(operator, standbyParams[i].operatorSet, standbyParams[i].onStandby);
         }
@@ -173,10 +173,7 @@ contract AVSDirectory is
 
             // Assert avs is on standby mode for the given `operator` and `operatorSetIds[i]`.
             if (operatorSignature.signature.length == 0) {
-                require(
-                    info.onStandby,
-                    "AVSDirectory.registerOperatorToOperatorSets: avs not on standby"
-                );
+                require(info.onStandby, "AVSDirectory.registerOperatorToOperatorSets: avs not on standby");
             }
 
             // Assert `operator` has not already been registered to `operatorSetIds[i]`.
@@ -225,7 +222,7 @@ contract AVSDirectory is
 
             // Mutate `isOperatorInOperatorSet` to `false` for `operatorSetIds[i]`.
             info.isRegistered = false;
-            
+
             unchecked {
                 info.deregistrationMaturity = uint240(block.timestamp + 2 weeks);
             }

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -56,25 +56,16 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
         strategyManager = _strategyManager;
     }
 
-    function onStandby(
-        address avs,
-        address operator,
-        uint32 operatorSetId
-    ) public view returns (bool) {
+    function onStandby(address avs, address operator, uint32 operatorSetId) public view returns (bool) {
         return operatorRegistrationInfo[avs][operator][operatorSetId].onStandby;
     }
 
-    function isOperatorInOperatorSet(
-        address avs,
-        address operator,
-        uint32 operatorSetId
-    ) public view returns (bool) {
+    function isOperatorInOperatorSet(address avs, address operator, uint32 operatorSetId) public view returns (bool) {
         return _isOperatorInOperatorSet(operatorRegistrationInfo[avs][operator][operatorSetId]);
     }
 
     function _isOperatorInOperatorSet(OperatorRegistrationInfo memory info) public view returns (bool) {
-        if (!info.isRegistered && block.timestamp > info.deregistrationMaturity) return false;
-        return true;
+        return info.isRegistered || block.timestamp < info.deregistrationMaturity;
     }
 
     /**

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -64,7 +64,7 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
         return _isOperatorInOperatorSet(operatorRegistrationInfo[avs][operator][operatorSetId]);
     }
 
-    function _isOperatorInOperatorSet(OperatorRegistrationInfo memory info) public view returns (bool) {
+    function _isOperatorInOperatorSet(OperatorRegistrationInfo memory info) internal view returns (bool) {
         return info.isRegistered || block.timestamp < info.deregistrationMaturity;
     }
 

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.12;
 import "../interfaces/IAVSDirectory.sol";
 import "../interfaces/IStrategyManager.sol";
 import "../interfaces/IDelegationManager.sol";
-import "../interfaces/ISlasher.sol";
-import "../interfaces/IEigenPodManager.sol";
 
 abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @notice The EIP-712 typehash for the contract's domain
@@ -16,8 +14,19 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     bytes32 public constant OPERATOR_AVS_REGISTRATION_TYPEHASH =
         keccak256("OperatorAVSRegistration(address operator,address avs,bytes32 salt,uint256 expiry)");
 
+    /// @notice The EIP-712 typehash for the `OperatorSetRegistration` struct used by the contract
+    bytes32 public constant OPERATOR_SET_REGISTRATION_TYPEHASH =
+        keccak256("OperatorSetRegistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
+
+    /// @notice The EIP-712 typehash for the `StandbyParams` struct used by the contract
+    bytes32 public constant OPERATOR_STANDBY_UPDATE =
+        keccak256("OperatorStandbyUpdate(StandbyParam[] standbyParams,bytes32 salt,uint256 expiry)");
+    
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegation;
+
+    /// @notice The StrategyManager contract for EigenLayer
+    IStrategyManager public immutable strategyManager;
 
     /**
      * @notice Original EIP-712 Domain separator for this contract.
@@ -25,16 +34,29 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
      * Use the getter function `domainSeparator` to get the current domain separator for this contract.
      */
     bytes32 internal _DOMAIN_SEPARATOR;
-    
+
     /// @notice Mapping: AVS => operator => enum of operator status to the AVS
     mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
 
     /// @notice Mapping: operator => 32-byte salt => whether or not the salt has already been used by the operator.
-    /// @dev Salt is used in the `registerOperatorToAVS` function.
+    /// @dev Salt is used in the `registerOperatorToAVS` and `registerOperatorToOperatorSet` function.
     mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
 
-    constructor(IDelegationManager _delegation) {
+    /// @notice Mapping: AVS => whether or not the AVS uses operator set
+    mapping(address => bool) public isOperatorSetAVS;
+
+    /// @notice Mapping: avs => operator => operatorSetID => whether the operator is registered for the operator set
+    mapping(address => mapping(address => mapping(uint32 => bool))) public isOperatorInOperatorSet;
+
+    /// @notice Mapping: avs => operator => number of operator sets the operator is registered for the AVS
+    mapping(address => mapping(address => uint256)) public operatorAVSOperatorSetCount;
+
+    /// @notice Mapping: avs = operator => operatorSetId => Whether the given operator set in standby mode or not
+    mapping(address => mapping(address => mapping(uint32 => bool))) public onStandby;
+
+    constructor(IDelegationManager _delegation, IStrategyManager _strategyManager) {
         delegation = _delegation;
+        strategyManager = _strategyManager;
     }
 
     /**
@@ -42,5 +64,5 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[47] private __gap;
+    uint256[43] private __gap;
 }

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -22,6 +22,16 @@ interface IAVSDirectory is ISignatureUtils {
         bool onStandby;
     }
 
+    /// @dev Details of an operator's registration status in a given operator set.
+    /// @param deregistrationMaturity The time when deregistration becomes effective, if non-zero.
+    /// @param isRegistered True if the operator is registered; false if not registered and `deregistrationMaturity` is zero.
+    /// @param onStandby Whether or not the operator is on standby mode for the given operator set.
+    struct OperatorRegistrationInfo {
+        uint240 deregistrationMaturity;
+        bool isRegistered;
+        bool onStandby;
+    }
+
     /**
      *  @notice Emitted when an operator's registration status with an AVS is updated.
      *  Specifically, when an operator enters its first operator set for an AVS, or

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -2,27 +2,71 @@
 pragma solidity >=0.5.0;
 
 import "./ISignatureUtils.sol";
+import "./IStrategy.sol";
 
 interface IAVSDirectory is ISignatureUtils {
-    /// @notice Enum representing the status of an operator's registration with an AVS
+    /// @notice Enum representing the registration status of an operator with an AVS.
     enum OperatorAVSRegistrationStatus {
-        UNREGISTERED,       // Operator not registered to AVS
-        REGISTERED          // Operator registered to AVS
+        UNREGISTERED, // Operator is not registered with the AVS.
+        REGISTERED // Operator is registered with the AVS.
+
+    }
+
+    struct OperatorSet {
+        address avs;
+        uint32 id;
+    }
+
+    struct StandbyParam {
+        OperatorSet operatorSet;
+        bool onStandby;
     }
 
     /**
-     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
-     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     *  @notice Emitted when an operator's registration status with an AVS is updated.
+     *  Specifically, when an operator enters its first operator set for an AVS, or
+     *  when it is removed from the last operator set.
      */
+    event OperatorAVSRegistrationStatusUpdated(
+        address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status
+    );
+
+    /// @notice Emitted when an operator is added to an operator set.
+    event OperatorAddedToOperatorSet(address operator, OperatorSet operatorSet);
+
+    /// @notice Emitted when an operator is removed from an operator set.
+    event OperatorRemovedFromOperatorSet(address operator, OperatorSet operatorSet);
+
+    /// @notice Emitted when an AVS updates their metadata URI (Uniform Resource Identifier).
+    /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an operator's registration status for an AVS is updated
-    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
+    /// @notice Emitted when an operator updates their standby parameters.
+    event StandbyParamUpdated(address operator, OperatorSet operatorSet, bool onStandby);
 
     /**
-     * @notice Called by an avs to register an operator with the avs.
-     * @param operator The address of the operator to register.
-     * @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     * @notice Updates the standby parameters for an operator across multiple operator sets.
+     * Allows the AVS to add the operator to a given operator set if they are not already registered.
+     *
+     * @param operator The address of the operator for which the standby parameters are being updated.
+     * @param standbyParams The new standby parameters for the operator.
+     * @param signature If non-empty, the signature of the operator authorizing the modification.
+     *                  If empty, the `msg.sender` must be the operator.
+     */
+    function updateStandbyParams(
+        address operator,
+        StandbyParam[] calldata standbyParams,
+        SignatureWithSaltAndExpiry calldata signature
+    ) external;
+
+    /**
+     *  @notice Called by the AVS's service manager contract to register an operator with the AVS.
+     *
+     *  @param operator The address of the operator to register.
+     *  @param operatorSignature The signature, salt, and expiry of the operator's signature.
+     *
+     *  @dev msg.sender must be the AVS.
+     *  @dev Only used by legacy M2 AVSs that have not integrated with operator sets.
      */
     function registerOperatorToAVS(
         address operator,
@@ -30,30 +74,71 @@ interface IAVSDirectory is ISignatureUtils {
     ) external;
 
     /**
-     * @notice Called by an avs to deregister an operator with the avs.
-     * @param operator The address of the operator to deregister.
+     *  @notice Called by an AVS to deregister an operator from the AVS.
+     *
+     *  @param operator The address of the operator to deregister.
+     *
+     *  @dev Only used by legacy M2 AVSs that have not integrated with operator sets.
      */
     function deregisterOperatorFromAVS(address operator) external;
 
     /**
-     * @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
-     * @param metadataURI The URI for metadata associated with an AVS
-     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AVSMetadataURIUpdated` event
+     *  @notice Called by AVSs to add an operator to an operator set.
+     *
+     *  @param operator The address of the operator to be added to the operator set.
+     *  @param operatorSetIds The IDs of the operator sets.
+     *  @param signature The signature of the operator on their intent to register.
+     *
+     *  @dev msg.sender is used as the AVS.
+     *  @dev The operator must not have a pending deregistration from the operator set.
+     *  @dev If this is the first operator set in the AVS that the operator is
+     *  registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
+     *  a REGISTERED status.
+     */
+    function registerOperatorToOperatorSets(
+        address operator,
+        uint32[] calldata operatorSetIds,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory signature
+    ) external;
+
+    /**
+     *  @notice Called by AVSs or operators to remove an operator from an operator set.
+     *
+     *  @param operator The address of the operator to be removed from the operator set.
+     *  @param operatorSetIds The IDs of the operator sets.
+     *
+     *  @dev msg.sender is used as the AVS.
+     *  @dev The operator must be registered for the msg.sender AVS and the given operator set.
+     *  @dev If this removes the operator from all operator sets for the msg.sender AVS,
+     *  then an OperatorAVSRegistrationStatusUpdated event is emitted with a DEREGISTERED status.
+     */
+    function deregisterOperatorFromOperatorSets(address operator, uint32[] calldata operatorSetIds) external;
+
+    // VIEW
+
+    /**
+     *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     *
+     *  @param metadataURI The URI for metadata associated with an AVS.
+     *
+     *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
      */
     function updateAVSMetadataURI(string calldata metadataURI) external;
 
     /**
-     * @notice Returns whether or not the salt has already been used by the operator.
-     * @dev Salts is used in the `registerOperatorToAVS` function.
+     *  @notice Returns whether the salt has already been used by the operator or not.
+     *
+     *  @dev The salt is used in the `registerOperatorToAVS` function.
      */
     function operatorSaltIsSpent(address operator, bytes32 salt) external view returns (bool);
 
     /**
-     * @notice Calculates the digest hash to be signed by an operator to register with an AVS
-     * @param operator The account registering as an operator
-     * @param avs The AVS the operator is registering to
-     * @param salt A unique and single use value associated with the approver signature.
-     * @param expiry Time after which the approver's signature becomes invalid
+     *  @notice Calculates the digest hash to be signed by an operator to register with an AVS.
+     *
+     *  @param operator The account registering as an operator.
+     *  @param avs The AVS the operator is registering with.
+     *  @param salt A unique and single-use value associated with the approver's signature.
+     *  @param expiry The time after which the approver's signature becomes invalid.
      */
     function calculateOperatorAVSRegistrationDigestHash(
         address operator,
@@ -62,6 +147,24 @@ interface IAVSDirectory is ISignatureUtils {
         uint256 expiry
     ) external view returns (bytes32);
 
-    /// @notice The EIP-712 typehash for the Registration struct used by the contract
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to register with an operator set.
+     *
+     * @param avs The AVS that operator is registering to operator sets for.
+     * @param operatorSetIds An array of operator set IDs the operator is registering to.
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid.
+     */
+    function calculateOperatorSetRegistrationDigestHash(
+        address avs,
+        uint32[] memory operatorSetIds,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32);
+
+    /// @notice The EIP-712 typehash for the Registration struct used by the contract.
     function OPERATOR_AVS_REGISTRATION_TYPEHASH() external view returns (bytes32);
+
+    /// @notice The EIP-712 typehash for the OperatorSetRegistration struct used by the contract.
+    function OPERATOR_SET_REGISTRATION_TYPEHASH() external view returns (bytes32);
 }

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -270,7 +270,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             delegationManager
         );
         delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, strategyManager);
 
         // Third, upgrade the proxy contracts to point to the implementations
         uint256 withdrawalDelayBlocks = 7 days / 12 seconds;
@@ -408,7 +408,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             delegationManager
         );
         delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, strategyManager);
 
         // Second, upgrade the proxy contracts to point to the implementations
         // DelegationManager
@@ -518,7 +518,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             delegationManager
         );
         delayedWithdrawalRouterImplementation = new DelayedWithdrawalRouter(eigenPodManager);
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, strategyManager);
 
         // Second, upgrade the proxy contracts to point to the implementations
         // DelegationManager

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -529,7 +529,12 @@ contract AVSDirectoryUnitTests_deregisterOperatorFromOperatorSets is AVSDirector
 
         avsDirectory.deregisterOperatorFromOperatorSets(operator, oids);
 
+        assertEq(avsDirectory.isOperatorInOperatorSet(address(this), operator, operatorSetId), true);
+
+        vm.warp(block.timestamp + 2 weeks);
+
         assertEq(avsDirectory.isOperatorInOperatorSet(address(this), operator, operatorSetId), false);
+
         assertEq(avsDirectory.operatorAVSOperatorSetCount(address(this), operator), 0);
         assertEq(
             uint8(avsDirectory.avsOperatorStatus(address(this), operator)),

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -16,6 +16,8 @@ import "src/test/utils/EigenLayerUnitTestSetup.sol";
  * Contracts not mocked: DelegationManager
  */
 contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
+    uint256 internal constant MAX_PRIVATE_KEY = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140;
+
     // Contract under test
     AVSDirectory avsDirectory;
     AVSDirectory avsDirectoryImplementation;
@@ -68,7 +70,7 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
         );
 
         // Deploy AVSDirectory implmentation and proxy
-        avsDirectoryImplementation = new AVSDirectory(delegationManager);
+        avsDirectoryImplementation = new AVSDirectory(delegationManager, IStrategyManager(address(strategyManagerMock)));
         avsDirectory = AVSDirectory(
             address(
                 new TransparentUpgradeableProxy(
@@ -93,11 +95,11 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
      */
 
     /**
-     * @notice internal function for calculating a signature from the operator corresponding to `_operatorPrivateKey`, delegating them to
+     * @notice internal function for calculating a signature from the operator corresponding to `operatorPk`, delegating them to
      * the `operator`, and expiring at `expiry`.
      */
-    function _getOperatorSignature(
-        uint256 _operatorPrivateKey,
+    function _getOperatorAVSRegistrationSignature(
+        uint256 operatorPk,
         address operator,
         address avs,
         bytes32 salt,
@@ -107,7 +109,7 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
         operatorSignature.salt = salt;
         {
             bytes32 digestHash = avsDirectory.calculateOperatorAVSRegistrationDigestHash(operator, avs, salt, expiry);
-            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_operatorPrivateKey, digestHash);
+            (uint8 v, bytes32 r, bytes32 s) = cheats.sign(operatorPk, digestHash);
             operatorSignature.signature = abi.encodePacked(r, s, v);
         }
         return operatorSignature;
@@ -170,6 +172,469 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
     }
 }
 
+contract AVSDirectoryUnitTests_initialize is AVSDirectoryUnitTests {
+    function testFuzz_Correctness(
+        address delegationManager,
+        address strategyManager,
+        address owner,
+        address pauserRegistry,
+        uint256 initialPausedStatus
+    ) public virtual {
+        AVSDirectory dir = new AVSDirectory(IDelegationManager(delegationManager), IStrategyManager(strategyManager));
+
+        assertEq(address(dir.delegation()), delegationManager);
+        assertEq(address(dir.strategyManager()), strategyManager);
+
+        cheats.expectRevert("Initializable: contract is already initialized");
+        dir.initialize(owner, IPauserRegistry(pauserRegistry), initialPausedStatus);
+    }
+}
+
+contract AVSDirectoryUnitTests_domainSeparator is AVSDirectoryUnitTests {
+    function test_domainSeparator() public virtual {
+        // This is just to get coverage up.
+        avsDirectory.domainSeparator();
+        cheats.chainId(0xC0FFEE);
+        avsDirectory.domainSeparator();
+    }
+}
+
+contract AVSDirectoryUnitTests_registerOperatorToOperatorSets is AVSDirectoryUnitTests {
+    event OperatorAddedToOperatorSet(address operator, IAVSDirectory.OperatorSet operatorSet);
+
+    function testFuzz_revert_SignatureIsExpired(
+        address operator,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        expiry = bound(expiry, 0, type(uint256).max - 1);
+        cheats.warp(type(uint256).max);
+
+        _registerOperatorWithBaseDetails(operator);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: operator signature expired");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), salt, expiry)
+        );
+    }
+
+    function testFuzz_revert_OperatorRegistered(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+        expiry = bound(expiry, 1, type(uint256).max);
+
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        (v, r, s) = cheats.sign(
+            operatorPk,
+            avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, keccak256(""), expiry)
+        );
+
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: operator already registered to operator set");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), keccak256(""), expiry)
+        );
+    }
+
+    function testFuzz_revert_OperatorNotRegistered(
+        address operator,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        cheats.assume(operator != address(0));
+        expiry = bound(expiry, 1, type(uint256).max);
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: operator not registered to EigenLayer yet");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), salt, expiry)
+        );
+    }
+
+    function testFuzz_revert_SaltSpent(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        operatorSetId = uint32(bound(operatorSetId, 1, type(uint32).max));
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+        expiry = bound(expiry, 1, type(uint256).max);
+
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: salt already spent");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, new uint32[](0), ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), salt, expiry)
+        );
+    }
+
+    function testFuzz_revert_WrongAVS(
+        address badAvs,
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        cheats.assume(badAvs != address(this));
+
+        operatorSetId = uint32(bound(operatorSetId, 1, type(uint32).max));
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+        expiry = bound(expiry, 1, type(uint256).max);
+
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        address operator = cheats.addr(operatorPk);
+
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        cheats.prank(badAvs);
+        cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+    }
+
+    function testFuzz_MultipleCorrectness(
+        uint256 operatorPk,
+        uint256 operatorSetIdsLength,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+        operatorSetIdsLength = bound(operatorSetIdsLength, 1, 16);
+        expiry = bound(expiry, 1, type(uint256).max);
+
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](operatorSetIdsLength);
+        for (uint256 i; i < oids.length; ++i) {
+            oids[i] = uint32(uint256(keccak256(abi.encodePacked(i))) % type(uint32).max);
+        }
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        cheats.expectEmit(true, false, false, false, address(avsDirectory));
+        emit OperatorAVSRegistrationStatusUpdated(
+            operator, address(this), IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED
+        );
+
+        for (uint256 i; i < oids.length; ++i) {
+            cheats.expectEmit(true, false, false, false, address(avsDirectory));
+            emit OperatorAddedToOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), oids[i]));
+        }
+
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        for (uint256 i; i < oids.length; ++i) {
+            assertTrue(avsDirectory.isOperatorInOperatorSet(address(this), operator, oids[i]));
+        }
+
+        assertEq(avsDirectory.operatorAVSOperatorSetCount(address(this), operator), oids.length);
+        assertEq(uint8(avsDirectory.avsOperatorStatus(address(this), operator)), 1);
+        assertTrue(avsDirectory.operatorSaltIsSpent(operator, salt));
+        assertTrue(avsDirectory.isOperatorSetAVS(address(this)));
+    }
+
+    function testFuzz_Correctness(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+        expiry = bound(expiry, 1, type(uint256).max);
+
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        cheats.expectEmit(true, false, false, false, address(avsDirectory));
+        emit OperatorAVSRegistrationStatusUpdated(
+            operator, address(this), IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED
+        );
+
+        cheats.expectEmit(true, false, false, false, address(avsDirectory));
+        emit OperatorAddedToOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), operatorSetId));
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        assertEq(avsDirectory.operatorAVSOperatorSetCount(address(this), operator), 1);
+        assertEq(uint8(avsDirectory.avsOperatorStatus(address(this), operator)), 1);
+        assertTrue(avsDirectory.isOperatorInOperatorSet(address(this), operator, operatorSetId));
+        assertTrue(avsDirectory.operatorSaltIsSpent(operator, salt));
+        assertTrue(avsDirectory.isOperatorSetAVS(address(this)));
+    }
+
+    function testFuzz_revert_NoSignatureNoStandby(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        // Make sure sigature is always non-expired.
+        cheats.warp(0);
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        IAVSDirectory.StandbyParam[] memory params = new IAVSDirectory.StandbyParam[](1);
+        params[0] = IAVSDirectory.StandbyParam(IAVSDirectory.OperatorSet(address(this), operatorSetId), true);
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) =
+            cheats.sign(operatorPk, avsDirectory.calculateUpdateStandbyDigestHash(params, keccak256(""), expiry));
+
+        _registerOperatorWithBaseDetails(operator);
+
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: avs not on standby");
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), salt, expiry)
+        );
+
+        avsDirectory.updateStandbyParams(
+            operator,
+            params,
+            ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), keccak256(""), expiry)
+        );
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), 0, 0)
+        );
+    }
+}
+
+contract AVSDirectoryUnitTests_deregisterOperatorFromOperatorSets is AVSDirectoryUnitTests {
+    event OperatorRemovedFromOperatorSet(address operator, IAVSDirectory.OperatorSet operatorSet);
+
+    function _registerOperatorToOperatorSets(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) internal virtual {
+        expiry = bound(expiry, 1, type(uint256).max);
+        cheats.warp(0);
+
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            operatorPk, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, salt, expiry)
+        );
+
+        _registerOperatorWithBaseDetails(operator);
+
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+    }
+
+    function testFuzz_revert_OperatorNotInOperatorSet(uint256 operatorPk, uint32 operatorSetId) public virtual {
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+
+        address operator = cheats.addr(operatorPk);
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        cheats.expectRevert("AVSDirectory.deregisterOperatorFromOperatorSet: operator not registered for operator set");
+        avsDirectory.deregisterOperatorFromOperatorSets(operator, oids);
+    }
+
+    function testFuzz_Correctness(
+        uint256 operatorPk,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry
+    ) public virtual {
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+
+        _registerOperatorToOperatorSets(operatorPk, operatorSetId, salt, expiry);
+
+        address operator = cheats.addr(operatorPk);
+        uint32[] memory oids = new uint32[](1);
+        oids[0] = operatorSetId;
+
+        cheats.expectEmit(true, false, false, false, address(avsDirectory));
+        emit OperatorRemovedFromOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), operatorSetId));
+
+        cheats.expectEmit(true, true, true, false, address(avsDirectory));
+        emit OperatorAVSRegistrationStatusUpdated(
+            operator, address(this), IAVSDirectory.OperatorAVSRegistrationStatus.REGISTERED
+        );
+
+        avsDirectory.deregisterOperatorFromOperatorSets(operator, oids);
+
+        assertEq(avsDirectory.isOperatorInOperatorSet(address(this), operator, operatorSetId), false);
+        assertEq(avsDirectory.operatorAVSOperatorSetCount(address(this), operator), 0);
+        assertEq(
+            uint8(avsDirectory.avsOperatorStatus(address(this), operator)),
+            uint8(IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED)
+        );
+    }
+}
+
+contract AVSDirectoryUnitTests_updateStandbyParams is AVSDirectoryUnitTests {
+    event StandbyParamUpdated(address operator, IAVSDirectory.OperatorSet operatorSet, bool onStandby);
+
+    function testFuzz_revert_CallerNotOperatorNoSignature(
+        address operator,
+        address avs,
+        uint32 operatorSetId,
+        bool standby
+    ) public virtual {
+        IAVSDirectory.StandbyParam[] memory params = new IAVSDirectory.StandbyParam[](1);
+        params[0] = IAVSDirectory.StandbyParam(IAVSDirectory.OperatorSet(avs, operatorSetId), standby);
+
+        cheats.expectRevert("AVSDirectory.updateStandbyParams: invalid signature");
+        avsDirectory.updateStandbyParams(
+            operator, params, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(0), bytes32(0), 0)
+        );
+    }
+
+    function testFuzz_revert_OperatorSignatureExpired(
+        address operator,
+        address avs,
+        uint32 operatorSetId,
+        bool standby,
+        uint256 expiry
+    ) public virtual {
+        // Make sure signature is always expired.
+        cheats.warp(type(uint256).max);
+        expiry = bound(expiry, 0, type(uint256).max - 1);
+
+        IAVSDirectory.StandbyParam[] memory params = new IAVSDirectory.StandbyParam[](1);
+        params[0] = IAVSDirectory.StandbyParam(IAVSDirectory.OperatorSet(avs, operatorSetId), standby);
+
+        // Assert operator signature reverts when non-zero.
+        cheats.expectRevert("AVSDirectory.updateStandbyParams: operator signature expired");
+        avsDirectory.updateStandbyParams(
+            operator, params, ISignatureUtils.SignatureWithSaltAndExpiry(new bytes(1), bytes32(0), expiry)
+        );
+    }
+
+    function testFuzz_revert_SaltSpent(
+        uint256 operatorPk,
+        address avs,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry,
+        bool standby
+    ) public virtual {
+        // Make sure sigature is always non-expired.
+        cheats.warp(0);
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+
+        IAVSDirectory.StandbyParam[] memory params = new IAVSDirectory.StandbyParam[](1);
+        params[0] = IAVSDirectory.StandbyParam(IAVSDirectory.OperatorSet(avs, operatorSetId), standby);
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) =
+            cheats.sign(operatorPk, avsDirectory.calculateUpdateStandbyDigestHash(params, salt, expiry));
+
+        avsDirectory.updateStandbyParams(
+            operator, params, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        cheats.expectRevert("AVSDirectory.updateStandbyParams: salt spent");
+        avsDirectory.updateStandbyParams(
+            operator, params, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+    }
+
+    function testFuzz_Correctness(
+        uint256 operatorPk,
+        address avs,
+        uint32 operatorSetId,
+        bytes32 salt,
+        uint256 expiry,
+        bool standby
+    ) public virtual {
+        // Make sure sigature is always non-expired.
+        cheats.warp(0);
+        operatorPk = bound(operatorPk, 1, MAX_PRIVATE_KEY);
+
+        IAVSDirectory.StandbyParam[] memory params = new IAVSDirectory.StandbyParam[](1);
+        params[0] = IAVSDirectory.StandbyParam(IAVSDirectory.OperatorSet(avs, operatorSetId), standby);
+
+        address operator = cheats.addr(operatorPk);
+        (uint8 v, bytes32 r, bytes32 s) =
+            cheats.sign(operatorPk, avsDirectory.calculateUpdateStandbyDigestHash(params, salt, expiry));
+
+        cheats.expectEmit(true, false, false, false, address(avsDirectory));
+        emit StandbyParamUpdated(operator, IAVSDirectory.OperatorSet(avs, operatorSetId), standby);
+        avsDirectory.updateStandbyParams(
+            operator, params, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
+        );
+
+        assertEq(avsDirectory.onStandby(avs, operator, operatorSetId), standby);
+    }
+}
+
 contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUnitTests {
     function test_revert_whenRegisterDeregisterToAVSPaused() public {
         // set the pausing flag
@@ -177,7 +642,9 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
         avsDirectory.pause(2 ** PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS);
 
         cheats.expectRevert("Pausable: index is paused");
-        avsDirectory.registerOperatorToAVS(address(0), ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(""), 0, 0));
+        avsDirectory.registerOperatorToAVS(
+            address(0), ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(""), 0, 0)
+        );
 
         cheats.expectRevert("Pausable: index is paused");
         avsDirectory.deregisterOperatorFromAVS(address(0));
@@ -207,7 +674,7 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
 
         cheats.prank(defaultAVS);
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         avsDirectory.registerOperatorToAVS(operator, operatorSignature);
     }
@@ -220,7 +687,7 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
         cheats.prank(defaultAVS);
         uint256 expiry = type(uint256).max;
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         cheats.expectRevert("AVSDirectory.registerOperatorToAVS: operator not registered to EigenLayer yet");
         avsDirectory.registerOperatorToAVS(operator, operatorSignature);
@@ -234,7 +701,7 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
 
         uint256 expiry = type(uint256).max;
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         cheats.expectRevert("EIP1271SignatureUtils.checkSignature_EIP1271: signature not from signer");
         cheats.prank(operator);
@@ -242,9 +709,9 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
     }
 
     // @notice Verifies an operator registers fails when the signature expiry already expires
-    function testFuzz_revert_whenExpiryHasExpired(
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
-    ) public {
+    function testFuzz_revert_whenExpiryHasExpired(ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature)
+        public
+    {
         address operator = cheats.addr(delegationSignerPrivateKey);
         operatorSignature.expiry = bound(operatorSignature.expiry, 0, block.timestamp - 1);
 
@@ -260,7 +727,7 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
 
         uint256 expiry = type(uint256).max;
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         cheats.startPrank(defaultAVS);
         avsDirectory.registerOperatorToAVS(operator, operatorSignature);
@@ -283,10 +750,14 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
         avsDirectory.cancelSalt(salt);
 
         assertTrue(avsDirectory.operatorSaltIsSpent(operator, salt), "salt was not successfully cancelled");
-        assertFalse(avsDirectory.operatorSaltIsSpent(defaultAVS, salt), "salt should only be cancelled for the operator");
+        assertFalse(
+            avsDirectory.operatorSaltIsSpent(defaultAVS, salt), "salt should only be cancelled for the operator"
+        );
 
-        bytes32 newSalt; 
-        unchecked { newSalt = bytes32(uint(salt) + 1); }
+        bytes32 newSalt;
+        unchecked {
+            newSalt = bytes32(uint256(salt) + 1);
+        }
 
         assertFalse(salt == newSalt, "bad test setup");
 
@@ -305,7 +776,7 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
 
         uint256 expiry = type(uint256).max;
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         cheats.prank(operator);
         avsDirectory.cancelSalt(salt);
@@ -316,24 +787,6 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
     }
 
     /// @notice Verifies that an operator cannot cancel the same salt twice
-    function testFuzz_revert_whenSaltCancelledTwice(bytes32 salt) public {
-        address operator = cheats.addr(delegationSignerPrivateKey);
-        assertFalse(delegationManager.isOperator(operator), "bad test setup");
-        _registerOperatorWithBaseDetails(operator);
-
-        uint256 expiry = type(uint256).max;
-        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
-
-        cheats.startPrank(operator);
-        avsDirectory.cancelSalt(salt);
-
-        cheats.expectRevert("AVSDirectory.cancelSalt: cannot cancel spent salt");
-        avsDirectory.cancelSalt(salt);
-        cheats.stopPrank();
-    }
-
-    /// @notice Verifies that an operator cannot cancel the same salt twice
     function testFuzz_revert_whenCancellingSaltUsedToRegister(bytes32 salt) public {
         address operator = cheats.addr(delegationSignerPrivateKey);
         assertFalse(delegationManager.isOperator(operator), "bad test setup");
@@ -341,13 +794,9 @@ contract AVSDirectoryUnitTests_operatorAVSRegisterationStatus is AVSDirectoryUni
 
         uint256 expiry = type(uint256).max;
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
-            _getOperatorSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
+            _getOperatorAVSRegistrationSignature(delegationSignerPrivateKey, operator, defaultAVS, salt, expiry);
 
         cheats.prank(defaultAVS);
         avsDirectory.registerOperatorToAVS(operator, operatorSignature);
-
-        cheats.prank(operator);
-        cheats.expectRevert("AVSDirectory.cancelSalt: cannot cancel spent salt");
-        avsDirectory.cancelSalt(salt);
     }
 }


### PR DESCRIPTION
#### Description
This PR is an alternative approach to https://github.com/Layr-Labs/eigenlayer-contracts/pull/613 that enforces a fixed 2 week delay from the time a deregistration call is made rather than 2 epochs which could be anywhere from 2 weeks - 2 weeks + (1 weeks - 1 seconds) depending on the time a call is made.

#### Notes
It's worth noting that this approach requires one less SLOAD on registration and deregistration since a mapping was able to be removed/combined. The epoch approach requires an additional key in one of the mappings preventing this optimization.