### PR TITLE
Support third party withdrawals with queueWithdrawalsWithSignature

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -328,7 +328,11 @@ contract DelegationManager is
         for (uint256 i = 0; i < queuedWithdrawalWithSigParams.length; i++) {
             require(
                 queuedWithdrawalWithSigParams[i].strategies.length == queuedWithdrawalWithSigParams[i].shares.length,
-                "DelegationManager.queueWithdrawal: input length mismatch"
+                "DelegationManager.queueWithdrawalsWithSignature: input length mismatch"
+            );
+            require(
+                queuedWithdrawalWithSigParams[i].expiry >= block.timestamp,
+                "DelegationManager.queueWithdrawalsWithSignature: signature expired"
             );
 
             uint256 nonce = withdrawerNonce[queuedWithdrawalWithSigParams[i].staker];
@@ -337,7 +341,8 @@ contract DelegationManager is
                 queuedWithdrawalWithSigParams[i].staker,
                 queuedWithdrawalWithSigParams[i].strategies,
                 queuedWithdrawalWithSigParams[i].shares,
-                nonce
+                nonce,
+                queuedWithdrawalWithSigParams[i].expiry
             );
 
             unchecked {
@@ -1046,7 +1051,8 @@ contract DelegationManager is
         address staker,
         IStrategy[] memory strategies,
         uint256[] memory shares,
-        uint256 _stakerNonce
+        uint256 stakerNonce,
+        uint256 expiry
     ) public view returns (bytes32) {
 
         // calculate the struct hash
@@ -1055,7 +1061,8 @@ contract DelegationManager is
             staker,
             strategies,
             shares,
-            _stakerNonce
+            stakerNonce,
+            expiry
         ));
         // calculate the digest hash
         bytes32 digestHash = keccak256(abi.encodePacked(

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -26,9 +26,9 @@ abstract contract DelegationManagerStorage is IDelegationManager {
         "DelegationApproval(address delegationApprover,address staker,address operator,bytes32 salt,uint256 expiry)"
     );
 
-    /// @notice The EIP-712 typehash for the deposit struct used by the contract
+    /// @notice The EIP-712 typehash for the `QueueWithdrawal` struct used by the contract
     bytes32 public constant QUEUE_WITHDRAWAL_TYPEHASH =
-        keccak256("QueueWithdrawal(address staker,address[] strategies,uint256[] shares,uint256 nonce)");
+        keccak256("QueueWithdrawal(address staker,address[] strategies,uint256[] shares,uint256 nonce,uint256 expiry)");
 
     /**
      * @notice Original EIP-712 Domain separator for this contract.

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -26,6 +26,10 @@ abstract contract DelegationManagerStorage is IDelegationManager {
         "DelegationApproval(address delegationApprover,address staker,address operator,bytes32 salt,uint256 expiry)"
     );
 
+    /// @notice The EIP-712 typehash for the deposit struct used by the contract
+    bytes32 public constant QUEUE_WITHDRAWAL_TYPEHASH =
+        keccak256("QueueWithdrawal(address staker,address[] strategies,uint256[] shares,uint256 nonce)");
+
     /**
      * @notice Original EIP-712 Domain separator for this contract.
      * @dev The domain separator may change in the event of a fork that modifies the ChainID.
@@ -68,6 +72,9 @@ abstract contract DelegationManagerStorage is IDelegationManager {
 
     /// @notice Mapping: staker => number of signed messages (used in `delegateToBySignature`) from the staker that this contract has already checked.
     mapping(address => uint256) public stakerNonce;
+
+    /// @notice Mapping: staker => number of signed messages (used in `queueWithdrawalWithSignature`) from the staker that this contract has already checked.
+    mapping(address => uint256) public withdrawerNonce;
 
     /**
      * @notice Mapping: delegationApprover => 32-byte salt => whether or not the salt has already been used by the delegationApprover.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -238,6 +238,20 @@ interface IDelegationManager is ISignatureUtils {
         returns (bytes32[] memory);
 
     /**
+     * Allows a third party to withdraw shares on behalf of a staker with their signature.
+     * Withdrawn shares/strategies are immediately removed from the staker.
+     * If the staker is delegated, withdrawn shares/strategies are also removed from
+     * their operator.
+     *
+     * All withdrawn shares/strategies are placed in a queue and can be fully withdrawn after a delay.
+     */
+    function queueWithdrawalsWithSignature(
+        QueuedWithdrawalParams[] calldata queuedWithdrawalParams,
+        address staker,
+        bytes memory stakerSignature
+    ) external returns (bytes32[] memory);
+
+    /**
      * @notice Used to complete the specified `withdrawal`. The caller must match `withdrawal.withdrawer`
      * @param withdrawal The Withdrawal to complete.
      * @param tokens Array in which the i-th entry specifies the `token` input to the 'withdraw' function of the i-th Strategy in the `withdrawal.strategies` array.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -99,6 +99,19 @@ interface IDelegationManager is ISignatureUtils {
         address withdrawer;
     }
 
+    struct QueuedWithdrawalWithSignatureParams {
+        // Array of strategies that the QueuedWithdrawal contains
+        IStrategy[] strategies;
+        // Array containing the amount of shares in each Strategy in the `strategies` array
+        uint256[] shares;
+        // The address of the withdrawer
+        address withdrawer;
+        // The address of the staker
+        address staker;
+        // signature of the staker
+        bytes  signature;
+    }
+
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
     event OperatorRegistered(address indexed operator, OperatorDetails operatorDetails);
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -109,7 +109,9 @@ interface IDelegationManager is ISignatureUtils {
         // The address of the staker
         address staker;
         // signature of the staker
-        bytes  signature;
+        bytes signature;
+        // expiration timestamp of the signature
+        uint256 expiry;
     }
 
     // @notice Emitted when a new operator registers in EigenLayer and provides their OperatorDetails.
@@ -450,7 +452,8 @@ interface IDelegationManager is ISignatureUtils {
         address staker,
         IStrategy[] memory strategies,
         uint256[] memory shares,
-        uint256 _stakerNonce
+        uint256 stakerNonce,
+        uint256 expiry
     ) external view returns (bytes32);
 
     /// @notice The EIP-712 typehash for the contract's domain

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -259,9 +259,7 @@ interface IDelegationManager is ISignatureUtils {
      * All withdrawn shares/strategies are placed in a queue and can be fully withdrawn after a delay.
      */
     function queueWithdrawalsWithSignature(
-        QueuedWithdrawalParams[] calldata queuedWithdrawalParams,
-        address staker,
-        bytes memory stakerSignature
+        QueuedWithdrawalWithSignatureParams[] calldata queuedWithdrawalWithSigParams
     ) external returns (bytes32[] memory);
 
     /**
@@ -446,6 +444,13 @@ interface IDelegationManager is ISignatureUtils {
         address _delegationApprover,
         bytes32 approverSalt,
         uint256 expiry
+    ) external view returns (bytes32);
+
+    function calculateQueueWithdrawalDigestHash(
+        address staker,
+        IStrategy[] memory strategies,
+        uint256[] memory shares,
+        uint256 _stakerNonce
     ) external view returns (bytes32);
 
     /// @notice The EIP-712 typehash for the contract's domain

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -123,7 +123,8 @@ contract DelegationManagerMock is IDelegationManager, Test {
         address /*staker*/,
         IStrategy[] memory /*strategies*/,
         uint256[] memory /*shares*/,
-        uint256 /*_stakerNonce*/
+        uint256 /*stakerNonce*/,
+        uint256 /*expiry*/
     ) external view returns (bytes32) {}
 
     function calculateStakerDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/)

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -22,7 +22,7 @@ contract DelegationManagerMock is IDelegationManager, Test {
     mapping (address => address) public delegatedTo;
 
     function registerAsOperator(OperatorDetails calldata /*registeringOperatorDetails*/, string calldata /*metadataURI*/) external pure {}
-    
+
     function updateOperatorMetadataURI(string calldata /*metadataURI*/) external pure {}
 
     function updateAVSMetadataURI(string calldata /*metadataURI*/) external pure {}
@@ -85,7 +85,7 @@ contract DelegationManagerMock is IDelegationManager, Test {
     function strategyWithdrawalDelayBlocks(IStrategy /*strategy*/) external pure returns (uint256) {
         return 0;
     }
-    
+
     function getOperatorShares(
         address operator,
         IStrategy[] memory strategies
@@ -117,6 +117,13 @@ contract DelegationManagerMock is IDelegationManager, Test {
         address /*_delegationApprover*/,
         bytes32 /*approverSalt*/,
         uint256 /*expiry*/
+    ) external view returns (bytes32) {}
+
+    function calculateQueueWithdrawalDigestHash(
+        address /*staker*/,
+        IStrategy[] memory /*strategies*/,
+        uint256[] memory /*shares*/,
+        uint256 /*_stakerNonce*/
     ) external view returns (bytes32) {}
 
     function calculateStakerDigestHash(address /*staker*/, address /*operator*/, uint256 /*expiry*/)
@@ -152,6 +159,10 @@ contract DelegationManagerMock is IDelegationManager, Test {
         QueuedWithdrawalParams[] calldata queuedWithdrawalParams
     ) external returns (bytes32[] memory) {}
 
+   function queueWithdrawalsWithSignature(
+        QueuedWithdrawalWithSignatureParams[] calldata queuedWithdrawalWithSigParams
+    ) external returns (bytes32[] memory) {}
+
     function completeQueuedWithdrawal(
         Withdrawal calldata withdrawal,
         IERC20[] calldata tokens,
@@ -165,7 +176,7 @@ contract DelegationManagerMock is IDelegationManager, Test {
         uint256[] calldata middlewareTimesIndexes,
         bool[] calldata receiveAsTokens
     ) external {}
-    
+
     // onlyDelegationManager functions in StrategyManager
     function addShares(
         IStrategyManager strategyManager,

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -195,12 +195,12 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     }
 
     function _getStakerQueueWithdrawalSignature(
-        uint256 stakerPrivateKey,
+        uint256 _stakerPrivateKey,
         IStrategy[] memory strategyArray,
         uint256[] memory withdrawalAmounts
-    ) internal returns (bytes memory) {
+    ) internal view returns (bytes memory) {
 
-        address staker = cheats.addr(stakerPrivateKey);
+        address staker = cheats.addr(_stakerPrivateKey);
         bytes32 digestHash = delegationManager.calculateQueueWithdrawalDigestHash(
             staker,
             strategyArray,
@@ -208,7 +208,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             0
         );
 
-        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(stakerPrivateKey, digestHash);
+        (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
         bytes memory stakerSignature = abi.encodePacked(r, s, v);
         return stakerSignature;
     }
@@ -391,11 +391,11 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     }
 
     function _setUpQueueWithdrawalsWithSignatureSingleStrat(
-        uint256 stakerPrivateKey,
+        uint256 _stakerPrivateKey,
         address withdrawer,
         IStrategy strategy,
         uint256 withdrawalAmount
-    ) internal returns (
+    ) internal view returns (
         IDelegationManager.QueuedWithdrawalWithSignatureParams[] memory,
         IDelegationManager.Withdrawal memory,
         bytes32
@@ -406,16 +406,16 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         uint256[] memory withdrawalAmounts = new uint256[](1);
         withdrawalAmounts[0] = withdrawalAmount;
 
-        address staker = cheats.addr(stakerPrivateKey);
+        address staker = cheats.addr(_stakerPrivateKey);
         bytes memory stakerSignature = _getStakerQueueWithdrawalSignature(
-            stakerPrivateKey,
+            _stakerPrivateKey,
             strategyArray,
             withdrawalAmounts
         );
 
-        IDelegationManager.QueuedWithdrawalWithSignatureParams[] memory queuedWithdrawalParams;
-        queuedWithdrawalParams = new IDelegationManager.QueuedWithdrawalWithSignatureParams[](1);
-        queuedWithdrawalParams[0] = IDelegationManager.QueuedWithdrawalWithSignatureParams({
+        IDelegationManager.QueuedWithdrawalWithSignatureParams[] memory queuedWithdrawalWithSigParams;
+        queuedWithdrawalWithSigParams = new IDelegationManager.QueuedWithdrawalWithSignatureParams[](1);
+        queuedWithdrawalWithSigParams[0] = IDelegationManager.QueuedWithdrawalWithSignatureParams({
             strategies: strategyArray,
             shares: withdrawalAmounts,
             withdrawer: withdrawer,
@@ -434,7 +434,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         });
         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
 
-        return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
+        return (queuedWithdrawalWithSigParams, withdrawal, withdrawalRoot);
     }
 
     function _setUpQueueWithdrawals(
@@ -2994,7 +2994,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             IDelegationManager.Withdrawal memory withdrawal,
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsWithSignatureSingleStrat({
-            stakerPrivateKey: _stakerPrivateKey,
+            _stakerPrivateKey: _stakerPrivateKey,
             withdrawer: staker,
             strategy: strategies[0],
             withdrawalAmount: withdrawalAmount

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -197,7 +197,9 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     function _getStakerQueueWithdrawalSignature(
         uint256 _stakerPrivateKey,
         IStrategy[] memory strategyArray,
-        uint256[] memory withdrawalAmounts
+        uint256[] memory withdrawalAmounts,
+        uint256 nonce,
+        uint256 expiry
     ) internal view returns (bytes memory) {
 
         address staker = cheats.addr(_stakerPrivateKey);
@@ -205,7 +207,8 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             staker,
             strategyArray,
             withdrawalAmounts,
-            0
+            nonce,
+            expiry
         );
 
         (uint8 v, bytes32 r, bytes32 s) = cheats.sign(_stakerPrivateKey, digestHash);
@@ -403,14 +406,20 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
 
         IStrategy[] memory strategyArray = new IStrategy[](1);
         strategyArray[0] = strategy;
+
         uint256[] memory withdrawalAmounts = new uint256[](1);
         withdrawalAmounts[0] = withdrawalAmount;
 
+        uint256 expiry = block.timestamp + 6 hours;
+        uint256 nonce = 0;
         address staker = cheats.addr(_stakerPrivateKey);
+
         bytes memory stakerSignature = _getStakerQueueWithdrawalSignature(
             _stakerPrivateKey,
             strategyArray,
-            withdrawalAmounts
+            withdrawalAmounts,
+            nonce,
+            expiry
         );
 
         IDelegationManager.QueuedWithdrawalWithSignatureParams[] memory queuedWithdrawalWithSigParams;
@@ -420,7 +429,8 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             shares: withdrawalAmounts,
             withdrawer: withdrawer,
             staker: staker,
-            signature: stakerSignature
+            signature: stakerSignature,
+            expiry: expiry
         });
 
         IDelegationManager.Withdrawal memory withdrawal = IDelegationManager.Withdrawal({

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -2965,7 +2965,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
     }
 
     /**
-     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
+     * @notice Verifies that `DelegationManager.queueWithdrawalsWithSignature` properly queues a withdrawal for the `withdrawer`
      * from the `strategy` for the `sharesAmount`.
      * - Asserts that staker is delegated to the operator
      * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`


### PR DESCRIPTION
**Description**
Support third party withdrawals by adding a `queueWithdrawalWithSignature` function in DelegationManager so that a contract can queue withdrawals on behalf of a user with their signature.

**Use Cases**
At the moment a contract (e.g. a contract facilitating L2 <-> L1 restaking and withdrawing) can conduct deposits on behalf of a staker with `depositIntoStrategyWithSignature` in the StrategyManager, but can't queue withdrawals on behalf of a staker. Adding this feature would enable withdrawing via L2.

The token which we are using for Dual Staking has most of it's liquidity and users on L2, and so we wanted to allow our users to both stake and withdraw from Eigenlayer from L2 instead of: requiring our users to bridge ETH back to L1, queueWithdrawal from Eigenlayer, waiting for the withdrawal period, completeWithdrawal, then bridging back to L2.

**Update:**
The Eigenlayer team mentioned this feature existed in the past but was removed due to phishing concerns. 
I'm wondering if adding a `whitelistThirdPartyWithdrawer(contractAddr, strategy)` with checks in the `queueWithdrawalWithSignature` function addresses these concerns sufficiently.

At the moment, queueWithdrawals already checks if [thirdPartyTransfersForbidden = false](https://github.com/Layr-Labs/eigenlayer-contracts/blob/00fc4b95e9c1a5c4f370e41f56d01052d186da07/src/contracts/core/DelegationManager.sol#L696) to allow third party withdrawals, however `thirdPartyTransfersForbidden` defaults to `false` in [StrategyFactory.deployNewStrategy()](https://github.com/Layr-Labs/eigenlayer-contracts/blob/00fc4b95e9c1a5c4f370e41f56d01052d186da07/src/contracts/strategies/StrategyFactory.sol#L68), so I'm unsure if the team wants to add a separate `thirdPartyWithdrawalsForbidden = false` requirement to allow for different defaults for third party deposits, and third party withdrawals. 

Happy to add a separate `thirdPartyWithdrawalsForbidden` feature in the PR as well if the team prefers the latter.
