### PR TITLE
SDA - two contract solution

### DIFF
--- a/docs/releases/slashing-release/interfaces/allocator.md
+++ b/docs/releases/slashing-release/interfaces/allocator.md
@@ -4,26 +4,108 @@ The `OperatorDetails` is modified to replace the `earningsReciever` field with t
 
 ```solidity
 interface IDelegationManager {
+	/// STRUCTS
+
+	/**
+     * Struct type used to specify an existing queued withdrawal. Rather than storing the entire struct, only a hash is stored.
+     * In functions that operate on existing queued withdrawals -- e.g. completeQueuedWithdrawal`, the data is resubmitted and the hash of the submitted
+     * data is computed by `calculateWithdrawalRoot` and checked against the stored hash in order to confirm the integrity of the submitted data.
+     */
+    struct Withdrawal {
+        // The address that originated the Withdrawal
+        address staker;
+        // The staker's allocator at the time of thhe queing of the withdrawal
+        address allocator;
+        // The address that can complete the Withdrawal + will receive funds when completing the withdrawal
+        address withdrawer;
+        // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
+        uint256 nonce;
+        // Block number when the Withdrawal was created
+        uint32 startBlock;
+        // Array of strategies that the Withdrawal contains
+        IStrategy[] strategies;
+        // Array containing the amount of shares in each Strategy in the `strategies` array
+        uint256[] shares;
+    }
+
 	/// EVENTS
 
-	/// @notice Emitted when an operator updates their OperatorDetails to @param newOperatorDetails
+	// @notice Emitted when a new allocator is registered in EigenLayer
+    event AllocatorRegistered(address indexed allocator, address selectionApprover);
+
+    /// @notice Emitted when an allocator updates their selection approver
+    event SelectionApproverUpdated(address indexed allocator, address selectionApprover);
+
+	/**
+     * @notice Emitted when @param allocator indicates that they are updating their MetadataURI string
+     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+     */
+    event AllocatorMetadataURIUpdated(address indexed allocator, string metadataURI);
+
+	/// @notice Emitted when an operator queues a handoff of their stake to a target allocator
 	event AllocatorHandoffQueued(address operator, address allocator, uint32 effectTimestamp);
 
-	
+	/// @notice Emitted when a handoff from an operator to an allocator is completed for a set of strategies
 	event AllocatorHandoffCompleted(address operator, address allocator, IStrategy[] strategies);
+
+	/// @notice Emitted whenever an allocator's shares are increased for a given strategy. Note that shares is the delta in the allocator's shares.
+    event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
+
+    /// @notice Emitted whenever an allocator's shares are decreased for a given strategy. Note that shares is the delta in the allocator's shares.
+    event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
+
+	/// @notice Emitted when @param staker selects @param allocator as their allocator
+    event StakerSelected(address indexed staker, address indexed allocator);
+
+    /// @notice Emitted when @param staker unselects their current allocator
+    event StakerUnselected(address indexed staker, address indexed allocator);
+
+    /// @notice Emitted when @param staker unselects an allocator via a call not originating from the staker themself
+    event StakerForceUnselected(address indexed staker, address indexed allocator);
 	
 	/// EXTERNAL - STATE MODIFYING
+
+	/**
+     * @notice Registers the caller as an allocator in EigenLayer.
+     * @param selectionApprover is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is 
+	 * required.
+     * @param metadataURI is a URI for the allocator's metadata, i.e. a link providing more details on the allocator.
+     *
+     * @dev Once an allocator is registered, they cannot 'allocator' as an operator, and they will forever be considered "select themself".
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AllocatorMetadataURIUpdated` event
+	 * @dev revert if the caller is already an operator
+     */
+    function registerAsAllocator(
+        address selectionApprover,
+        string calldata metadataURI
+    ) external;
+
+	/**
+	 * @notice Updates the selection approver for the calling allocator.
+	 *
+	 * @param selectionApprover is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is
+	 * required.
+	 */
+    function setSelectionApprover(address selectionApprover) external;
+
+    /**
+     * @notice Called by an allocator to emit an `AllocatorMetadataURIUpdated` event indicating the information has updated.
+     * @param metadataURI The URI for metadata associated with an allocator
+     * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AllocatorMetadataURIUpdated` event
+     */
+    function updateAllocatorMetadataURI(string calldata metadataURI) external;
 
 	/**
 	 * @notice Queues a handoff of the calling operator's delegated stake to a target allocator in 14 days
 	 *
 	 * @param allocator the target allocator to handoff delegated stake to
 	 * @param allocatorSignatureAndExpiry the signature of the allocator
+	 * @param allocatorSalt A unique single use value tied to an individual signature.
 	 *
 	 * @dev the handoff must be completed in a separate tx in 14 days. it is permissionless to complete
 	 * @dev further delegations and deposits to the operator are prohibited after this function is called
 	 */
-	function queueAllocatorHandoff(address allocator, SignatureWithExpiry memory allocatorSignatureAndExpiry) external;
+	function queueAllocatorHandoff(address allocator, SignatureWithExpiry memory allocatorSignatureAndExpiry, bytes32 allocatorSalt) external;
 
 	/**
 	 * @notice Completes a handoff queued via queueHandoff.
@@ -38,6 +120,46 @@ interface IDelegationManager {
 	 * complete the handoff for different strategies
 	 */
 	function completeAllocatorHandoff(address operator, address allocator, IStrategy[] calldata strategies) external;
+
+	/**
+	 * @notice Selects an allocator for the calling staker
+	 *
+	 * @param allocator the allocator selected by the calling staker
+	 * @param approverSignatureAndExpiry Verifies the operator approves of this delegation
+     * @param approverSalt A unique single use value tied to an individual signature.
+     * @dev The approverSignatureAndExpiry is used in the event that:
+     *          1) the allocator's `selectionApprover` address is set to a non-zero value.
+     *                  AND
+     *          2) neither the allocator nor their `selectionApprover` is the `msg.sender`, since in the event that the allocator
+     *             or their selectionApprover is the `msg.sender`, then approval is assumed.
+	 *
+	 * @dev Reverts if the allocatorFor the staker is already set or if the staker's M2 operator has handed off to an allocator
+	 */
+	function select(address allocator) external;
+
+	/**
+     * @notice Caller selects an allocator for a  a staker with valid signatures from both parties.
+     * @param staker The account delegating stake to an `operator` account
+     * @param allocator The account (`staker`) is selecting for allocation
+     * @param stakerSignatureAndExpiry Signed data from the staker authorizing assinging stake to an allocator
+     * @param approverSignatureAndExpiry is a parameter that will be used for verifying that the allocator approves of this delegation action in the event that:
+     * @param approverSalt Is a salt used to help guarantee signature uniqueness. Each salt can only be used once by a given approver.
+     *
+     * @dev If `staker` is an EOA, then `stakerSignature` is verified to be a valid ECDSA stakerSignature from `staker`, indicating their intention for this action.
+     * @dev If `staker` is a contract, then `stakerSignature` will be checked according to EIP-1271.
+     * @dev the allocator's `selectionApprover` address is set to a non-zero value.
+     * @dev neither the operator nor their `selectionApprover` is the `msg.sender`, since in the event that the operator or their selectionApprover
+     * is the `msg.sender`, then approval is assumed.
+     * @dev In the case that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
+     * in this case to save on complexity + gas costs
+     */
+    function selectBySignature(
+        address staker,
+        address operator,
+        SignatureWithExpiry memory stakerSignatureAndExpiry,
+        SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
+    ) external;
 	
 	/// VIEW
 	

--- a/docs/releases/slashing-release/interfaces/allocator.md
+++ b/docs/releases/slashing-release/interfaces/allocator.md
@@ -5,57 +5,57 @@ TODO: Handle elimination of operator delegation and deposits
 ```solidity
 interface IDelegationManager {
 	/// STRUCTS
-
+	
 	/**
-     * Struct type used to specify an existing queued withdrawal. Rather than storing the entire struct, only a hash is stored.
-     * In functions that operate on existing queued withdrawals -- e.g. completeQueuedWithdrawal`, the data is resubmitted and the hash of the submitted
-     * data is computed by `calculateWithdrawalRoot` and checked against the stored hash in order to confirm the integrity of the submitted data.
-     */
-    struct Withdrawal {
-        // The address that originated the Withdrawal
-        address staker;
-        // NEW: The staker's allocator at the time of thhe queing of the withdrawal
-        address allocator;
-        // The address that can complete the Withdrawal + will receive funds when completing the withdrawal
-        address withdrawer;
-        // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
-        uint256 nonce;
-        // Block number when the Withdrawal was created
-        uint32 startBlock;
-        // Array of strategies that the Withdrawal contains
-        IStrategy[] strategies;
-        // Array containing the amount of shares in each Strategy in the `strategies` array
-        uint256[] shares;
-    }
+	 * Struct type used to specify an existing queued withdrawal. Rather than storing the entire struct, only a hash is stored.
+	 * In functions that operate on existing queued withdrawals -- e.g. completeQueuedWithdrawal`, the data is resubmitted and the hash of the submitted
+	 * data is computed by `calculateWithdrawalRoot` and checked against the stored hash in order to confirm the integrity of the submitted data.
+	 */
+	struct Withdrawal {
+    	// The address that originated the Withdrawal
+    	address staker;
+	    // NEW: The staker's allocator at the time of thhe queing of the withdrawal
+    	address allocator;
+	    // The address that can complete the Withdrawal + will receive funds when completing the withdrawal
+    	address withdrawer;
+	    // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
+	    uint256 nonce;
+    	// Block number when the Withdrawal was created
+	    uint32 startBlock;
+	    // Array of strategies that the Withdrawal contains
+	    IStrategy[] strategies;
+	    // Array containing the amount of shares in each Strategy in the `strategies` array
+	    uint256[] shares;
+	}
 
 	/// EVENTS
 
 	// @notice Emitted when a new allocator is registered in EigenLayer
-    event AllocatorRegistered(address indexed allocator, address selectionApprover);
+	event AllocatorRegistered(address indexed allocator, address delegationApprovers);
 
-    /// @notice Emitted when an allocator updates their selection approver
-    event SelectionApproverUpdated(address indexed allocator, address selectionApprover);
+	/// @notice Emitted when an allocator updates their delegation approver
+	event DelegationApproverUpdated(address indexed allocator, address delegationApprover);
 
 	/**
-     * @notice Emitted when @param allocator indicates that they are updating their MetadataURI string
-     * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
-     */
-    event AllocatorMetadataURIUpdated(address indexed allocator, string metadataURI);
+	 * @notice Emitted when @param allocator indicates that they are updating their MetadataURI string
+	 * @dev Note that these strings are *never stored in storage* and are instead purely emitted in events for off-chain indexing
+	 */
+	event AllocatorMetadataURIUpdated(address indexed allocator, string metadataURI);
 
 	/// @notice Emitted whenever an allocator's shares are increased for a given strategy. Note that shares is the delta in the allocator's shares.
-    event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
+	event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
 
-    /// @notice Emitted whenever an allocator's shares are decreased for a given strategy. Note that shares is the delta in the allocator's shares.
-    event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
+	/// @notice Emitted whenever an allocator's shares are decreased for a given strategy. Note that shares is the delta in the allocator's shares.
+	event AllocatorSharesIncreased(address indexed allocator, address staker, IStrategy strategy, uint256 shares);
 
-	/// @notice Emitted when @param staker selects @param allocator as their allocator
-    event StakerSelected(address indexed staker, address indexed allocator);
+	/// @notice Emitted when @param staker delegated to @param allocator as their allocator
+	event StakerDelegated(address indexed staker, address indexed allocator);
 
-    /// @notice Emitted when @param staker unselects their current allocator
-    event StakerUnselected(address indexed staker, address indexed allocator);
+	/// @notice Emitted when @param staker undelegates from their current allocator
+	event StakerUndelegated(address indexed staker, address indexed allocator);
 
-    /// @notice Emitted when @param staker unselects an allocator via a call not originating from the staker themself
-    event StakerForceUnselected(address indexed staker, address indexed allocator);
+	/// @notice Emitted when @param staker undelegates from an allocator via a call not originating from the staker themself
+	event StakerForceUndelegated(address indexed staker, address indexed allocator);
 
 	/// @notice Emitted when an operator queues a handoff of their stake to a target allocator
 	event AllocatorHandoffQueued(address operator, address allocator, uint32 effectTimestamp);
@@ -67,26 +67,26 @@ interface IDelegationManager {
 
 	/**
      * @notice Registers the caller as an allocator in EigenLayer.
-     * @param selectionApprover is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is 
+     * @param delegationApprover is the address that must approve of the delegation of a staker's stake to the allocator. If set to 0, no approval is 
 	 * required.
      * @param metadataURI is a URI for the allocator's metadata, i.e. a link providing more details on the allocator.
      *
-     * @dev Once an allocator is registered, they cannot 'allocator' as an operator, and they will forever be considered "select themself".
+     * @dev Once an allocator is registered, they cannot 'allocator' as an operator, and they will forever be considered "delegated themself".
      * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `AllocatorMetadataURIUpdated` event
-	 * @dev revert if the caller is already an operator
+	 * @dev reverts if the caller is delegated to a pre-SDA operator
      */
     function registerAsAllocator(
-        address selectionApprover,
+        address delegationApprover,
         string calldata metadataURI
     ) external;
 
 	/**
-	 * @notice Updates the selection approver for the calling allocator.
+	 * @notice Updates the delegation approver for the calling allocator.
 	 *
-	 * @param selectionApprover is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is
+	 * @param delegationApprover is the address that must approve of the delegations of a staker's stake to the allocator. If set to 0, no approval is
 	 * required.
 	 */
-    function setSelectionApprover(address selectionApprover) external;
+    function setDelegationApprover(address delegationApprover) external;
 
     /**
      * @notice Called by an allocator to emit an `AllocatorMetadataURIUpdated` event indicating the information has updated.
@@ -96,61 +96,65 @@ interface IDelegationManager {
     function updateAllocatorMetadataURI(string calldata metadataURI) external;
 
 	/**
-	 * @notice Selects an allocator for the calling staker
+	 * @notice Delegates to an allocator for the calling staker
 	 *
-	 * @param allocator the allocator selected by the calling staker
+	 * @param allocator the allocator delegated to by the calling staker
 	 * @param approverSignatureAndExpiry Verifies the operator approves of this delegation
      * @param approverSalt A unique single use value tied to an individual signature.
      * @dev The approverSignatureAndExpiry is used in the event that:
-     *          1) the allocator's `selectionApprover` address is set to a non-zero value.
+     *          1) the allocator's `delegationApprover` address is set to a non-zero value.
      *                  AND
-     *          2) neither the allocator nor their `selectionApprover` is the `msg.sender`, since in the event that the allocator
-     *             or their selectionApprover is the `msg.sender`, then approval is assumed.
+     *          2) neither the allocator nor their `delegationApprover` is the `msg.sender`, since in the event that the allocator
+     *             or their delegationApprover is the `msg.sender`, then approval is assumed.
 	 *
 	 * @dev Reverts if the allocatorFor the staker is already set or if the staker's M2 operator has handed off to an allocator
 	 */
-	function select(address allocator) external;
+	function delegateTo(
+		address allocator,
+		SignatureWithExpiry memory approverSignatureAndExpiry,
+        bytes32 approverSalt
+	) external;
 
 	/**
-     * @notice Caller selects an allocator for a  a staker with valid signatures from both parties.
+     * @notice Caller delegates a staker to an allocator with valid signatures from both parties.
      * @param staker The account delegating stake to an `operator` account
-     * @param allocator The account (`staker`) is selecting for allocation
+     * @param allocator The account (`staker`) is delegating to
      * @param stakerSignatureAndExpiry Signed data from the staker authorizing assinging stake to an allocator
      * @param approverSignatureAndExpiry is a parameter that will be used for verifying that the allocator approves of this delegation action in the event that:
      * @param approverSalt Is a salt used to help guarantee signature uniqueness. Each salt can only be used once by a given approver.
      *
      * @dev If `staker` is an EOA, then `stakerSignature` is verified to be a valid ECDSA stakerSignature from `staker`, indicating their intention for this action.
      * @dev If `staker` is a contract, then `stakerSignature` will be checked according to EIP-1271.
-     * @dev the allocator's `selectionApprover` address is set to a non-zero value.
-     * @dev neither the operator nor their `selectionApprover` is the `msg.sender`, since in the event that the operator or their selectionApprover
+     * @dev the allocator's `delegationApprover` address is set to a non-zero value.
+     * @dev neither the operator nor their `delegationApprover` is the `msg.sender`, since in the event that the operator or their delegationApprover
      * is the `msg.sender`, then approval is assumed.
      * @dev In the case that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
      */
-    function selectBySignature(
+    function delegateToBySignature(
         address staker,
-        address operator,
+        address allocator,
         SignatureWithExpiry memory stakerSignatureAndExpiry,
         SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
     ) external;
 
 	/**
-     * @notice Unselects the staker's currently selected allocator and queues a withdrawal of all of the staker's shares
-     * @param staker The account to be unselected.
+     * @notice Undelegates the staker's currently chosed allocator and queues a withdrawal of all of the staker's shares
+     * @param staker The account to be undelegated.
      * @return withdrawalRoot The root of the newly queued withdrawal, if a withdrawal was queued. Otherwise just bytes32(0).
      *
      * @dev Reverts if the `staker` is also an allocator, since allocator are not allowed to undelegate from themselves.
-     * @dev Reverts if the caller is not the staker, nor the allocator who the staker is delegated to, nor the allocator's specified "selectionApprover"
-     * @dev Reverts if the `staker` is already unselected..
+     * @dev Reverts if the caller is not the staker, nor the allocator who the staker is delegated to, nor the allocator's specified "delegationApprover"
+     * @dev Reverts if the `staker` is already undelegated.
      */
-    function unselect(address staker) external returns (bytes32[] memory withdrawalRoot);
+    function undelegate(address staker) external returns (bytes32[] memory withdrawalRoot);
 
 	/**
 	 * @notice Queues a handoff of the calling operator's delegated stake to a target allocator in 14 days
 	 *
 	 * @param allocator the target allocator to handoff delegated stake to
-	 * @param approverSignatureAndExpiry the signature of the allocator's selection approver on their intent to accept the handoff
+	 * @param approverSignatureAndExpiry the signature of the allocator's delegation approver on their intent to accept the handoff
 	 * @param allocatorSalt A unique single use value tied to an individual signature.
 	 *
 	 * @dev the handoff can be completed in a separate tx in 14 days. it is permissionless to complete
@@ -186,18 +190,18 @@ interface IDelegationManager {
 
 ### registerAsAllocator
 
-This is called by accounts that wish to become allocators in EigenLayer. Allocators are responsible for allocating slashable stake to operatorSets. The `selectionApprover` is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is required.
+This is called by accounts that wish to become allocators in EigenLayer. Allocators are responsible for allocating slashable stake to operatorSets. The `delegationApprover` is the address that must approve of the delegation of a staker's stake to the allocator. If set to 0, no approval is required.
 
 Emits an `AllocatorRegistered` event.
 
 Reverts if:
-1. The caller is already an operator
+1. The caller is delegated to an pre-SDA operator. This includes pre-SDA operators themselves.
 
-### setSelectionApprover
+### setDelegationApprover
 
-This is called by an allocator to update their selection approver. The `selectionApprover` is the address that must approve of the selection of a staker's stake to the allocator. If set to 0, no approval is required.
+This is called by an allocator to update their delegation approver. The `delegationApprover` is the address that must approve of the delegation of a staker's stake to the allocator. If set to 0, no approval is required.
 
-Emits a `SelectionApproverUpdated` event.
+Emits a `DelegationApproverUpdated` event.
 
 Reverts if:
 1. The caller is not an allocator
@@ -211,47 +215,47 @@ Emits a `AllocatorMetadataURIUpdated` event.
 Reverts if:
 1. The caller is not an allocator
 
-### select
+### delegateTo
 
-This is called by stakers to select an allocator. The `allocator` is the allocator selected by the calling staker. An EIP-1271 signature from the allocator's selection approver is required.
+This is called by stakers to delegate to an allocator. The `allocator` is the allocator being delegated to by the calling staker. An EIP-1271 signature from the allocator's delegation approver is required.
 
-Stakers that are delegated to an M2 operator that has queued a handoff to an allocator are not allowed to select an allocator. However, stakers that are delegated to an M2 operator that has not queued a handoff to an allocator are allowed to select an allocator and instanaeously move their stake to the allocator.
+Stakers that are delegated to an M2 operator that has queued a handoff to an allocator are not allowed to delegate to an allocator. However, stakers that are delegated to an M2 operator that has not queued a handoff to an allocator are allowed to delegate to an allocator and instanaeously move their stake to the allocator.
 
-Emits a `StakerSelected` event.
+Emits a `StakerDelegated` event.
 
 Reverts if:
-1. `approverSignatureAndExpiry` is not from the allocator's `selectionApprover` and the allocator's `selectionApprover` is set to a non-zero value
+1. `approverSignatureAndExpiry` is not from the allocator's `delegationApprover` and the allocator's `delegationApprover` is set to a non-zero value
 2. the allocator for the staker is already set
 3. the staker is delegated to an M2 operator that has queued a handoff to an allocator
 
-### selectBySignature
+### delegateToBySignature
 
-Similar to `select`, but uses a signature from the staker. The staker's signature is verified to be a valid ECDSA signature from the staker, indicating their intention for this action. If the staker is a contract, the signature will be checked according to EIP-1271.
+Similar to `delegateTo`, but uses a signature from the staker. The staker's signature is verified to be a valid ECDSA signature from the staker, indicating their intention for this action. If the staker is a contract, the signature will be checked according to EIP-1271.
 
-Emits a `StakerSelected` event.
+Emits a `StakerDelegated` event.
 
 Reverts if:
 1. `stakerSignatureAndExpiry` is not from the staker
-2. `approverSignatureAndExpiry` is not from the allocator's `selectionApprover` and the allocator's `selectionApprover` is set to a non-zero value
+2. `approverSignatureAndExpiry` is not from the allocator's `delegationApprover` and the allocator's `delegationApprover` is set to a non-zero value
 3. the allocator for the staker is already set
 4. the staker is delegated to an M2 operator that has queued a handoff to an allocator
 
-### unselect
+### undelegate
 
-This is called by stakers to unselect their currently selected allocator and queue a withdrawal of all of the staker's shares.
+This is called by stakers to undelegate from their current allocator and queue a withdrawal of all of the staker's shares.
 
-The staker's allocator and the allocator's selection approver are allowed to unselect the staker. This is intended to help for compliance reasons.
+The staker's allocator and the allocator's delegation approver are allowed to undelegate the staker. This is intended to help for compliance reasons.
 
-Emits a `StakerUnselected` event.
+Emits a `StakerUndelegated` event.
 
 Reverts if:
 1. the staker is also an allocator
-2. the caller is not the staker, nor the allocator who the staker is delegated to, nor the allocator's specified selection approver
-3. the staker is already unselected
+2. the caller is not the staker, nor the allocator who the staker is delegated to, nor the allocator's specified delegation approver
+3. the staker is already undelegation
 
 ### queueAllocatorHandoff
 
-This is called by operators to queue a handoff of their delegated stake to a target allocator in 14 days. This allows stake to flow from staker-determined-operators to staker-determined-allocators initially without any staker involvement. A EIP-1271 signature from the allocator's selection approver is required.
+This is called by operators to queue a handoff of their delegated stake to a target allocator in 14 days. This allows stake to flow from staker-determined-operators to staker-determined-allocators initially without any staker involvement. A EIP-1271 signature from the allocator's delegation approver is required.
 
 The handoff must be completed in a separate transaction.
 
@@ -260,7 +264,7 @@ Emits a `AllocatorHandoffQueued` event.
 Reverts if:
 1. the operator is not registered with the DelegationManager
 2. the allocator is not registered with the DelegationManager
-3. `approverSignatureAndExpiry` is not from the allocator's selection approver and the allocator's selection approver is set to a non-zero value
+3. `approverSignatureAndExpiry` is not from the allocator's delegation approver and the allocator's delegation approver is set to a non-zero value
 2. the operator has already queued a handoff to an allocator
 
 ### completeAllocatorHandoff

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -306,6 +306,11 @@ contract AVSDirectory is
      *
      */
 
+    function totalMagnitude(address allocator, IStrategy strategy) external view override returns (uint256) {
+        // TODO
+        return 0;
+    }
+
     /**
      *  @notice Calculates the digest hash to be signed by an operator to register with an AVS.
      *

--- a/src/contracts/core/AllocatorManagerStorage.sol
+++ b/src/contracts/core/AllocatorManagerStorage.sol
@@ -61,11 +61,14 @@ abstract contract AllocatorManagerStorage is IAllocatorManager {
 
     mapping(address => AllocatorDetails) internal _allocatorDetails;
 
+    /// @notice Mapping: staker => whether the staker is a post SDA staker (i.e. they have no left over state unmigrated from the DelegationManager).
+    mapping(address => bool) public isPostSDAStaker;
+
     /**
      * @notice Mapping: staker => allocator whom the staker is currently delegated to.
      * @dev Note that returning address(0) indicates that the staker is not actively delegated to any allocator.
      */
-    mapping(address => address) public delegatedTo;
+    mapping(address => address) internal _delegatedTo;
 
     /// @notice Mapping: staker => number of signed messages (used in `delegateToBySignature`) from the staker that this contract has already checked.
     mapping(address => uint256) public stakerNonce;

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -600,6 +600,11 @@ contract DelegationManager is
         // Remove `withdrawalRoot` from pending roots
         delete pendingWithdrawals[withdrawalRoot];
 
+        require(
+            !isPendingHandoff(withdrawal.delegatedTo) || receiveAsTokens,
+            "DelegationManager._completeQueuedWithdrawal: a staker pending handoff cannot withdraw as shares"
+        );
+
         if (receiveAsTokens) {
             // Finalize action by converting shares to tokens for each strategy, or
             // by re-awarding shares in each strategy.

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -103,13 +103,8 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      */
     mapping(IStrategy => uint256) public strategyWithdrawalDelayBlocks;
 
-    struct Handoff {
-        address allocator;
-        uint32 completableTimestamp;
-    }
-
     /// @notice Mapping: M2 operator => their pending handoff to an allocator
-    mapping(address => Handoff) public handoffs;
+    mapping(address => Handoff) internal _handoffs;
 
     constructor(IStrategyManager _strategyManager, ISlasher _slasher, IEigenPodManager _eigenPodManager) {
         strategyManager = _strategyManager;

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -49,8 +49,8 @@ contract StrategyManager is
         _;
     }
 
-    modifier onlyDelegationManager() {
-        require(msg.sender == address(delegation), "StrategyManager.onlyDelegationManager: not the DelegationManager");
+    modifier onlyDelegationManagerOrAllocationManager() {
+        require(msg.sender == address(delegation) || msg.sender == address(allocatorManager), "StrategyManager.onlyDelegationManagerOrAllocationManager: not the DelegationManager");
         _;
     }
 
@@ -166,7 +166,7 @@ contract StrategyManager is
     }
 
     /// @notice Used by the DelegationManager to remove a Staker's shares from a particular strategy when entering the withdrawal queue
-    function removeShares(address staker, IStrategy strategy, uint256 shares) external onlyDelegationManager {
+    function removeShares(address staker, IStrategy strategy, uint256 shares) external onlyDelegationManagerOrAllocationManager {
         _removeShares(staker, strategy, shares);
     }
 
@@ -176,7 +176,7 @@ contract StrategyManager is
         IERC20 token,
         IStrategy strategy,
         uint256 shares
-    ) external onlyDelegationManager {
+    ) external onlyDelegationManagerOrAllocationManager {
         _addShares(staker, token, strategy, shares);
     }
 
@@ -186,7 +186,7 @@ contract StrategyManager is
         IStrategy strategy,
         uint256 shares,
         IERC20 token
-    ) external onlyDelegationManager {
+    ) external onlyDelegationManagerOrAllocationManager {
         strategy.withdraw(recipient, token, shares);
     }
 

--- a/src/contracts/core/StrategyManagerStorage.sol
+++ b/src/contracts/core/StrategyManagerStorage.sol
@@ -5,6 +5,7 @@ import "../interfaces/IStrategyManager.sol";
 import "../interfaces/IStrategy.sol";
 import "../interfaces/IEigenPodManager.sol";
 import "../interfaces/IDelegationManager.sol";
+import "../interfaces/IAllocatorManager.sol";
 import "../interfaces/ISlasher.sol";
 
 /**
@@ -25,6 +26,7 @@ abstract contract StrategyManagerStorage is IStrategyManager {
 
     // system contracts
     IDelegationManager public immutable delegation;
+    IAllocatorManager public immutable allocatorManager = IAllocatorManager(address(0));
     IEigenPodManager public immutable eigenPodManager;
     ISlasher public immutable slasher;
 

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity >=0.5.0;
 
+import "./IStrategy.sol";
 import "./ISignatureUtils.sol";
 
 interface IAVSDirectory is ISignatureUtils {
@@ -121,6 +122,8 @@ interface IAVSDirectory is ISignatureUtils {
     function memberInfo(address avs, address operator) external view returns (uint248 inTotalSets, bool isLegacyOperator);
 
     function isMember(address avs, address operator, uint32 operatorSetId) external view returns (bool);
+
+    function totalMagnitude(address allocator, IStrategy strategy) external view returns (uint256);
 
     /**
      *  @notice Calculates the digest hash to be signed by an operator to register with an AVS.

--- a/src/contracts/interfaces/IAllocatorManager.sol
+++ b/src/contracts/interfaces/IAllocatorManager.sol
@@ -268,7 +268,7 @@ interface IAllocatorManager is ISignatureUtils {
      * @notice Mapping: staker => operator whom the staker is currently delegated to.
      * @dev Note that returning address(0) indicates that the staker is not actively delegated to any operator.
      */
-    function delegatedTo(address staker) external view returns (address);
+    function delegatedToView(address staker) external view returns (address);
 
     /**
      * @notice Returns the delegationApprover account for an operator

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -362,6 +362,13 @@ interface IDelegationManager is ISignatureUtils {
      */
     function isOperator(address operator) external view returns (bool);
 
+    struct Handoff {
+        address allocator;
+        uint32 completableTimestamp;
+    }
+
+    function getHandoff(address staker) external view returns (Handoff memory);
+
     /// @notice Mapping: staker => number of signed delegation nonces (used in `delegateToBySignature`) from the staker that the contract has already checked
     function stakerNonce(address staker) external view returns (uint256);
 

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -35,9 +35,9 @@ contract EigenPodManager is
         _;
     }
 
-    modifier onlyDelegationManager() {
+    modifier onlyDelegationManagerOrAllocatorManager() {
         require(
-            msg.sender == address(delegationManager), "EigenPodManager.onlyDelegationManager: not the DelegationManager"
+            msg.sender == address(delegationManager) || msg.sender == address(allocatorManager), "EigenPodManager.onlyDelegationManagerOrAllocatorManager: not the DelegationManager"
         );
         _;
     }
@@ -152,7 +152,7 @@ contract EigenPodManager is
      * @dev Reverts if `shares` is not a whole Gwei amount
      * @dev The delegation manager validates that the podOwner is not address(0)
      */
-    function removeShares(address podOwner, uint256 shares) external onlyDelegationManager {
+    function removeShares(address podOwner, uint256 shares) external onlyDelegationManagerOrAllocatorManager {
         require(int256(shares) >= 0, "EigenPodManager.removeShares: shares cannot be negative");
         require(shares % GWEI_TO_WEI == 0, "EigenPodManager.removeShares: shares must be a whole Gwei amount");
         int256 updatedPodOwnerShares = podOwnerShares[podOwner] - int256(shares);
@@ -170,7 +170,7 @@ contract EigenPodManager is
      * in the event that the podOwner has an existing shares deficit (i.e. `podOwnerShares[podOwner]` starts below zero)
      * @dev Reverts if `shares` is not a whole Gwei amount
      */
-    function addShares(address podOwner, uint256 shares) external onlyDelegationManager returns (uint256) {
+    function addShares(address podOwner, uint256 shares) external onlyDelegationManagerOrAllocatorManager returns (uint256) {
         require(podOwner != address(0), "EigenPodManager.addShares: podOwner cannot be zero address");
         require(int256(shares) >= 0, "EigenPodManager.addShares: shares cannot be negative");
         require(shares % GWEI_TO_WEI == 0, "EigenPodManager.addShares: shares must be a whole Gwei amount");
@@ -199,7 +199,7 @@ contract EigenPodManager is
         address podOwner,
         address destination,
         uint256 shares
-    ) external onlyDelegationManager {
+    ) external onlyDelegationManagerOrAllocatorManager {
         require(podOwner != address(0), "EigenPodManager.withdrawSharesAsTokens: podOwner cannot be zero address");
         require(destination != address(0), "EigenPodManager.withdrawSharesAsTokens: destination cannot be zero address");
         require(int256(shares) >= 0, "EigenPodManager.withdrawSharesAsTokens: shares cannot be negative");

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -7,6 +7,7 @@ import "../interfaces/IStrategy.sol";
 import "../interfaces/IEigenPodManager.sol";
 import "../interfaces/IStrategyManager.sol";
 import "../interfaces/IDelegationManager.sol";
+import "../interfaces/IAllocatorManager.sol";
 import "../interfaces/IETHPOSDeposit.sol";
 import "../interfaces/IEigenPod.sol";
 
@@ -22,6 +23,8 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     /// @notice EigenLayer's Slasher contract
     ISlasher public immutable slasher;
+
+    IAllocatorManager public immutable allocatorManager = IAllocatorManager(address(0));
 
     /// @notice EigenLayer's DelegationManager contract
     IDelegationManager public immutable delegationManager;

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -63,6 +63,8 @@ contract DelegationManagerMock is IDelegationManager, Test {
         return returnValue;
     }
 
+    function getHandoff(address staker) public view returns (Handoff memory) {}
+
     function delegationApprover(address operator) external pure returns (address) {
         return operator;
     }

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -85,6 +85,15 @@ contract DelegationManagerMock is IDelegationManager, Test {
     function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external pure returns (uint256) {
         return 0;
     }
+
+    /**
+     * @notice Returns the migratable shares for an operator across given strategies and overwrite them to 0
+     * @param operator the operator to get migratable shares for
+     * @param allocator the allocator to get migratable shares to migrate to
+     * @param strategies the strategies to get migratable shares for
+     * @dev if any of the shares are 0, it will revert
+     */
+    function getMigratableOperatorShares(address operator, address allocator, IStrategy[] calldata strategies) external returns (uint256[] memory) {}
     
     function getOperatorShares(
         address operator,


### PR DESCRIPTION
The approach in this PR is to have an AllocatorManager contract which bridges to the previous DelegationManager to
1. make sure that stakers delegated to pre-SDA operators cant delegate to allocators
2. complete handoffs from pre-SDA operators to allocators 
3. migrate state for stakers that were handed off by pre-SDA operators

In addition, the DM `getOperatorShares` and `operatorShares` are reimplemented to return 0 for operators pending migration and read from XYZ new contract for the allocated shares to an operator.

Big TODOs:
- [ ] Hook up with total magnitude stuff and making withdrawal logic sound with scaled shares
- [ ] Implementing `getOperatorShares` and `operatorShares` to account for migrations and SDA
- [ ] Address EigenPodManager/StrategyManager interactions
- [x] State migration for handed off stakers
- [ ] TODOs :)

Choices of note:
1. Operator addresses must be either pre-SDA or post-SDA
2. Stakers must either be pre-SDA or post-SDA, but can migrate on the same address from pre to post

Notes on edge cases:

1. stakers cannot queue DM withdrawals after shares are migratable leading to them possibly having withdrawals in both contracts
3. what happens when handed off stakers or pre-SDA operators interact with contracts before migration is completed