### PR TITLE
bEIGEN/EIGEN changes

### DIFF
--- a/script/deploy/holesky/bEIGEN_and_EIGEN_upgrade.s.sol
+++ b/script/deploy/holesky/bEIGEN_and_EIGEN_upgrade.s.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import "../../../src/contracts/token/BackingEigen.sol";
+import "../../../src/contracts/token/Eigen.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+// # To load the variables in the .env file
+// source .env
+
+// # To deploy and verify our contract
+// forge script script/deploy/holesky/bEIGEN_and_EIGEN_upgrade.s.sol:bEIGEN_and_EIGEN_upgrade -vvv --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+contract bEIGEN_and_EIGEN_upgrade is Script, Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    BackingEigen public bEIGEN_proxy = BackingEigen(0x275cCf9Be51f4a6C94aBa6114cdf2a4c45B9cb27);
+    BackingEigen public bEIGEN_implementation;
+    Eigen public EIGEN_proxy = Eigen(0x3B78576F7D6837500bA3De27A60c7f594934027E);
+    Eigen public EIGEN_implementation;
+    ProxyAdmin public token_ProxyAdmin = ProxyAdmin(0x67482666771e82C9a73BB9e9A22B2B597f448BBf);
+    address public opsMultisig = 0xfaEF7338b7490b9E272d80A1a39f4657cAf2b97d;
+
+    IERC20 public bEIGEN_addressBefore;
+    IERC20 public EIGEN_addressBefore;
+
+    function run() external {
+        // Read and log the chain ID
+        uint256 chainId = block.chainid;
+        emit log_named_uint("You are deploying on ChainID", chainId);
+
+        if (chainId != 17000) {
+            revert("Chain not supported");
+        }
+
+        bEIGEN_addressBefore = EIGEN_proxy.bEIGEN();
+        EIGEN_addressBefore = bEIGEN_proxy.EIGEN();
+
+        require(bEIGEN_addressBefore == IERC20(0x275cCf9Be51f4a6C94aBa6114cdf2a4c45B9cb27),
+            "something horribly wrong");
+        require(EIGEN_addressBefore == IERC20(0x3B78576F7D6837500bA3De27A60c7f594934027E),
+            "something horribly wrong");
+
+        // Begin deployment
+        vm.startBroadcast();
+
+        // Deploy new implementation contracts
+        EIGEN_implementation = new Eigen({
+            _bEIGEN: bEIGEN_addressBefore
+        });
+        bEIGEN_implementation = new BackingEigen({
+            _EIGEN: EIGEN_addressBefore
+        });
+        vm.stopBroadcast();
+
+        emit log_named_address("EIGEN_implementation", address(EIGEN_implementation));
+        emit log_named_address("bEIGEN_implementation", address(bEIGEN_implementation));
+
+        // Perform post-upgrade tests
+        simulatePerformingUpgrade();
+        checkUpgradeCorrectness();
+        simulateWrapAndUnwrap();
+    }
+
+    function simulatePerformingUpgrade() public {
+        cheats.startPrank(opsMultisig);
+        // Upgrade contracts
+        token_ProxyAdmin.upgrade(TransparentUpgradeableProxy(payable(address(EIGEN_proxy))), address(EIGEN_implementation));
+        token_ProxyAdmin.upgrade(TransparentUpgradeableProxy(payable(address(bEIGEN_proxy))), address(bEIGEN_implementation));
+        cheats.stopPrank();
+    }
+
+    function checkUpgradeCorrectness() public {
+        vm.startPrank(opsMultisig);
+        require(token_ProxyAdmin.getProxyImplementation(TransparentUpgradeableProxy(payable(address(EIGEN_proxy)))) == address(EIGEN_implementation),
+            "implementation set incorrectly");
+        require(EIGEN_proxy.bEIGEN() == bEIGEN_addressBefore,
+            "bEIGEN address changed unexpectedly");
+        require(token_ProxyAdmin.getProxyImplementation(TransparentUpgradeableProxy(payable(address(bEIGEN_proxy)))) == address(bEIGEN_implementation),
+            "implementation set incorrectly");
+        require(bEIGEN_proxy.EIGEN() == EIGEN_addressBefore,
+            "EIGEN address changed unexpectedly");
+        cheats.stopPrank();
+    }
+
+    function simulateWrapAndUnwrap() public {
+        uint256 amount = 1e18;
+        cheats.prank(address(EIGEN_proxy));
+        bEIGEN_proxy.transfer(address(this), amount);
+
+        bEIGEN_proxy.approve(address(EIGEN_proxy), amount);
+        uint256 bEIGEN_balanceStart = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceStart = EIGEN_proxy.balanceOf(address(this));
+        EIGEN_proxy.wrap(amount);
+        uint256 bEIGEN_balanceMiddle = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceMiddle = EIGEN_proxy.balanceOf(address(this));
+        EIGEN_proxy.unwrap(amount);
+        uint256 bEIGEN_balanceAfter = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceAfter = EIGEN_proxy.balanceOf(address(this));
+
+        require(bEIGEN_balanceMiddle + amount == bEIGEN_balanceStart, "wrapping did not transfer out bEIGEN");
+        require(EIGEN_balanceMiddle == EIGEN_balanceStart + amount, "wrapping did not transfer in EIGEN");
+
+        require(bEIGEN_balanceAfter == bEIGEN_balanceStart, "unwrapping did not transfer in bEIGEN");
+        require(EIGEN_balanceAfter == EIGEN_balanceStart, "unwrapping did not transfer out EIGEN");
+    }
+}

--- a/script/deploy/mainnet/EIGEN_timelock_reduction.s.sol
+++ b/script/deploy/mainnet/EIGEN_timelock_reduction.s.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+// # To load the variables in the .env file
+// source .env
+
+// # To deploy and verify our contract
+// forge script script/deploy/mainnet/EIGEN_timelock_reduction.s.sol:EIGEN_timelock_reduction -vvvv --rpc-url $RPC_URL
+contract EIGEN_timelock_reduction is Script, Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    TimelockController public EIGEN_TimelockController = TimelockController(payable(0x2520C6b2C1FBE1813AB5c7c1018CDa39529e9FF2));
+    address public EIGEN_TimelockAdmin = 0xbb00DDa2832850a43840A3A86515E3Fe226865F2;
+
+    uint256 public newDelay = 0;
+
+    function run() external {
+        // Read and log the chain ID
+        uint256 chainId = block.chainid;
+        emit log_named_uint("You are deploying on ChainID", chainId);
+
+        if (chainId == 1) {
+            // rpcUrl = "RPC_MAINNET";
+        } else {
+            revert("Chain not supported");
+        }
+
+        uint256 minDelayBefore = EIGEN_TimelockController.getMinDelay();
+
+        require(minDelayBefore == 10 days,
+            "something horribly wrong");
+
+        bytes memory proposalData = abi.encodeWithSelector(
+                TimelockController.updateDelay.selector,
+                newDelay
+        );
+        emit log_named_bytes("proposalData", proposalData);
+
+        // propose change to zero delay
+        vm.startPrank(EIGEN_TimelockAdmin);
+        EIGEN_TimelockController.schedule({
+            target: address(EIGEN_TimelockController),
+            value: 0,
+            data: proposalData,
+            predecessor: bytes32(0),
+            salt: bytes32(0),
+            delay: minDelayBefore
+        });
+
+        // fast-forward to after current delay and execute
+        vm.warp(block.timestamp + minDelayBefore);
+        EIGEN_TimelockController.execute({
+            target: address(EIGEN_TimelockController),
+            value: 0,
+            payload: proposalData,
+            predecessor: bytes32(0),
+            salt: bytes32(0)
+        });
+
+        cheats.stopPrank();
+
+        uint256 minDelayAfter = EIGEN_TimelockController.getMinDelay();
+
+        require(minDelayAfter == 0,
+            "min delay not set to zero");
+    }
+}

--- a/script/deploy/mainnet/EIGEN_upgrade.s.sol
+++ b/script/deploy/mainnet/EIGEN_upgrade.s.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import "../../../src/contracts/token/BackingEigen.sol";
+import "../../../src/contracts/token/Eigen.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+// # To load the variables in the .env file
+// source .env
+
+// # To deploy and verify our contract
+// forge script script/deploy/mainnet/EIGEN_upgrade.s.sol:EIGEN_upgrade -vvvv --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+contract EIGEN_upgrade is Script, Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    BackingEigen public bEIGEN_proxy = BackingEigen(0x83E9115d334D248Ce39a6f36144aEaB5b3456e75);
+    BackingEigen public bEIGEN_implementation;
+    Eigen public EIGEN_proxy = Eigen(0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83);
+    Eigen public EIGEN_implementation;
+    ProxyAdmin public EIGEN_ProxyAdmin = ProxyAdmin(0xB8915E195121f2B5D989Ec5727fd47a5259F1CEC);
+    TimelockController public EIGEN_TimelockController = TimelockController(payable(0x2520C6b2C1FBE1813AB5c7c1018CDa39529e9FF2));
+    address public EIGEN_TimelockAdmin = 0xbb00DDa2832850a43840A3A86515E3Fe226865F2;
+
+    // // RPC url to fork from for pre-upgrade state change tests
+    // string public rpcUrl;
+
+    IERC20 public bEIGEN_addressBefore;
+
+    function run() external {
+        // Read and log the chain ID
+        uint256 chainId = block.chainid;
+        emit log_named_uint("You are deploying on ChainID", chainId);
+
+        if (chainId == 1) {
+            // rpcUrl = "RPC_MAINNET";
+        } else {
+            revert("Chain not supported");
+        }
+
+        bEIGEN_addressBefore = EIGEN_proxy.bEIGEN();
+
+        require(bEIGEN_addressBefore == IERC20(0x83E9115d334D248Ce39a6f36144aEaB5b3456e75),
+            "something horribly wrong");
+
+        // Begin deployment
+        vm.startBroadcast();
+
+        // Deploy new implmementation contract
+        EIGEN_implementation = new Eigen({
+            _bEIGEN: bEIGEN_addressBefore
+        });
+
+        vm.stopBroadcast();
+
+        emit log_named_address("EIGEN_implementation", address(EIGEN_implementation));
+
+        // Perform post-upgrade tests
+        simulatePerformingUpgrade();
+        checkUpgradeCorrectness();
+        simulateWrapAndUnwrap();
+    }
+
+    function simulatePerformingUpgrade() public {
+        // Upgrade beacon
+        uint256 delay = EIGEN_TimelockController.getMinDelay();
+        bytes memory data = abi.encodeWithSelector(
+                ProxyAdmin.upgrade.selector,
+                TransparentUpgradeableProxy(payable(address(EIGEN_proxy))),
+                EIGEN_implementation
+        );
+        emit log_named_bytes("data", data);
+
+        vm.startPrank(EIGEN_TimelockAdmin);
+        EIGEN_TimelockController.schedule({
+            target: address(EIGEN_ProxyAdmin),
+            value: 0,
+            data: data,
+            predecessor: bytes32(0),
+            salt: bytes32(0),
+            delay: delay
+        });
+
+        vm.warp(block.timestamp + delay);
+        EIGEN_TimelockController.execute({
+            target: address(EIGEN_ProxyAdmin),
+            value: 0,
+            payload: data,
+            predecessor: bytes32(0),
+            salt: bytes32(0)
+        });
+
+        cheats.stopPrank();
+    }
+
+    function checkUpgradeCorrectness() public {
+        vm.prank(address(EIGEN_TimelockController));
+        require(EIGEN_ProxyAdmin.getProxyImplementation(TransparentUpgradeableProxy(payable(address(EIGEN_proxy)))) == address(EIGEN_implementation),
+            "implementation set incorrectly");
+        require(EIGEN_proxy.bEIGEN() == bEIGEN_addressBefore,
+            "bEIGEN address changed unexpectedly");
+    }
+
+    function simulateWrapAndUnwrap() public {
+        uint256 amount = 1e18;
+        cheats.prank(address(EIGEN_proxy));
+        bEIGEN_proxy.transfer(address(this), amount);
+
+        bEIGEN_proxy.approve(address(EIGEN_proxy), amount);
+        uint256 bEIGEN_balanceStart = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceStart = EIGEN_proxy.balanceOf(address(this));
+        EIGEN_proxy.wrap(amount);
+        uint256 bEIGEN_balanceMiddle = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceMiddle = EIGEN_proxy.balanceOf(address(this));
+        EIGEN_proxy.unwrap(amount);
+        uint256 bEIGEN_balanceAfter = bEIGEN_proxy.balanceOf(address(this));
+        uint256 EIGEN_balanceAfter = EIGEN_proxy.balanceOf(address(this));
+
+        require(bEIGEN_balanceMiddle + amount == bEIGEN_balanceStart, "wrapping did not transfer out bEIGEN");
+        require(EIGEN_balanceMiddle == EIGEN_balanceStart + amount, "wrapping did not transfer in EIGEN");
+
+        require(bEIGEN_balanceAfter == bEIGEN_balanceStart, "unwrapping did not transfer in bEIGEN");
+        require(EIGEN_balanceAfter == EIGEN_balanceStart, "unwrapping did not transfer out EIGEN");
+    }
+}

--- a/script/deploy/mainnet/bEIGEN_timelock_reduction.s.sol
+++ b/script/deploy/mainnet/bEIGEN_timelock_reduction.s.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+// # To load the variables in the .env file
+// source .env
+
+// # To deploy and verify our contract
+// forge script script/deploy/mainnet/bEIGEN_timelock_reduction.s.sol:bEIGEN_timelock_reduction -vvvv --rpc-url $RPC_URL
+contract bEIGEN_timelock_reduction is Script, Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    TimelockController public bEIGEN_TimelockController = TimelockController(payable(0xd6EC41E453C5E7dA5494f4d51A053Ab571712E6f));
+    address public bEIGEN_TimelockAdmin = 0xbb00DDa2832850a43840A3A86515E3Fe226865F2;
+
+    uint256 public newDelay = 0;
+
+    function run() external {
+        // Read and log the chain ID
+        uint256 chainId = block.chainid;
+        emit log_named_uint("You are deploying on ChainID", chainId);
+
+        if (chainId == 1) {
+            // rpcUrl = "RPC_MAINNET";
+        } else {
+            revert("Chain not supported");
+        }
+
+        uint256 minDelayBefore = bEIGEN_TimelockController.getMinDelay();
+
+        require(minDelayBefore == 24 days,
+            "something horribly wrong");
+
+        bytes memory proposalData = abi.encodeWithSelector(
+                TimelockController.updateDelay.selector,
+                newDelay
+        );
+        emit log_named_bytes("proposalData", proposalData);
+
+        // propose change to zero delay
+        vm.startPrank(bEIGEN_TimelockAdmin);
+        bEIGEN_TimelockController.schedule({
+            target: address(bEIGEN_TimelockController),
+            value: 0,
+            data: proposalData,
+            predecessor: bytes32(0),
+            salt: bytes32(0),
+            delay: minDelayBefore
+        });
+
+        // fast-forward to after current delay and execute
+        vm.warp(block.timestamp + minDelayBefore);
+        bEIGEN_TimelockController.execute({
+            target: address(bEIGEN_TimelockController),
+            value: 0,
+            payload: proposalData,
+            predecessor: bytes32(0),
+            salt: bytes32(0)
+        });
+
+        cheats.stopPrank();
+
+        uint256 minDelayAfter = bEIGEN_TimelockController.getMinDelay();
+
+        require(minDelayAfter == 0,
+            "min delay not set to zero");
+    }
+}

--- a/script/deploy/mainnet/bEIGEN_upgrade.s.sol
+++ b/script/deploy/mainnet/bEIGEN_upgrade.s.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import "../../../src/contracts/token/BackingEigen.sol";
+
+import "forge-std/Script.sol";
+import "forge-std/Test.sol";
+
+// # To load the variables in the .env file
+// source .env
+
+// # To deploy and verify our contract
+// forge script script/deploy/mainnet/bEIGEN_upgrade.s.sol:bEIGEN_upgrade -vvvv --rpc-url $RPC_URL --private-key $PRIVATE_KEY --broadcast
+contract bEIGEN_upgrade is Script, Test {
+    Vm cheats = Vm(HEVM_ADDRESS);
+
+    BackingEigen public bEIGEN_proxy = BackingEigen(0x83E9115d334D248Ce39a6f36144aEaB5b3456e75);
+    BackingEigen public bEIGEN_implementation;
+    ProxyAdmin public bEIGEN_ProxyAdmin = ProxyAdmin(0x3f5Ab2D4418d38568705bFd6672630fCC3435CC9);
+    TimelockController public bEIGEN_TimelockController = TimelockController(payable(0xd6EC41E453C5E7dA5494f4d51A053Ab571712E6f));
+    address public bEIGEN_TimelockAdmin = 0xbb00DDa2832850a43840A3A86515E3Fe226865F2;
+
+    // // RPC url to fork from for pre-upgrade state change tests
+    // string public rpcUrl;
+
+    IERC20 public EIGEN_addressBefore;
+
+    function run() external {
+        // Read and log the chain ID
+        uint256 chainId = block.chainid;
+        emit log_named_uint("You are deploying on ChainID", chainId);
+
+        if (chainId == 1) {
+            // rpcUrl = "RPC_MAINNET";
+        } else {
+            revert("Chain not supported");
+        }
+
+        EIGEN_addressBefore = bEIGEN_proxy.EIGEN();
+
+        require(EIGEN_addressBefore == IERC20(0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83),
+            "something horribly wrong");
+
+        // Begin deployment
+        vm.startBroadcast();
+
+        // Deploy new implmementation contract
+        bEIGEN_implementation = new BackingEigen({
+            _EIGEN: EIGEN_addressBefore
+        });
+
+        vm.stopBroadcast();
+
+        emit log_named_address("bEIGEN_implementation", address(bEIGEN_implementation));
+
+        // Perform post-upgrade tests
+        simulatePerformingUpgrade();
+        checkUpgradeCorrectness();
+    }
+
+    function simulatePerformingUpgrade() public {
+        // Upgrade beacon
+        uint256 delay = bEIGEN_TimelockController.getMinDelay();
+        bytes memory data = abi.encodeWithSelector(
+                ProxyAdmin.upgrade.selector,
+                TransparentUpgradeableProxy(payable(address(bEIGEN_proxy))),
+                bEIGEN_implementation
+        );
+        emit log_named_bytes("data", data);
+
+        vm.startPrank(bEIGEN_TimelockAdmin);
+        bEIGEN_TimelockController.schedule({
+            target: address(bEIGEN_ProxyAdmin),
+            value: 0,
+            data: data,
+            predecessor: bytes32(0),
+            salt: bytes32(0),
+            delay: delay
+        });
+
+        vm.warp(block.timestamp + delay);
+        bEIGEN_TimelockController.execute({
+            target: address(bEIGEN_ProxyAdmin),
+            value: 0,
+            payload: data,
+            predecessor: bytes32(0),
+            salt: bytes32(0)
+        });
+
+        cheats.stopPrank();
+    }
+
+    function checkUpgradeCorrectness() public {
+        vm.prank(address(bEIGEN_TimelockController));
+        require(bEIGEN_ProxyAdmin.getProxyImplementation(TransparentUpgradeableProxy(payable(address(bEIGEN_proxy)))) == address(bEIGEN_implementation),
+            "implementation set incorrectly");
+        require(bEIGEN_proxy.EIGEN() == EIGEN_addressBefore,
+            "EIGEN address changed unexpectedly");
+    }
+}

--- a/src/contracts/interfaces/IBackingEigen.sol
+++ b/src/contracts/interfaces/IBackingEigen.sol
@@ -24,6 +24,33 @@ interface IBackingEigen is IERC20 {
     function disableTransferRestrictions() external;
 
     /**
+     * @notice An initializer function that sets initial values for the contract's state variables.
+     */
+    function initialize(address initialOwner) external;
+
+    // @notice Allows the contract owner to modify an entry in the `isMinter` mapping.
+    function setIsMinter(address minterAddress, bool newStatus) external;
+
+    /**
+     * @notice Allows any privileged address to mint `amount` new tokens to the address `to`.
+     * @dev Callable only by an address that has `isMinter` set to true.
+     */
+    function mint(address to, uint256 amount) external;
+
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) external;
+
+    /// @notice the address of the wrapped Eigen token EIGEN
+    function EIGEN() external view returns (IERC20);
+
+    /// @notice the timestamp after which transfer restrictions are disabled
+    function transferRestrictionsDisabledAfter() external view returns (uint256);
+
+    /**
      * @dev Clock used for flagging checkpoints. Has been overridden to implement timestamp based
      * checkpoints (and voting).
      */

--- a/src/contracts/interfaces/IEigen.sol
+++ b/src/contracts/interfaces/IEigen.sol
@@ -38,6 +38,12 @@ interface IEigen is IERC20 {
      */
     function unwrap(uint256 amount) external;
 
+    // @notice Burns EIGEN tokens held by the EIGEN token address itself
+    function burnExtraTokens() external;
+
+    /// @notice the address of the backing Eigen token bEIGEN
+    function bEIGEN() external view returns (IERC20);
+
     /**
      * @dev Clock used for flagging checkpoints. Has been overridden to implement timestamp based
      * checkpoints (and voting).

--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -123,14 +123,14 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
      */
     function wrap(uint256 amount) external {
         require(bEIGEN.transferFrom(msg.sender, address(this), amount), "Eigen.wrap: bEIGEN transfer failed");
-        _transfer(address(this), msg.sender, amount);
+        _mint(msg.sender, amount);
     }
 
     /**
      * @notice This function allows Eigen holders to unwrap their tokens into bEIGEN
      */
     function unwrap(uint256 amount) external {
-        _transfer(msg.sender, address(this), amount);
+        _burn(msg.sender, amount);
         require(bEIGEN.transfer(msg.sender, amount), "Eigen.unwrap: bEIGEN transfer failed");
     }
 
@@ -160,6 +160,15 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
             );
         }
         super._beforeTokenTransfer(from, to, amount);
+    }
+
+    /**
+     * @notice Overridden to return the total bEIGEN supply instead.
+     * @dev The issued supply of EIGEN should match the bEIGEN balance of this contract,
+     * less any bEIGEN tokens that were sent directly to the contract (rather than being wrapped)
+     */
+    function totalSupply() public view override returns (uint256) {
+        return bEIGEN.totalSupply();
     }
 
     /**

--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -155,7 +155,7 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
         if (block.timestamp <= transferRestrictionsDisabledAfter) {
             // if both from and to are not whitelisted
             require(
-                from == address(0) || from == address(this) || to == address(this) || allowedFrom[from] || allowedTo[to],
+                from == address(0) || to == address(0) || allowedFrom[from] || allowedTo[to],
                 "Eigen._beforeTokenTransfer: from or to must be whitelisted"
             );
         }

--- a/src/test/token/EigenTransferRestrictions.t.sol
+++ b/src/test/token/EigenTransferRestrictions.t.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.12;
 
 import "forge-std/Test.sol";
 
-import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
-import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin-v4.9.0/contracts/proxy/transparent/ProxyAdmin.sol";
+import "@openzeppelin-v4.9.0/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import "@openzeppelin-v4.9.0/contracts/token/ERC20/presets/ERC20PresetFixedSupply.sol";
 import "../harnesses/EigenHarness.sol";
 
 contract EigenTransferRestrictionsTest is Test {
@@ -38,8 +39,15 @@ contract EigenTransferRestrictionsTest is Test {
         vm.startPrank(minter1);
         proxyAdmin = new ProxyAdmin();
         // initialize with dummy BackingEigen address
-        eigenImpl = new EigenHarness(IERC20(address(0)));
+        
+        eigenImpl = new EigenHarness(new ERC20PresetFixedSupply({
+            name: "bEIGEN",
+            symbol: "bEIGEN",
+            initialSupply: totalSupply,
+            owner: minter1
+        }));
         eigen = Eigen(address(new TransparentUpgradeableProxy(address(eigenImpl), address(proxyAdmin), "")));
+        eigen.bEIGEN().transfer(address(eigen), totalSupply);
         vm.stopPrank();
 
         fuzzedOutAddresses[minter1] = true;

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -202,7 +202,6 @@ contract EigenWrappingTests is Test {
 
         vm.startPrank(minter1);
         bEIGEN.setAllowedFrom(minter1, true);
-        eigen.setAllowedTo(address(0), true);
         vm.stopPrank();
 
     }

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -72,10 +72,6 @@ contract EigenWrappingTests is Test {
         _simulateMint();
         _simulateBackingAndSetTransferRestrictions();
 
-        // initial bEIGEN balance
-        uint256 initialBEIGENBalanceOfEigenToken = bEIGEN.balanceOf(address(eigen));
-        // initial EIGEN token supply
-        uint256 initialEigenSupply = eigen.totalSupply();
         // minter1 balance
         uint256 minter1Balance = eigen.balanceOf(minter1);
 
@@ -83,15 +79,23 @@ contract EigenWrappingTests is Test {
         vm.prank(minter1);
         eigen.transfer(unwrapper, minter1Balance);
 
+        // initial bEIGEN balance
+        uint256 initialBEIGENBalanceOfEigenToken = bEIGEN.balanceOf(address(eigen));
+        // initial EIGEN token supply
+        assertEq(eigen.totalSupply(), bEIGEN.totalSupply(),
+            "eigen totalSupply changed incorrectly");
+
         // unwrap
         // unwrap amount should be less than minter1 balance
         unwrapAmount = unwrapAmount % minter1Balance;
         vm.prank(unwrapper);
         eigen.unwrap(unwrapAmount);
 
-        // check that the total supply of bEIGEN is equal to the total supply of EIGEN
-        assertEq(eigen.totalSupply(), initialEigenSupply);
-        assertEq(bEIGEN.balanceOf(address(eigen)), initialBEIGENBalanceOfEigenToken - unwrapAmount);
+        // check total supply and balance changes
+        assertEq(eigen.totalSupply(), bEIGEN.totalSupply(),
+            "eigen totalSupply changed incorrectly");
+        assertEq(bEIGEN.balanceOf(address(eigen)), initialBEIGENBalanceOfEigenToken - unwrapAmount,
+            "beigen balance of EIGEN tokens changed incorrectly");
         assertEq(eigen.balanceOf(address(unwrapper)), minter1Balance - unwrapAmount);
         assertEq(bEIGEN.balanceOf(address(unwrapper)), unwrapAmount);
     }
@@ -104,8 +108,6 @@ contract EigenWrappingTests is Test {
 
         // initial bEIGEN balance
         uint256 initialBEIGENBalanceOfEigenToken = bEIGEN.balanceOf(address(eigen));
-        // initial EIGEN token supply
-        uint256 initialEigenSupply = eigen.totalSupply();
         // minter1 balance
         uint256 minter1Balance = eigen.balanceOf(minter1);
 
@@ -117,6 +119,10 @@ contract EigenWrappingTests is Test {
         bEIGEN.transfer(wrapper, minter1Balance);
         vm.stopPrank();
 
+        // initial EIGEN token supply
+        assertEq(eigen.totalSupply(), bEIGEN.totalSupply(),
+            "eigen totalSupply changed incorrectly");
+
         // wrap
         // wrap amount should be less than minter1 balance
         wrapAmount = wrapAmount % minter1Balance;
@@ -127,8 +133,9 @@ contract EigenWrappingTests is Test {
         eigen.wrap(wrapAmount);
         vm.stopPrank();
 
-        // check that the total supply of bEIGEN is equal to the total supply of EIGEN
-        assertEq(eigen.totalSupply(), initialEigenSupply);
+        // check total supply and balance changes
+        assertEq(eigen.totalSupply(), bEIGEN.totalSupply(),
+            "eigen totalSupply changed incorrectly");
         assertEq(bEIGEN.balanceOf(address(eigen)), initialBEIGENBalanceOfEigenToken - minter1Balance + wrapAmount);
         assertEq(eigen.balanceOf(address(wrapper)), wrapAmount);
         assertEq(bEIGEN.balanceOf(address(wrapper)), minter1Balance - wrapAmount);
@@ -147,7 +154,7 @@ contract EigenWrappingTests is Test {
 
         // unwrap
         vm.prank(unwrapper);
-        vm.expectRevert("ERC20: transfer amount exceeds balance");
+        vm.expectRevert("ERC20: burn amount exceeds balance");
         eigen.unwrap(unwrapAmount + 1);
     }
 
@@ -195,6 +202,8 @@ contract EigenWrappingTests is Test {
 
         vm.startPrank(minter1);
         bEIGEN.setAllowedFrom(minter1, true);
+        eigen.setAllowedTo(address(0), true);
         vm.stopPrank();
+
     }
 }

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -202,6 +202,7 @@ contract EigenWrappingTests is Test {
 
         vm.startPrank(minter1);
         bEIGEN.setAllowedFrom(minter1, true);
+        eigen.setAllowedTo(address(0), true);
         vm.stopPrank();
 
     }


### PR DESCRIPTION
feat: add burn function and ~~one-time minter transfer~~  editable`isMinter` mapping to bEIGEN
new unit tests also included

EIGEN token also updated so that:

- `wrap` and `unwrap` now mint and burn EIGEN tokens rather than transferring them (like most standard "wrapped" tokens)
- `EIGEN.totalSupply()` is coded to return `bEIGEN.totalSupply()`