### PR TITLE
feat: operator set migration

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -102,7 +102,7 @@ contract AVSDirectory is
         uint32[][] calldata operatorSetIds
     ) external override onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
         // Assert that the AVS is an operator set AVS.
-        require(isOperatorSetAVS[msg.sender], "AVSDirectory.migrateOperatorsToOperatorSets: not an operator set AVS");
+        require(isOperatorSetAVS[msg.sender], "AVSDirectory.migrateOperatorsToOperatorSets: AVS is not an operator set AVS");
 
         for (uint256 i = 0; i < operators.length; i++) {
             // Assert that the operator is registered & has not been migrated.
@@ -148,6 +148,11 @@ contract AVSDirectory is
         require(
             delegation.isOperator(operator),
             "AVSDirectory.registerOperatorToOperatorSets: operator not registered to EigenLayer yet"
+        );
+        // Assert that the AVS is an operator set AVS.
+        require(
+            isOperatorSetAVS[avs], 
+            "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
         );
         // Assert operator's signature `salt` has not already been spent.
         require(
@@ -361,9 +366,6 @@ contract AVSDirectory is
      * @param operatorSetIds The IDs of the operator sets.
      */
     function _registerToOperatorSets(address avs, address operator, uint32[] calldata operatorSetIds) internal {
-        // Assert that the AVS is an operator set AVS.
-        require(isOperatorSetAVS[avs], "AVSDirectory._registerOperatorToOperatorSets: AVS is not an operator set AVS");
-
         // Loop over `operatorSetIds` array and register `operator` for each item.
         for (uint256 i = 0; i < operatorSetIds.length; ++i) {
             require(

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -52,7 +52,7 @@ contract AVSDirectory is
 
     /**
      *
-     *                         EXTERNAL FUNCTIONS
+     *                    EXTERNAL FUNCTIONS
      *
      */
 
@@ -87,6 +87,44 @@ contract AVSDirectory is
     }
 
     /**
+     * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
+     *
+     * @param operators The list of operators to migrate
+     * @param operatorSetIds The list of operatorSets to migrate the operators to
+     *
+     * @dev The msg.sender used is the AVS
+     * @dev The operator can only be migrated at most once per AVS
+     * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
+     * @dev The operator is deregistered from the M2 legacy AVS once migrated
+     */
+    function migrateOperatorsToOperatorSets(
+        address[] operators,
+        uint32[][] calldata operatorSetIds
+    ) external override onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+        // Assert that the AVS is an operator set AVS.
+        require(isOperatorSetAVS[msg.sender], "AVSDirectory.migrateOperatorsToOperatorSets: not an operator set AVS");
+
+        for (uint256 i = 0; i < operators.length; i++) {
+            // Assert that the operator is registered & has not been migrated.
+            require(
+                avsOperatorStatus[msg.sender][operators[i]] == OperatorAVSRegistrationStatus.REGISTERED,
+                "AVSDirectory.migrateOperatorsToOperatorSets: operator already migrated"
+            );
+
+            // Migrate operator to operator sets.
+            _registerToOperatorSets(msg.sender, operators[i], operatorSetIds[i]);
+
+            // Deregister operator from AVS - this prevents the operator from being migrated again since
+            // the AVS can no longer use the legacy M2 registration path
+            avsOperatorStatus[msg.sender][operators[i]] = OperatorAVSRegistrationStatus.UNREGISTERED;
+            emit OperatorAVSRegistrationStatusUpdated(
+                operators[i], msg.sender, OperatorAVSRegistrationStatus.UNREGISTERED
+            );
+            emit OperatorMigratedToOperatorSets(operator, msg.sender, operatorSetIds[i]);
+        }
+    }
+
+    /**
      *  @notice Called by AVSs to add an operator to a list of operatorSets.
      *
      *  @param operator The address of the operator to be added to the operator set.
@@ -111,15 +149,6 @@ contract AVSDirectory is
             !operatorSaltIsSpent[operator][operatorSignature.salt],
             "AVSDirectory.registerOperatorToOperatorSets: salt already spent"
         );
-        // Assert that the AVS is an operator set AVS.
-        require(
-            isOperatorSetAVS[msg.sender], "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
-        );
-        // Assert `operator` is actually an operator.
-        require(
-            delegation.isOperator(operator),
-            "AVSDirectory.registerOperatorToOperatorSets: operator not registered to EigenLayer yet"
-        );
 
         // Assert that `operatorSignature.signature` is a valid signature for operator set registrations.
         EIP1271SignatureUtils.checkSignature_EIP1271(
@@ -135,25 +164,6 @@ contract AVSDirectory is
 
         // Mutate `operatorSaltIsSpent` to `true` to prevent future respending.
         operatorSaltIsSpent[operator][operatorSignature.salt] = true;
-
-        // Loop over `operatorSetIds` array and register `operator` for each item.
-        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
-            require(
-                isOperatorSet[msg.sender][operatorSetIds[i]],
-                "AVSDirectory.registerOperatorToOperatorSets: invalid operator set"
-            );
-
-            // Assert `operator` has not already been registered to `operatorSetIds[i]`.
-            require(
-                !isMember[msg.sender][operator][operatorSetIds[i]],
-                "AVSDirectory.registerOperatorToOperatorSets: operator already registered to operator set"
-            );
-
-            // Mutate `isMember` to `true`.
-            isMember[msg.sender][operator][operatorSetIds[i]] = true;
-
-            emit OperatorAddedToOperatorSet(operator, msg.sender, operatorSetIds[i]);
-        }
     }
 
     /**
@@ -220,21 +230,32 @@ contract AVSDirectory is
         _deregisterFromOperatorSets(msg.sender, operator, operatorSetIds);
     }
 
-    function _deregisterFromOperatorSets(address avs, address operator, uint32[] calldata operatorSetIds) internal {
-        // Loop over `operatorSetIds` array and deregister `operator` for each item.
-        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
-            // Assert `operator` is registered for this iterations operator set.
-            require(
-                isMember[avs][operator][operatorSetIds[i]],
-                "AVSDirectory.deregisterOperatorFromOperatorSet: operator not registered for operator set"
-            );
-
-            // Mutate `isMember` to `false`.
-            isMember[avs][operator][operatorSetIds[i]] = false;
-
-            emit OperatorRemovedFromOperatorSet(operator, avs, operatorSetIds[i]);
-        }
+    /**
+     *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+     *
+     *  @param metadataURI The URI for metadata associated with an AVS.
+     *
+     *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
+     */
+    function updateAVSMetadataURI(string calldata metadataURI) external override {
+        emit AVSMetadataURIUpdated(msg.sender, metadataURI);
     }
+
+    /**
+     * @notice Called by an operator to cancel a salt that has been used to register with an AVS.
+     *
+     * @param salt A unique and single use value associated with the approver signature.
+     */
+    function cancelSalt(bytes32 salt) external override {
+        // Mutate `operatorSaltIsSpent` to `true` to prevent future spending.
+        operatorSaltIsSpent[msg.sender][salt] = true;
+    }
+
+    /**
+     *
+     *        LEGACY EXTERNAL FUNCTIONS - SUPPORT DEPRECATED BY SLASHING RELEASE
+     *
+     */
 
     /**
      *  @notice Called by the AVS's service manager contract to register an operator with the AVS.
@@ -321,24 +342,60 @@ contract AVSDirectory is
     }
 
     /**
-     *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
      *
-     *  @param metadataURI The URI for metadata associated with an AVS.
+     *                         INTERNAL FUNCTIONS
      *
-     *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
      */
-    function updateAVSMetadataURI(string calldata metadataURI) external override {
-        emit AVSMetadataURIUpdated(msg.sender, metadataURI);
+    function _registerToOperatorSets(address avs, address operator, uint32[] calldata operatorSetIds) internal {
+        // Assert that the AVS is an operator set AVS.
+        require(isOperatorSetAVS[avs], "AVSDirectory._registerOperatorToOperatorSets: AVS is not an operator set AVS");
+        // Assert `operator` is actually an operator.
+        require(
+            delegation.isOperator(operator),
+            "AVSDirectory._registerOperatorToOperatorSets: operator not registered to EigenLayer yet"
+        );
+
+        // Loop over `operatorSetIds` array and register `operator` for each item.
+        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
+            require(
+                isOperatorSet[AVSMetadataURIUpdated][operatorSetIds[i]],
+                "AVSDirectory.registerOperatorToOperatorSets: invalid operator set"
+            );
+
+            // Assert `operator` has not already been registered to `operatorSetIds[i]`.
+            require(
+                !isMember[avs][operator][operatorSetIds[i]],
+                "AVSDirectory.registerOperatorToOperatorSets: operator already registered to operator set"
+            );
+
+            // Mutate `isMember` to `true`.
+            isMember[avs][operator][operatorSetIds[i]] = true;
+
+            emit OperatorAddedToOperatorSet(operator, avs, operatorSetIds[i]);
+        }
     }
 
     /**
-     * @notice Called by an operator to cancel a salt that has been used to register with an AVS.
+     * @notice Internal function to deregister an operator from an operator set.
      *
-     * @param salt A unique and single use value associated with the approver signature.
+     * @param avs The AVS that the operator is deregistering from.
+     * @param operator The operator to deregister.
+     * @param operatorSetIds The IDs of the operator sets.
      */
-    function cancelSalt(bytes32 salt) external override {
-        // Mutate `operatorSaltIsSpent` to `true` to prevent future spending.
-        operatorSaltIsSpent[msg.sender][salt] = true;
+    function _deregisterFromOperatorSets(address avs, address operator, uint32[] calldata operatorSetIds) internal {
+        // Loop over `operatorSetIds` array and deregister `operator` for each item.
+        for (uint256 i = 0; i < operatorSetIds.length; ++i) {
+            // Assert `operator` is registered for this iterations operator set.
+            require(
+                isMember[avs][operator][operatorSetIds[i]],
+                "AVSDirectory._deregisterOperatorFromOperatorSet: operator not registered for operator set"
+            );
+
+            // Mutate `isMember` to `false`.
+            isMember[avs][operator][operatorSetIds[i]] = false;
+
+            emit OperatorRemovedFromOperatorSet(operator, avs, operatorSetIds[i]);
+        }
     }
 
     /**

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -151,7 +151,7 @@ contract AVSDirectory is
         );
         // Assert that the AVS is an operator set AVS.
         require(
-            isOperatorSetAVS[avs], 
+            isOperatorSetAVS[msg.sender], 
             "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
         );
         // Assert operator's signature `salt` has not already been spent.

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -102,7 +102,9 @@ contract AVSDirectory is
         uint32[][] calldata operatorSetIds
     ) external override onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
         // Assert that the AVS is an operator set AVS.
-        require(isOperatorSetAVS[msg.sender], "AVSDirectory.migrateOperatorsToOperatorSets: AVS is not an operator set AVS");
+        require(
+            isOperatorSetAVS[msg.sender], "AVSDirectory.migrateOperatorsToOperatorSets: AVS is not an operator set AVS"
+        );
 
         for (uint256 i = 0; i < operators.length; i++) {
             // Assert that the operator is registered & has not been migrated.
@@ -151,8 +153,7 @@ contract AVSDirectory is
         );
         // Assert that the AVS is an operator set AVS.
         require(
-            isOperatorSetAVS[msg.sender], 
-            "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
+            isOperatorSetAVS[msg.sender], "AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS"
         );
         // Assert operator's signature `salt` has not already been spent.
         require(

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -62,21 +62,21 @@ interface IAVSDirectory is ISignatureUtils {
      */
     function becomeOperatorSetAVS() external;
 
-	/**
-	 * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
-	 *
-	 * @param operators The list of operators to migrate
-	 * @param operatorSetIds The list of operatorSets to migrate the operators to
-	 *
-	 * @dev The msg.sender used is the AVS
-	 * @dev The operator can only be migrated at most once per AVS
-	 * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
-	 * @dev The operator is deregistered from the M2 legacy AVS once migrated
-	 */
-	function migrateOperatorsToOperatorSets(
-		address[] calldata operators,
-		uint32[][] calldata operatorSetIds
-	) external;
+    /**
+     * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
+     *
+     * @param operators The list of operators to migrate
+     * @param operatorSetIds The list of operatorSets to migrate the operators to
+     *
+     * @dev The msg.sender used is the AVS
+     * @dev The operator can only be migrated at most once per AVS
+     * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
+     * @dev The operator is deregistered from the M2 legacy AVS once migrated
+     */
+    function migrateOperatorsToOperatorSets(
+        address[] calldata operators,
+        uint32[][] calldata operatorSetIds
+    ) external;
 
     /**
      *  @notice Called by AVSs to add an operator to list of operatorSets.

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -33,8 +33,11 @@ interface IAVSDirectory is ISignatureUtils {
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an AVS migrates to using operator sets.abi
+    /// @notice Emitted when an AVS migrates to using operator sets.
     event AVSMigratedToOperatorSets(address indexed avs);
+
+    /// @notice Emitted when an operator is migrated from M2 registration to operator sets.
+    event OperatorMigratedToOperatorSets(address indexed operator, address indexed avs, uint32[] operatorSetIds);
 
     /**
      *
@@ -58,6 +61,22 @@ interface IAVSDirectory is ISignatureUtils {
      * @dev msg.sender must be the AVS.
      */
     function becomeOperatorSetAVS() external;
+
+	/**
+	 * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
+	 *
+	 * @param operators The list of operators to migrate
+	 * @param operatorSetIds The list of operatorSets to migrate the operators to
+	 *
+	 * @dev The msg.sender used is the AVS
+	 * @dev The operator can only be migrated at most once per AVS
+	 * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
+	 * @dev The operator is deregistered from the M2 legacy AVS once migrated
+	 */
+	function migrateOperatorsToOperatorSets(
+		address[] calldata operators,
+		uint32[][] calldata operatorSetIds
+	) external;
 
     /**
      *  @notice Called by AVSs to add an operator to list of operatorSets.

--- a/src/test/events/IAVSDirectoryEvents.sol
+++ b/src/test/events/IAVSDirectoryEvents.sol
@@ -23,6 +23,9 @@ interface IAVSDirectoryEvents {
     /// @dev The URI is never stored; it is simply emitted through an event for off-chain indexing.
     event AVSMetadataURIUpdated(address indexed avs, string metadataURI);
 
-    /// @notice Emitted when an AVS migrates to using operator sets.abi
+    /// @notice Emitted when an AVS migrates to using operator sets
     event AVSMigratedToOperatorSets(address indexed avs);
+
+    /// @notice Emitted when an operator is migrated from M2 registration to operator sets.
+    event OperatorMigratedToOperatorSets(address indexed operator, address indexed avs, uint32[] operatorSetIds);
 }

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -761,6 +761,10 @@ contract AVSDirectoryUnitTests_becomeOperatorSetAVS is AVSDirectoryUnitTests {
     }
 }
 
+contract AVSDirectoryUnitTests_migrateOperatorsToOperatorSets is AVSDirectoryUnitTests {
+
+}
+
 contract AVSDirectoryUnitTests_legacyOperatorAVSRegistration is AVSDirectoryUnitTests {
     function test_revert_whenRegisterDeregisterToAVSPaused() public {
         // set the pausing flag

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -289,7 +289,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
 
         _registerOperatorWithBaseDetails(operator);
 
-        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: AVS is not an operator set AVS");
+        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS");
         avsDirectory.registerOperatorToOperatorSets(
             operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
         );
@@ -782,7 +782,7 @@ contract AVSDirectoryUnitTests_migrateOperatorsToOperatorSets is AVSDirectoryUni
     }
 
     function test_revert_notOperatorSetAVS() public {
-        cheats.expectRevert("AVSDirectory.migrateOperatorsToOperatorSets: not an operator set AVS");
+        cheats.expectRevert("AVSDirectory.migrateOperatorsToOperatorSets: AVS is not an operator set AVS");
         cheats.prank(defaultAVS);
         avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
     }

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -212,6 +212,10 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
         oids[0] = operatorSetId;
         avsDirectory.createOperatorSets(oids);
     }
+
+    function _createOperatorSets(uint32[] memory operatorSetIds) internal {
+        avsDirectory.createOperatorSets(operatorSetIds);
+    }
 }
 
 contract AVSDirectoryUnitTests_initialize is AVSDirectoryUnitTests {
@@ -285,7 +289,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
 
         _registerOperatorWithBaseDetails(operator);
 
-        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: AVS is not an operator set AVS");
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: AVS is not an operator set AVS");
         avsDirectory.registerOperatorToOperatorSets(
             operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
         );
@@ -324,7 +328,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
             avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), oids, keccak256(""), expiry)
         );
 
-        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: operator already registered to operator set");
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: operator already registered to operator set");
         avsDirectory.registerOperatorToOperatorSets(
             operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), keccak256(""), expiry)
         );
@@ -446,7 +450,7 @@ contract AVSDirectoryUnitTests_registerOperatorToOperatorSet is AVSDirectoryUnit
 
         _registerOperatorWithBaseDetails(operator);
 
-        cheats.expectRevert("AVSDirectory.registerOperatorToOperatorSets: invalid operator set");
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: invalid operator set");
         avsDirectory.registerOperatorToOperatorSets(
             operator, oids, ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt, expiry)
         );
@@ -543,7 +547,7 @@ contract AVSDirectoryUnitTests_forceDeregisterFromOperatorSets is AVSDirectoryUn
         ISignatureUtils.SignatureWithSaltAndExpiry memory emptySig;
 
         cheats.prank(operator);
-        cheats.expectRevert("AVSDirectory.deregisterOperatorFromOperatorSet: operator not registered for operator set");
+        cheats.expectRevert("AVSDirectory._deregisterOperatorFromOperatorSet: operator not registered for operator set");
         
         avsDirectory.forceDeregisterFromOperatorSets(operator, address(this), oids, emptySig);
     }
@@ -690,7 +694,7 @@ contract AVSDirectoryUnitTests_deregisterOperatorFromOperatorSets is AVSDirector
         uint32[] memory oids = new uint32[](1);
         oids[0] = operatorSetId;
 
-        cheats.expectRevert("AVSDirectory.deregisterOperatorFromOperatorSet: operator not registered for operator set");
+        cheats.expectRevert("AVSDirectory._deregisterOperatorFromOperatorSet: operator not registered for operator set");
         avsDirectory.deregisterOperatorFromOperatorSets(operator, oids);
     }
 
@@ -762,7 +766,218 @@ contract AVSDirectoryUnitTests_becomeOperatorSetAVS is AVSDirectoryUnitTests {
 }
 
 contract AVSDirectoryUnitTests_migrateOperatorsToOperatorSets is AVSDirectoryUnitTests {
+    address[] operators = new address[](1);
+    uint32[][] operatorSetIds = new uint32[][](1);
 
+    function test_revert_paused() public {
+        cheats.prank(pauser);
+        avsDirectory.pause(2 ** PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS);
+
+        operators = new address[](1);
+        operatorSetIds = new uint32[][](1);
+
+        cheats.expectRevert("Pausable: index is paused");
+        cheats.prank(defaultAVS);
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function test_revert_notOperatorSetAVS() public {
+        cheats.expectRevert("AVSDirectory.migrateOperatorsToOperatorSets: not an operator set AVS");
+        cheats.prank(defaultAVS);
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function test_revert_operatorNotM2Registered() public {
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        operators = new address[](1);
+        operators[0] = operator;
+
+        avsDirectory.becomeOperatorSetAVS();
+        cheats.expectRevert("AVSDirectory.migrateOperatorsToOperatorSets: operator already migrated or not a legacy registered operator");
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function test_revert_operatorAlreadyMigrated(bytes32 salt) public {
+        // Register Operator to M2
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        _registerOperatorLegacyM2(delegationSignerPrivateKey, salt);
+
+        // Format calldata
+        operators = new address[](1);
+        operators[0] = operator;
+        operatorSetIds = new uint32[][](1);
+        operatorSetIds[0] = new uint32[](1);
+        operatorSetIds[0][0] = 1;
+
+        // Setup Operator Sets
+        _createOperatorSet(1);
+        avsDirectory.becomeOperatorSetAVS();
+
+        // Migrate Operator
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+
+        // Revert when trying to migrate operator again
+        cheats.expectRevert("AVSDirectory.migrateOperatorsToOperatorSets: operator already migrated or not a legacy registered operator");
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function testFuzz_revert_invalidOperatorSet(bytes32 salt) public {
+        // Register Operator to M2
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        _registerOperatorLegacyM2(delegationSignerPrivateKey, salt);
+
+        // Format calldata
+        operators = new address[](1);
+        operators[0] = operator;
+        operatorSetIds = new uint32[][](1);
+        operatorSetIds[0] = new uint32[](1);
+        operatorSetIds[0][0] = 1;
+
+        // Become operator set AVS
+        avsDirectory.becomeOperatorSetAVS();
+
+        // Revert
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: invalid operator set");
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function testFuzz_revert_operatorAlreadyRegisteredFromMigration(bytes32 salt) public {
+        // Register Operator to M2
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        _registerOperatorLegacyM2(delegationSignerPrivateKey, salt);
+
+        // Format calldata
+        operators = new address[](1);
+        operators[0] = operator;
+        operatorSetIds = new uint32[][](1);
+        operatorSetIds[0] = new uint32[](2);
+        operatorSetIds[0][0] = 1;
+        operatorSetIds[0][1] = 1;
+
+        // Become operator set AVS
+        _createOperatorSet(1);
+        avsDirectory.becomeOperatorSetAVS();
+
+        // Revert
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: operator already registered to operator set");
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function testFuzz_revert_operatorAlreadyRegisteredFromNormalReg(bytes32 salt1, bytes32 salt2) public {
+        // Register Operator to M2
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        _registerOperatorLegacyM2(delegationSignerPrivateKey, salt1);
+
+        // Format calldata
+        operators = new address[](1);
+        operators[0] = operator;
+        operatorSetIds = new uint32[][](1);
+        operatorSetIds[0] = new uint32[](1);
+        operatorSetIds[0][0] = 1;
+
+        // Register Operator To Operator Set - cannot use helper method since it re-registers operator in DM
+        avsDirectory.becomeOperatorSetAVS();
+        _createOperatorSet(1);
+        uint256 expiry = type(uint256).max;
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(
+            delegationSignerPrivateKey, avsDirectory.calculateOperatorSetRegistrationDigestHash(address(this), operatorSetIds[0], salt2, expiry)
+        );
+        avsDirectory.registerOperatorToOperatorSets(
+            operator, operatorSetIds[0], ISignatureUtils.SignatureWithSaltAndExpiry(abi.encodePacked(r, s, v), salt2, expiry)
+        );
+
+        // Revert
+        cheats.expectRevert("AVSDirectory._registerOperatorToOperatorSets: operator already registered to operator set");
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+    }
+
+    function testFuzz_correctness(bytes32 salt) public {
+        // Register Operator to M2
+        address operator = cheats.addr(delegationSignerPrivateKey);
+        _registerOperatorLegacyM2(delegationSignerPrivateKey, salt);
+
+        // Format calldata
+        operators = new address[](1);
+        operators[0] = operator;
+        operatorSetIds = new uint32[][](1);
+        operatorSetIds[0] = new uint32[](1);
+        operatorSetIds[0][0] = 1;
+
+        // Become operator set AVS
+        avsDirectory.becomeOperatorSetAVS();
+        _createOperatorSet(1);
+
+        // Expect Emits
+        cheats.expectEmit(true, true, true, true, address(avsDirectory));
+        emit OperatorAddedToOperatorSet(operator, address(this), 1);
+        cheats.expectEmit(true, true, true, true, address(avsDirectory));
+        emit OperatorAVSRegistrationStatusUpdated(operator, address(this), IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
+        cheats.expectEmit(true, true, true, true, address(avsDirectory));
+        emit OperatorMigratedToOperatorSets(operator, address(this), operatorSetIds[0]);
+
+        // Migrate
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+
+        // Checks
+        assertTrue(avsDirectory.isMember(address(this), operator, 1));
+        assertTrue(avsDirectory.avsOperatorStatus(address(this), operator) == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
+    }
+
+    function testFuzz_correctness_multiple(uint256 privateKey, uint8 numOperators, bytes32 salt, uint8 numOids) public {
+        // Create Operator Set IDs
+        uint32[] memory oids = new uint32[](numOids);
+        for (uint32 i = 0; i < numOids; i++) {
+            oids[i] = i;
+        }
+
+        // Create Operators, Initailize Calldata, Register Operators
+        privateKey = bound(privateKey, 1, MAX_PRIVATE_KEY - numOperators);
+        operators = new address[](numOperators);
+        operatorSetIds = new uint32[][](numOperators);
+        for (uint i = 0; i < numOperators; i++) {
+            _registerOperatorLegacyM2(privateKey + i, salt);
+            operators[i] = cheats.addr(privateKey + i);
+            operatorSetIds[i] = oids;
+        }
+
+        // Become operator set AVS
+        avsDirectory.becomeOperatorSetAVS();
+        _createOperatorSets(oids);
+
+        // Expect Emits
+        for (uint i = 0; i < numOperators; i++) {
+            for (uint j = 0; j < oids.length; j++) {
+                cheats.expectEmit(true, true, true, true, address(avsDirectory));
+                emit OperatorAddedToOperatorSet(operators[i], address(this), oids[j]);
+            }
+            cheats.expectEmit(true, true, true, true, address(avsDirectory));
+            emit OperatorAVSRegistrationStatusUpdated(operators[i], address(this), IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
+            cheats.expectEmit(true, true, true, true, address(avsDirectory));
+            emit OperatorMigratedToOperatorSets(operators[i], address(this), operatorSetIds[i]);
+        }
+
+        // Migrate
+        avsDirectory.migrateOperatorsToOperatorSets(operators, operatorSetIds);
+
+        // Checks
+        for (uint i = 0; i < numOperators; i++) {
+            for (uint j = 0; j < oids.length; j++) {
+                assertTrue(avsDirectory.isMember(address(this), operators[i], oids[j]));
+            }
+            assertTrue(avsDirectory.avsOperatorStatus(address(this), operators[i]) == IAVSDirectory.OperatorAVSRegistrationStatus.UNREGISTERED);
+        }
+    }
+
+    function _registerOperatorLegacyM2(uint256 privateKey, bytes32 salt) internal {
+        address operator = cheats.addr(privateKey);
+        _registerOperatorWithBaseDetails(operator);
+
+        uint256 expiry = type(uint256).max;
+        ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature =
+            _getOperatorAVSRegistrationSignature(privateKey, operator, address(this), salt, expiry);
+
+        avsDirectory.registerOperatorToAVS(operator, operatorSignature);
+    }
 }
 
 contract AVSDirectoryUnitTests_legacyOperatorAVSRegistration is AVSDirectoryUnitTests {


### PR DESCRIPTION
This PR adds the migration feature for operator sets. 

In lieu of adding additional storage, we use the previous `OperatorAVSStatus` mapping to gate migrations. If the operator is registered, we allow migration. Once the migration has completed, we deregister the operator from M2, which prevents future migrations. 