### PR TITLE
feat: fixed accounting bug and refactoring

### DIFF
--- a/src/contracts/core/StakeRootCompendiumStorage.sol
+++ b/src/contracts/core/StakeRootCompendiumStorage.sol
@@ -47,7 +47,7 @@ abstract contract StakeRootCompendiumStorage is IStakeRootCompendium, OwnableUpg
     /// @notice list of operator sets that have been configured to be in the StakeTree
     OperatorSet[] public operatorSets;
     /// @notice the total charge for a proofs at a certain time depending on the number of strategies
-    Snapshots.History internal totalChargeHistory;
+    Snapshots.History internal chargePerProof;
     /// @dev Contains cumulative charges for operator sets, strategies, and max total charge.
     ChargeParams public chargeParams;
     /// @dev Contains info about cumulative charges.

--- a/src/contracts/interfaces/IStakeRootCompendium.sol
+++ b/src/contracts/interfaces/IStakeRootCompendium.sol
@@ -22,7 +22,7 @@ interface IStakeRootCompendium {
     error TimestampAlreadyConfirmed();
     error MaxTotalChargeMustBeGreaterThanTheCurrentTotalCharge();
     error NoProofsThatHaveBeenChargedButNotSubmitted();
-    error ChargePerProofExceedsMaxTotalCharge();
+    error ChargePerProofExceedsMax();
     error InputArrayLengthMismatch();
     error InputCorrelatedVariableMismatch();
     error OutOfBounds();
@@ -36,7 +36,7 @@ interface IStakeRootCompendium {
     struct ChargeParams {
         uint96 chargePerOperatorSet;
         uint96 chargePerStrategy;
-        uint96 maxTotalCharge;
+        uint96 maxChargePerProof;
     }
 
     /// @dev Struct containing info about cumulative charges.
@@ -133,7 +133,6 @@ interface IStakeRootCompendium {
      * @dev operatorSetRoots must be ordered by the operatorSet index at the time of call
      */
     function getStakeRoot(
-        address avs,
         uint32[] calldata operatorSetIdsInStakeTree,
         bytes32[] calldata operatorSetRoots
     ) external view returns (bytes32);
@@ -282,13 +281,13 @@ interface IStakeRootCompendium {
     ) external view returns (uint256 balance);
 
     /**
-     * @notice set the maximum total charge for a stakeRoot proof
-     * @param _maxTotalCharge the maximum total charge for a stakeRoot proof
+     * @notice set the maximum charge for a stakeRoot proof
+     * @param _maxChargePerProof the maximum charge for a stakeRoot proof
      * @dev only callable by owner
      * @dev used to limit offchain computation
      */
-    function setMaxTotalCharge(
-        uint96 _maxTotalCharge
+    function setMaxChargePerProof(
+        uint96 _maxChargePerProof
     ) external;
 
     /**


### PR DESCRIPTION
There was an accounting bug when updating params this is fixed.

I'm comfortable with the refactor in #766 , so i'm building off of that and just keeping this branch separate until there's another review. If we toss out the  #766 refactor I can migrate the fix.

- simplified the naming of `totalCharge` to `chargePerProof`
- removed an "optimization" in #766 of copying storage to memory to avoid multiple sloads, but with some profiling the gas cost of memory copying doesn't make up for fewer reads from the same slot. In general KISS. Let's not over optimize here. I understand avoiding reading from new slots and storage packing, but reading the same slot is cheap. better not to sweat the small stuff
- removed the assembly and replaced with readable code