### PR TITLE
feat: operator set migration; completely separate legacy and opset reg

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -86,7 +86,7 @@ contract AVSDirectory is
     }
 
     /**
-     *  @notice Called by AVSs to add an operator to an operator set.
+     *  @notice Called by AVSs to add an operator to a list of operatorSets.
      *
      *  @param operator The address of the operator to be added to the operator set.
      *  @param operatorSetIds The IDs of the operator sets.
@@ -94,9 +94,6 @@ contract AVSDirectory is
      *
      *  @dev msg.sender is used as the AVS.
      *  @dev The operator must not have a pending deregistration from the operator set.
-     *  @dev If this is the first operator set in the AVS that the operator is
-     *  registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
-     *  a REGISTERED status.
      */
     function registerOperatorToOperatorSets(
         address operator,

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -57,19 +57,21 @@ contract AVSDirectory is
      */
 
     /**
-     * @notice Initializes an operator set for an AVS.
+     * @notice Called by an AVS to create a list of new operatorSets. 
      *
-     * @param operatorSetId The ID of the operator set to initialize.
+     * @param operatorSetIds The IDs of the operator set to initialize.
      *
      * @dev msg.sender must be the AVS.
      * @dev The AVS may create operator sets before it becomes an operator set AVS.
      */
-    function createOperatorSet(uint32 operatorSetId) external {
-        require(
-            !isOperatorSet[msg.sender][operatorSetId], "AVSDirectory.createOperatorSet: operator set already exists"
-        );
-        isOperatorSet[msg.sender][operatorSetId] = true;
-        emit OperatorSetCreated(msg.sender, operatorSetId);
+    function createOperatorSets(uint32[] calldata operatorSetIds) external {
+        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
+            require(
+                !isOperatorSet[msg.sender][operatorSetIds[i]], "AVSDirectory.createOperatorSet: operator set already exists"
+            );
+            isOperatorSet[msg.sender][operatorSetIds[i]] = true;
+            emit OperatorSetCreated(msg.sender, operatorSetIds[i]);        
+        }
     }
 
     /**

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -71,7 +71,7 @@ contract AVSDirectory is
                 "AVSDirectory.createOperatorSet: operator set already exists"
             );
             isOperatorSet[msg.sender][operatorSetIds[i]] = true;
-            emit OperatorSetCreated(msg.sender, operatorSetIds[i]);
+            emit OperatorSetCreated(OperatorSet({avs: msg.sender, operatorSetId: operatorSetIds[i]}));
         }
     }
 
@@ -383,7 +383,7 @@ contract AVSDirectory is
             // Mutate `isMember` to `true`.
             isMember[avs][operator][operatorSetIds[i]] = true;
 
-            emit OperatorAddedToOperatorSet(operator, avs, operatorSetIds[i]);
+            emit OperatorAddedToOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }
     }
 
@@ -406,7 +406,7 @@ contract AVSDirectory is
             // Mutate `isMember` to `false`.
             isMember[avs][operator][operatorSetIds[i]] = false;
 
-            emit OperatorRemovedFromOperatorSet(operator, avs, operatorSetIds[i]);
+            emit OperatorRemovedFromOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }
     }
 

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -57,7 +57,7 @@ contract AVSDirectory is
      */
 
     /**
-     * @notice Called by an AVS to create a list of new operatorSets. 
+     * @notice Called by an AVS to create a list of new operatorSets.
      *
      * @param operatorSetIds The IDs of the operator set to initialize.
      *
@@ -67,17 +67,18 @@ contract AVSDirectory is
     function createOperatorSets(uint32[] calldata operatorSetIds) external {
         for (uint256 i = 0; i < operatorSetIds.length; ++i) {
             require(
-                !isOperatorSet[msg.sender][operatorSetIds[i]], "AVSDirectory.createOperatorSet: operator set already exists"
+                !isOperatorSet[msg.sender][operatorSetIds[i]],
+                "AVSDirectory.createOperatorSet: operator set already exists"
             );
             isOperatorSet[msg.sender][operatorSetIds[i]] = true;
-            emit OperatorSetCreated(msg.sender, operatorSetIds[i]);        
+            emit OperatorSetCreated(msg.sender, operatorSetIds[i]);
         }
     }
 
     /**
      * @notice Sets the AVS as an operator set AVS, preventing legacy M2 operator registrations.
-     * 
-     * @dev msg.sender must be the AVS. 
+     *
+     * @dev msg.sender must be the AVS.
      */
     function becomeOperatorSetAVS() external {
         require(!isOperatorSetAVS[msg.sender], "AVSDirectory.becomeOperatorSetAVS: already an operator set AVS");
@@ -112,8 +113,7 @@ contract AVSDirectory is
         );
         // Assert that the AVS is an operator set AVS.
         require(
-            isOperatorSetAVS[msg.sender],
-            "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
+            isOperatorSetAVS[msg.sender], "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
         );
         // Assert `operator` is actually an operator.
         require(
@@ -162,10 +162,10 @@ contract AVSDirectory is
      * @param operator The operator to deregister from the operatorSets.
      * @param avs The address of the AVS to deregister the operator from.
      * @param operatorSetIds The IDs of the operator sets.
-	 * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
-	 *
-	 * @dev if the operatorSignature is empty, the caller must be the operator
-	 * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
+     * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
+     *
+     * @dev if the operatorSignature is empty, the caller must be the operator
+     * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
      */
     function forceDeregisterFromOperatorSets(
         address operator,
@@ -256,17 +256,14 @@ contract AVSDirectory is
         );
 
         // Assert that the AVS is not an operator set AVS.
-        require(
-            !isOperatorSetAVS[msg.sender], 
-            "AVSDirectory.registerOperatorToAVS: AVS is an operator set AVS"
-        );
+        require(!isOperatorSetAVS[msg.sender], "AVSDirectory.registerOperatorToAVS: AVS is an operator set AVS");
 
         // Assert that the `operator` is not actively registered to the AVS.
         require(
             avsOperatorStatus[msg.sender][operator] != OperatorAVSRegistrationStatus.REGISTERED,
             "AVSDirectory.registerOperatorToAVS: operator already registered"
         );
-        
+
         // Assert `operator` has not already spent `operatorSignature.salt`.
         require(
             !operatorSaltIsSpent[operator][operatorSignature.salt],

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -18,8 +18,8 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
         keccak256("OperatorSetRegistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
 
     /// @notice The EIP-712 typehash for the `OperatorSetMembership` struct used by the contract
-        bytes32 public constant OPERATOR_SET_FORCE_DEREGISTRATION_TYPEHASH =
-            keccak256("OperatorSetForceDeregistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
+    bytes32 public constant OPERATOR_SET_FORCE_DEREGISTRATION_TYPEHASH =
+        keccak256("OperatorSetForceDeregistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
 
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegation;
@@ -38,7 +38,7 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
 
     /// @notice Mapping: avs => whether it is a an operator set AVS
-    mapping (address => bool) public isOperatorSetAVS;
+    mapping(address => bool) public isOperatorSetAVS;
 
     /// @notice Mapping: avs => operatorSetId => whether the operatorSet exists
     mapping(address => mapping(uint32 => bool)) public isOperatorSet;

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -17,6 +17,10 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     bytes32 public constant OPERATOR_SET_REGISTRATION_TYPEHASH =
         keccak256("OperatorSetRegistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
 
+    /// @notice The EIP-712 typehash for the `OperatorSetMembership` struct used by the contract
+        bytes32 public constant OPERATOR_SET_FORCE_DEREGISTRATION_TYPEHASH =
+            keccak256("OperatorSetForceDeregistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
+
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegation;
 

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -27,12 +27,19 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
      */
     bytes32 internal _DOMAIN_SEPARATOR;
 
+    /// @notice Mapping: avs => operator => OperatorAVSRegistrationStatus struct
+    mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
+
+    /// @notice Mapping: operator => salt => whether the salt has been used
     mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
 
+    /// @notice Mapping: avs => whether it is a an operator set AVS
+    mapping (address => bool) public isOperatorSetAVS;
+
+    /// @notice Mapping: avs => operatorSetId => whether the operatorSet exists
     mapping(address => mapping(uint32 => bool)) public isOperatorSet;
 
-    mapping(address => mapping(address => MemberInfo)) public memberInfo;
-
+    /// @notice Mapping: avs = operator => operatorSetId => whether the operator is a member of the operatorSet
     mapping(address => mapping(address => mapping(uint32 => bool))) public isMember;
 
     constructor(IDelegationManager _delegation) {

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -33,8 +33,11 @@ interface IAVSDirectory is ISignatureUtils {
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an AVS migrates to using operator sets.abi
+    /// @notice Emitted when an AVS migrates to using operator sets.
     event AVSMigratedToOperatorSets(address indexed avs);
+
+    /// @notice Emitted when an operator is migrated from M2 registration to operator sets.
+    event OperatorMigratedToOperatorSets(address indexed operator, address indexed avs, uint32[] operatorSetIds);
 
     /**
      *
@@ -58,6 +61,22 @@ interface IAVSDirectory is ISignatureUtils {
      * @dev msg.sender must be the AVS.
      */
     function becomeOperatorSetAVS() external;
+
+    /**
+     * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
+     *
+     * @param operators The list of operators to migrate
+     * @param operatorSetIds The list of operatorSets to migrate the operators to
+     *
+     * @dev The msg.sender used is the AVS
+     * @dev The operator can only be migrated at most once per AVS
+     * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
+     * @dev The operator is deregistered from the M2 legacy AVS once migrated
+     */
+    function migrateOperatorsToOperatorSets(
+        address[] calldata operators,
+        uint32[][] calldata operatorSetIds
+    ) external;
 
     /**
      *  @notice Called by AVSs to add an operator to list of operatorSets.

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -9,6 +9,7 @@ interface IAVSDirectory is ISignatureUtils {
     enum OperatorAVSRegistrationStatus {
         UNREGISTERED, // Operator not registered to AVS
         REGISTERED // Operator registered to AVS
+
     }
 
     /// @notice Emitted when an operator set is created by an AVS.
@@ -18,7 +19,9 @@ interface IAVSDirectory is ISignatureUtils {
      *  @notice Emitted when an operator's registration status with an AVS id udpated
      *  @notice Only used by legacy M2 AVSs that have not integrated with operatorSets.
      */
-    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status);
+    event OperatorAVSRegistrationStatusUpdated(
+        address indexed operator, address indexed avs, OperatorAVSRegistrationStatus status
+    );
 
     /// @notice Emitted when an operator is added to an operator set.
     event OperatorAddedToOperatorSet(address operator, address avs, uint32 operatorSetId);
@@ -40,7 +43,7 @@ interface IAVSDirectory is ISignatureUtils {
      */
 
     /**
-     * @notice Called by an AVS to create a list of new operatorSets. 
+     * @notice Called by an AVS to create a list of new operatorSets.
      *
      * @param operatorSetIds The IDs of the operator set to initialize.
      *
@@ -51,8 +54,8 @@ interface IAVSDirectory is ISignatureUtils {
 
     /**
      * @notice Sets the AVS as an operator set AVS, preventing legacy M2 operator registrations.
-     * 
-     * @dev msg.sender must be the AVS. 
+     *
+     * @dev msg.sender must be the AVS.
      */
     function becomeOperatorSetAVS() external;
 
@@ -88,10 +91,10 @@ interface IAVSDirectory is ISignatureUtils {
      * @param operator The operator to deregister from the operatorSets.
      * @param avs The address of the AVS to deregister the operator from.
      * @param operatorSetIds The IDs of the operator sets.
-	 * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
-	 *
-	 * @dev if the operatorSignature is empty, the caller must be the operator
-	 * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
+     * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
+     *
+     * @dev if the operatorSignature is empty, the caller must be the operator
+     * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
      */
     function forceDeregisterFromOperatorSets(
         address operator,

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -12,8 +12,14 @@ interface IAVSDirectory is ISignatureUtils {
 
     }
 
+    /// @notice Struct representing an operator set
+    struct OperatorSet {
+        address avs;
+        uint32 operatorSetId;
+    }
+
     /// @notice Emitted when an operator set is created by an AVS.
-    event OperatorSetCreated(address indexed avs, uint32 operatorSetId);
+    event OperatorSetCreated(OperatorSet operatorSet);
 
     /**
      *  @notice Emitted when an operator's registration status with an AVS id udpated
@@ -24,10 +30,10 @@ interface IAVSDirectory is ISignatureUtils {
     );
 
     /// @notice Emitted when an operator is added to an operator set.
-    event OperatorAddedToOperatorSet(address operator, address avs, uint32 operatorSetId);
+    event OperatorAddedToOperatorSet(address indexed operator, OperatorSet operatorSet);
 
     /// @notice Emitted when an operator is removed from an operator set.
-    event OperatorRemovedFromOperatorSet(address operator, address avs, uint32 operatorSetId);
+    event OperatorRemovedFromOperatorSet(address indexed operator, OperatorSet operatorSet);
 
     /// @notice Emitted when an AVS updates their metadata URI (Uniform Resource Identifier).
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -73,16 +73,6 @@ interface IAVSDirectory is ISignatureUtils {
     ) external;
 
     /**
-     * @notice Called by an operator to deregister from an operator set
-     *
-     * @param avs The address of the AVS to deregister the operator from.
-     * @param operatorSetIds The IDs of the operator sets.
-     *
-     * @dev msg.sender used is the operator
-     */
-    function deregisterFromOperatorSets(address avs, uint32[] calldata operatorSetIds) external;
-
-    /**
      *  @notice Called by AVSs to remove an operator from an operator set.
      *
      *  @param operator The address of the operator to be removed from the operator set.
@@ -90,7 +80,25 @@ interface IAVSDirectory is ISignatureUtils {
      *
      *  @dev msg.sender is used as the AVS.
      */
-    function avsDeregisterFromOperatorSets(address operator, uint32[] calldata operatorSetIds) external;
+    function deregisterOperatorFromOperatorSets(address operator, uint32[] calldata operatorSetIds) external;
+
+    /**
+     * @notice Called by an operator to deregister from an operator set
+     *
+     * @param operator The operator to deregister from the operatorSets.
+     * @param avs The address of the AVS to deregister the operator from.
+     * @param operatorSetIds The IDs of the operator sets.
+	 * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
+	 *
+	 * @dev if the operatorSignature is empty, the caller must be the operator
+	 * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
+     */
+    function forceDeregisterFromOperatorSets(
+        address operator,
+        address avs,
+        uint32[] calldata operatorSetIds,
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+    ) external;
 
     /**
      *  @notice Called by the AVS's service manager contract to register an operator with the AVS.
@@ -164,6 +172,21 @@ interface IAVSDirectory is ISignatureUtils {
      * @param expiry Time after which the approver's signature becomes invalid.
      */
     function calculateOperatorSetRegistrationDigestHash(
+        address avs,
+        uint32[] calldata operatorSetIds,
+        bytes32 salt,
+        uint256 expiry
+    ) external view returns (bytes32);
+
+    /**
+     * @notice Calculates the digest hash to be signed by an operator to force deregister from an operator set.
+     *
+     * @param avs The AVS that operator is deregistering from.
+     * @param operatorSetIds An array of operator set IDs the operator is deregistering from.
+     * @param salt A unique and single use value associated with the approver signature.
+     * @param expiry Time after which the approver's signature becomes invalid.
+     */
+    function calculateOperatorSetForceDeregistrationTypehash(
         address avs,
         uint32[] calldata operatorSetIds,
         bytes32 salt,

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -57,7 +57,7 @@ interface IAVSDirectory is ISignatureUtils {
     function becomeOperatorSetAVS() external;
 
     /**
-     *  @notice Called by AVSs to add an operator to an operator set.
+     *  @notice Called by AVSs to add an operator to list of operatorSets.
      *
      *  @param operator The address of the operator to be added to the operator set.
      *  @param operatorSetIds The IDs of the operator sets.
@@ -65,9 +65,6 @@ interface IAVSDirectory is ISignatureUtils {
      *
      *  @dev msg.sender is used as the AVS.
      *  @dev The operator must not have a pending deregistration from the operator set.
-     *  @dev If this is the first operator set in the AVS that the operator is
-     *  registering for, a OperatorAVSRegistrationStatusUpdated event is emitted with
-     *  a REGISTERED status.
      */
     function registerOperatorToOperatorSets(
         address operator,

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -40,6 +40,23 @@ interface IAVSDirectory is ISignatureUtils {
      */
 
     /**
+     * @notice Called by an AVS to create a list of new operatorSets. 
+     *
+     * @param operatorSetIds The IDs of the operator set to initialize.
+     *
+     * @dev msg.sender must be the AVS.
+     * @dev The AVS may create operator sets before it becomes an operator set AVS.
+     */
+    function createOperatorSets(uint32[] calldata operatorSetIds) external;
+
+    /**
+     * @notice Sets the AVS as an operator set AVS, preventing legacy M2 operator registrations.
+     * 
+     * @dev msg.sender must be the AVS. 
+     */
+    function becomeOperatorSetAVS() external;
+
+    /**
      *  @notice Called by AVSs to add an operator to an operator set.
      *
      *  @param operator The address of the operator to be added to the operator set.

--- a/src/test/events/IAVSDirectoryEvents.sol
+++ b/src/test/events/IAVSDirectoryEvents.sol
@@ -5,7 +5,7 @@ import "src/contracts/interfaces/IAVSDirectory.sol";
 
 interface IAVSDirectoryEvents {
     /// @notice Emitted when an operator set is created by an AVS.
-    event OperatorSetCreated(address indexed avs, uint32 operatorSetId);
+    event OperatorSetCreated(IAVSDirectory.OperatorSet operatorSet);
 
     /**
      *  @notice Emitted when an operator's registration status with an AVS id udpated
@@ -14,10 +14,10 @@ interface IAVSDirectoryEvents {
     event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, IAVSDirectory.OperatorAVSRegistrationStatus status);
 
     /// @notice Emitted when an operator is added to an operator set.
-    event OperatorAddedToOperatorSet(address operator, address avs, uint32 operatorSetId);
+    event OperatorAddedToOperatorSet(address indexed operator, IAVSDirectory.OperatorSet operatorSet);
 
     /// @notice Emitted when an operator is removed from an operator set.
-    event OperatorRemovedFromOperatorSet(address operator, address avs, uint32 operatorSetId);
+    event OperatorRemovedFromOperatorSet(address indexed operator, IAVSDirectory.OperatorSet operatorSet);
 
     /// @notice Emitted when an AVS updates their metadata URI (Uniform Resource Identifier).
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.

--- a/src/test/events/IAVSDirectoryEvents.sol
+++ b/src/test/events/IAVSDirectoryEvents.sol
@@ -4,12 +4,25 @@ pragma solidity ^0.8.12;
 import "src/contracts/interfaces/IAVSDirectory.sol";
 
 interface IAVSDirectoryEvents {
+    /// @notice Emitted when an operator set is created by an AVS.
+    event OperatorSetCreated(address indexed avs, uint32 operatorSetId);
+
     /**
-     * @notice Emitted when @param avs indicates that they are updating their MetadataURI string
-     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     *  @notice Emitted when an operator's registration status with an AVS id udpated
+     *  @notice Only used by legacy M2 AVSs that have not integrated with operatorSets.
      */
+    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, IAVSDirectory.OperatorAVSRegistrationStatus status);
+
+    /// @notice Emitted when an operator is added to an operator set.
+    event OperatorAddedToOperatorSet(address operator, address avs, uint32 operatorSetId);
+
+    /// @notice Emitted when an operator is removed from an operator set.
+    event OperatorRemovedFromOperatorSet(address operator, address avs, uint32 operatorSetId);
+
+    /// @notice Emitted when an AVS updates their metadata URI (Uniform Resource Identifier).
+    /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an operator's registration status for an AVS is updated
-    event OperatorAVSRegistrationStatusUpdated(address indexed operator, address indexed avs, bool status);
+    /// @notice Emitted when an AVS migrates to using operator sets.abi
+    event AVSMigratedToOperatorSets(address indexed avs);
 }

--- a/src/test/events/IAVSDirectoryEvents.sol
+++ b/src/test/events/IAVSDirectoryEvents.sol
@@ -23,6 +23,9 @@ interface IAVSDirectoryEvents {
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an AVS migrates to using operator sets.abi
+    /// @notice Emitted when an AVS migrates to using operator sets
     event AVSMigratedToOperatorSets(address indexed avs);
+
+    /// @notice Emitted when an operator is migrated from M2 registration to operator sets.
+    event OperatorMigratedToOperatorSets(address indexed operator, address indexed avs, uint32[] operatorSetIds);
 }

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -484,7 +484,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
 
         for (uint256 i; i < oids.length; ++i) {
             cheats.expectEmit(true, false, false, false, address(avsDirectory));
-            emit OperatorAddedToOperatorSet(operator, address(this), oids[i]);
+            emit OperatorAddedToOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), oids[i]));
         }
 
         avsDirectory.registerOperatorToOperatorSets(
@@ -523,7 +523,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
         _registerOperatorWithBaseDetails(operator);
 
         cheats.expectEmit(true, false, false, false, address(avsDirectory));
-        emit OperatorAddedToOperatorSet(operator, address(this), operatorSetId);
+        emit OperatorAddedToOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), operatorSetId));
         avsDirectory.registerOperatorToOperatorSets(
             operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
         );
@@ -590,7 +590,7 @@ contract AVSDirectoryUnitTests_forceDeregisterFromOperatorSets is AVSDirectoryUn
         cheats.prank(operator);
         for(uint i = 0; i < oids.length; i++) {
             cheats.expectEmit(true, true, true, true, address(avsDirectory));
-            emit OperatorRemovedFromOperatorSet(operator, address(this), oids[i]);
+            emit OperatorRemovedFromOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), oids[i]));
         }
         avsDirectory.forceDeregisterFromOperatorSets(operator, address(this), oids, emptySig);
 
@@ -660,7 +660,7 @@ contract AVSDirectoryUnitTests_forceDeregisterFromOperatorSets is AVSDirectoryUn
         
         for (uint i = 0; i < oids.length; i++) {
             cheats.expectEmit(true, true, true, true, address(avsDirectory));
-            emit OperatorRemovedFromOperatorSet(operator, address(this), oids[i]);
+            emit OperatorRemovedFromOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), oids[i]));
         }
 
         avsDirectory.forceDeregisterFromOperatorSets(operator, address(this), oids, operatorSig);
@@ -715,7 +715,7 @@ contract AVSDirectoryUnitTests_deregisterOperatorFromOperatorSets is AVSDirector
         oids[0] = operatorSetId;
 
         cheats.expectEmit(true, false, false, false, address(avsDirectory));
-        emit OperatorRemovedFromOperatorSet(operator, address(this), operatorSetId);
+        emit OperatorRemovedFromOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), operatorSetId));
 
         avsDirectory.deregisterOperatorFromOperatorSets(operator, oids);
 
@@ -732,7 +732,7 @@ contract AVSDirectoryUnitTests_createOperatorSet is AVSDirectoryUnitTests {
 
         for(uint i = 0; i < oids.length; i++) {
             cheats.expectEmit(true, true, true, true, address(avsDirectory));
-            emit OperatorSetCreated(address(this), oids[i]);
+            emit OperatorSetCreated(IAVSDirectory.OperatorSet({avs: address(this), operatorSetId: oids[i]}));
         }
 
         avsDirectory.createOperatorSets(oids);
@@ -909,7 +909,7 @@ contract AVSDirectoryUnitTests_migrateOperatorsToOperatorSets is AVSDirectoryUni
 
         // Expect Emits
         cheats.expectEmit(true, true, true, true, address(avsDirectory));
-        emit OperatorAddedToOperatorSet(operator, address(this), 1);
+        emit OperatorAddedToOperatorSet(operator, IAVSDirectory.OperatorSet(address(this), 1));
         cheats.expectEmit(true, true, true, true, address(avsDirectory));
         emit OperatorAVSRegistrationStatusUpdated(operator, address(this), IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
         cheats.expectEmit(true, true, true, true, address(avsDirectory));
@@ -948,7 +948,7 @@ contract AVSDirectoryUnitTests_migrateOperatorsToOperatorSets is AVSDirectoryUni
         for (uint i = 0; i < numOperators; i++) {
             for (uint j = 0; j < oids.length; j++) {
                 cheats.expectEmit(true, true, true, true, address(avsDirectory));
-                emit OperatorAddedToOperatorSet(operators[i], address(this), oids[j]);
+                emit OperatorAddedToOperatorSet(operators[i], IAVSDirectory.OperatorSet(address(this), oids[j]));
             }
             cheats.expectEmit(true, true, true, true, address(avsDirectory));
             emit OperatorAVSRegistrationStatusUpdated(operators[i], address(this), IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);


### PR DESCRIPTION
Bring back the OperatorAVSRegistration storage that was previously overwritten.

Segregates the registration/deregistration on M2 Legacy & Operator Sets for consistency in offchain code paths. As a result, we remove the numAVSRegistered struct. 

The storage may be able to be condensed still, but haven't put further thought into this.   

Pending: Bring Back OpSet struct in a separate PR