### PR TITLE
feat: legacy withdrawals and cleanup for DelegationManager

### DIFF
--- a/script/deploy/devnet/operatorSets/DeployStrategies.s.sol
+++ b/script/deploy/devnet/operatorSets/DeployStrategies.s.sol
@@ -22,14 +22,13 @@ contract DeployStrategies is ExistingDeploymentParser {
         uint256 batchSize = 100;
 
         IStrategy[] memory strategies = new IStrategy[](batchSize * batches);
-        bool[] memory falses = new bool[](batchSize);
 
         for (uint256 i = 0; i < batches; i++) {
             IStrategy[] memory strategiesJustDeployed = strategyDeployer.createManyStrategies(batchSize);
             for (uint256 j = 0; j < batchSize; j++) {
                 strategies[i * batchSize + j] = strategiesJustDeployed[j];
             }
-            strategyManager.addStrategiesToDepositWhitelist(strategiesJustDeployed, falses);
+            strategyManager.addStrategiesToDepositWhitelist(strategiesJustDeployed);
         }
 
         vm.stopBroadcast();

--- a/script/deploy/holesky/Eigen_Strategy_Deploy.s.sol
+++ b/script/deploy/holesky/Eigen_Strategy_Deploy.s.sol
@@ -58,11 +58,9 @@ contract Eigen_Strategy_Deploy is ExistingDeploymentParser {
     function _verifyDeployment() internal {
         IStrategy[] memory strategies = new IStrategy[](1);
         strategies[0] = eigenStrategy;
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
-        thirdPartyTransfersForbiddenValues[0] = true;
 
         vm.prank(executorMultisig);
-        strategyManager.addStrategiesToDepositWhitelist(strategies, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategies);
 
         vm.startPrank(msg.sender);
         EIGEN.approve(address(strategyManager), type(uint256).max);

--- a/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
+++ b/script/deploy/holesky/M2_Deploy_From_Scratch.s.sol
@@ -171,7 +171,6 @@ contract M2_Deploy_Holesky_From_Scratch is ExistingDeploymentParser {
         uint256 numStrategiesToDeploy = strategiesToDeploy.length;
         // whitelist params
         IStrategy[] memory strategiesToWhitelist = new IStrategy[](numStrategiesToDeploy);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](numStrategiesToDeploy);
 
         for (uint256 i = 0; i < numStrategiesToDeploy; i++) {
             StrategyUnderlyingTokenConfig memory strategyConfig = strategiesToDeploy[i];
@@ -193,13 +192,12 @@ contract M2_Deploy_Holesky_From_Scratch is ExistingDeploymentParser {
             );
 
             strategiesToWhitelist[i] = strategy;
-            thirdPartyTransfersForbiddenValues[i] = false;
 
             deployedStrategyArray.push(strategy);
         }
 
         // Add strategies to whitelist and set whitelister to STRATEGY_MANAGER_WHITELISTER
-        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist);
         strategyManager.setStrategyWhitelister(STRATEGY_MANAGER_WHITELISTER);
 
         // Transfer ownership

--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -475,10 +475,7 @@ contract ExistingDeploymentParser is Script, Test {
         delegationManager.initialize(
             address(0),
             eigenLayerPauserReg,
-            0,
-            0, // minWithdrawalDelayBLocks
-            initializeStrategiesToSetDelayBlocks,
-            initializeWithdrawalDelayBlocks
+            0
         );
         // StrategyManager
         vm.expectRevert(bytes("Initializable: contract is already initialized"));
@@ -568,10 +565,6 @@ contract ExistingDeploymentParser is Script, Test {
         require(
             delegationManager.paused() == DELEGATION_MANAGER_INIT_PAUSED_STATUS,
             "delegationManager: init paused status set incorrectly"
-        );
-        require(
-            delegationManager.minWithdrawalDelayBlocks() == DELEGATION_MANAGER_MIN_WITHDRAWAL_DELAY_BLOCKS,
-            "delegationManager: minWithdrawalDelayBlocks not set correctly"
         );
         // StrategyManager
         require(

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -37,9 +37,7 @@ contract AVSDirectory is
      * @dev Initializes the immutable addresses of the strategy mananger, delegationManager, slasher,
      * and eigenpodManager contracts
      */
-    constructor(
-        IDelegationManager _delegation
-    ) AVSDirectoryStorage(_delegation) {
+    constructor(IDelegationManager _delegation) AVSDirectoryStorage(_delegation) {
         _disableInitializers();
         ORIGINAL_CHAIN_ID = block.chainid;
     }
@@ -72,9 +70,7 @@ contract AVSDirectory is
      * @dev msg.sender must be the AVS.
      * @dev The AVS may create operator sets before it becomes an operator set AVS.
      */
-    function createOperatorSets(
-        uint32[] calldata operatorSetIds
-    ) external {
+    function createOperatorSets(uint32[] calldata operatorSetIds) external {
         for (uint256 i = 0; i < operatorSetIds.length; ++i) {
             require(!isOperatorSet[msg.sender][operatorSetIds[i]], InvalidOperatorSet());
             isOperatorSet[msg.sender][operatorSetIds[i]] = true;
@@ -238,9 +234,7 @@ contract AVSDirectory is
      *
      *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
      */
-    function updateAVSMetadataURI(
-        string calldata metadataURI
-    ) external override {
+    function updateAVSMetadataURI(string calldata metadataURI) external override {
         emit AVSMetadataURIUpdated(msg.sender, metadataURI);
     }
 
@@ -249,9 +243,7 @@ contract AVSDirectory is
      *
      * @param salt A unique and single use value associated with the approver signature.
      */
-    function cancelSalt(
-        bytes32 salt
-    ) external override {
+    function cancelSalt(bytes32 salt) external override {
         // Mutate `operatorSaltIsSpent` to `true` to prevent future spending.
         operatorSaltIsSpent[msg.sender][salt] = true;
     }
@@ -322,9 +314,11 @@ contract AVSDirectory is
      *
      *  @dev Only used by legacy M2 AVSs that have not integrated with operator sets.
      */
-    function deregisterOperatorFromAVS(
-        address operator
-    ) external override onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS) {
+    function deregisterOperatorFromAVS(address operator)
+        external
+        override
+        onlyWhenNotPaused(PAUSED_OPERATOR_REGISTER_DEREGISTER_TO_AVS)
+    {
         // Assert that operator is registered for the AVS.
         require(avsOperatorStatus[msg.sender][operator] == OperatorAVSRegistrationStatus.REGISTERED, InvalidOperator());
         // Assert that the AVS is not an operator set AVS.
@@ -461,9 +455,7 @@ contract AVSDirectory is
      * @notice Returns the number of operators registered to an operatorSet.
      * @param operatorSet The operatorSet to get the member count for
      */
-    function getNumOperatorsInOperatorSet(
-        OperatorSet memory operatorSet
-    ) external view returns (uint256) {
+    function getNumOperatorsInOperatorSet(OperatorSet memory operatorSet) external view returns (uint256) {
         return _operatorSetMembers[_encodeOperatorSet(operatorSet)].length();
     }
 
@@ -471,9 +463,7 @@ contract AVSDirectory is
      *  @notice Returns the total number of operator sets an operator is registered to.
      *  @param operator The operator address to query.
      */
-    function inTotalOperatorSets(
-        address operator
-    ) external view returns (uint256) {
+    function inTotalOperatorSets(address operator) external view returns (uint256) {
         return _operatorSetsMemberOf[operator].length();
     }
 
@@ -558,26 +548,20 @@ contract AVSDirectory is
     }
 
     /// @notice Returns an EIP-712 encoded hash struct.
-    function _calculateDigestHash(
-        bytes32 structHash
-    ) internal view returns (bytes32) {
+    function _calculateDigestHash(bytes32 structHash) internal view returns (bytes32) {
         return keccak256(abi.encodePacked("\x19\x01", _calculateDomainSeparator(), structHash));
     }
 
     /// @dev Returns an `OperatorSet` encoded into a 32-byte value.
     /// @param operatorSet The `OperatorSet` to encode.
-    function _encodeOperatorSet(
-        OperatorSet memory operatorSet
-    ) internal pure returns (bytes32) {
+    function _encodeOperatorSet(OperatorSet memory operatorSet) internal pure returns (bytes32) {
         return bytes32(abi.encodePacked(operatorSet.avs, uint96(operatorSet.operatorSetId)));
     }
 
     /// @dev Returns an `OperatorSet` decoded from an encoded 32-byte value.
     /// @param encoded The encoded `OperatorSet` to decode.
     /// @dev Assumes `encoded` is encoded via `_encodeOperatorSet(operatorSet)`.
-    function _decodeOperatorSet(
-        bytes32 encoded
-    ) internal pure returns (OperatorSet memory) {
+    function _decodeOperatorSet(bytes32 encoded) internal pure returns (OperatorSet memory) {
         return OperatorSet({
             avs: address(uint160(uint256(encoded) >> 96)),
             operatorSetId: uint32(uint256(encoded) & type(uint96).max)

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -65,9 +65,7 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @notice Mapping: operator => avs => operatorSetId => operator registration status
     mapping(address => mapping(address => mapping(uint32 => OperatorSetRegistrationStatus))) public operatorSetStatus;
 
-    constructor(
-        IDelegationManager _delegation
-    ) {
+    constructor(IDelegationManager _delegation) {
         delegation = _delegation;
     }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -217,9 +217,7 @@ contract AllocationManager is
      *
      * @param salt A unique and single use value associated with the approver signature.
      */
-    function cancelSalt(
-        bytes32 salt
-    ) external override {
+    function cancelSalt(bytes32 salt) external override {
         // Mutate `operatorSaltIsSpent` to `true` to prevent future spending.
         operatorSaltIsSpent[msg.sender][salt] = true;
     }
@@ -700,26 +698,20 @@ contract AllocationManager is
     }
 
     /// @notice Returns an EIP-712 encoded hash struct.
-    function _calculateDigestHash(
-        bytes32 structHash
-    ) internal view returns (bytes32) {
+    function _calculateDigestHash(bytes32 structHash) internal view returns (bytes32) {
         return keccak256(abi.encodePacked("\x19\x01", _calculateDomainSeparator(), structHash));
     }
 
     /// @dev Returns an `OperatorSet` encoded into a 32-byte value.
     /// @param operatorSet The `OperatorSet` to encode.
-    function _encodeOperatorSet(
-        OperatorSet memory operatorSet
-    ) internal pure returns (bytes32) {
+    function _encodeOperatorSet(OperatorSet memory operatorSet) internal pure returns (bytes32) {
         return bytes32(abi.encodePacked(operatorSet.avs, uint96(operatorSet.operatorSetId)));
     }
 
     /// @dev Returns an `OperatorSet` decoded from an encoded 32-byte value.
     /// @param encoded The encoded `OperatorSet` to decode.
     /// @dev Assumes `encoded` is encoded via `_encodeOperatorSet(operatorSet)`.
-    function _decodeOperatorSet(
-        bytes32 encoded
-    ) internal pure returns (OperatorSet memory) {
+    function _decodeOperatorSet(bytes32 encoded) internal pure returns (OperatorSet memory) {
         return OperatorSet({
             avs: address(uint160(uint256(encoded) >> 96)),
             operatorSetId: uint32(uint256(encoded) & type(uint96).max)

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -771,7 +771,7 @@ contract DelegationManager is
     /**
      * @notice Removes `scaledShares` in `strategies` from `staker` who is currently delegated to `operator` and queues a withdrawal to the `withdrawer`.
      * @dev If the `operator` is indeed an operator, then the operator's delegated shares in the `strategies` are also decreased appropriately.
-     * @dev If `withdrawer` is not the same address as `staker`, then thirdPartyTransfersForbidden[strategy] must be set to false in the StrategyManager.
+     * @dev If `withdrawer` is not the same address as `staker`
      */
     function _removeSharesAndQueueWithdrawal(
         address staker,
@@ -783,6 +783,7 @@ contract DelegationManager is
     ) internal returns (bytes32) {
         require(staker != address(0), InputAddressZero());
         require(strategies.length != 0, InputArrayLengthZero());
+        require(staker == withdrawer, WithdrawerNotStaker());
 
         uint256[] memory scaledStakerShares = new uint256[](strategies.length);
 
@@ -835,10 +836,6 @@ contract DelegationManager is
                  */
                 eigenPodManager.removeShares(staker, sharesToDecrement);
             } else {
-                require(
-                    staker == withdrawer || !strategyManager.thirdPartyTransfersForbidden(strategies[i]),
-                    WithdrawerNotStaker()
-                );
                 // this call will revert if `scaledShares[i]` exceeds the Staker's current shares in `strategies[i]`
                 strategyManager.removeShares(staker, strategies[i], sharesToDecrement);
             }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -39,11 +39,11 @@ contract DelegationManager is
     uint256 internal immutable ORIGINAL_CHAIN_ID;
 
     /// @dev The minimum number of blocks to complete a withdrawal of a strategy. 50400 * 12 seconds = 1 week
-    uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50400;
+    uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50_400;
 
     /// @dev Wed Jan 01 2025 17:00:00 GMT+0000, timestamp used to check whether a pending withdrawal
     /// should be processed as legacy M2 or with slashing considered.
-    uint32 public constant LEGACY_WITHDRAWALS_TIMESTAMP = 1735750800;
+    uint32 public constant LEGACY_WITHDRAWALS_TIMESTAMP = 1_735_750_800;
 
     uint32 public constant WITHDRAWAL_DELAY = SlashingConstants.DEALLOCATION_DELAY;
 
@@ -131,9 +131,7 @@ contract DelegationManager is
      * after being set. This delay is required to be set for an operator to be able to allocate slashable magnitudes.
      * @param delay the allocation delay in seconds
      */
-    function initializeAllocationDelay(
-        uint32 delay
-    ) external {
+    function initializeAllocationDelay(uint32 delay) external {
         _initializeAllocationDelay(delay);
     }
 
@@ -143,9 +141,7 @@ contract DelegationManager is
      *
      * @dev The caller must have previously registered as an operator in EigenLayer.
      */
-    function modifyOperatorDetails(
-        OperatorDetails calldata newOperatorDetails
-    ) external {
+    function modifyOperatorDetails(OperatorDetails calldata newOperatorDetails) external {
         require(isOperator(msg.sender), OperatorNotRegistered());
         _setOperatorDetails(msg.sender, newOperatorDetails);
     }
@@ -154,9 +150,7 @@ contract DelegationManager is
      * @notice Called by an operator to emit an `OperatorMetadataURIUpdated` event indicating the information has updated.
      * @param metadataURI The URI for metadata associated with an operator
      */
-    function updateOperatorMetadataURI(
-        string calldata metadataURI
-    ) external {
+    function updateOperatorMetadataURI(string calldata metadataURI) external {
         require(isOperator(msg.sender), OperatorNotRegistered());
         emit OperatorMetadataURIUpdated(msg.sender, metadataURI);
     }
@@ -234,9 +228,11 @@ contract DelegationManager is
      * a staker from their operator. Undelegation immediately removes ALL active shares/strategies from
      * both the staker and operator, and places the shares and strategies in the withdrawal queue
      */
-    function undelegate(
-        address staker
-    ) external onlyWhenNotPaused(PAUSED_ENTER_WITHDRAWAL_QUEUE) returns (bytes32[] memory withdrawalRoots) {
+    function undelegate(address staker)
+        external
+        onlyWhenNotPaused(PAUSED_ENTER_WITHDRAWAL_QUEUE)
+        returns (bytes32[] memory withdrawalRoots)
+    {
         require(isDelegated(staker), NotActivelyDelegated());
         require(!isOperator(staker), OperatorsCannotUndelegate());
         require(staker != address(0), InputAddressZero());
@@ -296,9 +292,11 @@ contract DelegationManager is
      *
      * All withdrawn shares/strategies are placed in a queue and can be fully withdrawn after a delay.
      */
-    function queueWithdrawals(
-        QueuedWithdrawalParams[] calldata queuedWithdrawalParams
-    ) external onlyWhenNotPaused(PAUSED_ENTER_WITHDRAWAL_QUEUE) returns (bytes32[] memory) {
+    function queueWithdrawals(QueuedWithdrawalParams[] calldata queuedWithdrawalParams)
+        external
+        onlyWhenNotPaused(PAUSED_ENTER_WITHDRAWAL_QUEUE)
+        returns (bytes32[] memory)
+    {
         bytes32[] memory withdrawalRoots = new bytes32[](queuedWithdrawalParams.length);
         address operator = delegatedTo[msg.sender];
 
@@ -466,9 +464,7 @@ contract DelegationManager is
      * after being set. This delay is required to be set for an operator to be able to allocate slashable magnitudes.
      * @param delay the allocation delay in seconds
      */
-    function _initializeAllocationDelay(
-        uint32 delay
-    ) internal {
+    function _initializeAllocationDelay(uint32 delay) internal {
         require(isOperator(msg.sender), OperatorNotRegistered());
         require(!_operatorAllocationDelay[msg.sender].isSet, AllocationDelaySet());
         _operatorAllocationDelay[msg.sender] = AllocationDelayDetails({isSet: true, allocationDelay: delay});
@@ -580,7 +576,10 @@ contract DelegationManager is
             // this is a legacy M2 withdrawal using blocknumbers. We use the LEGACY_WITHDRAWALS_TIMESTAMP to check
             // if the withdrawal is a legacy withdrawal or not. It would take up to 600+ years for the blocknumber
             // to reach the LEGACY_WITHDRAWALS_TIMESTAMP, so this is a safe check.
-            require(withdrawal.startTimestamp + LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS <= block.number, WithdrawalDelayNotElapsed());
+            require(
+                withdrawal.startTimestamp + LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS <= block.number,
+                WithdrawalDelayNotElapsed()
+            );
             isLegacyWithdrawal = true;
         } else {
             // this is a post Slashing release withdrawal using timestamps
@@ -1023,27 +1022,21 @@ contract DelegationManager is
     /**
      * @notice Returns 'true' if `staker` *is* actively delegated, and 'false' otherwise.
      */
-    function isDelegated(
-        address staker
-    ) public view returns (bool) {
+    function isDelegated(address staker) public view returns (bool) {
         return (delegatedTo[staker] != address(0));
     }
 
     /**
      * @notice Returns true is an operator has previously registered for delegation.
      */
-    function isOperator(
-        address operator
-    ) public view returns (bool) {
+    function isOperator(address operator) public view returns (bool) {
         return operator != address(0) && delegatedTo[operator] == operator;
     }
 
     /**
      * @notice Returns the OperatorDetails struct associated with an `operator`.
      */
-    function operatorDetails(
-        address operator
-    ) external view returns (OperatorDetails memory) {
+    function operatorDetails(address operator) external view returns (OperatorDetails memory) {
         return _operatorDetails[operator];
     }
 
@@ -1051,27 +1044,21 @@ contract DelegationManager is
      * @notice Returns the AllocationDelayDetails struct associated with an `operator`
      * @dev If the operator has not set an allocation delay, then the `isSet` field will be `false`.
      */
-    function operatorAllocationDelay(
-        address operator
-    ) external view returns (AllocationDelayDetails memory) {
+    function operatorAllocationDelay(address operator) external view returns (AllocationDelayDetails memory) {
         return _operatorAllocationDelay[operator];
     }
 
     /**
      * @notice Returns the delegationApprover account for an operator
      */
-    function delegationApprover(
-        address operator
-    ) external view returns (address) {
+    function delegationApprover(address operator) external view returns (address) {
         return _operatorDetails[operator].delegationApprover;
     }
 
     /**
      * @notice Returns the stakerOptOutWindowBlocks for an operator
      */
-    function stakerOptOutWindowBlocks(
-        address operator
-    ) external view returns (uint256) {
+    function stakerOptOutWindowBlocks(address operator) external view returns (uint256) {
         return _operatorDetails[operator].stakerOptOutWindowBlocks;
     }
 
@@ -1117,9 +1104,7 @@ contract DelegationManager is
      * delegatable shares!
      * @dev Returns two empty arrays in the case that the Staker has no actively-delegateable shares.
      */
-    function getDelegatableShares(
-        address staker
-    ) public view returns (IStrategy[] memory, uint256[] memory) {
+    function getDelegatableShares(address staker) public view returns (IStrategy[] memory, uint256[] memory) {
         // Get current StrategyManager/EigenPodManager shares and strategies for `staker`
         // If `staker` is already delegated, these may not be the full withdrawable amounts due to slashing
         int256 podShares = eigenPodManager.podOwnerShares(staker);
@@ -1162,9 +1147,7 @@ contract DelegationManager is
     }
 
     /// @notice Returns the keccak256 hash of `withdrawal`.
-    function calculateWithdrawalRoot(
-        Withdrawal memory withdrawal
-    ) public pure returns (bytes32) {
+    function calculateWithdrawalRoot(Withdrawal memory withdrawal) public pure returns (bytes32) {
         return keccak256(abi.encode(withdrawal));
     }
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -38,14 +38,14 @@ contract DelegationManager is
     // @dev Chain ID at the time of contract deployment
     uint256 internal immutable ORIGINAL_CHAIN_ID;
 
-    // @dev Maximum Value for `stakerOptOutWindowBlocks`. Approximately equivalent to 6 months in blocks.
-    uint256 public constant MAX_STAKER_OPT_OUT_WINDOW_BLOCKS = (180 days) / 12;
+    /// @dev The minimum number of blocks to complete a withdrawal of a strategy. 50400 * 12 seconds = 1 week
+    uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50400;
 
-    // The max configurable withdrawal delay per strategy. Set to 30 days in seconds
-    uint256 public constant MAX_WITHDRAWAL_DELAY = 30 days;
+    /// @dev Wed Jan 01 2025 17:00:00 GMT+0000, timestamp used to check whether a pending withdrawal
+    /// should be processed as legacy M2 or with slashing considered.
+    uint32 public constant LEGACY_WITHDRAWALS_TIMESTAMP = 1735750800;
 
-    // the number of 12-second blocks in 30 days (60 * 60 * 24 * 30 / 12 = 216,000)
-    uint256 public constant MAX_WITHDRAWAL_DELAY_BLOCKS = MAX_WITHDRAWAL_DELAY / 12;
+    uint32 public constant WITHDRAWAL_DELAY = SlashingConstants.DEALLOCATION_DELAY;
 
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
@@ -86,16 +86,11 @@ contract DelegationManager is
     function initialize(
         address initialOwner,
         IPauserRegistry _pauserRegistry,
-        uint256 initialPausedStatus,
-        uint256 _minWithdrawalDelayBlocks,
-        IStrategy[] calldata _strategies,
-        uint256[] calldata _withdrawalDelayBlocks
+        uint256 initialPausedStatus
     ) external initializer {
         _initializePauser(_pauserRegistry, initialPausedStatus);
         _DOMAIN_SEPARATOR = _calculateDomainSeparator();
         _transferOwnership(initialOwner);
-        _setMinWithdrawalDelayBlocks(_minWithdrawalDelayBlocks);
-        _setStrategyWithdrawalDelayBlocks(_strategies, _withdrawalDelayBlocks);
     }
 
     /**
@@ -451,44 +446,6 @@ contract DelegationManager is
     }
 
     /**
-     * @notice Owner-only function for modifying the value of the `minWithdrawalDelayBlocks` variable.
-     * @param newMinWithdrawalDelayBlocks new value of `minWithdrawalDelayBlocks`.
-     */
-    function setMinWithdrawalDelayBlocks(
-        uint256 newMinWithdrawalDelayBlocks
-    ) external onlyOwner {
-        _setMinWithdrawalDelayBlocks(newMinWithdrawalDelayBlocks);
-    }
-
-    /**
-     * @notice Called by owner to set the minimum withdrawal delay blocks for each passed in strategy
-     * Note that the min number of blocks to complete a withdrawal of a strategy is
-     * MAX(minWithdrawalDelayBlocks, strategyWithdrawalDelayBlocks[strategy])
-     * @param strategies The strategies to set the minimum withdrawal delay blocks for
-     * @param withdrawalDelayBlocks The minimum withdrawal delay blocks to set for each strategy
-     */
-    function setStrategyWithdrawalDelayBlocks(
-        IStrategy[] calldata strategies,
-        uint256[] calldata withdrawalDelayBlocks
-    ) external onlyOwner {
-        _setStrategyWithdrawalDelayBlocks(strategies, withdrawalDelayBlocks);
-    }
-
-    /**
-     * @notice Called by owner to set the minimum withdrawal delay for each passed in strategy
-     * Note that the min number of blocks to complete a withdrawal of a strategy is
-     * MAX(minWithdrawalDelay, strategyWithdrawalDelay[strategy])
-     * @param strategies The strategies to set the minimum withdrawal delay for
-     * @param withdrawalDelays The minimum withdrawal delay (in seconds) to set for each strategy
-     */
-    function setStrategyWithdrawalDelay(
-        IStrategy[] calldata strategies,
-        uint256[] calldata withdrawalDelays
-    ) external onlyOwner {
-        _setStrategyWithdrawalDelay(strategies, withdrawalDelays);
-    }
-
-    /**
      *
      *                         INTERNAL FUNCTIONS
      *
@@ -500,14 +457,6 @@ contract DelegationManager is
      * @param newOperatorDetails The new parameters for the operator
      */
     function _setOperatorDetails(address operator, OperatorDetails calldata newOperatorDetails) internal {
-        require(
-            newOperatorDetails.stakerOptOutWindowBlocks <= MAX_STAKER_OPT_OUT_WINDOW_BLOCKS,
-            StakerOptOutWindowBlocksExceedsMax()
-        );
-        require(
-            newOperatorDetails.stakerOptOutWindowBlocks >= _operatorDetails[operator].stakerOptOutWindowBlocks,
-            StakerOptOutWindowBlocksCannotDecrease()
-        );
         _operatorDetails[operator] = newOperatorDetails;
         emit OperatorDetailsModified(msg.sender, newOperatorDetails);
     }
@@ -622,27 +571,36 @@ contract DelegationManager is
         bool receiveAsTokens
     ) internal {
         require(tokens.length == withdrawal.strategies.length, InputArrayLengthMismatch());
-
+        require(msg.sender == withdrawal.withdrawer, WithdrawerNotCaller());
         bytes32 withdrawalRoot = calculateWithdrawalRoot(withdrawal);
+        bool isLegacyWithdrawal = false;
 
         require(pendingWithdrawals[withdrawalRoot], WithdrawalNotQueued());
-        require(withdrawal.startTimestamp + minWithdrawalDelay <= block.number, WithdrawalDelayNotElapsed());
-        require(msg.sender == withdrawal.withdrawer, WithdrawerNotCaller());
+        if (withdrawal.startTimestamp < LEGACY_WITHDRAWALS_TIMESTAMP) {
+            // this is a legacy M2 withdrawal using blocknumbers. We use the LEGACY_WITHDRAWALS_TIMESTAMP to check
+            // if the withdrawal is a legacy withdrawal or not. It would take up to 600+ years for the blocknumber
+            // to reach the LEGACY_WITHDRAWALS_TIMESTAMP, so this is a safe check.
+            require(withdrawal.startTimestamp + LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS <= block.number, WithdrawalDelayNotElapsed());
+            isLegacyWithdrawal = true;
+        } else {
+            // this is a post Slashing release withdrawal using timestamps
+            require(withdrawal.startTimestamp + WITHDRAWAL_DELAY <= block.timestamp, WithdrawalDelayNotElapsed());
+        }
 
         // read delegated operator's totalMagnitudes at time of withdrawal to scale shares again if any slashing has occurred
         // during withdrawal delay period
         uint64[] memory totalMagnitudes = allocationManager.getTotalMagnitudesAtTimestamp({
             operator: withdrawal.delegatedTo,
             strategies: withdrawal.strategies,
-            timestamp: withdrawal.startTimestamp + SlashingConstants.DEALLOCATION_DELAY
+            timestamp: withdrawal.startTimestamp + WITHDRAWAL_DELAY
         });
 
         if (receiveAsTokens) {
             // complete the withdrawal by converting shares to tokens
-            _completeReceiveAsTokens(withdrawal, tokens, totalMagnitudes);
+            _completeReceiveAsTokens(withdrawal, tokens, totalMagnitudes, isLegacyWithdrawal);
         } else {
             // Award shares back in StrategyManager/EigenPodManager.
-            _completeReceiveAsShares(withdrawal, tokens, totalMagnitudes);
+            _completeReceiveAsShares(withdrawal, tokens, totalMagnitudes, isLegacyWithdrawal);
         }
 
         // Remove `withdrawalRoot` from pending roots
@@ -658,21 +616,22 @@ contract DelegationManager is
     function _completeReceiveAsTokens(
         Withdrawal calldata withdrawal,
         IERC20[] calldata tokens,
-        uint64[] memory totalMagnitudes
+        uint64[] memory totalMagnitudes,
+        bool isLegacyWithdrawal
     ) internal {
         // Finalize action by converting scaled shares to tokens for each strategy, or
         // by re-awarding shares in each strategy.
         for (uint256 i = 0; i < withdrawal.strategies.length; ++i) {
-            require(
-                withdrawal.startTimestamp + strategyWithdrawalDelays[withdrawal.strategies[i]] <= block.timestamp,
-                WithdrawalDelayNotElapsed()
-            );
-
-            // Take already scaled staker shares and scale again according to current operator totalMagnitude
-            // This is because the totalMagnitude may have changed since withdrawal was queued and the staker shares
-            // are still susceptible to slashing
-            uint256 sharesToWithdraw =
-                _calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
+            uint256 sharesToWithdraw;
+            if (isLegacyWithdrawal) {
+                // This is a legacy M2 withdrawal. There is no slashing applied to the withdrawn shares.
+                sharesToWithdraw = withdrawal.scaledShares[i];
+            } else {
+                // Take already scaled staker shares and scale again according to current operator totalMagnitude
+                // This is because the totalMagnitude may have changed since withdrawal was queued and the staker shares
+                // are still susceptible to slashing
+                sharesToWithdraw = _calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
+            }
 
             _withdrawSharesAsTokens({
                 staker: withdrawal.staker,
@@ -694,24 +653,25 @@ contract DelegationManager is
     function _completeReceiveAsShares(
         Withdrawal calldata withdrawal,
         IERC20[] calldata tokens,
-        uint64[] memory totalMagnitudes
+        uint64[] memory totalMagnitudes,
+        bool isLegacyWithdrawal
     ) internal {
         // read delegated operator for scaling and adding shares back if needed
         address currentOperator = delegatedTo[msg.sender];
 
         for (uint256 i = 0; i < withdrawal.strategies.length; ++i) {
-            require(
-                withdrawal.startTimestamp + strategyWithdrawalDelays[withdrawal.strategies[i]] <= block.number,
-                WithdrawalDelayNotElapsed()
-            );
-
-            // Take already scaled staker shares and scale again according to current operator totalMagnitude
-            // This is because the totalMagnitude may have changed since withdrawal was queued and the staker shares
-            // are still susceptible to slashing
-            uint256 shares = _calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
-
             // store existing shares to calculate new staker scaling factor later
             uint256 existingShares;
+            uint256 shares;
+            if (isLegacyWithdrawal) {
+                // This is a legacy M2 withdrawal. There is no slashing applied to withdrawn shares
+                shares = withdrawal.scaledShares[i];
+            } else {
+                // Take already scaled staker shares and scale again according to current operator totalMagnitude
+                // This is because the totalMagnitude may have changed since withdrawal was queued and the staker shares
+                // are still susceptible to slashing
+                shares = _calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
+            }
 
             /**
              * When awarding podOwnerShares in EigenPodManager, we need to be sure to only give them back to the original podOwner.
@@ -927,60 +887,6 @@ contract DelegationManager is
                 shares: shares,
                 token: token
             });
-        }
-    }
-
-    function _setMinWithdrawalDelayBlocks(
-        uint256 _minWithdrawalDelayBlocks
-    ) internal {
-        require(_minWithdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS, WithdrawalDelayExeedsMax());
-        emit MinWithdrawalDelayBlocksSet(minWithdrawalDelayBlocks, _minWithdrawalDelayBlocks);
-        minWithdrawalDelayBlocks = _minWithdrawalDelayBlocks;
-    }
-
-    /**
-     * @notice Sets the withdrawal delay blocks for each strategy in `_strategies` to `_withdrawalDelayBlocks`.
-     * gets called when initializing contract or by calling `setStrategyWithdrawalDelayBlocks`
-     */
-    function _setStrategyWithdrawalDelayBlocks(
-        IStrategy[] calldata _strategies,
-        uint256[] calldata _withdrawalDelayBlocks
-    ) internal {
-        require(_strategies.length == _withdrawalDelayBlocks.length, InputArrayLengthMismatch());
-        uint256 numStrats = _strategies.length;
-        for (uint256 i = 0; i < numStrats; ++i) {
-            IStrategy strategy = _strategies[i];
-            uint256 prevStrategyWithdrawalDelayBlocks = strategyWithdrawalDelayBlocks[strategy];
-            uint256 newStrategyWithdrawalDelayBlocks = _withdrawalDelayBlocks[i];
-            require(newStrategyWithdrawalDelayBlocks <= MAX_WITHDRAWAL_DELAY_BLOCKS, WithdrawalDelayExeedsMax());
-
-            // set the new withdrawal delay blocks
-            strategyWithdrawalDelayBlocks[strategy] = newStrategyWithdrawalDelayBlocks;
-            emit StrategyWithdrawalDelayBlocksSet(
-                strategy, prevStrategyWithdrawalDelayBlocks, newStrategyWithdrawalDelayBlocks
-            );
-        }
-    }
-
-    /**
-     * @notice Sets the withdrawal delay (in seconds) for each strategy in `_strategies` to `_withdrawalDelay`.
-     * gets called when initializing contract or by calling `setStrategyWithdrawalDelay`
-     */
-    function _setStrategyWithdrawalDelay(
-        IStrategy[] calldata _strategies,
-        uint256[] calldata _withdrawalDelays
-    ) internal {
-        require(_strategies.length == _withdrawalDelays.length, InputArrayLengthMismatch());
-        uint256 numStrats = _strategies.length;
-        for (uint256 i = 0; i < numStrats; ++i) {
-            IStrategy strategy = _strategies[i];
-            uint256 prevStrategyWithdrawalDelay = strategyWithdrawalDelays[strategy];
-            uint256 newStrategyWithdrawalDelay = _withdrawalDelays[i];
-            require(newStrategyWithdrawalDelay <= MAX_WITHDRAWAL_DELAY, WithdrawalDelayExeedsMax());
-
-            // set the new withdrawal delay (in seconds)
-            strategyWithdrawalDelays[strategy] = newStrategyWithdrawalDelay;
-            emit StrategyWithdrawalDelaySet(strategy, prevStrategyWithdrawalDelay, newStrategyWithdrawalDelay);
         }
     }
 
@@ -1256,24 +1162,6 @@ contract DelegationManager is
         }
 
         return (strategies, shares);
-    }
-
-    /**
-     * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
-     * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
-     * @param strategies The strategies to check withdrawal delays for
-     */
-    function getWithdrawalDelay(
-        IStrategy[] calldata strategies
-    ) public view returns (uint256) {
-        uint256 withdrawalDelay = minWithdrawalDelayBlocks;
-        for (uint256 i = 0; i < strategies.length; ++i) {
-            uint256 currWithdrawalDelay = strategyWithdrawalDelayBlocks[strategies[i]];
-            if (currWithdrawalDelay > withdrawalDelay) {
-                withdrawalDelay = currWithdrawalDelay;
-            }
-        }
-        return withdrawalDelay;
     }
 
     /// @notice Returns the keccak256 hash of `withdrawal`.

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -90,7 +90,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * To withdraw from a strategy, max(minWithdrawalDelayBlocks, strategyWithdrawalDelayBlocks[strategy]) number of blocks must have passed.
      * See mapping strategyWithdrawalDelayBlocks below for per-strategy withdrawal delays.
      */
-    uint256 public minWithdrawalDelayBlocks;
+    uint256 private __deprecated_minWithdrawalDelayBlocks;
 
     /// @notice Mapping: hash of withdrawal inputs, aka 'withdrawalRoot' => whether the withdrawal is pending
     mapping(bytes32 => bool) public pendingWithdrawals;
@@ -107,23 +107,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
      * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
      */
-    mapping(IStrategy => uint256) public strategyWithdrawalDelayBlocks;
-
-    /**
-     * @notice Global minimum withdrawal delay for all strategy withdrawals.
-     * NOTE: This is used equivalently to minWithdrawalDelayBlocks and strategyWithdrawalDelayBlocks but
-     * using timestamps instead in the Slashing release.
-     * In addition, we now also configure withdrawal delays on a per-strategy basis.
-     * To withdraw from a strategy, max(minWithdrawalDelay, strategyWithdrawalDelay[strategy]) number of seconds must have passed.
-     * See mapping strategyWithdrawalDelay below for per-strategy withdrawal delays.
-     */
-    uint256 public minWithdrawalDelay;
-
-    /**
-     * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in seconds, and adjustable by this contract's owner,
-     * up to a maximum of `MAX_WITHDRAWAL_DELAY`. Minimum value is 0 (i.e. no delay enforced).
-     */
-    mapping(IStrategy => uint256) public strategyWithdrawalDelays;
+    mapping(IStrategy => uint256) private __deprecated_strategyWithdrawalDelayBlocks;
 
     /// @notice Mapping: staker => strategy => scaling factor used to calculate the staker's withdrawable shares in the strategy.
     /// This is updated upon each deposit based on the staker's currently delegated operator's totalMagnitude.
@@ -152,5 +136,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[37] private __gap;
+    uint256[39] private __gap;
 }

--- a/src/contracts/core/RewardsCoordinator.sol
+++ b/src/contracts/core/RewardsCoordinator.sol
@@ -137,9 +137,11 @@ contract RewardsCoordinator is
      * @dev This function will revert if the `rewardsSubmission` is malformed,
      * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
      */
-    function createAVSRewardsSubmission(
-        RewardsSubmission[] calldata rewardsSubmissions
-    ) external onlyWhenNotPaused(PAUSED_AVS_REWARDS_SUBMISSION) nonReentrant {
+    function createAVSRewardsSubmission(RewardsSubmission[] calldata rewardsSubmissions)
+        external
+        onlyWhenNotPaused(PAUSED_AVS_REWARDS_SUBMISSION)
+        nonReentrant
+    {
         for (uint256 i = 0; i < rewardsSubmissions.length;) {
             RewardsSubmission calldata rewardsSubmission = rewardsSubmissions[i];
             uint256 nonce = submissionNonce[msg.sender];
@@ -173,9 +175,12 @@ contract RewardsCoordinator is
      * a permissioned call based on isRewardsForAllSubmitter mapping.
      * @param rewardsSubmissions The rewards submissions being created
      */
-    function createRewardsForAllSubmission(
-        RewardsSubmission[] calldata rewardsSubmissions
-    ) external onlyWhenNotPaused(PAUSED_REWARDS_FOR_ALL_SUBMISSION) onlyRewardsForAllSubmitter nonReentrant {
+    function createRewardsForAllSubmission(RewardsSubmission[] calldata rewardsSubmissions)
+        external
+        onlyWhenNotPaused(PAUSED_REWARDS_FOR_ALL_SUBMISSION)
+        onlyRewardsForAllSubmitter
+        nonReentrant
+    {
         for (uint256 i = 0; i < rewardsSubmissions.length;) {
             RewardsSubmission calldata rewardsSubmission = rewardsSubmissions[i];
             uint256 nonce = submissionNonce[msg.sender];
@@ -216,9 +221,11 @@ contract RewardsCoordinator is
      * @dev The tokens in the rewards submissions are sent to the `RewardsCoordinator` contract
      * @dev Strategies of each rewards submission must be in ascending order of addresses to check for duplicates
      */
-    function rewardOperatorSetForRange(
-        OperatorSetRewardsSubmission[] calldata rewardsSubmissions
-    ) external onlyWhenNotPaused(PAUSED_REWARD_OPERATOR_SET) nonReentrant {
+    function rewardOperatorSetForRange(OperatorSetRewardsSubmission[] calldata rewardsSubmissions)
+        external
+        onlyWhenNotPaused(PAUSED_REWARD_OPERATOR_SET)
+        nonReentrant
+    {
         for (uint256 i = 0; i < rewardsSubmissions.length;) {
             OperatorSetRewardsSubmission calldata rewardsSubmission = rewardsSubmissions[i];
             uint256 nonce = submissionNonce[msg.sender];
@@ -319,9 +326,7 @@ contract RewardsCoordinator is
      * @notice allow the rewardsUpdater to disable/cancel a pending root submission in case of an error
      * @param rootIndex The index of the root to be disabled
      */
-    function disableRoot(
-        uint32 rootIndex
-    ) external onlyWhenNotPaused(PAUSED_SUBMIT_DISABLE_ROOTS) onlyRewardsUpdater {
+    function disableRoot(uint32 rootIndex) external onlyWhenNotPaused(PAUSED_SUBMIT_DISABLE_ROOTS) onlyRewardsUpdater {
         require(rootIndex < _distributionRoots.length, InvalidRootIndex());
         DistributionRoot storage root = _distributionRoots[rootIndex];
         require(!root.disabled, RootDisabled());
@@ -335,9 +340,7 @@ contract RewardsCoordinator is
      * @param claimer The address of the entity that can call `processClaim` on behalf of the earner
      * @dev Only callable by the `earner`
      */
-    function setClaimerFor(
-        address claimer
-    ) external {
+    function setClaimerFor(address claimer) external {
         address earner = msg.sender;
         address prevClaimer = claimerFor[earner];
         claimerFor[earner] = claimer;
@@ -382,9 +385,7 @@ contract RewardsCoordinator is
      * @dev Only callable by the contract owner
      * @param _activationDelay The new value for activationDelay
      */
-    function setActivationDelay(
-        uint32 _activationDelay
-    ) external onlyOwner {
+    function setActivationDelay(uint32 _activationDelay) external onlyOwner {
         _setActivationDelay(_activationDelay);
     }
 
@@ -393,9 +394,7 @@ contract RewardsCoordinator is
      * @dev Only callable by the contract owner
      * @param _globalCommissionBips The commission for all operators across all avss
      */
-    function setGlobalOperatorCommission(
-        uint16 _globalCommissionBips
-    ) external onlyOwner {
+    function setGlobalOperatorCommission(uint16 _globalCommissionBips) external onlyOwner {
         _setGlobalOperatorCommission(_globalCommissionBips);
     }
 
@@ -404,9 +403,7 @@ contract RewardsCoordinator is
      * @dev Only callable by the contract owner
      * @param _rewardsUpdater The address of the new rewardsUpdater
      */
-    function setRewardsUpdater(
-        address _rewardsUpdater
-    ) external onlyOwner {
+    function setRewardsUpdater(address _rewardsUpdater) external onlyOwner {
         _setRewardsUpdater(_rewardsUpdater);
     }
 
@@ -558,23 +555,17 @@ contract RewardsCoordinator is
         );
     }
 
-    function _setActivationDelay(
-        uint32 _activationDelay
-    ) internal {
+    function _setActivationDelay(uint32 _activationDelay) internal {
         emit ActivationDelaySet(activationDelay, _activationDelay);
         activationDelay = _activationDelay;
     }
 
-    function _setGlobalOperatorCommission(
-        uint16 _globalCommissionBips
-    ) internal {
+    function _setGlobalOperatorCommission(uint16 _globalCommissionBips) internal {
         emit GlobalCommissionBipsSet(globalOperatorCommissionBips, _globalCommissionBips);
         globalOperatorCommissionBips = _globalCommissionBips;
     }
 
-    function _setRewardsUpdater(
-        address _rewardsUpdater
-    ) internal {
+    function _setRewardsUpdater(address _rewardsUpdater) internal {
         emit RewardsUpdaterSet(rewardsUpdater, _rewardsUpdater);
         rewardsUpdater = _rewardsUpdater;
     }
@@ -586,24 +577,18 @@ contract RewardsCoordinator is
      */
 
     /// @notice return the hash of the earner's leaf
-    function calculateEarnerLeafHash(
-        EarnerTreeMerkleLeaf calldata leaf
-    ) public pure returns (bytes32) {
+    function calculateEarnerLeafHash(EarnerTreeMerkleLeaf calldata leaf) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(EARNER_LEAF_SALT, leaf.earner, leaf.earnerTokenRoot));
     }
 
     /// @notice returns the hash of the earner's token leaf
-    function calculateTokenLeafHash(
-        TokenTreeMerkleLeaf calldata leaf
-    ) public pure returns (bytes32) {
+    function calculateTokenLeafHash(TokenTreeMerkleLeaf calldata leaf) public pure returns (bytes32) {
         return keccak256(abi.encodePacked(TOKEN_LEAF_SALT, leaf.token, leaf.cumulativeEarnings));
     }
 
     /// @notice returns 'true' if the claim would currently pass the check in `processClaims`
     /// but will revert if not valid
-    function checkClaim(
-        RewardsMerkleClaim calldata claim
-    ) public view returns (bool) {
+    function checkClaim(RewardsMerkleClaim calldata claim) public view returns (bool) {
         _checkClaim(claim, _distributionRoots[claim.rootIndex]);
         return true;
     }
@@ -633,9 +618,7 @@ contract RewardsCoordinator is
         return _distributionRoots.length;
     }
 
-    function getDistributionRootAtIndex(
-        uint256 index
-    ) external view returns (DistributionRoot memory) {
+    function getDistributionRootAtIndex(uint256 index) external view returns (DistributionRoot memory) {
         return _distributionRoots[index];
     }
 
@@ -656,9 +639,7 @@ contract RewardsCoordinator is
     }
 
     /// @notice loop through distribution roots from reverse and return hash
-    function getRootIndexFromHash(
-        bytes32 rootHash
-    ) public view returns (uint32) {
+    function getRootIndexFromHash(bytes32 rootHash) public view returns (uint32) {
         for (uint32 i = uint32(_distributionRoots.length); i > 0; i--) {
             if (_distributionRoots[i - 1].root == rootHash) {
                 return i - 1;

--- a/src/contracts/core/Slasher.sol
+++ b/src/contracts/core/Slasher.sol
@@ -29,17 +29,11 @@ contract Slasher is Initializable, OwnableUpgradeable, ISlasher, Pausable {
 
     function initialize(address, IPauserRegistry, uint256) external {}
 
-    function optIntoSlashing(
-        address
-    ) external {}
+    function optIntoSlashing(address) external {}
 
-    function freezeOperator(
-        address
-    ) external {}
+    function freezeOperator(address) external {}
 
-    function resetFrozenStatus(
-        address[] calldata
-    ) external {}
+    function resetFrozenStatus(address[] calldata) external {}
 
     function recordFirstStakeUpdate(address, uint32) external {}
 
@@ -51,9 +45,7 @@ contract Slasher is Initializable, OwnableUpgradeable, ISlasher, Pausable {
 
     function delegation() external view returns (IDelegationManager) {}
 
-    function isFrozen(
-        address
-    ) external view returns (bool) {}
+    function isFrozen(address) external view returns (bool) {}
 
     function canSlash(address, address) external view returns (bool) {}
 
@@ -67,17 +59,13 @@ contract Slasher is Initializable, OwnableUpgradeable, ISlasher, Pausable {
 
     function operatorToMiddlewareTimes(address, uint256) external view returns (MiddlewareTimes memory) {}
 
-    function middlewareTimesLength(
-        address
-    ) external view returns (uint256) {}
+    function middlewareTimesLength(address) external view returns (uint256) {}
 
     function getMiddlewareTimesIndexStalestUpdateBlock(address, uint32) external view returns (uint32) {}
 
     function getMiddlewareTimesIndexServeUntilBlock(address, uint32) external view returns (uint32) {}
 
-    function operatorWhitelistedContractsLinkedListSize(
-        address
-    ) external view returns (uint256) {}
+    function operatorWhitelistedContractsLinkedListSize(address) external view returns (uint256) {}
 
     function operatorWhitelistedContractsLinkedListEntry(
         address,

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -39,9 +39,7 @@ contract StrategyManager is
         _;
     }
 
-    modifier onlyStrategiesWhitelistedForDeposit(
-        IStrategy strategy
-    ) {
+    modifier onlyStrategiesWhitelistedForDeposit(IStrategy strategy) {
         require(strategyIsWhitelistedForDeposit[strategy], StrategyNotWhitelisted());
         _;
     }
@@ -190,9 +188,7 @@ contract StrategyManager is
      * @notice Owner-only function to change the `strategyWhitelister` address.
      * @param newStrategyWhitelister new address for the `strategyWhitelister`.
      */
-    function setStrategyWhitelister(
-        address newStrategyWhitelister
-    ) external onlyOwner {
+    function setStrategyWhitelister(address newStrategyWhitelister) external onlyOwner {
         _setStrategyWhitelister(newStrategyWhitelister);
     }
 
@@ -200,9 +196,10 @@ contract StrategyManager is
      * @notice Owner-only function that adds the provided Strategies to the 'whitelist' of strategies that stakers can deposit into
      * @param strategiesToWhitelist Strategies that will be added to the `strategyIsWhitelistedForDeposit` mapping (if they aren't in it already)
      */
-    function addStrategiesToDepositWhitelist(
-        IStrategy[] calldata strategiesToWhitelist
-    ) external onlyStrategyWhitelister {
+    function addStrategiesToDepositWhitelist(IStrategy[] calldata strategiesToWhitelist)
+        external
+        onlyStrategyWhitelister
+    {
         uint256 strategiesToWhitelistLength = strategiesToWhitelist.length;
         for (uint256 i = 0; i < strategiesToWhitelistLength; ++i) {
             // change storage and emit event only if strategy is not already in whitelist
@@ -217,9 +214,10 @@ contract StrategyManager is
      * @notice Owner-only function that removes the provided Strategies from the 'whitelist' of strategies that stakers can deposit into
      * @param strategiesToRemoveFromWhitelist Strategies that will be removed to the `strategyIsWhitelistedForDeposit` mapping (if they are in it)
      */
-    function removeStrategiesFromDepositWhitelist(
-        IStrategy[] calldata strategiesToRemoveFromWhitelist
-    ) external onlyStrategyWhitelister {
+    function removeStrategiesFromDepositWhitelist(IStrategy[] calldata strategiesToRemoveFromWhitelist)
+        external
+        onlyStrategyWhitelister
+    {
         uint256 strategiesToRemoveFromWhitelistLength = strategiesToRemoveFromWhitelist.length;
         for (uint256 i = 0; i < strategiesToRemoveFromWhitelistLength; ++i) {
             // change storage and emit event only if strategy is already in whitelist
@@ -362,9 +360,7 @@ contract StrategyManager is
      * @notice Internal function for modifying the `strategyWhitelister`. Used inside of the `setStrategyWhitelister` and `initialize` functions.
      * @param newStrategyWhitelister The new address for the `strategyWhitelister` to take.
      */
-    function _setStrategyWhitelister(
-        address newStrategyWhitelister
-    ) internal {
+    function _setStrategyWhitelister(address newStrategyWhitelister) internal {
         emit StrategyWhitelisterChanged(strategyWhitelister, newStrategyWhitelister);
         strategyWhitelister = newStrategyWhitelister;
     }
@@ -376,9 +372,7 @@ contract StrategyManager is
      * @param staker The staker of interest, whose deposits this function will fetch
      * @return (staker's strategies, shares in these strategies)
      */
-    function getDeposits(
-        address staker
-    ) external view returns (IStrategy[] memory, uint256[] memory) {
+    function getDeposits(address staker) external view returns (IStrategy[] memory, uint256[] memory) {
         uint256 strategiesLength = stakerStrategyList[staker].length;
         uint256[] memory shares = new uint256[](strategiesLength);
 
@@ -389,9 +383,7 @@ contract StrategyManager is
     }
 
     /// @notice Simple getter function that returns `stakerStrategyList[staker].length`.
-    function stakerStrategyListLength(
-        address staker
-    ) external view returns (uint256) {
+    function stakerStrategyListLength(address staker) external view returns (uint256) {
         return stakerStrategyList[staker].length;
     }
 

--- a/src/contracts/core/StrategyManagerStorage.sol
+++ b/src/contracts/core/StrategyManagerStorage.sol
@@ -72,7 +72,7 @@ abstract contract StrategyManagerStorage is IStrategyManager {
      * if true for a strategy, a user cannot depositIntoStrategyWithSignature into that strategy for another staker
      * and also when performing queueWithdrawals, a staker can only withdraw to themselves
      */
-    mapping(IStrategy => bool) public thirdPartyTransfersForbidden;
+    mapping(IStrategy => bool) private __deprecated_thirdPartyTransfersForbidden;
 
     constructor(
         IDelegationManager _delegation,

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -407,15 +407,6 @@ interface IDelegationManager is ISignatureUtils {
         address operator
     ) external view returns (uint256);
 
-    // /**
-    //  * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
-    //  * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
-    //  * @param strategies The strategies to check withdrawal delays for
-    //  */
-    // function getWithdrawalDelay(
-    //     IStrategy[] calldata strategies
-    // ) external view returns (uint256);
-
     /**
      * @notice returns the total number of scaled shares (i.e. shares scaled down by a factor of the `operator`'s
      * totalMagnitude) in `strategy` that are delegated to `operator`.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -190,15 +190,6 @@ interface IDelegationManager is ISignatureUtils {
     /// @notice Emitted when a queued withdrawal is completed
     event WithdrawalCompleted(bytes32 withdrawalRoot);
 
-    /// @notice Emitted when the `minWithdrawalDelayBlocks` variable is modified from `previousValue` to `newValue`.
-    event MinWithdrawalDelayBlocksSet(uint256 previousValue, uint256 newValue);
-
-    /// @notice Emitted when the `strategyWithdrawalDelayBlocks` variable is modified from `previousValue` to `newValue`.
-    event StrategyWithdrawalDelayBlocksSet(IStrategy strategy, uint256 previousValue, uint256 newValue);
-
-    /// @notice Emitted when the `strategyWithdrawalDelay` variable is modified from `previousValue` to `newValue`.
-    event StrategyWithdrawalDelaySet(IStrategy strategy, uint256 previousValue, uint256 newValue);
-
     /**
      * @notice Registers the caller as an operator in EigenLayer.
      * @param registeringOperatorDetails is the `OperatorDetails` for the operator.
@@ -416,14 +407,14 @@ interface IDelegationManager is ISignatureUtils {
         address operator
     ) external view returns (uint256);
 
-    /**
-     * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
-     * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
-     * @param strategies The strategies to check withdrawal delays for
-     */
-    function getWithdrawalDelay(
-        IStrategy[] calldata strategies
-    ) external view returns (uint256);
+    // /**
+    //  * @notice Given a list of strategies, return the minimum number of blocks that must pass to withdraw
+    //  * from all the inputted strategies. Return value is >= minWithdrawalDelayBlocks as this is the global min withdrawal delay.
+    //  * @param strategies The strategies to check withdrawal delays for
+    //  */
+    // function getWithdrawalDelay(
+    //     IStrategy[] calldata strategies
+    // ) external view returns (uint256);
 
     /**
      * @notice returns the total number of scaled shares (i.e. shares scaled down by a factor of the `operator`'s
@@ -461,22 +452,6 @@ interface IDelegationManager is ISignatureUtils {
      * signature + the provided salt if the operator being delegated to has specified a nonzero address as their `delegationApprover`.
      */
     function delegationApproverSaltIsSpent(address _delegationApprover, bytes32 salt) external view returns (bool);
-
-    /**
-     * @notice Minimum delay enforced by this contract for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
-     * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
-     * Note that strategies each have a separate withdrawal delay, which can be greater than this value. So the minimum number of blocks that must pass
-     * to withdraw a strategy is MAX(minWithdrawalDelayBlocks, strategyWithdrawalDelayBlocks[strategy])
-     */
-    function minWithdrawalDelayBlocks() external view returns (uint256);
-
-    /**
-     * @notice Minimum delay enforced by this contract per Strategy for completing queued withdrawals. Measured in blocks, and adjustable by this contract's owner,
-     * up to a maximum of `MAX_WITHDRAWAL_DELAY_BLOCKS`. Minimum value is 0 (i.e. no delay enforced).
-     */
-    function strategyWithdrawalDelayBlocks(
-        IStrategy strategy
-    ) external view returns (uint256);
 
     /// @notice return address of the beaconChainETHStrategy
     function beaconChainETHStrategy() external view returns (IStrategy);

--- a/src/contracts/interfaces/IStrategyFactory.sol
+++ b/src/contracts/interfaces/IStrategyFactory.sol
@@ -50,14 +50,8 @@ interface IStrategyFactory {
      * @notice Owner-only function to pass through a call to `StrategyManager.addStrategiesToDepositWhitelist`
      */
     function whitelistStrategies(
-        IStrategy[] calldata strategiesToWhitelist,
-        bool[] calldata thirdPartyTransfersForbiddenValues
+        IStrategy[] calldata strategiesToWhitelist
     ) external;
-
-    /**
-     * @notice Owner-only function to pass through a call to `StrategyManager.setThirdPartyTransfersForbidden`
-     */
-    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external;
 
     /**
      * @notice Owner-only function to pass through a call to `StrategyManager.removeStrategiesFromDepositWhitelist`

--- a/src/contracts/libraries/SlashingConstants.sol
+++ b/src/contracts/libraries/SlashingConstants.sol
@@ -14,5 +14,6 @@ library SlashingConstants {
     uint256 public constant PRECISION_FACTOR_SQUARED = 1e36;
 
     /// @dev Delay before deallocations are completable and can be added back into freeMagnitude
+    /// This is also the same delay for withdrawals to be completable
     uint32 public constant DEALLOCATION_DELAY = 17.5 days;
 }

--- a/src/contracts/strategies/StrategyFactory.sol
+++ b/src/contracts/strategies/StrategyFactory.sol
@@ -60,10 +60,8 @@ contract StrategyFactory is StrategyFactoryStorage, OwnableUpgradeable, Pausable
         );
         _setStrategyForToken(token, strategy);
         IStrategy[] memory strategiesToWhitelist = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         strategiesToWhitelist[0] = strategy;
-        thirdPartyTransfersForbiddenValues[0] = false;
-        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist);
         return strategy;
     }
 
@@ -106,17 +104,9 @@ contract StrategyFactory is StrategyFactoryStorage, OwnableUpgradeable, Pausable
      * @notice Owner-only function to pass through a call to `StrategyManager.addStrategiesToDepositWhitelist`
      */
     function whitelistStrategies(
-        IStrategy[] calldata strategiesToWhitelist,
-        bool[] calldata thirdPartyTransfersForbiddenValues
+        IStrategy[] calldata strategiesToWhitelist
     ) external onlyOwner {
-        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
-    }
-
-    /**
-     * @notice Owner-only function to pass through a call to `StrategyManager.setThirdPartyTransfersForbidden`
-     */
-    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external onlyOwner {
-        strategyManager.setThirdPartyTransfersForbidden(strategy, value);
+        strategyManager.addStrategiesToDepositWhitelist(strategiesToWhitelist);
     }
 
     /**

--- a/src/test/events/IStrategyManagerEvents.sol
+++ b/src/test/events/IStrategyManagerEvents.sol
@@ -46,9 +46,6 @@ interface IStrategyManagerEvents {
         bytes32 withdrawalRoot
     );
 
-    /// @notice Emitted when `thirdPartyTransfersForbidden` is updated for a strategy and value by the owner
-    event UpdatedThirdPartyTransfersForbidden(IStrategy strategy, bool value);
-
     /// @notice Emitted when the `strategyWhitelister` is changed
     event StrategyWhitelisterChanged(address previousAddress, address newAddress);
 

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1003,7 +1003,8 @@ abstract contract IntegrationBase is IntegrationDeployer {
         //         blocksToRoll = withdrawalDelayBlocks;
         //     }
         // }
-        cheats.roll(block.number + delegationManager.getWithdrawalDelay(strategies));
+        // TODO: Fix this with withdrawal changes
+        // cheats.roll(block.number + delegationManager.getWithdrawalDelay(strategies));
     }
 
     /// @dev Uses timewarp modifier to get operator shares at the last snapshot

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -589,7 +589,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
 
         // Whitelist strategy
         IStrategy[] memory strategies = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
         strategies[0] = strategy;
 
         if (forkType == MAINNET) {
@@ -599,7 +598,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             StrategyBaseTVLLimits(address(strategy)).setTVLLimits(type(uint256).max, type(uint256).max);
         } else {
             cheats.prank(strategyManager.strategyWhitelister());
-            strategyManager.addStrategiesToDepositWhitelist(strategies, _thirdPartyTransfersForbiddenValues);
+            strategyManager.addStrategiesToDepositWhitelist(strategies);
         }
 
         // Add to lstStrats and allStrats

--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -34,8 +34,6 @@ contract StrategyManagerMock is
 
     /// @notice Mapping: staker => cumulative number of queued withdrawals they have ever initiated. only increments (doesn't decrement)
     mapping(address => uint256) public cumulativeWithdrawalsQueued;
-    
-    mapping(IStrategy => bool) public thirdPartyTransfersForbidden;
 
     function setAddresses(IDelegationManager _delegation, IEigenPodManager _eigenPodManager, ISlasher _slasher) external
     {
@@ -76,11 +74,6 @@ contract StrategyManagerMock is
         require(_strategiesToReturn.length == _sharesToReturn.length, "StrategyManagerMock: length mismatch");
         strategiesToReturn[staker] = _strategiesToReturn;
         sharesToReturn[staker] = _sharesToReturn;
-    }
-
-    function setThirdPartyTransfersForbidden(IStrategy strategy, bool value) external {
-        emit UpdatedThirdPartyTransfersForbidden(strategy, value);
-        thirdPartyTransfersForbidden[strategy] = value;
     }
 
     /**
@@ -127,12 +120,10 @@ contract StrategyManagerMock is
     // function withdrawalDelayBlocks() external view returns (uint256) {}
 
     function addStrategiesToDepositWhitelist(
-        IStrategy[] calldata strategiesToWhitelist,
-        bool[] calldata thirdPartyTransfersForbiddenValues
+        IStrategy[] calldata strategiesToWhitelist
     ) external {
         for (uint256 i = 0; i < strategiesToWhitelist.length; ++i) {
             strategyIsWhitelistedForDeposit[strategiesToWhitelist[i]] = true;
-            thirdPartyTransfersForbidden[strategiesToWhitelist[i]] = thirdPartyTransfersForbiddenValues[i];
         }
     }
 

--- a/src/test/unit/AVSDirectoryUnit.t.sol
+++ b/src/test/unit/AVSDirectoryUnit.t.sol
@@ -198,8 +198,6 @@ contract AVSDirectoryUnitTests is EigenLayerUnitTestSetup, IAVSDirectoryEvents {
     ) internal view {
         // filter out zero address since people can't delegate to the zero address and operators are delegated to themselves
         cheats.assume(operator != address(0));
-        // filter out disallowed stakerOptOutWindowBlocks values
-        cheats.assume(operatorDetails.stakerOptOutWindowBlocks <= delegationManager.MAX_STAKER_OPT_OUT_WINDOW_BLOCKS());
     }
 
     function _registerOperatorToOperatorSet(

--- a/src/test/unit/StrategyFactoryUnit.t.sol
+++ b/src/test/unit/StrategyFactoryUnit.t.sol
@@ -116,7 +116,6 @@ contract StrategyFactoryUnitTests is EigenLayerUnitTestSetup {
         require(newStrategy.pauserRegistry() == pauserRegistry, "pauserRegistry not set correctly");
         require(newStrategy.underlyingToken() == underlyingToken, "underlyingToken not set correctly");
         require(strategyManagerMock.strategyIsWhitelistedForDeposit(newStrategy), "underlyingToken is not whitelisted");
-        require(!strategyManagerMock.thirdPartyTransfersForbidden(newStrategy), "newStrategy has 3rd party transfers forbidden");
     }
 
     function test_deployNewStrategy_revert_StrategyAlreadyExists() public {
@@ -159,38 +158,18 @@ contract StrategyFactoryUnitTests is EigenLayerUnitTestSetup {
     function test_whitelistStrategies() public {
         StrategyBase strategy = _deployStrategy();
         IStrategy[] memory strategiesToWhitelist = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         strategiesToWhitelist[0] = strategy;
-        thirdPartyTransfersForbiddenValues[0] = true;
-        strategyFactory.whitelistStrategies(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
+        strategyFactory.whitelistStrategies(strategiesToWhitelist);
 
         assertTrue(strategyManagerMock.strategyIsWhitelistedForDeposit(strategy), "Strategy not whitelisted");
-        require(strategyManagerMock.thirdPartyTransfersForbidden(strategy), "3rd party transfers forbidden not set correctly");
     }
 
     function test_whitelistStrategies_revert_notOwner() public {
         IStrategy[] memory strategiesToWhitelist = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
 
         cheats.expectRevert("Ownable: caller is not the owner");
         cheats.prank(notOwner);
-        strategyFactory.whitelistStrategies(strategiesToWhitelist, thirdPartyTransfersForbiddenValues);
-    }
-
-    function test_setThirdPartyTransfersForbidden_revert_notOwner() public {
-        IStrategy strategy;
-
-        cheats.expectRevert("Ownable: caller is not the owner");
-        cheats.prank(notOwner);
-        strategyFactory.setThirdPartyTransfersForbidden(strategy, true);
-    }
-
-    function test_setThirdPartyTransfersFrobidden() public {
-        StrategyBase strategy = _deployStrategy();
-        bool thirdPartyTransfersForbidden = true;
-
-        strategyFactory.setThirdPartyTransfersForbidden(strategy, thirdPartyTransfersForbidden);
-        assertTrue(strategyManagerMock.thirdPartyTransfersForbidden(strategy), "3rd party transfers forbidden not set");
+        strategyFactory.whitelistStrategies(strategiesToWhitelist);
     }
 
     function test_removeStrategiesFromWhitelist_revert_notOwner() public {

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -66,17 +66,12 @@ contract StrategyManagerUnitTests is EigenLayerUnitTestSetup, IStrategyManagerEv
         _strategies[0] = dummyStrat;
         _strategies[1] = dummyStrat2;
         _strategies[2] = dummyStrat3;
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](3);
-        _thirdPartyTransfersForbiddenValues[0] = false;
-        _thirdPartyTransfersForbiddenValues[1] = false;
-        _thirdPartyTransfersForbiddenValues[2] = false;
         for (uint256 i = 0; i < _strategies.length; ++i) {
             cheats.expectEmit(true, true, true, true, address(strategyManager));
             emit StrategyAddedToDepositWhitelist(_strategies[i]);
-            cheats.expectEmit(true, true, true, true, address(strategyManager));
-            emit UpdatedThirdPartyTransfersForbidden(_strategies[i], _thirdPartyTransfersForbiddenValues[i]);
+
         }
-        strategyManager.addStrategiesToDepositWhitelist(_strategies, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategies);
 
         addressIsExcludedFromFuzzedInputs[address(reenterer)] = true;
     }
@@ -219,7 +214,6 @@ contract StrategyManagerUnitTests is EigenLayerUnitTestSetup, IStrategyManagerEv
      */
     function _addStrategiesToWhitelist(uint8 numberOfStrategiesToAdd) internal returns (IStrategy[] memory) {
         IStrategy[] memory strategyArray = new IStrategy[](numberOfStrategiesToAdd);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](numberOfStrategiesToAdd);
         // loop that deploys a new strategy and adds it to the array
         for (uint256 i = 0; i < numberOfStrategiesToAdd; ++i) {
             IStrategy _strategy = _deployNewStrategy(dummyToken, strategyManager, pauserRegistry, dummyAdmin);
@@ -232,7 +226,7 @@ contract StrategyManagerUnitTests is EigenLayerUnitTestSetup, IStrategyManagerEv
             cheats.expectEmit(true, true, true, true, address(strategyManager));
             emit StrategyAddedToDepositWhitelist(strategyArray[i]);
         }
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
 
         for (uint256 i = 0; i < numberOfStrategiesToAdd; ++i) {
             assertTrue(strategyManager.strategyIsWhitelistedForDeposit(strategyArray[i]), "strategy not whitelisted");
@@ -342,13 +336,12 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         _strategy[0] = IStrategy(address(reenterer));
         for (uint256 i = 0; i < _strategy.length; ++i) {
             cheats.expectEmit(true, true, true, true, address(strategyManager));
             emit StrategyAddedToDepositWhitelist(_strategy[i]);
         }
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         reenterer.prepareReturnData(abi.encode(amount));
@@ -374,10 +367,9 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
 
         _strategy[0] = dummyStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = address(this);
@@ -398,9 +390,8 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
         _strategy[0] = dummyStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = address(this);
@@ -420,9 +411,8 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
         _strategy[0] = dummyStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = address(this);
@@ -442,10 +432,9 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
 
         _strategy[0] = dummyStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = address(this);
@@ -480,10 +469,9 @@ contract StrategyManagerUnitTests_depositIntoStrategy is StrategyManagerUnitTest
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
 
         _strategy[0] = dummyStrat;
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = address(this);
@@ -692,15 +680,13 @@ contract StrategyManagerUnitTests_depositIntoStrategyWithSignature is StrategyMa
         // whitelist the strategy for deposit
         cheats.startPrank(strategyManager.owner());
         IStrategy[] memory _strategy = new IStrategy[](1);
-        bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
-
         
         _strategy[0] = IStrategy(address(reenterer));
         for (uint256 i = 0; i < _strategy.length; ++i) {
             cheats.expectEmit(true, true, true, true, address(strategyManager));
             emit StrategyAddedToDepositWhitelist(_strategy[i]);
         }
-        strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(_strategy);
         cheats.stopPrank();
 
         address staker = cheats.addr(privateKey);
@@ -785,19 +771,6 @@ contract StrategyManagerUnitTests_depositIntoStrategyWithSignature is StrategyMa
         string
             memory expectedRevertMessage = "StrategyManager.onlyStrategiesWhitelistedForDeposit: strategy not whitelisted";
         _depositIntoStrategyWithSignature(staker, amount, type(uint256).max, expectedRevertMessage);
-    }
-    
-    function testFuzz_Revert_WhenThirdPartyTransfersForbidden(uint256 amount, uint256 expiry) public {
-        // min shares must be minted on strategy
-        cheats.assume(amount >= 1);
-
-        cheats.prank(strategyManager.strategyWhitelister());
-        strategyManager.setThirdPartyTransfersForbidden(dummyStrat, true);
-
-        address staker = cheats.addr(privateKey);
-        // not expecting a revert, so input an empty string
-        string memory expectedRevertMessage = "StrategyManager.depositIntoStrategyWithSignature: third transfers disabled";
-        _depositIntoStrategyWithSignature(staker, amount, expiry, expectedRevertMessage);
     }
 }
 
@@ -1090,10 +1063,9 @@ contract StrategyManagerUnitTests_addShares is StrategyManagerUnitTests {
             // whitelist the strategy for deposit
             cheats.startPrank(strategyManager.owner());
             IStrategy[] memory _strategy = new IStrategy[](1);
-            bool[] memory _thirdPartyTransfersForbiddenValues = new bool[](1);
 
             _strategy[0] = dummyStrat;
-            strategyManager.addStrategiesToDepositWhitelist(_strategy, _thirdPartyTransfersForbiddenValues);
+            strategyManager.addStrategiesToDepositWhitelist(_strategy);
             cheats.stopPrank();
         }
 
@@ -1184,43 +1156,38 @@ contract StrategyManagerUnitTests_addStrategiesToDepositWhitelist is StrategyMan
     ) external filterFuzzedAddressInputs(notStrategyWhitelister) {
         cheats.assume(notStrategyWhitelister != strategyManager.strategyWhitelister());
         IStrategy[] memory strategyArray = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         IStrategy _strategy = _deployNewStrategy(dummyToken, strategyManager, pauserRegistry, dummyAdmin);
         strategyArray[0] = _strategy;
 
         cheats.prank(notStrategyWhitelister);
         cheats.expectRevert("StrategyManager.onlyStrategyWhitelister: not the strategyWhitelister");
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
     }
 
     function test_AddSingleStrategyToWhitelist() external {
         IStrategy[] memory strategyArray = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         IStrategy strategy = _deployNewStrategy(dummyToken, strategyManager, pauserRegistry, dummyAdmin);
         strategyArray[0] = strategy;
         assertFalse(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should not be whitelisted");
         cheats.expectEmit(true, true, true, true, address(strategyManager));
         emit StrategyAddedToDepositWhitelist(strategy);
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
         assertTrue(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should be whitelisted");
     }
 
     function test_AddAlreadyWhitelistedStrategy() external {
         IStrategy[] memory strategyArray = new IStrategy[](1);
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         IStrategy strategy = _deployNewStrategy(dummyToken, strategyManager, pauserRegistry, dummyAdmin);
         strategyArray[0] = strategy;
         assertFalse(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should not be whitelisted");
         cheats.expectEmit(true, true, true, true, address(strategyManager));
         emit StrategyAddedToDepositWhitelist(strategy);
-        cheats.expectEmit(true, true, true, true, address(strategyManager));
-        emit UpdatedThirdPartyTransfersForbidden(strategy, false);
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
         assertTrue(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should be whitelisted");
         // Make sure event not emitted by checking logs length
         cheats.recordLogs();
         uint256 numLogsBefore = cheats.getRecordedLogs().length;
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
         uint256 numLogsAfter = cheats.getRecordedLogs().length;
         assertEq(numLogsBefore, numLogsAfter, "event emitted when strategy already whitelisted");
         assertTrue(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should still be whitelisted");
@@ -1272,12 +1239,11 @@ contract StrategyManagerUnitTests_removeStrategiesFromDepositWhitelist is Strate
         IStrategy[] memory strategyArray = new IStrategy[](1);
         IStrategy strategy = _deployNewStrategy(dummyToken, strategyManager, pauserRegistry, dummyAdmin);
         strategyArray[0] = strategy;
-        bool[] memory thirdPartyTransfersForbiddenValues = new bool[](1);
         assertFalse(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should not be whitelisted");
         // Add strategy to whitelist first
         cheats.expectEmit(true, true, true, true, address(strategyManager));
         emit StrategyAddedToDepositWhitelist(strategy);
-        strategyManager.addStrategiesToDepositWhitelist(strategyArray, thirdPartyTransfersForbiddenValues);
+        strategyManager.addStrategiesToDepositWhitelist(strategyArray);
         assertTrue(strategyManager.strategyIsWhitelistedForDeposit(strategy), "strategy should be whitelisted");
 
         // Now remove strategy from whitelist


### PR DESCRIPTION
**Description**:
1. Includes support for legacy M2 withdrawals
The withdrawal struct has converted the uint32 `startBlock` field to `startTimestamp`. We simply check that this value is < `LEGACY_WITHDRAWALS_TIMESTAMP` (Jan 01 2025 17:00:00 GMT+0000) and process as an old legacy withdrawal if so. We just need to ensure this timestamped value is < whatever the current timestamp is when the upgrade takes place. It would take 600+ years for the current blocknumber on mainnet to reach this threshold. We should be good

3. Removing thirdPartyTransfersForbidden and deprecating the storage


**DM codesize after cleanup and optimizer-runs = 5**
![image](https://github.com/user-attachments/assets/1c37e0cc-8705-4cb9-be65-f40fb9017e7d)
