### PR TITLE
refactor: receive as shares callback

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -709,25 +709,27 @@ contract DelegationManager is
              */
             if (withdrawal.strategies[i] == beaconChainETHStrategy) {
                 // TODO: REFACTOR EPM AND NEGATIVE SHARES
+                // below commented code will simply be the following:
+                // eigenPodManager.addShares({podOwner: withdrawal.staker, shares: shares});
 
-                address staker = withdrawal.staker;
-                /**
-                 * Update shares amount depending upon the returned value.
-                 * The return value will be lower than the input value in the case where the staker has an existing share deficit
-                 */
-                (shares, existingShares) = eigenPodManager.addShares({podOwner: staker, shares: shares});
-                address podOwnerOperator = delegatedTo[staker];
-                // Similar to `isDelegated` logic
-                if (podOwnerOperator != address(0)) {
-                    _increaseOperatorScaledShares({
-                        operator: podOwnerOperator,
-                        // the 'staker' here is the address receiving new shares
-                        staker: staker,
-                        strategy: withdrawal.strategies[i],
-                        shares: shares,
-                        totalMagnitude: totalMagnitudes[i]
-                    });
-                }
+                // address staker = withdrawal.staker;
+                // /**
+                //  * Update shares amount depending upon the returned value.
+                //  * The return value will be lower than the input value in the case where the staker has an existing share deficit
+                //  */
+                // (shares, existingShares) = eigenPodManager.addShares({podOwner: staker, shares: shares});
+                // address podOwnerOperator = delegatedTo[staker];
+                // // Similar to `isDelegated` logic
+                // if (podOwnerOperator != address(0)) {
+                //     _increaseOperatorScaledShares({
+                //         operator: podOwnerOperator,
+                //         // the 'staker' here is the address receiving new shares
+                //         staker: staker,
+                //         strategy: withdrawal.strategies[i],
+                //         shares: shares,
+                //         totalMagnitude: totalMagnitudes[i]
+                //     });
+                // }
             } else {
                 strategyManager.addShares(msg.sender, tokens[i], withdrawal.strategies[i], shares);
             }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -610,33 +610,7 @@ contract DelegationManager is
             timestamp: withdrawal.startTimestamp + MIN_WITHDRAWAL_DELAY
         });
 
-        if (receiveAsTokens) {
-            // complete the withdrawal by converting shares to tokens
-            _completeReceiveAsTokens(withdrawal, tokens, totalMagnitudes, isLegacyWithdrawal);
-        } else {
-            // Award shares back in StrategyManager/EigenPodManager.
-            _completeReceiveAsShares(withdrawal, tokens, totalMagnitudes, isLegacyWithdrawal);
-        }
-
-        // Remove `withdrawalRoot` from pending roots
-        delete pendingWithdrawals[withdrawalRoot];
-        emit WithdrawalCompleted(withdrawalRoot);
-    }
-
-    /**
-     * @dev This function completes a queued withdrawal for a staker by converting shares to tokens and transferring to the withdrawer.
-     * This will apply any slashing that has occurred since the scaledShares were initially set in the Withdrawal struct
-     * by reading the original delegated operator's totalMagnitude at the time of withdrawal completion.
-     */
-    function _completeReceiveAsTokens(
-        Withdrawal calldata withdrawal,
-        IERC20[] calldata tokens,
-        uint64[] memory totalMagnitudes,
-        bool isLegacyWithdrawal
-    ) internal {
-        // Finalize action by converting scaled shares to tokens for each strategy, or
-        // by re-awarding shares in each strategy.
-        for (uint256 i = 0; i < withdrawal.strategies.length;) {
+        for (uint256 i = 0; i < withdrawal.strategies.length; i++) {
             uint256 sharesToWithdraw;
             if (isLegacyWithdrawal) {
                 // This is a legacy M2 withdrawal. There is no slashing applied to the withdrawn shares.
@@ -649,95 +623,43 @@ contract DelegationManager is
                     SlashingLib.calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
             }
 
-            // Withdraws `shares` in `strategy` to `withdrawer`. If the shares are virtual beaconChainETH shares,
-            // then a call is ultimately forwarded to the `staker`s EigenPod; otherwise a call is ultimately forwarded
-            // to the `strategy` with info on the `token`.
-            if (withdrawal.strategies[i] == beaconChainETHStrategy) {
-                eigenPodManager.withdrawSharesAsTokens({
-                    podOwner: withdrawal.staker,
-                    destination: msg.sender,
-                    shares: sharesToWithdraw
-                });
-            } else {
-                strategyManager.withdrawSharesAsTokens({
-                    recipient: msg.sender,
-                    strategy: withdrawal.strategies[i],
-                    shares: sharesToWithdraw,
-                    token: tokens[i]
-                });
-            }
+            if (receiveAsTokens) {
+                // withdraws the underlying token of the strategy to the staker
 
-            unchecked {
-                ++i;
-            }
+                // Withdraws `shares` in `strategy` to `withdrawer`. If the shares are virtual beaconChainETH shares,
+                // then a call is ultimately forwarded to the `staker`s EigenPod; otherwise a call is ultimately forwarded
+                // to the `strategy` with info on the `token`.
+                if (withdrawal.strategies[i] == beaconChainETHStrategy) {
+                    eigenPodManager.withdrawSharesAsTokens({
+                        podOwner: withdrawal.staker,
+                        destination: msg.sender,
+                        shares: sharesToWithdraw
+                    });
+                } else {
+                    strategyManager.withdrawSharesAsTokens({
+                        recipient: msg.sender,
+                        strategy: withdrawal.strategies[i],
+                        shares: sharesToWithdraw,
+                        token: tokens[i]
+                    });
+                }
+            } else {
+                // adds the withdrawable shares back to the stakers account
+
+                // Award shares back in StrategyManager/EigenPodManager.
+                if (withdrawal.strategies[i] == beaconChainETHStrategy) {
+                    // Award shares back in EigenPodManager.
+                    // big fukn TODO: refactor EPM to increaseDelegatedShares if applicable. this is completely broken as is
+                    eigenPodManager.addShares({podOwner: withdrawal.staker, shares: sharesToWithdraw});
+                } else {
+                    strategyManager.addShares(msg.sender, tokens[i], withdrawal.strategies[i], sharesToWithdraw);
+                }
+            }           
         }
-    }
 
-    /**
-     * @dev This function completes a queued withdrawal for a staker by receiving them back as shares
-     * in the StrategyManager/EigenPodManager. If the withdrawer is delegated to an operator, this will also
-     * increase the operator's scaled shares.
-     * This will apply any slashing that has occurred since the scaledShares were initially set in the Withdrawal struct
-     * by reading the original delegated operator's totalMagnitude at the time of withdrawal completion.
-     */
-    function _completeReceiveAsShares(
-        Withdrawal calldata withdrawal,
-        IERC20[] calldata tokens,
-        uint64[] memory totalMagnitudes,
-        bool isLegacyWithdrawal
-    ) internal {
-        // read delegated operator for scaling and adding shares back if needed
-        address currentOperator = delegatedTo[msg.sender];
-
-        for (uint256 i = 0; i < withdrawal.strategies.length;) {
-            // store existing shares to calculate new staker scaling factor later
-            uint256 existingShares;
-            uint256 shares;
-            if (isLegacyWithdrawal) {
-                // This is a legacy M2 withdrawal. There is no slashing applied to withdrawn shares
-                shares = withdrawal.scaledShares[i];
-            } else {
-                // Take already scaled staker shares and scale again according to current operator totalMagnitude
-                // This is because the totalMagnitude may have changed since withdrawal was queued and the staker shares
-                // are still susceptible to slashing
-                shares = SlashingLib.calculateSharesToCompleteWithdraw(withdrawal.scaledShares[i], totalMagnitudes[i]);
-            }
-
-            /**
-             * When awarding podOwnerShares in EigenPodManager, we need to be sure to only give them back to the original podOwner.
-             * Other strategy shares can + will be awarded to the withdrawer.
-             */
-            if (withdrawal.strategies[i] == beaconChainETHStrategy) {
-                // TODO: REFACTOR EPM AND NEGATIVE SHARES
-                // below commented code will simply be the following:
-                // eigenPodManager.addShares({podOwner: withdrawal.staker, shares: shares});
-
-                // address staker = withdrawal.staker;
-                // /**
-                //  * Update shares amount depending upon the returned value.
-                //  * The return value will be lower than the input value in the case where the staker has an existing share deficit
-                //  */
-                // (shares, existingShares) = eigenPodManager.addShares({podOwner: staker, shares: shares});
-                // address podOwnerOperator = delegatedTo[staker];
-                // // Similar to `isDelegated` logic
-                // if (podOwnerOperator != address(0)) {
-                //     _increaseOperatorScaledShares({
-                //         operator: podOwnerOperator,
-                //         // the 'staker' here is the address receiving new shares
-                //         staker: staker,
-                //         strategy: withdrawal.strategies[i],
-                //         shares: shares,
-                //         totalMagnitude: totalMagnitudes[i]
-                //     });
-                // }
-            } else {
-                strategyManager.addShares(msg.sender, tokens[i], withdrawal.strategies[i], shares);
-            }
-
-            unchecked {
-                ++i;
-            }
-        }
+        // Remove `withdrawalRoot` from pending roots
+        delete pendingWithdrawals[withdrawalRoot];
+        emit WithdrawalCompleted(withdrawalRoot);
     }
 
     /**

--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -99,12 +99,7 @@ interface IStrategyManager {
     function removeShares(address staker, IStrategy strategy, uint256 shares) external;
 
     /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
-    function addShares(
-        address staker,
-        IERC20 token,
-        IStrategy strategy,
-        uint256 shares
-    ) external returns (uint256 existingShares);
+    function addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) external;
 
     /// @notice Used by the DelegationManager to convert withdrawn descaled shares to tokens and send them to a recipient
     function withdrawSharesAsTokens(address recipient, IStrategy strategy, uint256 shares, IERC20 token) external;

--- a/src/test/mocks/StrategyManagerMock.sol
+++ b/src/test/mocks/StrategyManagerMock.sol
@@ -110,7 +110,7 @@ contract StrategyManagerMock is
 
     function removeShares(address staker, IStrategy strategy, uint256 shares) external {}
 
-    function addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) external returns (uint256 existingShares) {}
+    function addShares(address staker, IERC20 token, IStrategy strategy, uint256 shares) external {}
     
     function withdrawSharesAsTokens(address recipient, IStrategy strategy, uint256 shares, IERC20 token) external {}
 


### PR DESCRIPTION
Receive as shares is essentially duplicated logic of deposits. This includes refactoring the addShares function in SM to call increaseDelegatedShares. Changes to EPM are still pending