### PR TITLE
fix: block m2 deregistrations for opset AVSs

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -353,6 +353,12 @@ contract AVSDirectory is
             "AVSDirectory.deregisterOperatorFromAVS: operator not registered"
         );
 
+        // Assert that the AVS is not an operator set AVS.
+        require(
+            !isOperatorSetAVS[msg.sender], 
+            "AVSDirectory.deregisterOperatorFromAVS: AVS is an operator set AVS"
+        );
+
         // Set the operator as deregistered
         avsOperatorStatus[msg.sender][operator] = OperatorAVSRegistrationStatus.UNREGISTERED;
 

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -1178,7 +1178,7 @@ contract AVSDirectoryUnitTests_legacyOperatorAVSRegistration is AVSDirectoryUnit
         avsDirectory.deregisterOperatorFromAVS(address(0));
     }
 
-    function test_revert_deregisterOperatorFromAVS_notM2AVS() public {
+    function test_revert_deregisterOperatorFromAVS_whenAVSISOperatorSetAVS() public {
         // Register operator
         bytes32 salt = bytes32(0);
         address operator = cheats.addr(delegationSignerPrivateKey);


### PR DESCRIPTION
- Prevent race condition when AVSs migrate & an AVS also deregisters operator during multi-block operation.