### PR TITLE
feat: encoded operatorSet mapping keys and duplicate check

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -270,8 +270,11 @@ contract AVSDirectory is
      * @param operator address to modify allocations for
      * @param allocations array of magnitude adjustments for multiple strategies and corresponding operator sets
      * @param operatorSignature signature of the operator if msg.sender is not the operator
-     * @dev updates freeMagnitude for the updated strategies
-     * @dev must be called by the operator
+     * @dev Updates freeMagnitude for the updated strategies
+     * @dev Must be called by the operator or with a valid operator signature
+     * @dev For each allocation, allocation.operatorSets MUST be ordered in ascending order according to the
+     * encoding of the operatorSet. This is to prevent duplicate operatorSets being passed in. The easiest way to ensure
+     * ordering is to sort allocated operatorSets by address first, and then sort for each avs by ascending operatorSetIds.
      */
     function modifyAllocations(
         address operator,
@@ -549,6 +552,9 @@ contract AVSDirectory is
      * @param allocation the magnitude allocations to modify for a single strategy
      * @param allocationEffectTimestamp the timestamp when the allocations will take effect
      * @param deallocationCompletableTimestamp the timestamp when the deallocations will be completable
+     * @dev For each allocation, allocation.operatorSets MUST be ordered in ascending order according to the
+     * encoding of the operatorSet. This is to prevent duplicate operatorSets being passed in. The easiest way to ensure
+     * ordering is to sort allocated operatorSets by address first, and then sort for each avs by ascending operatorSetIds.
      */
     function _modifyAllocations(
         address operator,
@@ -649,6 +655,12 @@ contract AVSDirectory is
         freeMagnitude[operator][allocation.strategy] = newFreeMagnitude;
     }
 
+    /**
+     * @notice Get the number of queued dealloations for the given (operator, strategy, operatorSetKey) tuple
+     * @param operator address to get queued deallocations for
+     * @param strategy the strategy to get queued deallocations for
+     * @param operatorSetKey the encoded operatorSet to get queued deallocations for
+     */
     function _getNumQueuedDeallocations(
         address operator,
         IStrategy strategy,

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -26,8 +26,9 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
         keccak256("OperatorSetForceDeregistration(address avs,uint32[] operatorSetIds,bytes32 salt,uint256 expiry)");
 
     /// @notice The EIP-712 typehash for the `MagnitudeAdjustments` struct used by the contract
-    bytes32 public constant MAGNITUDE_ADJUSTMENT_TYPEHASH =
-        keccak256("MagnitudeAdjustments(address operator,MagnitudeAdjustment(address strategy, OperatorSet(address avs, uint32 operatorSetId)[], uint64[] magnitudeDiffs)[],bytes32 salt,uint256 expiry)");
+    bytes32 public constant MAGNITUDE_ADJUSTMENT_TYPEHASH = keccak256(
+        "MagnitudeAdjustments(address operator,MagnitudeAdjustment(address strategy, OperatorSet(address avs, uint32 operatorSetId)[], uint64[] magnitudeDiffs)[],bytes32 salt,uint256 expiry)"
+    );
 
     /// @notice The DelegationManager contract for EigenLayer
     IDelegationManager public immutable delegation;
@@ -66,9 +67,8 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// Note that totalMagnitude is monotonically decreasing and only gets updated upon slashing
     mapping(address => mapping(IStrategy => Checkpoints.History)) internal _totalMagnitudeUpdate;
 
-    /// @notice Mapping: operator => strategy => avs => operatorSetId => checkpointed magnitude
-    mapping(address => mapping(IStrategy => mapping(address => mapping(uint32 => Checkpoints.History)))) internal
-        _magnitudeUpdate;
+    /// @notice Mapping: operator => strategy => operatorSet (encoded) => checkpointed magnitude
+    mapping(address => mapping(IStrategy => mapping(bytes32 => Checkpoints.History))) internal _magnitudeUpdate;
 
     /// @notice Mapping: operator => strategy => free available magnitude that can be allocated to operatorSets
     /// Decrements whenever allocations take place and increments when deallocations are completed
@@ -80,9 +80,8 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @notice Mapping: operator => strategy => index pointing to next pendingFreeMagnitude to complete and add to freeMagnitude
     mapping(address => mapping(IStrategy => uint256)) internal _nextPendingFreeMagnitudeIndex;
 
-    /// @notice Mapping: operator => strategy => avs => operatorSetId => list of queuedDeallocation indices
-    mapping(address => mapping(IStrategy => mapping(address => mapping(uint32 => uint256[])))) internal
-        _queuedDeallocationIndices;
+    /// @notice Mapping: operator => strategy => operatorSet (encoded) => list of queuedDeallocation indices
+    mapping(address => mapping(IStrategy => mapping(bytes32 => uint256[]))) internal _queuedDeallocationIndices;
 
     /// @notice Mapping: operator => allocation delay (in seconds) for the operator.
     /// This determines how long it takes for allocations to take in the future. Can only be set one time for each operator

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -298,8 +298,10 @@ interface IAVSDirectory is ISignatureUtils {
      * @notice Get the allocation delay (in seconds) for an operator. Can only be configured one-time
      * from calling initializeAllocationDelay.
      * @param operator the operator to get the allocation delay for
+     * @return isSet whether the allocation delay is set and the operator can call `modifyAllocations`
+     * @return allocationDelay the allocation delay in seconds
      */
-    function getAllocationDelay(address operator) external view returns (uint32);
+    function getAllocationDelay(address operator) external view returns (bool, uint32);
 
     /**
      * @notice operator is slashable by operatorSet if currently registered OR last deregistered within 21 days

--- a/src/test/mocks/AVSDirectoryMock.sol
+++ b/src/test/mocks/AVSDirectoryMock.sol
@@ -91,7 +91,7 @@ contract AVSDirectoryMock is IAVSDirectory, Test {
         uint16 numToComplete
     ) external view returns (uint64) {}
 
-    function getAllocationDelay(address operator) external view returns (uint32) {}
+    function getAllocationDelay(address operator) external view returns (bool, uint32) {}
 
     function calculateOperatorAVSRegistrationDigestHash(
         address operator,


### PR DESCRIPTION
Updates to slashing-magnitudes

1. Using `_encodeOperator` to get the encoded bytes32 of the operatorSets to use as mapping keys in `_queuedDeallocationIndices` and `_magnitudeUpdate`. Provides a small lookup optimization and helps for readability. This is used for internal functions as this would cause more confusion for public function mappings like `isOperatorSet`
2. `_modifyAllocations` checks for ascending order of encoded operatorSets. This is to check for duplicate operatorSets being passed in for allocation.
3. ~Checks for proper ordering of future allocations by comparing `allocationEffectTimestamp` with the latest checkpoint timestamp. This could be a potential issue if an operator configures their allocation delay to be less than the default but they have a pending allocation in the future and then try to make another allocation shortly after. This would break the invariant that all checkpointed values must be sorted by ascending timestamp.~ Simply requiring allocationDelay to be set before calling `modifyAllocations` to avoid this.
