### PR TITLE
feat: deploy strat factory

### DIFF
--- a/script/configs/mainnet/Deploy_Mainnet_StrategyFactory.config.json
+++ b/script/configs/mainnet/Deploy_Mainnet_StrategyFactory.config.json
@@ -1,0 +1,8 @@
+{
+    owner: ,
+    strategyImplementation: ,
+    strategyManager: ,
+    eigenLayerProxyAdmin: ,
+    pauserRegistry: ,
+    initialPausedStatus: 
+}

--- a/script/deploy/holesky/Deploy_Preprod_StrategyFactory.s.sol
+++ b/script/deploy/holesky/Deploy_Preprod_StrategyFactory.s.sol
@@ -10,8 +10,14 @@ import "forge-std/Test.sol";
 import "../../../src/contracts/strategies/EigenStrategy.sol";
 import "../../../src/contracts/strategies/StrategyFactory.sol";
 
-// forge script script/Deploy_StrategyManager.s.sol:Deploy_StrategyManager --rpc-url $--HOL private-key $DATN -vvvv --etherscan-api-key D6ZFHU3MWZXE4Z17ICWBA1IR8A4JEPK1ZJ --verify
-contract Deploy_StrategyManager is Script, Test {
+// forge script script/Deploy_Preprod_StrategyFactory.s.sol:Deploy_Preprod_StrategyFactory
+//      --rpc-url $RPC_URL
+//      --private-key $PRIVATE_KEY
+//      --etherscan-api-key $ETHERSCAN_API_KEY
+//      --verify
+//      --broadcast
+//      --vvvv
+contract Deploy_Preprod_StrategyManager is Script, Test {
     // https://docs.google.com/spreadsheets/d/1w8ckBfdVyv-Xh6iPwZ3hseDfX1gEptoJfomuwA8h3Jo/edit?gid=1046619329#gid=1046619329
     address owner = 0xDA29BB71669f46F2a779b4b62f03644A84eE3479;
     IPauserRegistry pauserRegistry = IPauserRegistry(0x9Ab2FEAf0465f0eD51Fc2b663eF228B418c9Dad1);

--- a/script/deploy/holesky/Deploy_Preprod_StrategyFactory.s.sol
+++ b/script/deploy/holesky/Deploy_Preprod_StrategyFactory.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+import "../../../src/contracts/strategies/EigenStrategy.sol";
+import "../../../src/contracts/strategies/StrategyFactory.sol";
+
+// forge script script/Deploy_StrategyManager.s.sol:Deploy_StrategyManager --rpc-url $--HOL private-key $DATN -vvvv --etherscan-api-key D6ZFHU3MWZXE4Z17ICWBA1IR8A4JEPK1ZJ --verify
+contract Deploy_StrategyManager is Script, Test {
+    // https://docs.google.com/spreadsheets/d/1w8ckBfdVyv-Xh6iPwZ3hseDfX1gEptoJfomuwA8h3Jo/edit?gid=1046619329#gid=1046619329
+    address owner = 0xDA29BB71669f46F2a779b4b62f03644A84eE3479;
+    IPauserRegistry pauserRegistry = IPauserRegistry(0x9Ab2FEAf0465f0eD51Fc2b663eF228B418c9Dad1);
+    IStrategyManager strategyManager = IStrategyManager(0xF9fbF2e35D8803273E214c99BF15174139f4E67a);
+    address eigenLayerProxyAdmin = 0x1BEF05C7303d44e0E2FCD2A19d993eDEd4c51b5B;
+    uint256 initialPausedStatus = 0;
+
+    function run()
+        external
+        returns (
+            UpgradeableBeacon strategyBeacon,
+            EigenStrategy strategyImplementation,
+            StrategyFactory strategyFactoryImplementation,
+            StrategyFactory strategyFactory
+        )
+    {
+        vm.startBroadcast();
+
+        strategyFactoryImplementation = new StrategyFactory(strategyManager);
+        strategyImplementation = new EigenStrategy(strategyManager);
+        strategyBeacon = new UpgradeableBeacon(address(strategyImplementation));
+        strategyFactory = StrategyFactory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(strategyFactoryImplementation),
+                    eigenLayerProxyAdmin,
+                    abi.encodeWithSelector(
+                        StrategyFactory.initialize.selector, owner, pauserRegistry, initialPausedStatus, strategyBeacon
+                    )
+                )
+            )
+        );
+
+        strategyBeacon.transferOwnership(owner);
+        vm.stopBroadcast();
+    }
+}

--- a/script/deploy/mainnet/Deploy_Mainnet_StrategyFactory.s.sol
+++ b/script/deploy/mainnet/Deploy_Mainnet_StrategyFactory.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+import "../../../src/contracts/strategies/StrategyFactory.sol";
+
+// forge script script/deploy/mainnet/Deploy_Preprod_StrategyFactory.s.sol:Deploy_Preprod_StrategyFactory
+//      --rpc-url $RPC_URL
+//      --private-key $PRIVATE_KEY
+//      --etherscan-api-key $ETHERSCAN_API_KEY
+//      --verify
+//      --broadcast
+//      --vvvv
+contract Deploy_Mainnet_StrategyFactory is Script, Test {
+    function _addr(bytes memory b) internal pure returns (address) {
+        return address(uint160(uint256(bytes32(b))));
+    }
+
+    function run() external {
+        vm.startBroadcast();
+
+        string memory json = "../../configs/mainnet/Deploy_Mainnet_StrategyFactory.config.json";
+
+        address owner = _addr(vm.parseJson(json, "owner"));
+        address strategyImplementation = _addr(vm.parseJson(json, "strategyImplementation"));
+        address strategyManager = _addr(vm.parseJson(json, "strategyManager"));
+        address eigenLayerProxyAdmin = _addr(vm.parseJson(json, "eigenLayerProxyAdmin"));
+        address pauserRegistry = _addr(vm.parseJson(json, "pauserRegistry"));
+        uint256 initialPausedStatus = uint256(bytes32(vm.parseJson(json, "initialPausedStatus")));
+
+        // Deploy a Proxy Beacon for the strategy and transfer ownership.
+        UpgradeableBeacon strategyBeacon = new UpgradeableBeacon(strategyImplementation);
+
+        strategyBeacon.transferOwnership(owner);
+
+        // Deploy a Strategy Factory implementation.
+        StrategyFactory strategyFactoryImplementation = new StrategyFactory(IStrategyManager(strategyManager));
+        // Deploy a Upgradeable Strategy Factory proxy.
+        StrategyFactory strategyFactory = StrategyFactory(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(strategyFactoryImplementation),
+                    eigenLayerProxyAdmin,
+                    abi.encodeWithSelector(
+                        StrategyFactory.initialize.selector, owner, pauserRegistry, initialPausedStatus, strategyBeacon
+                    )
+                )
+            )
+        );
+
+        console.log("Strategy Proxy Beacon: ", address(strategyBeacon));
+        console.log("Strategy Factory Implementation: ", address(strategyFactoryImplementation));
+        console.log("Strategy Factory Proxy: ", address(strategyFactory));
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/deploy/mainnet/Deploy_Mainnet_StrategyFactory.s.sol
+++ b/script/deploy/mainnet/Deploy_Mainnet_StrategyFactory.s.sol
@@ -17,6 +17,10 @@ import "../../../src/contracts/strategies/StrategyFactory.sol";
 //      --broadcast
 //      --vvvv
 contract Deploy_Mainnet_StrategyFactory is Script, Test {
+    UpgradeableBeacon strategyBeacon;
+    StrategyFactory strategyFactoryImplementation;
+    StrategyFactory strategyFactory;
+
     function _addr(bytes memory b) internal pure returns (address) {
         return address(uint160(uint256(bytes32(b))));
     }
@@ -34,14 +38,14 @@ contract Deploy_Mainnet_StrategyFactory is Script, Test {
         uint256 initialPausedStatus = uint256(bytes32(vm.parseJson(json, "initialPausedStatus")));
 
         // Deploy a Proxy Beacon for the strategy and transfer ownership.
-        UpgradeableBeacon strategyBeacon = new UpgradeableBeacon(strategyImplementation);
+        strategyBeacon = new UpgradeableBeacon(strategyImplementation);
 
         strategyBeacon.transferOwnership(owner);
 
         // Deploy a Strategy Factory implementation.
-        StrategyFactory strategyFactoryImplementation = new StrategyFactory(IStrategyManager(strategyManager));
+        strategyFactoryImplementation = new StrategyFactory(IStrategyManager(strategyManager));
         // Deploy a Upgradeable Strategy Factory proxy.
-        StrategyFactory strategyFactory = StrategyFactory(
+        strategyFactory = StrategyFactory(
             address(
                 new TransparentUpgradeableProxy(
                     address(strategyFactoryImplementation),


### PR DESCRIPTION
Since the StrategyFactory is decoupled from the core contracts, the deployment scripts are quite simple.

Config for testnet is currently empty, this will change after deployment and before merging.