### PR TITLE
feat: eigenpodManager scaled shares

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -1071,7 +1071,7 @@ contract DelegationManager is
             scaledShares[0] = uint256(scaledPodShares);
         } else {
             // Has shares in both
-
+// TODO: make more efficient by resizing array
             // 1. Allocate return arrays
             strategies = new IStrategy[](strategyManagerStrats.length + 1);
             scaledShares = new uint256[](strategies.length);

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -97,6 +97,9 @@ interface IEigenPodManager is IPausable {
      */
     function podOwnerShares(address podOwner) external view returns (int256);
 
+    /// TODO: natspec
+    function podOwnerScaledShares(address podOwner) external view returns (int256);
+
     /// @notice returns canonical, virtual beaconChainETH strategy
     function beaconChainETHStrategy() external view returns (IStrategy);
 
@@ -108,7 +111,7 @@ interface IEigenPodManager is IPausable {
      * shares from the operator to whom the staker is delegated.
      * @dev Reverts if `shares` is not a whole Gwei amount
      */
-    function removeShares(address podOwner, uint256 shares) external;
+    function removeScaledShares(address podOwner, uint256 scaledShares) external;
 
     /**
      * @notice Increases the `podOwner`'s shares by `shares`, paying off deficit if possible.
@@ -117,7 +120,7 @@ interface IEigenPodManager is IPausable {
      * in the event that the podOwner has an existing shares deficit (i.e. `podOwnerShares[podOwner]` starts below zero)
      * @dev Reverts if `shares` is not a whole Gwei amount
      */
-    function addShares(address podOwner, uint256 shares) external returns (uint256);
+    function addScaledShares(address podOwner, uint256 scaledShares) external returns (uint256);
 
     /**
      * @notice Used by the DelegationManager to complete a withdrawal, sending tokens to some destination address

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -111,53 +111,62 @@ contract EigenPodManager is
             sharesDelta % int256(GWEI_TO_WEI) == 0,
             "EigenPodManager.recordBeaconChainETHBalanceUpdate: sharesDelta must be a whole Gwei amount"
         );
-        int256 currentPodOwnerShares = podOwnerShares[podOwner];
-        int256 updatedPodOwnerShares = currentPodOwnerShares + sharesDelta;
-        podOwnerShares[podOwner] = updatedPodOwnerShares;
+        int256 currentPodOwnerScaledShares = podOwnerScaledShares[podOwner];
+
+        int256 updatedPodOwnerScaledShares;
+        // scale the sharesDelta and add to the podOwnerShares
+        if (sharesDelta < 0) {
+            updatedPodOwnerScaledShares = currentPodOwnerScaledShares -
+                int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(-sharesDelta)));
+        } else {
+            updatedPodOwnerScaledShares = currentPodOwnerScaledShares +
+                int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(sharesDelta)));
+        }
+        podOwnerScaledShares[podOwner] = updatedPodOwnerScaledShares;
 
         // inform the DelegationManager of the change in delegateable shares
-        int256 changeInDelegatableShares = _calculateChangeInDelegatableShares({
-            sharesBefore: currentPodOwnerShares,
-            sharesAfter: updatedPodOwnerShares
+        int256 changeInDelegatableScaledShares = _calculateChangeInDelegatableShares({
+            sharesBefore: currentPodOwnerScaledShares,
+            sharesAfter: updatedPodOwnerScaledShares
         });
         // skip making a call to the DelegationManager if there is no change in delegateable shares
-        if (changeInDelegatableShares != 0) {
-            if (changeInDelegatableShares < 0) {
+        if (changeInDelegatableScaledShares != 0) {
+            if (changeInDelegatableScaledShares < 0) {
                 delegationManager.decreaseDelegatedScaledShares({
                     staker: podOwner,
                     strategy: beaconChainETHStrategy,
-                    scaledShares: uint256(-changeInDelegatableShares)
+                    scaledShares: uint256(-changeInDelegatableScaledShares)
                 });
             } else {
                 delegationManager.increaseDelegatedScaledShares({
                     staker: podOwner,
                     strategy: beaconChainETHStrategy,
-                    scaledShares: uint256(changeInDelegatableShares)
+                    scaledShares: uint256(changeInDelegatableScaledShares)
                 });
             }
         }
         emit PodSharesUpdated(podOwner, sharesDelta);
-        emit NewTotalShares(podOwner, updatedPodOwnerShares);
+        emit NewTotalShares(podOwner, updatedPodOwnerScaledShares);
     }
 
     /**
      * @notice Used by the DelegationManager to remove a pod owner's shares while they're in the withdrawal queue.
      * Simply decreases the `podOwner`'s shares by `shares`, down to a minimum of zero.
-     * @dev This function reverts if it would result in `podOwnerShares[podOwner]` being less than zero, i.e. it is forbidden for this function to
+     * @dev This function reverts if it would result in `podOwnerScaledShares[podOwner]` being less than zero, i.e. it is forbidden for this function to
      * result in the `podOwner` incurring a "share deficit". This behavior prevents a Staker from queuing a withdrawal which improperly removes excessive
      * shares from the operator to whom the staker is delegated.
      * @dev Reverts if `shares` is not a whole Gwei amount
      * @dev The delegation manager validates that the podOwner is not address(0)
      */
-    function removeShares(address podOwner, uint256 shares) external onlyDelegationManager {
-        require(int256(shares) >= 0, "EigenPodManager.removeShares: shares cannot be negative");
-        require(shares % GWEI_TO_WEI == 0, "EigenPodManager.removeShares: shares must be a whole Gwei amount");
-        int256 updatedPodOwnerShares = podOwnerShares[podOwner] - int256(shares);
+    function removeScaledShares(address podOwner, uint256 scaledShares) external onlyDelegationManager {
+        require(int256(scaledShares) >= 0, "EigenPodManager.removeShares: shares cannot be negative");
+        require(scaledShares % GWEI_TO_WEI == 0, "EigenPodManager.removeShares: shares must be a whole Gwei amount");
+        int256 updatedPodOwnerShares = podOwnerScaledShares[podOwner] - int256(scaledShares);
         require(
             updatedPodOwnerShares >= 0,
             "EigenPodManager.removeShares: cannot result in pod owner having negative shares"
         );
-        podOwnerShares[podOwner] = updatedPodOwnerShares;
+        podOwnerScaledShares[podOwner] = updatedPodOwnerShares;
 
         emit NewTotalShares(podOwner, updatedPodOwnerShares);
     }
@@ -165,25 +174,25 @@ contract EigenPodManager is
     /**
      * @notice Increases the `podOwner`'s shares by `shares`, paying off deficit if possible.
      * Used by the DelegationManager to award a pod owner shares on exiting the withdrawal queue
-     * @dev Returns the number of shares added to `podOwnerShares[podOwner]` above zero, which will be less than the `shares` input
-     * in the event that the podOwner has an existing shares deficit (i.e. `podOwnerShares[podOwner]` starts below zero)
+     * @dev Returns the number of shares added to `podOwnerScaledShares[podOwner]` above zero, which will be less than the `shares` input
+     * in the event that the podOwner has an existing shares deficit (i.e. `podOwnerScaledShares[podOwner]` starts below zero)
      * @dev Reverts if `shares` is not a whole Gwei amount
      */
-    function addShares(address podOwner, uint256 shares) external onlyDelegationManager returns (uint256) {
+    function addScaledShares(address podOwner, uint256 scaledShares) external onlyDelegationManager returns (uint256) {
         require(podOwner != address(0), "EigenPodManager.addShares: podOwner cannot be zero address");
-        require(int256(shares) >= 0, "EigenPodManager.addShares: shares cannot be negative");
-        require(shares % GWEI_TO_WEI == 0, "EigenPodManager.addShares: shares must be a whole Gwei amount");
-        int256 currentPodOwnerShares = podOwnerShares[podOwner];
-        int256 updatedPodOwnerShares = currentPodOwnerShares + int256(shares);
-        podOwnerShares[podOwner] = updatedPodOwnerShares;
+        require(int256(scaledShares) >= 0, "EigenPodManager.addShares: shares cannot be negative");
+        require(scaledShares % GWEI_TO_WEI == 0, "EigenPodManager.addShares: shares must be a whole Gwei amount");
+        int256 currentPodOwnerScaledShares = podOwnerScaledShares[podOwner];
+        int256 updatedPodOwnerScaledShares = currentPodOwnerScaledShares + int256(scaledShares);
+        podOwnerScaledShares[podOwner] = updatedPodOwnerScaledShares;
 
-        emit PodSharesUpdated(podOwner, int256(shares));
-        emit NewTotalShares(podOwner, updatedPodOwnerShares);
+        emit PodSharesUpdated(podOwner, int256(scaledShares));
+        emit NewTotalShares(podOwner, updatedPodOwnerScaledShares);
 
         return uint256(
             _calculateChangeInDelegatableShares({
-                sharesBefore: currentPodOwnerShares,
-                sharesAfter: updatedPodOwnerShares
+                sharesBefore: currentPodOwnerScaledShares,
+                sharesAfter: updatedPodOwnerScaledShares
             })
         );
     }
@@ -204,22 +213,22 @@ contract EigenPodManager is
         require(destination != address(0), "EigenPodManager.withdrawSharesAsTokens: destination cannot be zero address");
         require(int256(shares) >= 0, "EigenPodManager.withdrawSharesAsTokens: shares cannot be negative");
         require(shares % GWEI_TO_WEI == 0, "EigenPodManager.withdrawSharesAsTokens: shares must be a whole Gwei amount");
-        int256 currentPodOwnerShares = podOwnerShares[podOwner];
+        int256 currentPodOwnerScaledShares = podOwnerScaledShares[podOwner];
 
         // if there is an existing shares deficit, prioritize decreasing the deficit first
-        if (currentPodOwnerShares < 0) {
-            uint256 currentShareDeficit = uint256(-currentPodOwnerShares);
+        if (currentPodOwnerScaledShares < 0) {
+            uint256 currentShareDeficit = uint256(-currentPodOwnerScaledShares);
 
             if (shares > currentShareDeficit) {
                 // get rid of the whole deficit if possible, and pass any remaining shares onto destination
-                podOwnerShares[podOwner] = 0;
+                podOwnerScaledShares[podOwner] = 0;
                 shares -= currentShareDeficit;
                 emit PodSharesUpdated(podOwner, int256(currentShareDeficit));
                 emit NewTotalShares(podOwner, 0);
             } else {
                 // otherwise get rid of as much deficit as possible, and return early, since there is nothing left over to forward on
-                int256 updatedPodOwnerShares = podOwnerShares[podOwner] + int256(shares);
-                podOwnerShares[podOwner] = updatedPodOwnerShares;
+                int256 updatedPodOwnerShares = podOwnerScaledShares[podOwner] + int256(shares);
+                podOwnerScaledShares[podOwner] = updatedPodOwnerShares;
                 emit PodSharesUpdated(podOwner, int256(shares));
                 emit NewTotalShares(podOwner, updatedPodOwnerShares);
                 return;
@@ -279,6 +288,17 @@ contract EigenPodManager is
     }
 
     // VIEW FUNCTIONS
+    /// @notice Return the real number of ETH shares that the `podOwner` has
+    function podOwnerShares(address podOwner) public view returns (int256) {
+        int256 podOwnerShares;
+        if (podOwnerScaledShares[podOwner] < 0) {
+            podOwnerShares = -int256(delegationManager.getStakerShares(podOwner, beaconChainETHStrategy, uint256(-podOwnerScaledShares[podOwner])));
+        } else {
+            podOwnerShares = int256(delegationManager.getStakerShares(podOwner, beaconChainETHStrategy, uint256(podOwnerScaledShares[podOwner])));
+        }
+        return podOwnerShares;
+    }
+
     /// @notice Returns the address of the `podOwner`'s EigenPod (whether it is deployed yet or not).
     function getPod(address podOwner) public view returns (IEigenPod) {
         IEigenPod pod = ownerToPod[podOwner];

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -112,15 +112,14 @@ contract EigenPodManager is
             "EigenPodManager.recordBeaconChainETHBalanceUpdate: sharesDelta must be a whole Gwei amount"
         );
         int256 currentPodOwnerScaledShares = podOwnerScaledShares[podOwner];
-
         int256 updatedPodOwnerScaledShares;
         // scale the sharesDelta and add to the podOwnerShares
         if (sharesDelta < 0) {
-            updatedPodOwnerScaledShares = currentPodOwnerScaledShares -
-                int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(-sharesDelta)));
+            updatedPodOwnerScaledShares = currentPodOwnerScaledShares
+                - int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(-sharesDelta)));
         } else {
-            updatedPodOwnerScaledShares = currentPodOwnerScaledShares +
-                int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(sharesDelta)));
+            updatedPodOwnerScaledShares = currentPodOwnerScaledShares
+                + int256(delegationManager.getStakerScaledShares(podOwner, beaconChainETHStrategy, uint256(sharesDelta)));
         }
         podOwnerScaledShares[podOwner] = updatedPodOwnerScaledShares;
 
@@ -292,9 +291,17 @@ contract EigenPodManager is
     function podOwnerShares(address podOwner) public view returns (int256) {
         int256 podOwnerShares;
         if (podOwnerScaledShares[podOwner] < 0) {
-            podOwnerShares = -int256(delegationManager.getStakerShares(podOwner, beaconChainETHStrategy, uint256(-podOwnerScaledShares[podOwner])));
+            podOwnerShares = -int256(
+                delegationManager.getStakerShares(
+                    podOwner, beaconChainETHStrategy, uint256(-podOwnerScaledShares[podOwner])
+                )
+            );
         } else {
-            podOwnerShares = int256(delegationManager.getStakerShares(podOwner, beaconChainETHStrategy, uint256(podOwnerScaledShares[podOwner])));
+            podOwnerShares = int256(
+                delegationManager.getStakerShares(
+                    podOwner, beaconChainETHStrategy, uint256(podOwnerScaledShares[podOwner])
+                )
+            );
         }
         return podOwnerShares;
     }

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -75,7 +75,7 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * Likewise, when a withdrawal is completed, this "deficit" is decreased and the withdrawal amount is decreased; We can think of this
      * as the withdrawal "paying off the deficit".
      */
-    mapping(address => int256) public podOwnerShares;
+    mapping(address => int256) public podOwnerScaledShares;
 
     uint64 internal __deprecated_denebForkTimestamp;
 

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -68,7 +68,10 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     // BEGIN STORAGE VARIABLES ADDED AFTER MAINNET DEPLOYMENT -- DO NOT SUGGEST REORDERING TO CONVENTIONAL ORDER
     /**
-     * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.
+     * @notice Mapping from Pod owner owner to the number of scaled shares they have in the virtual beacon chain ETH strategy.
+     * NOTE: This mapping was previously named `podOwnerShares` but will now store scaled shares based on the currently delegated operator
+     * for the podOwner to account for Slashing in EigenLayer. There is a backwards compatible view function `podOwnerShares` that will convert
+     * scaled shares to its actual ETH shares.
      * @dev The share amount can become negative. This is necessary to accommodate the fact that a pod owner's virtual beacon chain ETH shares can
      * decrease between the pod owner queuing and completing a withdrawal.
      * When the pod owner's shares would otherwise increase, this "deficit" is decreased first _instead_.

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -41,6 +41,10 @@ contract EigenPodManagerMock is IEigenPodManager, Test, Pausable {
         return false;
     }
 
+    function podOwnerScaledShares(address podOwner) external view returns (int256) {
+        return podShares[podOwner];
+    }
+
     function podOwnerShares(address podOwner) external view returns (int256) {
         return podShares[podOwner];
     }
@@ -49,14 +53,14 @@ contract EigenPodManagerMock is IEigenPodManager, Test, Pausable {
         podShares[podOwner] = shares;
     }
 
-    function addShares(address /*podOwner*/, uint256 shares) external pure returns (uint256) {
+    function addScaledShares(address /*podOwner*/, uint256 scaledShares) external pure returns (uint256) {
         // this is the "increase in delegateable tokens"
-        return (shares);
+        return (scaledShares);
     }
 
     function withdrawSharesAsTokens(address podOwner, address destination, uint256 shares) external {}
 
-    function removeShares(address podOwner, uint256 shares) external {}
+    function removeScaledShares(address podOwner, uint256 scaledShares) external {}
 
     function numPods() external view returns (uint256) {}
 

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -190,35 +190,35 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
                                 Add Shares Tests
     *******************************************************************************/
 
-    function testFuzz_addShares_revert_notDelegationManager(address notDelegationManager) public filterFuzzedAddressInputs(notDelegationManager){
+    function testFuzz_addScaledShares_revert_notDelegationManager(address notDelegationManager) public filterFuzzedAddressInputs(notDelegationManager){
         cheats.assume(notDelegationManager != address(delegationManagerMock));
         cheats.prank(notDelegationManager);
         cheats.expectRevert("EigenPodManager.onlyDelegationManager: not the DelegationManager");
-        eigenPodManager.addShares(defaultStaker, 0);
+        eigenPodManager.addScaledShares(defaultStaker, 0);
     }
     
-    function test_addShares_revert_podOwnerZeroAddress() public {
+    function test_addScaledShares_revert_podOwnerZeroAddress() public {
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.addShares: podOwner cannot be zero address");
-        eigenPodManager.addShares(address(0), 0);
+        cheats.expectRevert("EigenPodManager.addScaledShares: podOwner cannot be zero address");
+        eigenPodManager.addScaledShares(address(0), 0);
     }
 
-    function testFuzz_addShares_revert_sharesNegative(int256 shares) public {
+    function testFuzz_addScaledShares_revert_sharesNegative(int256 shares) public {
         cheats.assume(shares < 0);
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.addShares: shares cannot be negative");
-        eigenPodManager.addShares(defaultStaker, uint256(shares));
+        cheats.expectRevert("EigenPodManager.addScaledShares: shares cannot be negative");
+        eigenPodManager.addScaledShares(defaultStaker, uint256(shares));
     }
 
-    function testFuzz_addShares_revert_sharesNotWholeGwei(uint256 shares) public {
+    function testFuzz_addScaledShares_revert_sharesNotWholeGwei(uint256 shares) public {
         cheats.assume(int256(shares) >= 0);
         cheats.assume(shares % GWEI_TO_WEI != 0);
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.addShares: shares must be a whole Gwei amount");
-        eigenPodManager.addShares(defaultStaker, shares);
+        cheats.expectRevert("EigenPodManager.addScaledShares: shares must be a whole Gwei amount");
+        eigenPodManager.addScaledShares(defaultStaker, shares);
     }
 
-    function testFuzz_addShares(uint256 shares) public {
+    function testFuzz_addScaledShares(uint256 shares) public {
         // Fuzz inputs
         cheats.assume(defaultStaker != address(0));
         shares = shares - (shares % GWEI_TO_WEI); // Round down to nearest Gwei
@@ -226,7 +226,7 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
 
         // Add shares
         cheats.prank(address(delegationManagerMock));
-        eigenPodManager.addShares(defaultStaker, shares);
+        eigenPodManager.addScaledShares(defaultStaker, shares);
 
         // Check storage update
         assertEq(eigenPodManager.podOwnerShares(defaultStaker), int256(shares), "Incorrect number of shares added");
@@ -236,29 +236,29 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
                                 Remove Shares Tests
     ******************************************************************************/
 
-    function testFuzz_removeShares_revert_notDelegationManager(address notDelegationManager) public filterFuzzedAddressInputs(notDelegationManager) {
+    function testFuzz_removeScaledShares_revert_notDelegationManager(address notDelegationManager) public filterFuzzedAddressInputs(notDelegationManager) {
         cheats.assume(notDelegationManager != address(delegationManagerMock));
         cheats.prank(notDelegationManager);
         cheats.expectRevert("EigenPodManager.onlyDelegationManager: not the DelegationManager");
-        eigenPodManager.removeShares(defaultStaker, 0);
+        eigenPodManager.removeScaledShares(defaultStaker, 0);
     }
 
-    function testFuzz_removeShares_revert_sharesNegative(int256 shares) public {
+    function testFuzz_removeScaledShares_revert_sharesNegative(int256 shares) public {
         cheats.assume(shares < 0);
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.removeShares: shares cannot be negative");
-        eigenPodManager.removeShares(defaultStaker, uint256(shares));
+        cheats.expectRevert("EigenPodManager.removeScaledShares: shares cannot be negative");
+        eigenPodManager.removeScaledShares(defaultStaker, uint256(shares));
     }
     
-    function testFuzz_removeShares_revert_sharesNotWholeGwei(uint256 shares) public {
+    function testFuzz_removeScaledShares_revert_sharesNotWholeGwei(uint256 shares) public {
         cheats.assume(int256(shares) >= 0);
         cheats.assume(shares % GWEI_TO_WEI != 0);
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.removeShares: shares must be a whole Gwei amount");
-        eigenPodManager.removeShares(defaultStaker, shares);
+        cheats.expectRevert("EigenPodManager.removeScaledShares: shares must be a whole Gwei amount");
+        eigenPodManager.removeScaledShares(defaultStaker, shares);
     }
 
-    function testFuzz_removeShares_revert_tooManySharesRemoved(uint224 sharesToAdd, uint224 sharesToRemove) public {
+    function testFuzz_removeScaledShares_revert_tooManySharesRemoved(uint224 sharesToAdd, uint224 sharesToRemove) public {
         // Constrain inputs
         cheats.assume(sharesToRemove > sharesToAdd);
         uint256 sharesAdded = sharesToAdd * GWEI_TO_WEI;
@@ -269,11 +269,11 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
 
         // Remove shares
         cheats.prank(address(delegationManagerMock));
-        cheats.expectRevert("EigenPodManager.removeShares: cannot result in pod owner having negative shares");
-        eigenPodManager.removeShares(defaultStaker, sharesRemoved);
+        cheats.expectRevert("EigenPodManager.removeScaledShares: cannot result in pod owner having negative shares");
+        eigenPodManager.removeScaledShares(defaultStaker, sharesRemoved);
     }
 
-    function testFuzz_removeShares(uint224 sharesToAdd, uint224 sharesToRemove) public {
+    function testFuzz_removeScaledShares(uint224 sharesToAdd, uint224 sharesToRemove) public {
         // Constain inputs
         cheats.assume(sharesToRemove <= sharesToAdd);
         uint256 sharesAdded = sharesToAdd * GWEI_TO_WEI;
@@ -284,13 +284,13 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
 
         // Remove shares
         cheats.prank(address(delegationManagerMock));
-        eigenPodManager.removeShares(defaultStaker, sharesRemoved);
+        eigenPodManager.removeScaledShares(defaultStaker, sharesRemoved);
 
         // Check storage
         assertEq(eigenPodManager.podOwnerShares(defaultStaker), int256(sharesAdded - sharesRemoved), "Incorrect number of shares removed");
     }
 
-    function testFuzz_removeShares_zeroShares(address podOwner, uint256 shares) public filterFuzzedAddressInputs(podOwner) {
+    function testFuzz_removeScaledShares_zeroShares(address podOwner, uint256 shares) public filterFuzzedAddressInputs(podOwner) {
         // Constrain inputs
         cheats.assume(podOwner != address(0));
         cheats.assume(shares < type(uint256).max / 2);
@@ -302,7 +302,7 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
 
         // Remove shares
         cheats.prank(address(delegationManagerMock));
-        eigenPodManager.removeShares(podOwner, shares);
+        eigenPodManager.removeScaledShares(podOwner, shares);
 
         // Check storage update
         assertEq(eigenPodManager.podOwnerShares(podOwner), 0, "Shares not reset to zero");
@@ -342,7 +342,7 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
 
     /**
      * @notice The `withdrawSharesAsTokens` is called in the `completeQueuedWithdrawal` function from the 
-     *         delegationManager. When a withdrawal is queued in the delegationManager, `removeShares is called`
+     *         delegationManager. When a withdrawal is queued in the delegationManager, `removeScaledShares is called`
      */
     function test_withdrawSharesAsTokens_reduceEntireDeficit() public {
         // Shares to initialize & withdraw


### PR DESCRIPTION
`podOwnerShares` is now updated to be `podOwnerScaledShares` where all shares are scaled according to the podOwner's delegated operator (if there exists any) and their totalMagnitude. Only upon `withdrawSharesAsTokens` are scaled shares descaled into real ETH amounts and withdrawn.