### PR TITLE
feat: add selector upload to workflows

### DIFF
--- a/.github/workflows/upload-selectors.yml
+++ b/.github/workflows/upload-selectors.yml
@@ -1,0 +1,28 @@
+name: 📤 Publish Selectors
+
+on:
+  push:
+    branches:
+      - dev
+      - mainnet
+      - testnet-holesky
+
+jobs:
+  upload-selectors:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      - name: Publish selectors to openchain.xyz
+        run: |
+          forge selectors upload --all


### PR DESCRIPTION
**Motivation:**

Custom errors need to be uploaded to places like openchain.xyz so they're parsable by block explorers / viem / and other tooling

**Modifications:**

Adds workflow to upload selectors to a shared database

**Result:**

custom error selectors will be publicly searchable on openchain.xyz