### PR TITLE
feat: track total members and sets

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -382,12 +382,10 @@ contract AVSDirectory is
                 "AVSDirectory._registerOperatorToOperatorSets: operator already registered to operator set"
             );
 
+            ++operatorSetMemberCount[avs][operatorSetIds[i]];
+
             // Mutate `isMember` to `true`.
             isMember[avs][operator][operatorSetIds[i]] = true;
-
-            unchecked {
-                ++operatorSetMemberCount[avs][operatorSetIds[i]];
-            }
 
             emit OperatorAddedToOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }
@@ -409,12 +407,10 @@ contract AVSDirectory is
                 "AVSDirectory._deregisterOperatorFromOperatorSet: operator not registered for operator set"
             );
 
+            --operatorSetMemberCount[avs][operatorSetIds[i]];
+
             // Mutate `isMember` to `false`.
             isMember[avs][operator][operatorSetIds[i]] = false;
-
-            unchecked {
-                --operatorSetMemberCount[avs][operatorSetIds[i]];
-            }
 
             emit OperatorRemovedFromOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -73,6 +73,8 @@ contract AVSDirectory is
             isOperatorSet[msg.sender][operatorSetIds[i]] = true;
             emit OperatorSetCreated(OperatorSet({avs: msg.sender, operatorSetId: operatorSetIds[i]}));
         }
+        operatorSetCount += operatorSetIds.length;
+        avsOperatorSetCount[msg.sender] += operatorSetIds.length;
     }
 
     /**
@@ -382,6 +384,10 @@ contract AVSDirectory is
 
             // Mutate `isMember` to `true`.
             isMember[avs][operator][operatorSetIds[i]] = true;
+
+            unchecked {
+                ++operatorSetMemberCount[avs][operatorSetIds[i]];
+            }
 
             emit OperatorAddedToOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -412,6 +412,10 @@ contract AVSDirectory is
             // Mutate `isMember` to `false`.
             isMember[avs][operator][operatorSetIds[i]] = false;
 
+            unchecked {
+                --operatorSetMemberCount[avs][operatorSetIds[i]];
+            }
+
             emit OperatorRemovedFromOperatorSet(operator, OperatorSet({avs: avs, operatorSetId: operatorSetIds[i]}));
         }
     }

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -40,10 +40,10 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @notice Mapping: avs => Whether it is a an operator set AVS or not.
     mapping(address => bool) public isOperatorSetAVS;
 
-    /// @notice Mapping: avs => operatorSetId => Info about the given operator set.
+    /// @notice Mapping: avs => operatorSetId => Whether or not an operator set is valid.
     mapping(address => mapping(uint32 => bool)) public isOperatorSet;
 
-    /// @notice Mapping: avs = operator => operatorSetId => whether the operator is a member of the operatorSet
+    /// @notice Mapping: avs = operator => operatorSetId => Whether or not an operator is a member of an operator set.
     mapping(address => mapping(address => mapping(uint32 => bool))) public isMember;
 
     /// @notice Mapping: avs => operatorSetId => Total operators within the given operator set.
@@ -64,5 +64,5 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[43] private __gap;
+    uint256[40] private __gap;
 }

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -34,17 +34,26 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @notice Mapping: avs => operator => OperatorAVSRegistrationStatus struct
     mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
 
-    /// @notice Mapping: operator => salt => whether the salt has been used
+    /// @notice Mapping: operator => salt => Whether the salt has been used or not.
     mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
 
-    /// @notice Mapping: avs => whether it is a an operator set AVS
+    /// @notice Mapping: avs => Whether it is a an operator set AVS or not.
     mapping(address => bool) public isOperatorSetAVS;
 
-    /// @notice Mapping: avs => operatorSetId => whether the operatorSet exists
+    /// @notice Mapping: avs => operatorSetId => Info about the given operator set.
     mapping(address => mapping(uint32 => bool)) public isOperatorSet;
 
     /// @notice Mapping: avs = operator => operatorSetId => whether the operator is a member of the operatorSet
     mapping(address => mapping(address => mapping(uint32 => bool))) public isMember;
+
+    /// @notice Mapping: avs => operatorSetId => Total operators within the given operator set.
+    mapping(address => mapping(uint32 => uint256)) public operatorSetMemberCount;
+
+    /// @notice Mapping: avs => Total amount of operator sets created for a given AVS.
+    mapping(address => uint256) public avsOperatorSetCount;
+
+    /// @notice Total amount of operators sets created.
+    uint256 public operatorSetCount;
 
     constructor(IDelegationManager _delegation) {
         delegation = _delegation;


### PR DESCRIPTION
Adds tracking in storage for:

`operatorSetMemberCount`: The total members (operators) within a given operator set.

* Adds an additional `SLOAD` and `SSTORE` on registrations and deregistrations.

`operatorSetCount`: The total number of operator sets.

* Adds an additional `SLOAD` and `SSTORE` on operator set creation.

`avsOperatorSetCount`: The total number of operator sets for a given AVS.

* Adds an additional `SLOAD` and `SSTORE` on operator set creation.
