### PR TITLE
feat: add pass thoughts for all `strategyWhitelister` gated functions

### DIFF
--- a/src/contracts/interfaces/IStrategyFactory.sol
+++ b/src/contracts/interfaces/IStrategyFactory.sol
@@ -46,9 +46,7 @@ interface IStrategyFactory {
     /**
      * @notice Owner-only function to pass through a call to `StrategyManager.removeStrategiesFromDepositWhitelist`
      */
-    function removeStrategiesFromWhitelist (
-        IStrategy[] calldata strategiesToRemoveFromWhitelist
-    ) external;
+    function removeStrategiesFromWhitelist(IStrategy[] calldata strategiesToRemoveFromWhitelist) external;
 
     // @notice Emitted when the `strategyBeacon` is changed
     event StrategyBeaconModified(IBeacon previousBeacon, IBeacon newBeacon);

--- a/src/contracts/interfaces/IStrategyFactory.sol
+++ b/src/contracts/interfaces/IStrategyFactory.sol
@@ -22,6 +22,7 @@ interface IStrategyFactory {
 
     /**
      * @notice Deploy a new strategyBeacon contract for the ERC20 token.
+     * @param token the token to deploy a strategy for
      * @dev A strategy contract must not yet exist for the token.
      * $dev Immense caution is warranted for non-standard ERC20 tokens, particularly "reentrant" tokens
      * like those that conform to ERC777.
@@ -35,6 +36,18 @@ interface IStrategyFactory {
     function whitelistStrategies(
         IStrategy[] calldata strategiesToWhitelist,
         bool[] calldata thirdPartyTransfersForbiddenValues
+    ) external;
+
+    /**
+     * @notice Owner-only function to pass through a call to `StrategyManager.setThirdPartyTransfersForbidden`
+     */
+    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external;
+
+    /**
+     * @notice Owner-only function to pass through a call to `StrategyManager.removeStrategiesFromDepositWhitelist`
+     */
+    function removeStrategiesFromWhitelist (
+        IStrategy[] calldata strategiesToRemoveFromWhitelist
     ) external;
 
     // @notice Emitted when the `strategyBeacon` is changed

--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -115,6 +115,15 @@ interface IStrategyManager {
      */
     function removeStrategiesFromDepositWhitelist(IStrategy[] calldata strategiesToRemoveFromWhitelist) external;
 
+    /**
+     * If true for a strategy, a user cannot depositIntoStrategyWithSignature into that strategy for another staker
+     * and also when performing DelegationManager.queueWithdrawals, a staker can only withdraw to themselves.
+     * Defaulted to false for all existing strategies.
+     * @param strategy The strategy to set `thirdPartyTransfersForbidden` value to
+     * @param value bool value to set `thirdPartyTransfersForbidden` to
+     */
+    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external;
+
     /// @notice Returns the single, central Delegation contract of EigenLayer
     function delegation() external view returns (IDelegationManager);
 

--- a/src/contracts/strategies/StrategyFactory.sol
+++ b/src/contracts/strategies/StrategyFactory.sol
@@ -93,6 +93,22 @@ contract StrategyFactory is StrategyFactoryStorage, OwnableUpgradeable, Pausable
         strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
     }
 
+    /**
+     * @notice Owner-only function to pass through a call to `StrategyManager.setThirdPartyTransfersForbidden`
+     */
+    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external onlyOwner {
+        strategyManager.setThirdPartyTransfersForbidden(strategy, value);
+    }
+
+    /**
+     * @notice Owner-only function to pass through a call to `StrategyManager.removeStrategiesFromDepositWhitelist`
+     */
+    function removeStrategiesFromWhitelist (
+        IStrategy[] calldata strategiesToRemoveFromWhitelist
+    ) external onlyOwner {
+        strategyManager.removeStrategiesFromDepositWhitelist(strategiesToRemoveFromWhitelist);
+    }
+
     function _setStrategyForToken(IERC20 token, IStrategy strategy) internal {
         tokenStrategy[token] = strategy;
         emit StrategySetForToken(token, strategy);

--- a/src/contracts/strategies/StrategyFactory.sol
+++ b/src/contracts/strategies/StrategyFactory.sol
@@ -103,9 +103,7 @@ contract StrategyFactory is StrategyFactoryStorage, OwnableUpgradeable, Pausable
     /**
      * @notice Owner-only function to pass through a call to `StrategyManager.removeStrategiesFromDepositWhitelist`
      */
-    function removeStrategiesFromWhitelist (
-        IStrategy[] calldata strategiesToRemoveFromWhitelist
-    ) external onlyOwner {
+    function removeStrategiesFromWhitelist(IStrategy[] calldata strategiesToRemoveFromWhitelist) external onlyOwner {
         strategyManager.removeStrategiesFromDepositWhitelist(strategiesToRemoveFromWhitelist);
     }
 


### PR DESCRIPTION
Add pass throughs for `removeStrategiesFromDepositWhitelist` and `setThirdPartyTransfersForbidden`