### PR TITLE
eigenpods slashing updates

### DIFF
--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -116,9 +116,13 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      */
     mapping(IStrategy => uint256) private __deprecated_strategyWithdrawalDelayBlocks;
 
-    /// @notice Mapping: staker => strategy => scaling factor used to calculate the staker's shares in the strategy.
-    /// This is updated upon each deposit based on the staker's currently delegated operator's totalMagnitude.
-    mapping(address => mapping(IStrategy => uint256)) public depositScalingFactors;
+    /// @notice Mapping: staker => strategy =>
+    ///    (
+    ///       scaling factor used to calculate the staker's shares in the strategy,
+    ///       beacon chain scaling factor used to calculate the staker's withdrawable shares in the strategy.
+    ///    )
+    /// Note that we don't need the beaconChainScalingFactor for non beaconChainETHStrategy strategies, but it's nicer syntactically to keep it.
+    mapping(address => mapping(IStrategy => StakerScalingFactors)) public stakerScalingFactors;
 
     constructor(
         IStrategyManager _strategyManager,

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -18,6 +18,8 @@ import "../libraries/SlashingLib.sol";
 interface IDelegationManager is ISignatureUtils {
     /// @dev Thrown when msg.sender is not allowed to call a function
     error UnauthorizedCaller();
+    /// @dev Thrown when msg.sender is not the EigenPodManager
+    error OnlyEigenPodManager();
 
     /// Delegation Status
 
@@ -362,19 +364,21 @@ interface IDelegationManager is ISignatureUtils {
         OwnedShares addedOwnedShares
     ) external;
 
-    /**
-     * @notice Decreases a staker's delegated share balance in a strategy. Note that before removing from operator shares,
-     * the delegated shares are scaled according to the operator's total magnitude as part of slashing accounting. Unlike
-     * `increaseDelegatedShares`, the staker's depositScalingFactor is not updated here.
-     * @param staker The address to increase the delegated scaled shares for their operator.
-     * @param strategy The strategy in which to decrease the delegated scaled shares.
-     * @param removedOwnedShares The number of shares to decremented for the strategy in the
-     * StrategyManager/EigenPodManager
+        /**
+     * @notice Decreases a native restaker's delegated share balance in a strategy due to beacon chain slashing. This updates their beaconChainScalingFactor.
+     * Their operator's stakeShares are also updated (if they are delegated).
+     * @param staker The address to increase the delegated stakeShares for their operator.
+     * @param existingShares The number of shares the staker already has in the EPM. This does not change upon decreasing shares.
+     * @param proportionOfOldBalance The current pod owner shares proportion of the previous pod owner shares
      *
-     * @dev *If the staker is actively delegated*, then decreases the `staker`'s delegated scaled shares in `strategy` by `scaledShares`. Otherwise does nothing.
-     * @dev Callable only by the StrategyManager or EigenPodManager.
+     * @dev *If the staker is actively delegated*, then decreases the `staker`'s delegated stakeShares in `strategy` by `proportionPodBalanceDecrease` proportion. Otherwise does nothing.
+     * @dev Callable only by the EigenPodManager.
      */
-    function decreaseDelegatedShares(address staker, IStrategy strategy, OwnedShares removedOwnedShares) external;
+    function decreaseBeaconChainScalingFactor(
+        address staker,
+        Shares existingShares,
+        uint64 proportionOfOldBalance
+    ) external;
 
     /**
      * @notice returns the address of the operator that `staker` is delegated to.

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -102,9 +102,14 @@ interface IEigenPod {
         bytes32 beaconBlockRoot;
         uint24 proofsRemaining;
         uint64 podBalanceGwei;
-        int128 balanceDeltasGwei;
+        // this used to be an int128 before the slashing release
+        // now it is an int64. (2^63 - 1) gwei * 1e-9 eth/gwei = 9_223_372_036.85 eth = 9 billion eth
+        int64 balanceDeltasGwei;
+        uint64 beaconChainBalanceBeforeGwei;
+    }
+
+    struct ExtendedCheckpoint {
         uint128 beaconChainBalanceBefore;
-        uint128 beaconChainBalanceAfter;
     }
 
     /**

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -13,8 +13,12 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  *   to account balances in terms of gwei in the EigenPod contract and convert to wei when making calls to other contracts
  */
 interface IEigenPod {
-    /// @dev Thrown when msg.sender is not allowed to call a function
-    error UnauthorizedCaller();
+    /// @dev Thrown when msg.sender is not the EPM.
+    error OnlyEigenPodManager();
+    /// @dev Thrown when msg.sender is not the pod owner.
+    error OnlyEigenPodOwner();
+    /// @dev Thrown when msg.sender is not owner or the proof submitter.
+    error OnlyEigenPodOwnerOrProofSubmitter();
     /// @dev Thrown when attempting an action that is currently paused.
     error CurrentlyPaused();
 
@@ -99,6 +103,8 @@ interface IEigenPod {
         uint24 proofsRemaining;
         uint64 podBalanceGwei;
         int128 balanceDeltasGwei;
+        uint128 beaconChainBalanceBefore;
+        uint128 beaconChainBalanceAfter;
     }
 
     /**

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -28,6 +28,9 @@ interface IEigenPodManager is IShareManager, IPausable {
     error SharesNegative();
     /// @dev Thrown when the strategy is not the beaconChainETH strategy.
     error InvalidStrategy();
+     /// @dev Thrown when the pods shares are negative and a beacon chain balance update is attempted. 
+     /// The podOwner should complete legacy withdrawal first.
+    error LegacyWithdrawalsNotCompleted();
 
     /// @notice Emitted to notify the deployment of an EigenPod
     event PodDeployed(address indexed eigenPod, address indexed podOwner);
@@ -72,10 +75,15 @@ interface IEigenPodManager is IShareManager, IPausable {
      * to ensure that delegated shares are also tracked correctly
      * @param podOwner is the pod owner whose balance is being updated.
      * @param sharesDelta is the change in podOwner's beaconChainETHStrategy shares
+     * @param proportionPodBalanceDecrease is the proportion (of WAD) of the podOwner's balance that has changed
      * @dev Callable only by the podOwner's EigenPod contract.
      * @dev Reverts if `sharesDelta` is not a whole Gwei amount
      */
-    function recordBeaconChainETHBalanceUpdate(address podOwner, int256 sharesDelta) external;
+    function recordBeaconChainETHBalanceUpdate(
+        address podOwner,
+        int256 sharesDelta,
+        uint64 proportionPodBalanceDecrease
+    ) external;
 
     /// @notice Returns the address of the `podOwner`'s EigenPod if it has been deployed.
     function ownerToPod(

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -10,7 +10,7 @@ uint64 constant WAD = 1e18;
 
 /*
  * There are 3 types of shares:
- *      1. ownedShares
+ *      1. shares
  *          - These can be converted to an amount of tokens given a strategy
  *              - by calling `sharesToUnderlying` on the strategy address (they're already tokens 
  *              in the case of EigenPods)
@@ -35,71 +35,32 @@ uint64 constant WAD = 1e18;
  *          - These live in the storage of the StrategyManager/EigenPodManager
  *              - `stakerStrategyShares` in the SM is the staker's shares that have not been queued for withdrawal in a strategy
  *              - `podOwnerShares` in the EPM is the staker's shares that have not been queued for withdrawal in the beaconChainETHStrategy
+ * 
+ * Note that `withdrawal.delegatedShares` is scaled for the beaconChainETHStrategy to divide by the beaconChainScalingFactor upon queueing
+ * and multiply by the beaconChainScalingFactor upon withdrawal
  */
 
 type OwnedShares is uint256;
 type DelegatedShares is uint256;
 type Shares is uint256;
+struct StakerScalingFactors {
+    uint256 depositScalingFactor;
+
+    // we need to know if the beaconChainScalingFactor is set because it can be set to 0 through 100% slashing
+    bool isBeaconChainScalingFactorSet;
+    uint64 beaconChainScalingFactor;
+}
+
 
 using SlashingLib for OwnedShares global;
 using SlashingLib for DelegatedShares global;
 using SlashingLib for Shares global;
+using SlashingLib for StakerScalingFactors global;
 
+// TODO: validate order of operations everywhere
 library SlashingLib {
     using Math for uint256;
     using SlashingLib for uint256;
-
-    function toShares(
-        DelegatedShares delegatedShares,
-        uint256 depositScalingFactor
-    ) internal pure returns (Shares) {
-        if (depositScalingFactor == 0) {
-            depositScalingFactor = WAD;
-        }
-
-        // forgefmt: disable-next-item
-        return delegatedShares
-            .unwrap()
-            .divWad(depositScalingFactor)
-            .wrapShares();
-    }
-
-    function toDelegatedShares(
-        Shares shares,
-        uint256 depositScalingFactor
-    ) internal pure returns (DelegatedShares) {
-        if (depositScalingFactor == 0) {
-            depositScalingFactor = WAD;
-        }
-
-        // forgefmt: disable-next-item
-        return shares
-            .unwrap()
-            .mulWad(depositScalingFactor)
-            .wrapDelegated();
-    }
-
-    function toOwnedShares(
-        DelegatedShares delegatedShares, 
-        uint256 magnitude
-    ) internal pure returns (OwnedShares) {
-        // forgefmt: disable-next-item
-        return delegatedShares
-            .unwrap()
-            .mulWad(magnitude)
-            .wrapOwned();
-    }
-
-    function toDelegatedShares(
-        OwnedShares shares, 
-        uint256 magnitude
-    ) internal pure returns (DelegatedShares) {
-        // forgefmt: disable-next-item
-        return shares
-            .unwrap()
-            .divWad(magnitude)
-            .wrapDelegated();
-    }
 
     // MATH
 
@@ -139,6 +100,71 @@ library SlashingLib {
         return x.unwrap() - y;
     }
 
+    /// @dev beaconChainScalingFactor = 0 -> WAD for all non beaconChainETH strategies
+    function toShares(
+        DelegatedShares delegatedShares,
+        StakerScalingFactors storage ssf
+    ) internal view returns (Shares) {
+        return delegatedShares.unwrap()
+                .divWad(ssf.getDepositScalingFactor())
+                .divWad(ssf.getBeaconChainScalingFactor())
+                .wrapShares();
+    }
+
+    function toDelegatedShares(
+        OwnedShares shares, 
+        uint256 magnitude
+    ) internal pure returns (DelegatedShares) {
+        // forgefmt: disable-next-item
+        return shares
+            .unwrap()
+            .divWad(magnitude)
+            .wrapDelegated();
+    }
+
+    function toOwnedShares(DelegatedShares delegatedShares, uint256 magnitude) internal view returns (OwnedShares) {
+        return delegatedShares
+                .unwrap()
+                .mulWad(magnitude)
+                .wrapOwned();
+    }
+
+    function scaleForQueueWithdrawal(DelegatedShares delegatedShares, StakerScalingFactors storage ssf) internal view returns (DelegatedShares) {
+        return delegatedShares
+                .unwrap()
+                .divWad(ssf.getBeaconChainScalingFactor())
+                .wrapDelegated();
+    }
+
+    function scaleForCompleteWithdrawal(DelegatedShares delegatedShares, StakerScalingFactors storage ssf) internal view returns (DelegatedShares) {
+        return delegatedShares
+                .unwrap()
+                .mulWad(ssf.getBeaconChainScalingFactor())
+                .wrapDelegated();
+    }
+
+    function decreaseBeaconChainScalingFactor(StakerScalingFactors storage ssf, uint64 proportionOfOldBalance) internal {
+        ssf.beaconChainScalingFactor = uint64(uint256(ssf.beaconChainScalingFactor).mulWad(proportionOfOldBalance));
+        ssf.isBeaconChainScalingFactorSet = true;
+    }
+
+    /// @dev beaconChainScalingFactor = 0 -> WAD for all non beaconChainETH strategies
+    function toDelegatedShares(
+        Shares shares,
+        StakerScalingFactors storage ssf
+    ) internal view returns (DelegatedShares) {
+        return shares.unwrap()
+                .mulWad(ssf.getDepositScalingFactor())
+                .mulWad(ssf.getBeaconChainScalingFactor())
+                .wrapDelegated();
+    }
+
+    function toDelegatedShares(Shares shares, uint256 magnitude) internal view returns (DelegatedShares) {
+        return shares.unwrap()
+                .mulWad(magnitude)
+                .wrapDelegated();
+    }
+
     // WAD MATH
 
     function mulWad(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -173,5 +199,13 @@ library SlashingLib {
 
     function wrapOwned(uint256 x) internal pure returns (OwnedShares) {
         return OwnedShares.wrap(x);
+    }
+
+    function getDepositScalingFactor(StakerScalingFactors storage ssf) internal view returns (uint256) {
+        return ssf.depositScalingFactor == 0 ? WAD : ssf.depositScalingFactor;
+    }
+    
+    function getBeaconChainScalingFactor(StakerScalingFactors storage ssf) internal view returns (uint64) {
+        return !ssf.isBeaconChainScalingFactorSet && ssf.beaconChainScalingFactor == 0 ? WAD : ssf.beaconChainScalingFactor;
     }
 }

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -10,7 +10,7 @@ uint64 constant WAD = 1e18;
 
 /*
  * There are 3 types of shares:
- *      1. shares
+ *      1. ownedShares
  *          - These can be converted to an amount of tokens given a strategy
  *              - by calling `sharesToUnderlying` on the strategy address (they're already tokens 
  *              in the case of EigenPods)

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -189,7 +189,7 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
             // If the proof shows the validator has a balance of 0, they are marked `WITHDRAWN`.
             // The assumption is that if this is the case, any withdrawn ETH was already in
             // the pod when `startCheckpoint` was originally called.
-            (int128 balanceDeltaGwei, uint64 exitedBalanceGwei) = _verifyCheckpointProof({
+            (uint64 prevBalanceGwei, int64 balanceDeltaGwei, uint64 exitedBalanceGwei) = _verifyCheckpointProof({
                 validatorInfo: validatorInfo,
                 checkpointTimestamp: checkpointTimestamp,
                 balanceContainerRoot: balanceContainerProof.balanceContainerRoot,
@@ -197,6 +197,7 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
             });
 
             checkpoint.proofsRemaining--;
+            checkpoint.beaconChainBalanceBeforeGwei += prevBalanceGwei;
             checkpoint.balanceDeltasGwei += balanceDeltaGwei;
             exitedBalancesGwei += exitedBalanceGwei;
 
@@ -258,6 +259,10 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
                 validatorFieldsProofs[i],
                 validatorFields[i]
             );
+        }
+
+        if (currentCheckpointTimestamp != 0) {
+            _currentCheckpoint.beaconChainBalanceBeforeGwei += uint64(totalAmountToBeRestakedWei / GWEI_TO_WEI);
         }
 
         // Update the EigenPodManager on this pod's new balance
@@ -493,8 +498,6 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
         uint64 lastCheckpointedAt = lastCheckpointTimestamp;
         if (currentCheckpointTimestamp != 0) {
             lastCheckpointedAt = currentCheckpointTimestamp;
-            _currentCheckpoint.beaconChainBalanceBefore += uint128(restakedBalanceGwei);
-            _currentCheckpoint.beaconChainBalanceAfter += uint128(restakedBalanceGwei);
         }
 
         // Proofs complete - create the validator in state
@@ -515,11 +518,11 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
         uint64 checkpointTimestamp,
         bytes32 balanceContainerRoot,
         BeaconChainProofs.BalanceProof calldata proof
-    ) internal returns (int128 balanceDeltaGwei, uint64 exitedBalanceGwei) {
+    ) internal returns (uint64 prevBalanceGwei, int64 balanceDeltaGwei, uint64 exitedBalanceGwei) {
         uint40 validatorIndex = uint40(validatorInfo.validatorIndex);
 
         // Verify validator balance against `balanceContainerRoot`
-        uint64 prevBalanceGwei = validatorInfo.restakedBalanceGwei;
+        prevBalanceGwei = validatorInfo.restakedBalanceGwei;
         uint64 newBalanceGwei = BeaconChainProofs.verifyValidatorBalance({
             balanceContainerRoot: balanceContainerRoot,
             validatorIndex: validatorIndex,
@@ -534,10 +537,6 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
                 previousAmountGwei: prevBalanceGwei
             });
 
-            // Update the checkpoint values
-            _currentCheckpoint.beaconChainBalanceBefore += uint128(prevBalanceGwei);
-            _currentCheckpoint.beaconChainBalanceAfter += uint128(newBalanceGwei);
-
             emit ValidatorBalanceUpdated(validatorIndex, checkpointTimestamp, newBalanceGwei);
         }
 
@@ -550,12 +549,12 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
             validatorInfo.status = VALIDATOR_STATUS.WITHDRAWN;
             // If we reach this point, `balanceDeltaGwei` should always be negative,
             // so this should be a safe conversion
-            exitedBalanceGwei = uint64(uint128(-balanceDeltaGwei));
+            exitedBalanceGwei = uint64(-balanceDeltaGwei);
 
             emit ValidatorWithdrawn(checkpointTimestamp, validatorIndex);
         }
 
-        return (balanceDeltaGwei, exitedBalanceGwei);
+        return (prevBalanceGwei, balanceDeltaGwei, exitedBalanceGwei);
     }
 
     /**
@@ -607,8 +606,7 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
             proofsRemaining: uint24(activeValidatorCount),
             podBalanceGwei: podBalanceGwei,
             balanceDeltasGwei: 0,
-            beaconChainBalanceBefore: 0,
-            beaconChainBalanceAfter: 0
+            beaconChainBalanceBeforeGwei: 0
         });
 
         // Place checkpoint in storage. If `proofsRemaining` is 0, the checkpoint
@@ -646,8 +644,8 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
             // Calculate the slashing proportion
             uint64 proportionOfOldBalance = 0;
             if (totalShareDeltaWei < 0) {
-                uint256 totalBefore = withdrawableRestakedExecutionLayerGwei + checkpoint.beaconChainBalanceBefore;
-                proportionOfOldBalance = uint64((totalBefore + uint256(-totalShareDeltaWei)) * WAD / totalBefore);
+                uint256 totalRestakedBeforeWei = (withdrawableRestakedExecutionLayerGwei + checkpoint.beaconChainBalanceBeforeGwei) * GWEI_TO_WEI;
+                proportionOfOldBalance = uint64((totalRestakedBeforeWei + uint256(-totalShareDeltaWei)) * WAD / totalRestakedBeforeWei);
             }
 
             // Update pod owner's shares
@@ -675,8 +673,8 @@ contract EigenPod is Initializable, ReentrancyGuardUpgradeable, EigenPodPausingC
     }
 
     /// @dev Calculates the delta between two Gwei amounts and returns as an int256
-    function _calcBalanceDelta(uint64 newAmountGwei, uint64 previousAmountGwei) internal pure returns (int128) {
-        return int128(uint128(newAmountGwei)) - int128(uint128(previousAmountGwei));
+    function _calcBalanceDelta(uint64 newAmountGwei, uint64 previousAmountGwei) internal pure returns (int64) {
+        return int64(newAmountGwei) - int64(previousAmountGwei);
     }
 
     /**

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -68,7 +68,7 @@ abstract contract EigenPodStorage is IEigenPod {
     mapping(uint64 => uint64) public checkpointBalanceExitedGwei;
 
     /// @notice The current checkpoint, if there is one active
-    Checkpoint internal _currentCheckpoint;
+    Checkpoint internal _currentCheckpoint; // TODO: this storage is fucked need split structs
 
     /// @notice An address with permissions to call `startCheckpoint` and `verifyWithdrawalCredentials`, set
     /// by the podOwner. This role exists to allow a podOwner to designate a hot wallet that can call
@@ -81,5 +81,5 @@ abstract contract EigenPodStorage is IEigenPod {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[36] private __gap;
+    uint256[35] private __gap; // Reduced the gap size by 1 to accommodate the new variable
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -68,7 +68,7 @@ abstract contract EigenPodStorage is IEigenPod {
     mapping(uint64 => uint64) public checkpointBalanceExitedGwei;
 
     /// @notice The current checkpoint, if there is one active
-    Checkpoint internal _currentCheckpoint; // TODO: this storage is fucked need split structs
+    Checkpoint internal _currentCheckpoint; 
 
     /// @notice An address with permissions to call `startCheckpoint` and `verifyWithdrawalCredentials`, set
     /// by the podOwner. This role exists to allow a podOwner to designate a hot wallet that can call
@@ -76,10 +76,13 @@ abstract contract EigenPodStorage is IEigenPod {
     /// @dev If this address is NOT set, only the podOwner can call `startCheckpoint` and `verifyWithdrawalCredentials`
     address public proofSubmitter;
 
+    /// @notice The total balance of the pod before the current checkpoint
+    uint128 public beaconChainBalanceBeforeCurrentCheckpoint;
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[35] private __gap; // Reduced the gap size by 1 to accommodate the new variable
+    uint256[35] private __gap;
 }


### PR DESCRIPTION
## Summary
This proposal
- this would get rid of negative shares (going forward)
- more intuitive slashing model between LSTs and EigenPods

by using a separate beaconChainScalingFactor that is decreased upon negative deltas

## Migration

### WIP: EigenPod.sol

Since EigenPods are updated to record a _proportion delta_ in the EPM instead of the abosolute share delta upon deposits, an "edge" case exists where uncompleted checkpoints exist during the slashing upgrade and can no longer call back to the EPM.

I'm still looking into it but I believe our choices are the following:

1. Pause/Unpause
a. pause checkpoint creation
b. complete all existing checkpoints
c. execute the slashing upgrade
d. unpause checkpoint creation (we'd already have an unpause tx in the timelock controller)
2. Upgrade pods in UNIPRINT
a. upgrade EigenPod.sol in UNIPRINT to keep track of total beaconChain shares before and after checkpoints, but don't change any interactions (i.e. don't upgrade the EPM or DM)
b. make sure all existing checkpoints that were started before UNIPRINT are completed (via completion if necessary)
c. execute the slashing upgrade (this works because deltas are easily calculable from total beaconChain shares, which were kept track of in a)
3. Keep decreaseDelegatedShares around in the DM/EPM for the existing checkpoints at time of queueing
a. decreaseDelegatedShares would only be called for negative deltas that result from existing checkpoints from before the slashing release

(1) is less operations than (2), but more time pressure and downtime than (2).
(3) is less operations than (2), better uptime and time pressure than (1), but is the most code.

Still looking for way to calculate share deltas without changing what we're keeping track of but doesn't look promising


### Getting all shares positive

Next, we need to make sure all podOwnerShares are positive in order for checkpoints to successfully go through.

The only way that a pod's shares are negative is that the podOwner has queued a bunch of withdrawals and negative share deltas have occured afterwards. The pod's shares can always become nonnegative if all withdrawals are completed.  So in order to migrate to a nonnegative share system, we essentially break all shareDeltas from being propagated to the EPM until the podOwner completes enough withdrawals to make their shares nonnegative. 

### UX

This doesn't effect AVS UX because the podOwner's shares are not counted in the DM if they're already negative, so they don't care about further updates.

It effects podOwner UX, since they must complete their withdrawals before completing any more checkpoints. In addition, there is a small pause in checkpoint creation.