### PR TITLE
add charging implementation

### DIFF
--- a/script/deploy/devnet/operatorSets/PopulateSRC.sol
+++ b/script/deploy/devnet/operatorSets/PopulateSRC.sol
@@ -23,9 +23,10 @@ contract PopulateSRC is Script, Test, ExistingDeploymentParser {
         IStakeRootCompendium stakeRootCompendiumImplementation =  new StakeRootCompendium({
             _delegationManager: delegationManager,
             _avsDirectory: avsDirectory,
+            _proofInterval: 1 hours,
             _blacklistWindow: 12 seconds
         });
-        StakeRootCompendium stakeRootCompendium = StakeRootCompendium(address(new TransparentUpgradeableProxy(
+        StakeRootCompendium stakeRootCompendium = StakeRootCompendium(payable(new TransparentUpgradeableProxy(
             address(stakeRootCompendiumImplementation),
             address(msg.sender),
             ""

--- a/src/contracts/core/StakeRootCompendium.sol
+++ b/src/contracts/core/StakeRootCompendium.sol
@@ -274,7 +274,11 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
         for (uint256 i = latestChargedSubmissionIndexMemory; i < endIndex; i++) {
             StakeRootSubmission memory stakeRootSubmission = stakeRootSubmissions[i];
             // if the stakeRootSubmission is blacklisted or force posted, skip it
-            if (stakeRootSubmission.blacklisted || stakeRootSubmission.forcePosted) {
+            if (
+                block.timestamp < stakeRootSubmission.submissionTimestamp + blacklistWindow ||
+                stakeRootSubmission.blacklisted || 
+                stakeRootSubmission.forcePosted
+            ) {
                 continue;
             }
             // if the charge recipient has changed, transfer the total charge to the previous recipient

--- a/src/contracts/core/StakeRootCompendium.sol
+++ b/src/contracts/core/StakeRootCompendium.sol
@@ -25,20 +25,34 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     /// @notice the placeholder index used for operator sets that are removed from the StakeTree
     uint32 public constant REMOVED_INDEX = type(uint32).max;
 
+    /// @notice the minimum balance that must be maintained for an operatorSet
+    uint256 public constant MIN_DEPOSIT_BALANCE = 0.1 ether;
+
     /// @notice the delegation manager contract
     IDelegationManager public immutable delegationManager;
     /// @notice the AVS directory contract
     IAVSDirectory public immutable avsDirectory;
+
+    /// @notice the interval at which proofs can be posted, to not overcharge the operatorSets
+    uint32 public immutable proofInterval;
     /// @notice the period of time within which a root can be marked as blacklisted
     uint32 public immutable blacklistWindow;
+
+    /// @notice charge per strategy per proof
+    uint256 public charge;
+
+    /// @notice deposit balance to be deducted for operatorSets
+    mapping(address => mapping(uint32 => DepositBalanceInfo)) public depositBalanceInfo;
 
     /// @notice map from operator set to a trace of their index over time
     mapping(address => mapping(uint32 => Checkpoints.History)) internal operatorSetToIndex;
     /// @notice list of operator sets that have been configured to be in the StakeTree
     IAVSDirectory.OperatorSet[] public operatorSets;
+
+    /// @notice the total number of strategies across all operator sets over time
+    Checkpoints.History internal totalStrategies;
     /// @notice the number of operator sets that have been configured to be in the StakeTree
     mapping(address => mapping(uint32 => EnumerableMap.AddressToUintMap)) internal operatorSetToStrategyAndMultipliers;
-
     /// @notice the extraData for each operator in each operator set
     mapping(address => mapping(uint32 => mapping(address => bytes32))) internal extraDatas;
 
@@ -47,25 +61,44 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     /// @notice the id of the program being verified when roots are posted
     bytes32 public imageId;
 
+    /// @notice the index of the latest stake root submission that has been charged
+    uint256 public latestChargedSubmissionIndex;
+    /// @notice the stake root submissions that have been posted
     StakeRootSubmission[] public stakeRootSubmissions;
 
     constructor(
         IDelegationManager _delegationManager,
         IAVSDirectory _avsDirectory,
+        uint32 _proofInterval,
         uint32 _blacklistWindow
     ) {
         // _disableInitializers();
         delegationManager = _delegationManager;
         avsDirectory = _avsDirectory;
+        proofInterval = _proofInterval;
         blacklistWindow = _blacklistWindow;
     }
 
-    function initialize(address initialOwner) public initializer {
+    function initialize(address initialOwner, uint256 _charge) public initializer {
         __Ownable_init();
         _transferOwnership(initialOwner);
+        _setCharge(_charge);
     }
 
-    /// CALLED BY AVS
+    /// OPERATORSET CONFIGURATION
+
+    /// @inheritdoc IStakeRootCompendium
+    function depositForOperatorSet(IAVSDirectory.OperatorSet calldata operatorSet) external payable {
+        require(avsDirectory.isOperatorSet(operatorSet.avs, operatorSet.operatorSetId), "StakeRootCompendium.depositForOperatorSet: operator set does not exist");
+        depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance += msg.value;
+        require(
+            depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance > 2 * MIN_DEPOSIT_BALANCE, 
+            "StakeRootCompendium.depositForOperatorSet: depositer must have 2x the minimum balance on deposit"
+        );
+
+        // update the deposit balance for the operator set whenever a deposit is made
+        _updateDepositBalanceInfo(operatorSet, true);
+    }
 
     /// @inheritdoc IStakeRootCompendium
     function addStrategiesAndMultipliers(
@@ -74,42 +107,49 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     ) external {
         require(strategiesAndMultipliers.length > 0, "StakeRootCompendium.setStrategiesAndMultipliers: no strategies and multipliers provided");
         require(avsDirectory.isOperatorSet(msg.sender, operatorSetId), "StakeRootCompendium.setStrategiesAndMultipliers: operator set does not exist");
-        uint256 lengthBefore = operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length();
+
+        IAVSDirectory.OperatorSet memory operatorSet = IAVSDirectory.OperatorSet({avs: msg.sender, operatorSetId: operatorSetId});
+        uint224 lengthBefore = uint224(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length());
         // if the operator set has been configured to have a positive number of strategies, increment the number of configured operator sets
         if (lengthBefore == 0) {
             require(operatorSets.length < MAX_NUM_OPERATOR_SETS, "StakeRootCompendium.setStrategiesAndMultipliers: too many operator sets");
-            operatorSets.push(IAVSDirectory.OperatorSet(msg.sender, operatorSetId));
-            operatorSetToIndex[msg.sender][operatorSetId].push(uint32(block.timestamp), uint208(operatorSets.length - 1));
+            operatorSetToIndex[msg.sender][operatorSetId].push(uint32(block.timestamp), uint208(operatorSets.length));
+            operatorSets.push(operatorSet);
         }
+        
+        // update the deposit balance for the operator set whenever number of strategies is changed
+        _updateDepositBalanceInfo(operatorSet, true);
         
         // set the strategies and multipliers for the operator set
         for (uint256 i = 0; i < strategiesAndMultipliers.length; i++) {
             operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].set(address(strategiesAndMultipliers[i].strategy), uint256(strategiesAndMultipliers[i].multiplier));
         }
-        require(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length() <= MAX_NUM_STRATEGIES, "StakeRootCompendium.setStrategiesAndMultipliers: too many strategies");
+        uint224 lengthAfter = uint224(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length());
+        require(lengthAfter <= MAX_NUM_STRATEGIES, "StakeRootCompendium.setStrategiesAndMultipliers: too many strategies");
+        totalStrategies.push(uint32(block.timestamp), totalStrategies.latest() + lengthAfter - lengthBefore);
     }
 
     /// @inheritdoc IStakeRootCompendium
     function removeStrategiesAndMultipliers(
         uint32 operatorSetId,
         IStrategy[] calldata strategies
-    ) external {        
+    ) external {   
+        IAVSDirectory.OperatorSet memory operatorSet = IAVSDirectory.OperatorSet({avs: msg.sender, operatorSetId: operatorSetId});
+        // update the deposit balance for the operator set whenever number of strategies is changed
+        _updateDepositBalanceInfo(operatorSet, true);
+
+        uint224 lengthBefore = uint224(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length());
         // remove the strategies and multipliers for the operator set
         for (uint256 i = 0; i < strategies.length; i++) {
             require(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].remove(address(strategies[i])), "StakeRootCompendium.removeStrategiesAndMultipliers: strategy not found");
         }
 
+        uint224 lengthAfter = uint224(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length());
         // if the operator set has been configured to have no strategies, decrement the number of configured operator sets
-        if(operatorSetToStrategyAndMultipliers[msg.sender][operatorSetId].length() == 0) {
-            IAVSDirectory.OperatorSet memory operatorSet = operatorSets[operatorSets.length - 1];
-            uint224 operatorSetIndex = operatorSetToIndex[msg.sender][operatorSetId].latest();
-            operatorSets[operatorSetIndex] = operatorSet;
-            operatorSets.pop();
-            
-            // update the index of the operator set
-            operatorSetToIndex[msg.sender][operatorSetId].push(uint32(block.timestamp), REMOVED_INDEX);
-            operatorSetToIndex[operatorSet.avs][operatorSet.operatorSetId].push(uint32(block.timestamp), operatorSetIndex);
+        if(lengthAfter == 0) {
+            _removeOperatorSet(operatorSet);
         }
+        totalStrategies.push(uint32(block.timestamp), totalStrategies.latest() - lengthBefore + lengthAfter);
     }
 
     /// @inheritdoc IStakeRootCompendium
@@ -121,6 +161,7 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
 	) external {
         (bool exists,,uint224 index) = operatorSetToIndex[msg.sender][operatorSetId].latestCheckpoint();
         require(exists && index != REMOVED_INDEX, "StakeRootCompendium.setExtraData: operatorSet is not in stakeTree");
+        _updateDepositBalanceInfo(IAVSDirectory.OperatorSet({avs: msg.sender, operatorSetId: operatorSetId}), true);
         extraDatas[msg.sender][operatorSetId][operator] = extraData;
     }
 
@@ -150,13 +191,13 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
         require(operators.length == avsDirectory.operatorSetMemberCount(operatorSet.avs, operatorSet.operatorSetId), "AVSSyncTree.getOperatorSetRoot: operator set size mismatch");
 
         bytes32[] memory operatorLeaves = new bytes32[](operators.length);
-        uint160 prevOperator = 0;
+        address prevOperator;
         for (uint256 i = 0; i < operators.length; i++) {
             require(avsDirectory.isMember(operators[i], operatorSet), "AVSSyncTree.getOperatorSetRoot: operator not in operator set");
             
             // ensure that operators are sorted
-            require(uint160(operators[i]) > prevOperator, "AVSSyncTree.getOperatorSetRoot: operators not sorted");
-            prevOperator = uint160(operators[i]);
+            require(operators[i] > prevOperator, "AVSSyncTree.getOperatorSetRoot: operators not sorted");
+            prevOperator = operators[i];
 
             // calculate the weighted sum of the operator's shares for the strategies given the multipliers
             IStrategy[] memory strategies = new IStrategy[](operatorSetToStrategyAndMultipliers[operatorSet.avs][operatorSet.operatorSetId].length());
@@ -186,10 +227,10 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     /// POSTING ROOTS AND BLACKLISTING
 
     /// @inheritdoc IStakeRootCompendium
-    function verifyStakeRoot(uint32 calculationTimestamp, bytes32 stakeRoot, Proof calldata proof) external {
+    function verifyStakeRoot(uint32 calculationTimestamp, bytes32 stakeRoot, address chargeRecipient, Proof calldata proof) external {
         // TODO: verify proof
 
-        _postStakeRoot(calculationTimestamp, stakeRoot, false);
+        _postStakeRoot(calculationTimestamp, stakeRoot, chargeRecipient, false);
     }
     
     
@@ -204,43 +245,140 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     
     /// @inheritdoc IStakeRootCompendium
     function forcePostStakeRoot(uint32 calculationTimestamp, bytes32 stakeRoot) external onlyOwner {
-        _postStakeRoot(calculationTimestamp, stakeRoot, true);
+        _postStakeRoot(calculationTimestamp, stakeRoot, address(0), true);
+    }
+
+    /// CHARGE MANAGEMENT
+
+    /// @inheritdoc IStakeRootCompendium
+    function updateDepositBalanceInfos(IAVSDirectory.OperatorSet[] calldata operatorSetsToUpdate) external {
+        uint256 penalty = 0;
+        for(uint256 i = 0; i < operatorSetsToUpdate.length; i++) {
+            penalty += _updateDepositBalanceInfo(operatorSetsToUpdate[i], false);
+        }
+        if (penalty > 0) {
+            payable(msg.sender).transfer(penalty);
+        }
+    }
+
+    /**
+     * @notice Process charges for the next numToCharge stakeRootSubmissions that have not been redeemed
+     * @param numToCharge the number of charges to redeem
+     */
+    function processCharges(uint256 numToCharge) external {
+        uint256 latestChargedSubmissionIndexMemory = latestChargedSubmissionIndex;
+        uint256 endIndex = latestChargedSubmissionIndexMemory + numToCharge;
+        if (endIndex > stakeRootSubmissions.length) {
+            endIndex = stakeRootSubmissions.length;
+        }
+
+        address prevRecipient;
+        uint256 totalCharge;
+        for (uint256 i = latestChargedSubmissionIndexMemory; i < endIndex; i++) {
+            StakeRootSubmission memory stakeRootSubmission = stakeRootSubmissions[i];
+            // if the stakeRootSubmission is blacklisted or force posted, skip it
+            if (stakeRootSubmission.blacklisted || stakeRootSubmission.forcePosted) {
+                continue;
+            }
+            // if the charge recipient has changed, transfer the total charge to the previous recipient
+            if(stakeRootSubmission.chargeRecipient != prevRecipient) {
+                if (totalCharge > 0) {
+                    payable(prevRecipient).transfer(totalCharge);
+                }
+                totalCharge = 0;
+                prevRecipient = stakeRootSubmission.chargeRecipient;
+            }
+            // total charge is the charge per strategy per proof times the number of strategies at the time of proof
+            totalCharge += charge * totalStrategies.upperLookup(stakeRootSubmissions[i].calculationTimestamp);
+        }
     }
 
     /// PERMISSIONED SETTERS
 
-    /**
-     * @notice sets the verifier contract that will be used to verify snark proofs
-     * @param _verifier the address of the verifier contract
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc IStakeRootCompendium
     function setVerifier(address _verifier) external onlyOwner {
         address oldVerifier = verifier; 
         verifier = _verifier;
         emit VerifierChanged(oldVerifier, verifier);
     }
 
-    /**
-     * @notice sets/changes the id of the program being verified when roots are posted
-     * @param _imageId the new imageId to set
-     * @dev only callable by the owner
-     */
+    /// @inheritdoc IStakeRootCompendium
     function setImageId(bytes32 _imageId) external onlyOwner {
         bytes32 oldImageId = imageId;
         imageId = _imageId;
         emit ImageIdChanged(oldImageId, imageId);
     }
 
+    /// VIEW FUNCTIONS
+    
+    function getDepositBalance(IAVSDirectory.OperatorSet memory operatorSet) public view returns (uint256 balance, uint256 penalty) {
+        // the total charge for the operator set is the charge per strategy per proof
+        uint256 totalCharge = 
+            charge * 
+            operatorSetToStrategyAndMultipliers[operatorSet.avs][operatorSet.operatorSetId].length() * 
+            (stakeRootSubmissions.length - depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].cumulativeProofsCheckpointed);
+        uint256 storedBalance = depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance;
+
+        // if the charge would take the balance below the minimum deposit balance, return 0
+        balance = storedBalance < totalCharge + MIN_DEPOSIT_BALANCE ? 0 : storedBalance - totalCharge;
+        // if the balance is 0, then the charger may be able to claim the penalty for removing the operatorSet from the stakeTree
+        penalty = balance == 0 ? totalCharge + MIN_DEPOSIT_BALANCE - storedBalance : 0;
+        return (balance, penalty);
+    }
+
+    /// Misc
+
+    receive() external payable {}
+
     /// INTERNAL FUNCTIONS
 
-    function _postStakeRoot(uint32 calculationTimestamp, bytes32 stakeRoot, bool forcePosted) internal {
+    function _removeOperatorSet(IAVSDirectory.OperatorSet memory operatorSet) internal {
+        IAVSDirectory.OperatorSet memory substituteOperatorSet = operatorSets[operatorSets.length - 1];
+        uint224 operatorSetIndex = operatorSetToIndex[operatorSet.avs][operatorSet.operatorSetId].latest();
+        operatorSets[operatorSetIndex] = substituteOperatorSet;
+        operatorSets.pop();
+        
+        // update the index of the operator sets
+        operatorSetToIndex[operatorSet.avs][operatorSet.operatorSetId].push(uint32(block.timestamp), REMOVED_INDEX);
+        operatorSetToIndex[operatorSet.avs][operatorSet.operatorSetId].push(uint32(block.timestamp), operatorSetIndex);
+    }
+
+    function _setCharge(uint256 _charge) internal {
+        charge = _charge;
+        // TODO: emit event
+    }
+
+    // updates the deposit balance for the operator set and returns the penalty if the operator set has fallen below the minimum deposit balance
+    function _updateDepositBalanceInfo(IAVSDirectory.OperatorSet memory operatorSet, bool sendPenalty) internal returns(uint256) {
+        (uint256 depositBalance, uint256 penalty) = getDepositBalance(operatorSet);
+        depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance = depositBalance;
+        depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].cumulativeProofsCheckpointed = uint32(stakeRootSubmissions.length);
+
+        // if the operatorSet has fallen below the minimum deposit balance, remove it from the stakeTree
+        if (penalty > 0) {
+            _removeOperatorSet(operatorSet);
+            if (sendPenalty) {
+                payable(msg.sender).transfer(penalty);
+            }
+        }
+
+        return penalty;
+    }
+
+    function _postStakeRoot(uint32 calculationTimestamp, bytes32 stakeRoot, address chargeRecipient, bool forcePosted) internal {
+        require(calculationTimestamp % proofInterval == 0, "StakeRootCompendium._postStakeRoot: calculationTimestamp must be a multiple of proofInterval");
+
         uint256 stakeRootSubmissionsLength = stakeRootSubmissions.length;
         if (stakeRootSubmissionsLength != 0) {
-            require(stakeRootSubmissions[stakeRootSubmissionsLength - 1].calculationTimestamp < calculationTimestamp, "StakeRootCompendium._postStakeRoot: calculationTimestamp must be greater than the last posted calculationTimestamp");
+            require(
+                stakeRootSubmissions[stakeRootSubmissionsLength - 1].calculationTimestamp < calculationTimestamp, 
+                "StakeRootCompendium._postStakeRoot: calculationTimestamp must be greater than the last posted calculationTimestamp"
+            );
         }
 
         stakeRootSubmissions.push(StakeRootSubmission({
             stakeRoot: stakeRoot,
+            chargeRecipient: msg.sender,
             calculationTimestamp: calculationTimestamp,
             submissionTimestamp: uint32(block.timestamp),
             blacklisted: false,

--- a/src/contracts/core/StakeRootCompendium.sol
+++ b/src/contracts/core/StakeRootCompendium.sol
@@ -314,7 +314,7 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
         uint256 totalCharge = 
             charge * 
             operatorSetToStrategyAndMultipliers[operatorSet.avs][operatorSet.operatorSetId].length() * 
-            (stakeRootSubmissions.length - depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].cumulativeProofsCheckpointed);
+            (block.timestamp - depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].lastUpdatedAt) / proofInterval;
         uint256 storedBalance = depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance;
 
         // if the charge would take the balance below the minimum deposit balance, return 0
@@ -350,7 +350,7 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     function _updateDepositBalanceInfo(IAVSDirectory.OperatorSet memory operatorSet, bool sendPenalty) internal returns(uint256) {
         (uint256 depositBalance, uint256 penalty) = getDepositBalance(operatorSet);
         depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].balance = depositBalance;
-        depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].cumulativeProofsCheckpointed = uint32(stakeRootSubmissions.length);
+        depositBalanceInfo[operatorSet.avs][operatorSet.operatorSetId].lastUpdatedAt = uint32(block.timestamp);
 
         // if the operatorSet has fallen below the minimum deposit balance, remove it from the stakeTree
         if (penalty > 0) {

--- a/src/contracts/core/StakeRootCompendium.sol
+++ b/src/contracts/core/StakeRootCompendium.sol
@@ -261,10 +261,7 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
         }
     }
 
-    /**
-     * @notice Process charges for the next numToCharge stakeRootSubmissions that have not been redeemed
-     * @param numToCharge the number of charges to redeem
-     */
+    /// @inheritdoc IStakeRootCompendium
     function processCharges(uint256 numToCharge) external {
         uint256 latestChargedSubmissionIndexMemory = latestChargedSubmissionIndex;
         uint256 endIndex = latestChargedSubmissionIndexMemory + numToCharge;
@@ -310,7 +307,8 @@ contract StakeRootCompendium is IStakeRootCompendium, OwnableUpgradeable {
     }
 
     /// VIEW FUNCTIONS
-    
+
+    /// @inheritdoc IStakeRootCompendium
     function getDepositBalance(IAVSDirectory.OperatorSet memory operatorSet) public view returns (uint256 balance, uint256 penalty) {
         // the total charge for the operator set is the charge per strategy per proof
         uint256 totalCharge = 

--- a/src/contracts/interfaces/IStakeRootCompendium.sol
+++ b/src/contracts/interfaces/IStakeRootCompendium.sol
@@ -121,7 +121,7 @@ interface IStakeRootCompendium {
 
     /**
      * @notice Process charges for the next numToCharge stakeRootSubmissions that have not been redeemed
-     * @param numToCharge the number of charges to redeem
+     * @param numToCharge the number of charges to process
      */
     function processCharges(uint256 numToCharge) external;
 
@@ -165,4 +165,12 @@ interface IStakeRootCompendium {
      * @dev only callable by the owner
      */
     function setImageId(bytes32 _imageId) external;
+
+    /**
+     * @notice get the deposit balance for the operator set
+     * @param operatorSet the operator set to get the deposit balance for
+     * @return balance the deposit balance for the operator set
+     * @return penalty the penalty to be received by calling updateDepositBalanceInfos if the operator set has fallen below the minimum deposit balance
+     */
+    function getDepositBalance(IAVSDirectory.OperatorSet memory operatorSet) external view returns (uint256 balance, uint256 penalty);
 }

--- a/src/contracts/interfaces/IStakeRootCompendium.sol
+++ b/src/contracts/interfaces/IStakeRootCompendium.sol
@@ -39,10 +39,19 @@ interface IStakeRootCompendium {
     function MAX_NUM_OPERATOR_SETS() external view returns (uint32);
     function MAX_NUM_STRATEGIES() external view returns (uint32);
 
+    /// @notice the minimum balance that must be maintained for an operatorSet
+    function MIN_DEPOSIT_BALANCE() external view returns (uint256);
+
     function delegationManager() external view returns (IDelegationManager);
     function avsDirectory() external view returns (IAVSDirectory);
     function verifier() external view returns (address);
     function imageId() external view returns (bytes32);
+    
+    /// @notice charge per strategy per proof
+    function charge() external view returns (uint256);
+
+    /// @notice the interval at which proofs can be posted, to not overcharge the operatorSets
+    function proofInterval() external view returns (uint32);
 
     /**
      * @notice called offchain with the operatorSet roots ordered by the operatorSet index at the timestamp to calculate the stake root

--- a/src/contracts/interfaces/IStakeRootCompendium.sol
+++ b/src/contracts/interfaces/IStakeRootCompendium.sol
@@ -18,7 +18,7 @@ interface IStakeRootCompendium {
     }
 
     struct DepositBalanceInfo {
-        uint32 cumulativeProofsCheckpointed;
+        uint32 lastUpdatedAt;
         uint256 balance;
     }
 


### PR DESCRIPTION
- operatorSets deposit funds for proof charges
- charges are per strategy per proof
- operatorSets must maintain a `MINIMUM_DEPOSIT_BALANCE`, otherwise they can be lose their deposit balance and be removed from the stakeTree
- addresses the race condition with removing strategies right before proofs are submitted by setting a proofInterval  which calculationTimestamps need to be a multiple of and charging users according to how many proof intervals have passed
- the main downside is that the price is not modifiable. in the terrible case that we have to change the price due to a drop in ETH (idk if we'd even want to do this), we'd basically pause verifyStakeRoot , updateBalanceInfo for every operatorSet, update the price, and then unpause verifyStakeRoot,