### PR TITLE
DM Cleanup

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -244,7 +244,11 @@ contract AllocationManager is
             // 2. update totalMagnitude, get total magnitude and subtract slashedMagnitude
             // this will be reflected in the conversion of delegatedShares to shares in the DM
             Snapshots.History storage totalMagnitudes = _totalMagnitudeUpdate[operator][strategies[i]];
-            totalMagnitudes.push({key: uint32(block.timestamp), value: totalMagnitudes.latest() - slashedMagnitude});
+            uint64 totalMagnitudeBeforeSlashing = uint64(totalMagnitudes.latest());
+            totalMagnitudes.push({key: uint32(block.timestamp), value: totalMagnitudeBeforeSlashing - slashedMagnitude});
+
+            // 3. Decrease operators shares in the DM
+            delegation.decreaseOperatorShares(operator, strategies[i], totalMagnitudeBeforeSlashing, uint64(totalMagnitudes.latest()));
         }
     }
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -43,6 +43,11 @@ contract DelegationManager is
         _;
     }
 
+    modifier onlyAllocationManager() {
+        require(msg.sender == address(allocationManager), OnlyAllocationManager());
+        _;
+    }
+
     /**
      *
      *                         INITIALIZING FUNCTIONS
@@ -226,9 +231,9 @@ contract DelegationManager is
             CallerCannotUndelegate()
         );
 
-        // Gather strategies and shares from the staker. Calculate delegatedShares to remove from operator during undelegation
+        // Gather strategies and shares from the staker. Calculate depositedShares to remove from operator during undelegation
         // Undelegation removes ALL currently-active strategies and shares
-        (IStrategy[] memory strategies, OwnedShares[] memory ownedShares) = getDelegatableShares(staker);
+        (IStrategy[] memory strategies, uint256[] memory depositedShares) = getDepositedShares(staker);
 
         // emit an event if this action was not initiated by the staker themselves
         if (msg.sender != staker) {
@@ -239,7 +244,7 @@ contract DelegationManager is
         emit StakerUndelegated(staker, operator);
         delegatedTo[staker] = address(0);
 
-        // if no delegatable shares, return an empty array, and don't queue a withdrawal
+        // if no deposited shares, return an empty array, and don't queue a withdrawal
         if (strategies.length == 0) {
             withdrawalRoots = new bytes32[](0);
         } else {
@@ -248,23 +253,27 @@ contract DelegationManager is
 
             for (uint256 i = 0; i < strategies.length; i++) {
                 IStrategy[] memory singleStrategy = new IStrategy[](1);
-                OwnedShares[] memory singleOwnedShare = new OwnedShares[](1);
+                uint256[] memory singleShares = new uint256[](1);
                 uint64[] memory singleTotalMagnitude = new uint64[](1);
                 singleStrategy[0] = strategies[i];
-                singleOwnedShare[0] = ownedShares[i];
+                // TODO: this part is a bit gross, can we make it better?
+                singleShares[0] = depositedShares[i].toShares(
+                    stakerScalingFactor[staker][strategies[i]],
+                    totalMagnitudes[i]
+                );
                 singleTotalMagnitude[0] = totalMagnitudes[i];
 
                 withdrawalRoots[i] = _removeSharesAndQueueWithdrawal({
                     staker: staker,
                     operator: operator,
                     strategies: singleStrategy,
-                    ownedSharesToWithdraw: singleOwnedShare,
+                    sharesToWithdraw: singleShares,
                     totalMagnitudes: singleTotalMagnitude
                 });
 
                 // all shares and queued withdrawn and no delegated operator
                 // reset staker's depositScalingFactor to default
-                stakerScalingFactors[staker][strategies[i]].depositScalingFactor = WAD;
+                stakerScalingFactor[staker][strategies[i]].depositScalingFactor = WAD;
             }
         }
 
@@ -301,7 +310,7 @@ contract DelegationManager is
                 staker: msg.sender,
                 operator: operator,
                 strategies: queuedWithdrawalParams[i].strategies,
-                ownedSharesToWithdraw: queuedWithdrawalParams[i].ownedShares,
+                sharesToWithdraw: queuedWithdrawalParams[i].ownedShares,
                 totalMagnitudes: totalMagnitudes
             });
         }
@@ -350,9 +359,9 @@ contract DelegationManager is
      * the delegated delegatedShares. The staker's depositScalingFactor is updated here.
      * @param staker The address to increase the delegated shares for their operator.
      * @param strategy The strategy in which to increase the delegated shares.
-     * @param existingShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
+     * @param existingDepositShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
      * StrategyManager/EigenPodManager for the staker's shares.
-     * @param addedOwnedShares The number of shares to added to the staker's shares in the strategy
+     * @param addedDepositShares The number of deposit shares added to the staker's shares in the strategy
      *
      * @dev *If the staker is actively delegated*, then increases the `staker`'s delegated delegatedShares in `strategy`.
      * Otherwise does nothing.
@@ -361,8 +370,8 @@ contract DelegationManager is
     function increaseDelegatedShares(
         address staker,
         IStrategy strategy,
-        Shares existingShares,
-        OwnedShares addedOwnedShares
+        uint256 existingDepositShares,
+        uint256 addedDepositShares
     ) external onlyStrategyManagerOrEigenPodManager {
         // if the staker is delegated to an operator
         if (isDelegated(staker)) {
@@ -374,8 +383,8 @@ contract DelegationManager is
                 operator: operator,
                 staker: staker,
                 strategy: strategy,
-                existingShares: existingShares,
-                addedOwnedShares: addedOwnedShares,
+                existingDepositShares: existingDepositShares,
+                addedDepositShares: addedDepositShares,
                 totalMagnitude: totalMagnitude
             });
         }
@@ -385,7 +394,7 @@ contract DelegationManager is
      * @notice Decreases a native restaker's delegated share balance in a strategy due to beacon chain slashing. This updates their beaconChainScalingFactor.
      * Their operator's stakeShares are also updated (if they are delegated).
      * @param staker The address to increase the delegated stakeShares for their operator.
-     * @param existingShares The number of shares the staker already has in the EPM. This does not change upon decreasing shares.
+     * @param existingDepositShares The number of shares the staker already has in the EPM. This does not change upon decreasing shares.
      * @param proportionOfOldBalance The current pod owner shares proportion of the previous pod owner shares
      *
      * @dev *If the staker is actively delegated*, then decreases the `staker`'s delegated stakeShares in `strategy` by `proportionPodBalanceDecrease` proportion. Otherwise does nothing.
@@ -393,31 +402,40 @@ contract DelegationManager is
      */
     function decreaseBeaconChainScalingFactor(
         address staker,
-        Shares existingShares,
+        uint256 existingDepositShares,
         uint64 proportionOfOldBalance
     ) external onlyEigenPodManager {
-        DelegatedShares delegatedSharesBefore =
-            existingShares.toDelegatedShares(stakerScalingFactors[staker][beaconChainETHStrategy]);
-
         // decrease the staker's beaconChainScalingFactor proportionally
-        // forgefmt: disable-next-item
-        stakerScalingFactors[staker][beaconChainETHStrategy].decreaseBeaconChainScalingFactor(proportionOfOldBalance);
+        address operator = delegatedTo[staker];
+        uint64 totalMagnitude = allocationManager.getTotalMagnitude(operator, beaconChainETHStrategy);
 
-        DelegatedShares delegatedSharesAfter =
-            existingShares.toDelegatedShares(stakerScalingFactors[staker][beaconChainETHStrategy]);
+        uint256 sharesBefore = existingDepositShares.toShares(stakerScalingFactor[staker][beaconChainETHStrategy], totalMagnitude);
+        stakerScalingFactor[staker][beaconChainETHStrategy].decreaseBeaconChainScalingFactor(proportionOfOldBalance);
+        uint256 sharesAfter = existingDepositShares.toShares(stakerScalingFactor[staker][beaconChainETHStrategy], totalMagnitude);
 
         // if the staker is delegated to an operators
         if (isDelegated(staker)) {
-            address operator = delegatedTo[staker];
-
             // subtract strategy shares from delegated scaled shares
             _decreaseDelegation({
                 operator: operator,
                 staker: staker,
                 strategy: beaconChainETHStrategy,
-                delegatedShares: delegatedSharesBefore.sub(delegatedSharesAfter)
+                // TODO: fix this
+                operatorSharesToDecrease: sharesBefore - sharesAfter
             });
         }
+    }
+
+    /**
+     * @notice Decreases the operators shares in storage after a slash
+     * @param operator The operator to decrease shares for
+     * @param strategy The strategy to decrease shares for
+     * @param previousMagnitude The magnitude before the slash
+     * @param newMagnitude The magnitude after the slash
+     * @dev Callable only by the AllocationManager
+     */
+    function decreaseOperatorShares(address operator, IStrategy strategy, uint64 previousMagnitude, uint64 newMagnitude) external onlyAllocationManager {
+        operatorShares[operator][strategy] = operatorShares[operator][strategy].decreaseOperatorShares(previousMagnitude, newMagnitude);
     }
 
     /**
@@ -492,9 +510,9 @@ contract DelegationManager is
         delegatedTo[staker] = operator;
         emit StakerDelegated(staker, operator);
 
-        // read staker's delegatable shares and strategies to add to operator's delegatedShares
+        // read staker's deposited shares and strategies to add to operator's shares
         // and also update the staker depositScalingFactor for each strategy
-        (IStrategy[] memory strategies, OwnedShares[] memory ownedShares) = getDelegatableShares(staker);
+        (IStrategy[] memory strategies, uint256[] memory depositedShares) = getDepositedShares(staker);
         uint64[] memory totalMagnitudes = allocationManager.getTotalMagnitudes(operator, strategies);
 
         for (uint256 i = 0; i < strategies.length; ++i) {
@@ -503,8 +521,8 @@ contract DelegationManager is
                 operator: operator, 
                 staker: staker, 
                 strategy: strategies[i],
-                existingShares: uint256(0).wrapShares(),
-                addedOwnedShares: ownedShares[i],
+                existingDepositShares: uint256(0),
+                addedDepositShares: depositedShares[i],
                 totalMagnitude: totalMagnitudes[i]
             });
         }
@@ -540,9 +558,10 @@ contract DelegationManager is
 
         for (uint256 i = 0; i < withdrawal.strategies.length; i++) {
             IShareManager shareManager = _getShareManager(withdrawal.strategies[i]);
-            OwnedShares ownedSharesToWithdraw = withdrawal.delegatedShares[i].scaleForCompleteWithdrawal(
-                stakerScalingFactors[withdrawal.staker][withdrawal.strategies[i]]
-            ).toOwnedShares(totalMagnitudes[i]);
+            uint256 sharesToWithdraw = withdrawal.scaledSharesToWithdraw[i].scaleSharesForCompleteWithdrawal(
+                stakerScalingFactor[withdrawal.staker][withdrawal.strategies[i]],
+                totalMagnitudes[i]
+            );
 
             if (receiveAsTokens) {
                 // Withdraws `shares` in `strategy` to `withdrawer`. If the shares are virtual beaconChainETH shares,
@@ -552,15 +571,15 @@ contract DelegationManager is
                     staker: withdrawal.staker,
                     strategy: withdrawal.strategies[i],
                     token: tokens[i],
-                    ownedShares: ownedSharesToWithdraw
+                    shares: sharesToWithdraw
                 });
             } else {
                 // Award shares back in StrategyManager/EigenPodManager.
-                shareManager.addOwnedShares({
+                shareManager.addShares({
                     staker: withdrawal.staker,
                     strategy: withdrawal.strategies[i],
                     token: tokens[i],
-                    ownedShares: ownedSharesToWithdraw
+                    shares: sharesToWithdraw
                 });
             }
         }
@@ -571,58 +590,62 @@ contract DelegationManager is
     }
 
     /**
-     * @notice Increases `operator`s delegated delegatedShares in `strategy` based on staker's added shares and operator's totalMagnitude
+     * @notice Increases `operator`s depositedShares in `strategy` based on staker's addedDepositShares
      * and increases the staker's depositScalingFactor for the strategy.
      * @param operator The operator to increase the delegated delegatedShares for
      * @param staker The staker to increase the depositScalingFactor for
      * @param strategy The strategy to increase the delegated delegatedShares and the depositScalingFactor for
-     * @param existingShares The number of deposit shares the staker already has in the strategy.
-     * @param addedOwnedShares The shares added to the staker in the StrategyManager/EigenPodManager
+     * @param existingDepositShares The number of deposit shares the staker already has in the strategy.
+     * @param addedDepositShares The shares added to the staker in the StrategyManager/EigenPodManager
      * @param totalMagnitude The current total magnitude of the operator for the strategy
      */
     function _increaseDelegation(
         address operator,
         address staker,
         IStrategy strategy,
-        Shares existingShares,
-        OwnedShares addedOwnedShares,
+        uint256 existingDepositShares,
+        uint256 addedDepositShares,
         uint64 totalMagnitude
     ) internal {
-        _updateDepositScalingFactor({
-            staker: staker,
-            strategy: strategy,
-            existingShares: existingShares,
-            addedOwnedShares: addedOwnedShares,
-            totalMagnitude: totalMagnitude
-        });
+        //TODO: double check ordering here
+        operatorShares[operator][strategy] += addedDepositShares.toShares(stakerScalingFactor[staker][strategy], totalMagnitude);
 
-        // based on total magnitude, update operators delegatedShares
-        DelegatedShares delegatedShares = addedOwnedShares.toDelegatedShares(totalMagnitude);
-        // forgefmt: disable-next-line
-        operatorDelegatedShares[operator][strategy] = operatorDelegatedShares[operator][strategy].add(delegatedShares);
+        uint256 newDepositScalingFactor;
+        if (existingDepositShares == 0) {
+            newDepositScalingFactor = WAD / totalMagnitude;
+        } else {
+            newDepositScalingFactor = SlashingLib.calculateNewDepositScalingFactor(
+                existingDepositShares,
+                addedDepositShares,
+                stakerScalingFactor[staker][strategy],
+                totalMagnitude
+            );
+        }
+
+        // update the staker's depositScalingFactor
+        stakerScalingFactor[staker][strategy].depositScalingFactor = newDepositScalingFactor;
 
         // TODO: What to do about event wrt scaling?
-        emit OperatorSharesIncreased(operator, staker, strategy, delegatedShares);
+        emit OperatorSharesIncreased(operator, staker, strategy, addedDepositShares);
     }
 
     /**
-     * @notice Decreases `operator`s delegated delegatedShares in `strategy` based on staker's removed shares and operator's totalMagnitude
+     * @notice Decreases `operator`s shares in `strategy` based on staker's removed shares and operator's totalMagnitude
      * @param operator The operator to decrease the delegated delegated shares for
      * @param staker The staker to decrease the delegated delegated shares for
      * @param strategy The strategy to decrease the delegated delegated shares for
-     * @param delegatedShares The delegatedShares to remove from the operator's delegated shares
+     * @param operatorSharesToDecrease The delegatedShares to remove from the operator's delegated shares
      */
     function _decreaseDelegation(
         address operator,
         address staker,
         IStrategy strategy,
-        DelegatedShares delegatedShares
+        uint256 operatorSharesToDecrease
     ) internal {
-        // based on total magnitude, decrement operator's delegatedShares
-        operatorDelegatedShares[operator][strategy] = operatorDelegatedShares[operator][strategy].sub(delegatedShares);
-
-        // TODO: What to do about event wrt scaling?
-        emit OperatorSharesDecreased(operator, staker, strategy, delegatedShares);
+        // Decrement operator shares
+        operatorShares[operator][strategy] -= operatorSharesToDecrease;
+        
+        emit OperatorSharesDecreased(operator, staker, strategy, operatorSharesToDecrease);
     }
 
     /**
@@ -634,27 +657,24 @@ contract DelegationManager is
         address staker,
         address operator,
         IStrategy[] memory strategies,
-        OwnedShares[] memory ownedSharesToWithdraw,
+        uint256[] memory sharesToWithdraw,
         uint64[] memory totalMagnitudes
     ) internal returns (bytes32) {
         require(staker != address(0), InputAddressZero());
         require(strategies.length != 0, InputArrayLengthZero());
 
-        DelegatedShares[] memory delegatedSharesToWithdraw = new DelegatedShares[](strategies.length);
+        uint256[] memory scaledSharesToWithdraw = new uint256[](strategies.length);
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
         for (uint256 i = 0; i < strategies.length; ++i) {
             IShareManager shareManager = _getShareManager(strategies[i]);
-
-            // delegatedShares for staker to place into queueWithdrawal
-            DelegatedShares delegatedSharesToRemove = ownedSharesToWithdraw[i].toDelegatedShares(totalMagnitudes[i]);
-            // TODO: should this include beaconChainScalingFactor?
-            Shares sharesToWithdraw = delegatedSharesToRemove.toShares(stakerScalingFactors[staker][strategies[i]]);
-            // TODO: maybe have a getter to get shares for all strategies, like getDelegatableShares
+            
+            uint256 depositSharesToRemove  = sharesToWithdraw[i].toDepositShares(stakerScalingFactor[staker][strategies[i]], totalMagnitudes[i]);
+            // TODO: maybe have a getter to get shares for all strategies,
             // check sharesToWithdraw is valid
             // but for inputted strategies
-            Shares sharesWithdrawable = shareManager.stakerStrategyShares(staker, strategies[i]);
-            require(sharesToWithdraw.unwrap() <= sharesWithdrawable.unwrap(), WithdrawalExeedsMax());
+            uint256 depositSharesWithdrawable = shareManager.stakerDepositShares(staker, strategies[i]);
+            require(depositSharesToRemove <= depositSharesWithdrawable, WithdrawalExeedsMax());
 
             // Similar to `isDelegated` logic
             if (operator != address(0)) {
@@ -663,16 +683,15 @@ contract DelegationManager is
                     operator: operator, 
                     staker: staker, 
                     strategy: strategies[i], 
-                    delegatedShares: delegatedSharesToRemove
+                    operatorSharesToDecrease: sharesToWithdraw[i]
                 });
             }
-            delegatedSharesToWithdraw[i] =
-                delegatedSharesToRemove.scaleForQueueWithdrawal(stakerScalingFactors[staker][strategies[i]]);
+            scaledSharesToWithdraw[i] = sharesToWithdraw[i].scaleSharesForQueuedWithdrawal(stakerScalingFactor[staker][strategies[i]], totalMagnitudes[i]);
 
             // Remove active shares from EigenPodManager/StrategyManager
             // EigenPodManager: this call will revert if it would reduce the Staker's virtual beacon chain ETH shares below zero
             // StrategyManager: this call will revert if `sharesToDecrement` exceeds the Staker's current deposit shares in `strategies[i]`
-            shareManager.removeShares(staker, strategies[i], sharesToWithdraw);
+            shareManager.removeDepositShares(staker, strategies[i], depositSharesToRemove);
         }
 
         // Create queue entry and increment withdrawal nonce
@@ -686,7 +705,7 @@ contract DelegationManager is
             nonce: nonce,
             startTimestamp: uint32(block.timestamp),
             strategies: strategies,
-            delegatedShares: delegatedSharesToWithdraw
+            scaledSharesToWithdraw: scaledSharesToWithdraw
         });
 
         bytes32 withdrawalRoot = calculateWithdrawalRoot(withdrawal);
@@ -721,48 +740,6 @@ contract DelegationManager is
      *                              SHARES CONVERSION FUNCTIONS
      *
      */
-
-    /**
-     * @notice helper to calculate the new depositScalingFactor after adding shares. This is only used
-     * when a staker is depositing through the StrategyManager or EigenPodManager. A staker's depositScalingFactor
-     * is only updated when they have new deposits and their shares are being increased.
-     */
-    function _updateDepositScalingFactor(
-        address staker,
-        IStrategy strategy,
-        uint64 totalMagnitude,
-        Shares existingShares,
-        OwnedShares addedOwnedShares
-    ) internal {
-        uint256 newDepositScalingFactor;
-        if (existingShares.unwrap() == 0) {
-            newDepositScalingFactor = WAD / totalMagnitude;
-        } else {
-            // otherwise since
-            //
-            // newShares
-            //      = existingShares + addedShares
-            //      = existingPrincipalShares.toDelegatedShares(stakerScalingFactors[staker][strategy).toOwnedShares(totalMagnitude) + addedShares
-            //
-            // and it also is
-            //
-            // newShares
-            //     = newPrincipalShares.toDelegatedShares(stakerScalingFactors[staker][strategy).toOwnedShares(totalMagnitude)
-            //     = newPrincipalShares * newDepositScalingFactor / WAD * beaonChainScalingFactor / WAD * totalMagnitude / WAD
-            //     = (existingPrincipalShares + addedShares) * newDepositScalingFactor / WAD * beaonChainScalingFactor / WAD * totalMagnitude / WAD
-            //
-            // we can solve for
-            //
-            OwnedShares existingOwnedShares =
-                existingShares.toDelegatedShares(stakerScalingFactors[staker][strategy]).toOwnedShares(totalMagnitude);
-            newDepositScalingFactor = existingOwnedShares.add(addedOwnedShares).unwrap().divWad(
-                existingShares.unwrap() + addedOwnedShares.unwrap()
-            ).divWad(stakerScalingFactors[staker][strategy].getBeaconChainScalingFactor()).divWad(totalMagnitude);
-        }
-
-        // update the staker's depositScalingFactor
-        stakerScalingFactors[staker][strategy].depositScalingFactor = newDepositScalingFactor;
-    }
 
     function _getShareManager(
         IStrategy strategy
@@ -838,22 +815,16 @@ contract DelegationManager is
         return _operatorDetails[operator].stakerOptOutWindowBlocks;
     }
 
-    /// @notice a legacy function that returns the total delegated shares for an operator and strategy
-    function operatorShares(address operator, IStrategy strategy) public view returns (uint256) {
-        uint64 totalMagnitude = allocationManager.getTotalMagnitude(operator, strategy);
-        return operatorDelegatedShares[operator][strategy].toOwnedShares(totalMagnitude).unwrap();
-    }
-
     /**
      * @notice Given a staker and a set of strategies, return the shares they can queue for withdrawal.
      * This value depends on which operator the staker is delegated to.
      * The shares amount returned is the actual amount of Strategy shares the staker would receive (subject
      * to each strategy's underlying shares to token ratio).
      */
-    function getDelegatableShares(
+    function getWithdrawableShares(
         address staker,
         IStrategy[] memory strategies
-    ) public view returns (OwnedShares[] memory ownedShares) {
+    ) public view returns (uint256[] memory withdrawableShares) {
         address operator = delegatedTo[staker];
         for (uint256 i = 0; i < strategies.length; ++i) {
             IShareManager shareManager = _getShareManager(strategies[i]);
@@ -861,7 +832,7 @@ contract DelegationManager is
             // 1. read strategy deposit shares
 
             // forgefmt: disable-next-item
-            Shares shares = shareManager.stakerStrategyShares(staker, strategies[i]);
+            uint256 depositShares = shareManager.stakerDepositShares(staker, strategies[i]);
 
             // 2. if the staker is delegated, actual withdrawable shares can be different from what is stored
             // in the StrategyManager/EigenPodManager because they could have been slashed
@@ -869,34 +840,43 @@ contract DelegationManager is
                 uint64 totalMagnitude = allocationManager.getTotalMagnitude(operator, strategies[i]);
 
                 // forgefmt: disable-next-item
-                ownedShares[i] = shares
-                    .toDelegatedShares(stakerScalingFactors[staker][strategies[i]])
-                    .toOwnedShares(totalMagnitude);
+                withdrawableShares[i] = depositShares.toShares(
+                    stakerScalingFactor[staker][strategies[i]],
+                    totalMagnitude
+                );
+            } else {
+                withdrawableShares[i] = depositShares;
             }
         }
-        return ownedShares;
+        return withdrawableShares;
     }
 
     /**
-     * @notice Returns the number of actively-delegatable shares a staker has across all strategies.
-     * @dev Returns two empty arrays in the case that the Staker has no actively-delegateable shares.
+     * @notice Returns the number of shares in storage for a staker and all their strategies
+     * TODO: make cleaner, get rid of assembly
      */
-    function getDelegatableShares(
+    function getDepositedShares(
         address staker
-    ) public view returns (IStrategy[] memory, OwnedShares[] memory) {
+    ) public view returns (IStrategy[] memory, uint256[] memory) {
         // Get a list of all the strategies to check
         IStrategy[] memory strategies = strategyManager.getStakerStrategyList(staker);
+        
         // resize and add beaconChainETH to the end
         assembly {
             mstore(strategies, add(mload(strategies), 1))
         }
         strategies[strategies.length - 1] = beaconChainETHStrategy;
+        uint256[] memory shares = new uint256[](strategies.length);
 
-        // get the delegatable shares for each strategy
-        OwnedShares[] memory shares = getDelegatableShares(staker, strategies);
+        // Get owned shares for each strategy
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            IShareManager shareManager = _getShareManager(strategies[i]);
+            shares[i] = shareManager.stakerDepositShares(staker, strategies[i]);
+        }
+        strategies[strategies.length - 1] = beaconChainETHStrategy;
 
         // if the last shares are 0, remove them
-        if (shares[strategies.length - 1].unwrap() == 0) {
+        if (shares[strategies.length - 1] == 0) {
             // resize the arrays
             assembly {
                 mstore(strategies, sub(mload(strategies), 1))

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -80,13 +80,12 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     bytes32 internal _DOMAIN_SEPARATOR;
 
     /**
-     * @notice returns the total number of delegatedShares (i.e. shares divided by the `operator`'s
-     * totalMagnitude) in `strategy` that are delegated to `operator`.
-     * @notice Mapping: operator => strategy => total number of delegatedShares in the strategy delegated to the operator.
+     * @notice returns the total number of shares of the operator
+     * @notice Mapping: operator => strategy => total number of shares of the operator
+     * 
      * @dev By design, the following invariant should hold for each Strategy:
      * (operator's delegatedShares in delegation manager) = sum (delegatedShares above zero of all stakers delegated to operator)
      * = sum (delegateable delegatedShares of all stakers delegated to the operator)
-     * @dev FKA `operatorShares`
      */
     mapping(address => mapping(IStrategy => DelegatedShares)) public operatorDelegatedShares;
 
@@ -144,7 +143,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     ///       beacon chain scaling factor used to calculate the staker's withdrawable shares in the strategy.
     ///    )
     /// Note that we don't need the beaconChainScalingFactor for non beaconChainETHStrategy strategies, but it's nicer syntactically to keep it.
-    mapping(address => mapping(IStrategy => StakerScalingFactors)) public stakerScalingFactors;
+    mapping(address => mapping(IStrategy => StakerScalingFactors)) public stakerScalingFactor;
 
     // Construction
 

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -86,7 +86,7 @@ contract StrategyManager is
      * @param strategy is the specified strategy where deposit is to be made,
      * @param token is the denomination in which the deposit is to be made,
      * @param amount is the amount of token to be deposited in the strategy by the staker
-     * @return shares The amount of new shares in the `strategy` created as part of the action.
+     * @return depositedShares The amount of new shares in the `strategy` created as part of the action.
      * @dev The `msg.sender` must have previously approved this contract to transfer at least `amount` of `token` on their behalf.
      *
      * WARNING: Depositing tokens that allow reentrancy (eg. ERC-777) into a strategy is not recommended.  This can lead to attack vectors
@@ -96,8 +96,8 @@ contract StrategyManager is
         IStrategy strategy,
         IERC20 token,
         uint256 amount
-    ) external onlyWhenNotPaused(PAUSED_DEPOSITS) nonReentrant returns (OwnedShares shares) {
-        shares = _depositIntoStrategy(msg.sender, strategy, token, amount);
+    ) external onlyWhenNotPaused(PAUSED_DEPOSITS) nonReentrant returns (uint256 depositedShares) {
+        depositedShares = _depositIntoStrategy(msg.sender, strategy, token, amount);
     }
 
     /**
@@ -112,7 +112,7 @@ contract StrategyManager is
      * @param expiry the timestamp at which the signature expires
      * @param signature is a valid signature from the `staker`. either an ECDSA signature if the `staker` is an EOA, or data to forward
      * following EIP-1271 if the `staker` is a contract
-     * @return shares The amount of new shares in the `strategy` created as part of the action.
+     * @return depositedShares The amount of new shares in the `strategy` created as part of the action.
      * @dev The `msg.sender` must have previously approved this contract to transfer at least `amount` of `token` on their behalf.
      * @dev A signature is required for this function to eliminate the possibility of griefing attacks, specifically those
      * targeting stakers who may be attempting to undelegate.
@@ -127,7 +127,7 @@ contract StrategyManager is
         address staker,
         uint256 expiry,
         bytes memory signature
-    ) external onlyWhenNotPaused(PAUSED_DEPOSITS) nonReentrant returns (OwnedShares shares) {
+    ) external onlyWhenNotPaused(PAUSED_DEPOSITS) nonReentrant returns (uint256 depositedShares) {
         require(expiry >= block.timestamp, SignatureExpired());
         // calculate struct hash, then increment `staker`'s nonce
         uint256 nonce = nonces[staker];
@@ -148,20 +148,21 @@ contract StrategyManager is
         EIP1271SignatureUtils.checkSignature_EIP1271(staker, digestHash, signature);
 
         // deposit the tokens (from the `msg.sender`) and credit the new shares to the `staker`
-        shares = _depositIntoStrategy(staker, strategy, token, amount);
+        depositedShares = _depositIntoStrategy(staker, strategy, token, amount);
     }
 
     /// @notice Used by the DelegationManager to remove a Staker's shares from a particular strategy when entering the withdrawal queue
-    function removeShares(address staker, IStrategy strategy, Shares shares) external onlyDelegationManager {
-        _removeShares(staker, strategy, shares);
+    function removeDepositShares(address staker, IStrategy strategy, uint256 depositSharesToRemove) external onlyDelegationManager {
+        _removeDepositShares(staker, strategy, depositSharesToRemove);
     }
 
     /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
-    function addOwnedShares(
+    /// @dev    Specifically, this function is called when a withdrawal is completed as shares. 
+    function addShares(
         address staker,
         IStrategy strategy,
         IERC20 token,
-        OwnedShares ownedShares
+        uint256 shares
     ) external onlyDelegationManager {
         _addOwnedShares(staker, token, strategy, ownedShares);
     }
@@ -173,9 +174,9 @@ contract StrategyManager is
         address staker,
         IStrategy strategy,
         IERC20 token,
-        OwnedShares ownedShares
+        uint256 shares
     ) external onlyDelegationManager {
-        strategy.withdraw(staker, token, ownedShares.unwrap());
+        strategy.withdraw(staker, token, shares);
     }
 
     /**
@@ -231,7 +232,7 @@ contract StrategyManager is
      * @param strategy The Strategy in which the `staker` is receiving shares
      * @param ownedShares The amount of ownedShares to grant to the `staker`
      * @dev In particular, this function calls `delegation.increaseDelegatedShares(staker, strategy, shares)` to ensure that all
-     * delegated shares are tracked, increases the stored share amount in `stakerStrategyShares[staker][strategy]`, and adds `strategy`
+     * delegated shares are tracked, increases the stored share amount in `stakerDepositShares[staker][strategy]`, and adds `strategy`
      * to the `staker`'s list of strategies, if it is not in the list already.
      */
     function _addOwnedShares(address staker, IERC20 token, IStrategy strategy, OwnedShares ownedShares) internal {
@@ -239,16 +240,24 @@ contract StrategyManager is
         require(staker != address(0), StakerAddressZero());
         require(ownedShares.unwrap() != 0, SharesAmountZero());
 
-        Shares existingShares = stakerStrategyShares[staker][strategy];
+        uint256 existingShares = stakerDepositShares[staker][strategy];
 
-        // if they dont have existing ownedShares of this strategy, add it to their strats
-        if (existingShares.unwrap() == 0) {
+        // if they dont have existingShares of this strategy, add it to their strats
+        if (existingShares == 0) {
             require(stakerStrategyList[staker].length < MAX_STAKER_STRATEGY_LIST_LENGTH, MaxStrategiesExceeded());
             stakerStrategyList[staker].push(strategy);
         }
 
-        // add the returned ownedShares to their existing shares for this strategy
-        stakerStrategyShares[staker][strategy] = existingShares.add(ownedShares.unwrap()).wrapShares();
+        // add the returned depositedShares to their existing shares for this strategy
+        stakerDepositShares[staker][strategy] = existingShares + shares;
+
+        // Increase shares delegated to operator, if needed
+        delegation.increaseDelegatedShares({
+            staker: staker,
+            strategy: strategy,
+            existingDepositShares: existingShares,
+            addedShares: shares
+        });
 
         // Increase shares delegated to operator, if needed
         delegation.increaseDelegatedShares({
@@ -285,33 +294,33 @@ contract StrategyManager is
         // add the returned shares to the staker's existing shares for this strategy
         _addOwnedShares(staker, token, strategy, ownedShares);
 
-        return ownedShares;
+        return shares;
     }
 
     /**
-     * @notice Decreases the shares that `staker` holds in `strategy` by `shareAmount`.
+     * @notice Decreases the shares that `staker` holds in `strategy` by `depositSharesToRemove`.
      * @param staker The address to decrement shares from
      * @param strategy The strategy for which the `staker`'s shares are being decremented
-     * @param shareAmount The amount of shares to decrement
+     * @param depositSharesToRemove The amount of deposit shares to decrement
      * @dev If the amount of shares represents all of the staker`s shares in said strategy,
      * then the strategy is removed from stakerStrategyList[staker] and 'true' is returned. Otherwise 'false' is returned.
      */
-    function _removeShares(address staker, IStrategy strategy, Shares shareAmount) internal returns (bool) {
+    function _removeDepositShares(address staker, IStrategy strategy, uint256 depositSharesToRemove) internal returns (bool) {
         // sanity checks on inputs
-        require(shareAmount.unwrap() != 0, SharesAmountZero());
+        require(depositSharesToRemove != 0, SharesAmountZero());
 
         //check that the user has sufficient shares
-        Shares userShares = stakerStrategyShares[staker][strategy];
+        uint256 userDepositShares = stakerDepositShares[staker][strategy];
 
-        require(shareAmount.unwrap() <= userShares.unwrap(), SharesAmountTooHigh());
+        require(depositSharesToRemove <= userDepositShares, SharesAmountTooHigh());
 
-        userShares = userShares.sub(shareAmount.unwrap()).wrapShares();
-
+        userDepositShares = userDepositShares - depositSharesToRemove;
+    
         // subtract the shares from the staker's existing shares for this strategy
-        stakerStrategyShares[staker][strategy] = userShares;
+        stakerDepositShares[staker][strategy] = userDepositShares;
 
         // if no existing shares, remove the strategy from the staker's dynamic array of strategies
-        if (userShares.unwrap() == 0) {
+        if (userDepositShares == 0) {
             _removeStrategyFromStakerStrategyList(staker, strategy);
 
             // return true in the event that the strategy was removed from stakerStrategyList[staker]
@@ -357,7 +366,7 @@ contract StrategyManager is
     // VIEW FUNCTIONS
 
     /**
-     * @notice Get all details on the staker's deposits and corresponding shares
+     * @notice Get all details on the staker's strategies and shares deposited into
      * @param staker The staker of interest, whose deposits this function will fetch
      * @return (staker's strategies, shares in these strategies)
      */
@@ -365,12 +374,18 @@ contract StrategyManager is
         address staker
     ) external view returns (IStrategy[] memory, Shares[] memory) {
         uint256 strategiesLength = stakerStrategyList[staker].length;
-        Shares[] memory shares = new Shares[](strategiesLength);
+        uint256[] memory depositedShares = new uint256[](strategiesLength);
 
         for (uint256 i = 0; i < strategiesLength; ++i) {
-            shares[i] = stakerStrategyShares[staker][stakerStrategyList[staker][i]];
+            depositedShares[i] = stakerDepositShares[staker][stakerStrategyList[staker][i]];
         }
-        return (stakerStrategyList[staker], shares);
+        return (stakerStrategyList[staker], depositedShares);
+    }
+
+    function getStakerStrategyList(
+        address staker
+    ) external view returns (IStrategy[] memory) {
+        return stakerStrategyList[staker];
     }
 
     function getStakerStrategyList(

--- a/src/contracts/core/StrategyManagerStorage.sol
+++ b/src/contracts/core/StrategyManagerStorage.sol
@@ -59,10 +59,9 @@ abstract contract StrategyManagerStorage is IStrategyManager {
      * This variable was migrated to the DelegationManager instead.
      */
     uint256 private __deprecated_withdrawalDelayBlocks;
-
-    /// @notice Mapping: staker => Strategy => number of shares which they currently hold
-    mapping(address => mapping(IStrategy => Shares)) public stakerStrategyShares;
-
+    /// @notice Mapping: staker => Strategy => number of shares which they have deposited. All of these shares
+    ///         may not be withdrawable if the staker has delegated to an operator that has been slashed.
+    mapping(address => mapping(IStrategy => uint256)) public stakerDepositShares;
     /// @notice Mapping: staker => array of strategies in which they have nonzero shares
     mapping(address => IStrategy[]) public stakerStrategyList;
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -20,6 +20,11 @@ interface IDelegationManager is ISignatureUtils {
     error UnauthorizedCaller();
     /// @dev Thrown when msg.sender is not the EigenPodManager
     error OnlyEigenPodManager();
+<<<<<<< HEAD
+=======
+    /// @dev Throw when msg.sender is not the AllocationManager
+    error OnlyAllocationManager();
+>>>>>>> c902d747 (feat: dm cleanup)
 
     /// Delegation Status
 
@@ -156,17 +161,29 @@ interface IDelegationManager is ISignatureUtils {
         uint32 startTimestamp;
         // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
+<<<<<<< HEAD
         // Array containing the amount of staker's delegatedShares for withdrawal in each Strategy in the `strategies` array
         // Note that these shares need to be multiplied by the operator's totalMagnitude at completion to include
         // slashing occurring during the queue withdrawal delay
         DelegatedShares[] delegatedShares;
+=======
+        // TODO: Find a better name for this
+        // Array containing the amount of staker's scaledSharesToWithdraw for withdrawal in each Strategy in the `strategies` array
+        // Note that these shares need to be multiplied by the operator's totalMagnitude at completion to include
+        // slashing occurring during the queue withdrawal delay
+        uint256[] scaledSharesToWithdraw;
+>>>>>>> c902d747 (feat: dm cleanup)
     }
 
     struct QueuedWithdrawalParams {
         // Array of strategies that the QueuedWithdrawal contains
         IStrategy[] strategies;
         // Array containing the amount of withdrawable shares for withdrawal in each Strategy in the `strategies` array
+<<<<<<< HEAD
         OwnedShares[] ownedShares;
+=======
+        uint256[] ownedShares;
+>>>>>>> c902d747 (feat: dm cleanup)
         // The address of the withdrawer
         address withdrawer;
     }
@@ -184,6 +201,7 @@ interface IDelegationManager is ISignatureUtils {
     event OperatorMetadataURIUpdated(address indexed operator, string metadataURI);
 
     /// @notice Emitted whenever an operator's shares are increased for a given strategy. Note that shares is the delta in the operator's shares.
+<<<<<<< HEAD
     event OperatorSharesIncreased(
         address indexed operator, address staker, IStrategy strategy, DelegatedShares delegatedShares
     );
@@ -192,6 +210,12 @@ interface IDelegationManager is ISignatureUtils {
     event OperatorSharesDecreased(
         address indexed operator, address staker, IStrategy strategy, DelegatedShares delegatedShares
     );
+=======
+    event OperatorSharesIncreased(address indexed operator, address staker, IStrategy strategy, uint256 delegatedShares);
+
+    /// @notice Emitted whenever an operator's shares are decreased for a given strategy. Note that shares is the delta in the operator's shares.
+    event OperatorSharesDecreased(address indexed operator, address staker, IStrategy strategy, uint256 delegatedShares);
+>>>>>>> c902d747 (feat: dm cleanup)
 
     /// @notice Emitted when @param staker delegates to @param operator.
     event StakerDelegated(address indexed staker, address indexed operator);
@@ -348,24 +372,22 @@ interface IDelegationManager is ISignatureUtils {
 
     /**
      * @notice Increases a staker's delegated share balance in a strategy. Note that before adding to operator shares,
-     * the delegated shares are scaled according to the operator's total magnitude as part of slashing accounting.
-     * The staker's depositScalingFactor is updated here.
+     * the delegated delegatedShares. The staker's depositScalingFactor is updated here.
      * @param staker The address to increase the delegated shares for their operator.
      * @param strategy The strategy in which to increase the delegated shares.
-     * @param existingShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
+     * @param existingDepositShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
      * StrategyManager/EigenPodManager for the staker's shares.
-     * @param addedOwnedShares The number of shares to added to the staker's shares in the strategy. This amount will be scaled prior to adding
-     * to the operator's scaled shares.
+     * @param addedShares The number of shares added to the staker's shares in the strategy
      *
-     * @dev *If the staker is actively delegated*, then increases the `staker`'s delegated scaled shares in `strategy`.
+     * @dev *If the staker is actively delegated*, then increases the `staker`'s delegated delegatedShares in `strategy`.
      * Otherwise does nothing.
      * @dev Callable only by the StrategyManager or EigenPodManager.
      */
     function increaseDelegatedShares(
         address staker,
         IStrategy strategy,
-        Shares existingShares,
-        OwnedShares addedOwnedShares
+        uint256 existingDepositShares,
+        uint256 addedShares
     ) external;
 
     /**
@@ -380,9 +402,19 @@ interface IDelegationManager is ISignatureUtils {
      */
     function decreaseBeaconChainScalingFactor(
         address staker,
-        Shares existingShares,
+        uint256 existingShares,
         uint64 proportionOfOldBalance
     ) external;
+
+    /**
+     * @notice Decreases the operators shares in storage after a slash
+     * @param operator The operator to decrease shares for
+     * @param strategy The strategy to decrease shares for
+     * @param previousMagnitude The magnitude before the slash
+     * @param newMagnitude The magnitude after the slash
+     * @dev Callable only by the AllocationManager
+     */
+    function decreaseOperatorShares(address operator, IStrategy strategy, uint64 previousMagnitude, uint64 newMagnitude) external;
 
     /**
      * @notice returns the address of the operator that `staker` is delegated to.
@@ -413,17 +445,6 @@ interface IDelegationManager is ISignatureUtils {
     function stakerOptOutWindowBlocks(
         address operator
     ) external view returns (uint256);
-
-    /**
-     * @notice returns the total number of delegatedShares (i.e. shares divided by the `operator`'s
-     * totalMagnitude) in `strategy` that are delegated to `operator`.
-     * @notice Mapping: operator => strategy => total number of delegatedShares in the strategy delegated to the operator.
-     * @dev By design, the following invariant should hold for each Strategy:
-     * (operator's delegatedShares in delegation manager) = sum (delegatedShares above zero of all stakers delegated to operator)
-     * = sum (delegateable delegatedShares of all stakers delegated to the operator)
-     * @dev FKA `operatorShares`
-     */
-    function operatorDelegatedShares(address operator, IStrategy strategy) external view returns (DelegatedShares);
 
     /**
      * @notice Returns 'true' if `staker` *is* actively delegated, and 'false' otherwise.

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -119,7 +119,7 @@ interface IEigenPodManager is IShareManager, IPausable {
      * Likewise, when a withdrawal is completed, this "deficit" is decreased and the withdrawal amount is decreased; We can think of this
      * as the withdrawal "paying off the deficit".
      */
-    function podOwnerShares(
+    function podOwnerDepositShares(
         address podOwner
     ) external view returns (int256);
 

--- a/src/contracts/interfaces/IShareManager.sol
+++ b/src/contracts/interfaces/IShareManager.sol
@@ -14,25 +14,20 @@ import "./IStrategy.sol";
 interface IShareManager {
     /// @notice Used by the DelegationManager to remove a Staker's shares from a particular strategy when entering the withdrawal queue
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
-    function removeShares(address staker, IStrategy strategy, Shares shares) external;
+    function removeDepositShares(address staker, IStrategy strategy, uint256 depositSharesToRemove) external;
 
     /// @notice Used by the DelegationManager to award a Staker some shares that have passed through the withdrawal queue
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
     /// @dev token is not validated when talking to the EigenPodManager
-    function addOwnedShares(address staker, IStrategy strategy, IERC20 token, OwnedShares ownedShares) external;
+    function addShares(address staker, IStrategy strategy,  IERC20 token, uint256 shares) external;
 
     /// @notice Used by the DelegationManager to convert withdrawn descaled shares to tokens and send them to a staker
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
     /// @dev token is not validated when talking to the EigenPodManager
-    function withdrawSharesAsTokens(
-        address staker,
-        IStrategy strategy,
-        IERC20 token,
-        OwnedShares ownedShares
-    ) external;
+    function withdrawSharesAsTokens(address staker, IStrategy strategy,  IERC20 token, uint256 shares) external;
 
     /// @notice Returns the current shares of `user` in `strategy`
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
     /// @dev returns 0 if the user has negative shares
-    function stakerStrategyShares(address user, IStrategy strategy) external view returns (Shares shares);
+    function stakerDepositShares(address user, IStrategy strategy) external view returns (uint256 depositShares);
 }

--- a/src/contracts/interfaces/IStrategyManager.sol
+++ b/src/contracts/interfaces/IStrategyManager.sol
@@ -41,7 +41,7 @@ interface IStrategyManager is IShareManager {
      * @param token Is the token that `staker` deposited.
      * @param shares Is the number of new shares `staker` has been granted in `strategy`.
      */
-    event Deposit(address staker, IERC20 token, IStrategy strategy, OwnedShares shares);
+    event Deposit(address staker, IERC20 token, IStrategy strategy, uint256 shares);
 
     /// @notice Emitted when the `strategyWhitelister` is changed
     event StrategyWhitelisterChanged(address previousAddress, address newAddress);
@@ -97,7 +97,7 @@ interface IStrategyManager is IShareManager {
         address staker,
         uint256 expiry,
         bytes memory signature
-    ) external returns (OwnedShares shares);
+    ) external returns (uint256 shares);
 
     /**
      * @notice Get all details on the staker's deposits and corresponding shares
@@ -111,10 +111,17 @@ interface IStrategyManager is IShareManager {
         address staker
     ) external view returns (IStrategy[] memory);
 
+    function getStakerStrategyList(
+        address staker
+    ) external view returns (IStrategy[] memory);
+
     /// @notice Simple getter function that returns `stakerStrategyList[staker].length`.
     function stakerStrategyListLength(
         address staker
     ) external view returns (uint256);
+
+    /// @notice Returns the current shares of `user` in `strategy`
+    function stakerDepositShares(address user, IStrategy strategy) external view returns (uint256 shares);
 
     /**
      * @notice Owner-only function that adds the provided Strategies to the 'whitelist' of strategies that stakers can deposit into

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -3,48 +3,25 @@ pragma solidity ^0.8.27;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
-/// @dev the stakerScalingFactor and totalMagnitude have initial default values to 1e18 as "1"
+/// @dev the stakerScalingFactor and operatorMagnitude have initial default values to 1e18 as "1"
 /// to preserve precision with uint256 math. We use `WAD` where these variables are used
 /// and divide to represent as 1
 uint64 constant WAD = 1e18;
 
 /*
- * There are 3 types of shares:
- *      1. ownedShares
+ * There are 2 types of shares:
+ *      1. depositShares
  *          - These can be converted to an amount of tokens given a strategy
  *              - by calling `sharesToUnderlying` on the strategy address (they're already tokens 
  *              in the case of EigenPods)
- *          - These are comparable between operators and stakers.
- *          - These live in the storage of StrategyManager strategies: 
- *              - `totalShares` is the total amount of shares delegated to a strategy
- *      2. delegatedShares
- *          - These can be converted to shares given an operator and a strategy
- *              - by multiplying by the operator's totalMagnitude for the strategy
- *          - These values automatically update their conversion into tokens
- *              - when the operator's total magnitude for the strategy is decreased upon slashing
- *          - These live in the storage of the DelegationManager:
- *              - `delegatedShares` is the total amount of delegatedShares delegated to an operator for a strategy
- *              - `withdrawal.delegatedShares` is the amount of delegatedShares in a withdrawal          
- *      3. shares 
- *          - These can be converted into delegatedShares given a staker and a strategy
- *              - by multiplying by the staker's depositScalingFactor for the strategy
- *          - These values automatically update their conversion into tokens
- *             - when the staker's depositScalingFactor for the strategy is increased upon new deposits
- *             - or when the staker's operator's total magnitude for the strategy is decreased upon slashing
- *          - These represent the total amount of shares the staker would have of a strategy if they were never slashed
- *          - These live in the storage of the StrategyManager/EigenPodManager
- *              - `stakerStrategyShares` in the SM is the staker's shares that have not been queued for withdrawal in a strategy
- *              - `podOwnerShares` in the EPM is the staker's shares that have not been queued for withdrawal in the beaconChainETHStrategy
+ *          - These live in the storage of EPM and SM strategies 
+ *      2. shares
+ *          - For a staker, this is the amount of shares that they can withdraw
+ *          - For an operator, this is the sum of its staker's withdrawable shares       
  * 
- * Note that `withdrawal.delegatedShares` is scaled for the beaconChainETHStrategy to divide by the beaconChainScalingFactor upon queueing
+ * Note that `withdrawal.scaledSharesToWithdraw` is scaled for the beaconChainETHStrategy to divide by the beaconChainScalingFactor upon queueing
  * and multiply by the beaconChainScalingFactor upon withdrawal
  */
-
-type OwnedShares is uint256;
-
-type DelegatedShares is uint256;
-
-type Shares is uint256;
 
 struct StakerScalingFactors {
     uint256 depositScalingFactor;
@@ -52,110 +29,12 @@ struct StakerScalingFactors {
     bool isBeaconChainScalingFactorSet;
     uint64 beaconChainScalingFactor;
 }
-
-using SlashingLib for OwnedShares global;
-using SlashingLib for DelegatedShares global;
-using SlashingLib for Shares global;
 using SlashingLib for StakerScalingFactors global;
 
 // TODO: validate order of operations everywhere
 library SlashingLib {
     using Math for uint256;
     using SlashingLib for uint256;
-
-    // MATH
-
-    function add(Shares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() + y;
-    }
-
-    function add(DelegatedShares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() + y;
-    }
-
-    function add(DelegatedShares x, DelegatedShares y) internal pure returns (DelegatedShares) {
-        return (x.unwrap() + y.unwrap()).wrapDelegated();
-    }
-
-    function add(OwnedShares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() + y;
-    }
-
-    function add(OwnedShares x, OwnedShares y) internal pure returns (OwnedShares) {
-        return (x.unwrap() + y.unwrap()).wrapOwned();
-    }
-
-    function sub(Shares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() - y;
-    }
-
-    function sub(DelegatedShares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() - y;
-    }
-
-    function sub(DelegatedShares x, DelegatedShares y) internal pure returns (DelegatedShares) {
-        return (x.unwrap() - y.unwrap()).wrapDelegated();
-    }
-
-    function sub(OwnedShares x, uint256 y) internal pure returns (uint256) {
-        return x.unwrap() - y;
-    }
-
-    /// @dev beaconChainScalingFactor = 0 -> WAD for all non beaconChainETH strategies
-    function toShares(
-        DelegatedShares delegatedShares,
-        StakerScalingFactors storage ssf
-    ) internal view returns (Shares) {
-        return delegatedShares.unwrap().divWad(ssf.getDepositScalingFactor()).divWad(ssf.getBeaconChainScalingFactor())
-            .wrapShares();
-    }
-
-    function toDelegatedShares(OwnedShares shares, uint256 magnitude) internal pure returns (DelegatedShares) {
-        // forgefmt: disable-next-item
-        return shares
-            .unwrap()
-            .divWad(magnitude)
-            .wrapDelegated();
-    }
-
-    function toOwnedShares(DelegatedShares delegatedShares, uint256 magnitude) internal view returns (OwnedShares) {
-        return delegatedShares.unwrap().mulWad(magnitude).wrapOwned();
-    }
-
-    function scaleForQueueWithdrawal(
-        DelegatedShares delegatedShares,
-        StakerScalingFactors storage ssf
-    ) internal view returns (DelegatedShares) {
-        return delegatedShares.unwrap().divWad(ssf.getBeaconChainScalingFactor()).wrapDelegated();
-    }
-
-    function scaleForCompleteWithdrawal(
-        DelegatedShares delegatedShares,
-        StakerScalingFactors storage ssf
-    ) internal view returns (DelegatedShares) {
-        return delegatedShares.unwrap().mulWad(ssf.getBeaconChainScalingFactor()).wrapDelegated();
-    }
-
-    function decreaseBeaconChainScalingFactor(
-        StakerScalingFactors storage ssf,
-        uint64 proportionOfOldBalance
-    ) internal {
-        ssf.beaconChainScalingFactor = uint64(uint256(ssf.beaconChainScalingFactor).mulWad(proportionOfOldBalance));
-        ssf.isBeaconChainScalingFactorSet = true;
-    }
-
-    /// @dev beaconChainScalingFactor = 0 -> WAD for all non beaconChainETH strategies
-    function toDelegatedShares(
-        Shares shares,
-        StakerScalingFactors storage ssf
-    ) internal view returns (DelegatedShares) {
-        return shares.unwrap().mulWad(ssf.getDepositScalingFactor()).mulWad(ssf.getBeaconChainScalingFactor())
-            .wrapDelegated();
-    }
-
-    function toDelegatedShares(Shares shares, uint256 magnitude) internal view returns (DelegatedShares) {
-        return shares.unwrap().mulWad(magnitude).wrapDelegated();
-    }
 
     // WAD MATH
 
@@ -167,54 +46,110 @@ library SlashingLib {
         return x.mulDiv(WAD, y);
     }
 
-    // TYPE CASTING
+    // GETTERS
 
-    function unwrap(
-        Shares x
-    ) internal pure returns (uint256) {
-        return Shares.unwrap(x);
-    }
 
-    function unwrap(
-        DelegatedShares x
-    ) internal pure returns (uint256) {
-        return DelegatedShares.unwrap(x);
-    }
-
-    function unwrap(
-        OwnedShares x
-    ) internal pure returns (uint256) {
-        return OwnedShares.unwrap(x);
-    }
-
-    function wrapShares(
-        uint256 x
-    ) internal pure returns (Shares) {
-        return Shares.wrap(x);
-    }
-
-    function wrapDelegated(
-        uint256 x
-    ) internal pure returns (DelegatedShares) {
-        return DelegatedShares.wrap(x);
-    }
-
-    function wrapOwned(
-        uint256 x
-    ) internal pure returns (OwnedShares) {
-        return OwnedShares.wrap(x);
-    }
-
-    function getDepositScalingFactor(
-        StakerScalingFactors storage ssf
-    ) internal view returns (uint256) {
+    function getDepositScalingFactor(StakerScalingFactors memory ssf) internal pure returns (uint256) {
         return ssf.depositScalingFactor == 0 ? WAD : ssf.depositScalingFactor;
     }
-
-    function getBeaconChainScalingFactor(
-        StakerScalingFactors storage ssf
-    ) internal view returns (uint64) {
-        return
-            !ssf.isBeaconChainScalingFactorSet && ssf.beaconChainScalingFactor == 0 ? WAD : ssf.beaconChainScalingFactor;
+    
+    function getBeaconChainScalingFactor(StakerScalingFactors memory ssf) internal pure returns (uint64) {
+        return !ssf.isBeaconChainScalingFactorSet && ssf.beaconChainScalingFactor == 0 ? WAD : ssf.beaconChainScalingFactor;
     }
+
+
+    function scaleSharesForQueuedWithdrawal(uint256 sharesToWithdraw, StakerScalingFactors memory ssf, uint64 operatorMagnitude) internal pure returns (uint256) {
+        return 
+            sharesToWithdraw
+                .divWad(uint256(ssf.getBeaconChainScalingFactor()))
+                .divWad(uint256(operatorMagnitude));
+    }
+
+    function scaleSharesForCompleteWithdrawal(uint256 scaledSharesToWithdraw, StakerScalingFactors memory ssf, uint64 operatorMagnitude) internal pure returns (uint256) {
+        return 
+            scaledSharesToWithdraw
+                .mulWad(uint256(ssf.getBeaconChainScalingFactor()))
+                .mulWad(uint256(operatorMagnitude));
+    }
+
+    function decreaseOperatorShares(uint256 operatorShares, uint64 previousMagnitude, uint64 newMagnitude) internal pure returns (uint256) {
+        return operatorShares.divWad(previousMagnitude).mulWad(newMagnitude);    
+    }
+
+    function decreaseBeaconChainScalingFactor(StakerScalingFactors storage ssf, uint64 proportionOfOldBalance) internal {
+        ssf.beaconChainScalingFactor = uint64(uint256(ssf.beaconChainScalingFactor).mulWad(proportionOfOldBalance));
+        ssf.isBeaconChainScalingFactorSet = true;
+    }
+
+    function calculateNewDepositScalingFactor(
+        uint256 currentDepositShares,
+        uint256 addedDepositShares,
+        StakerScalingFactors memory ssf,
+        uint64 magnitude
+    ) internal pure returns (uint64) {
+        // TODO: update equation for beacon chain scaling factor
+        /**
+         * Base Equations:
+         * (1) newShares = currentShares + addedDepositShares
+         * (2) newOwnedShares = currentOwnedShares + addedDepositShares
+         * (3) newOwnedShares = newShares * newStakerDepositScalingFactor * newMagnitude
+         * 
+         * Plugging (3) into (2):
+         * (4) newShares * newStakerDepositScalingFactor * newMagnitude = currentOwnedShares + addedDepositShares
+         * 
+         * Solving for newStakerDepositScalingFactor
+         * (5) newStakerDepositScalingFactor = (ownedShares + addedDepositShares) / (newShares * newMagnitude)
+         * 
+         * We also know that the magnitude remains constant on deposits, thus
+         * (6) newMagnitude = oldMagnitude
+         * 
+         * Plugging in (6) and (1) into (5):
+         * (7) newStakerDepositScalingFactor = (ownedShares + addedDepositShares) / ((currentShares + addedDepositShares) * oldMagnitude)
+         * Note that magnitudes must be divided by WAD for precision. Thus,
+         * 
+         * (8) newStakerDepositScalingFactor = (ownedShares + addedDepositShares) / ((currentShares + addedDepositShares) * oldMagnitude / WAD)
+         * (9) newStakerDepositScalingFactor = (ownedShares + addedDepositShares) / ((currentShares + addedDepositShares) / WAD) * (oldMagnitude / WAD))
+         */
+
+        // Step 1: Calculate Numerator
+        uint256 currentShares = currentDepositShares.toShares(ssf, magnitude);
+
+        // Step 2: Compute currentShares + addedShares
+        uint256 newShares = currentShares + addedDepositShares;
+
+        // Step 3: Calculate newStakerDepositScalingFactor
+        // Note: We divide by magnitude to preserve 
+
+        //TODO: figure out if we only need to do one divWad here
+        uint256 newStakerDepositScalingFactor = 
+            newShares
+            .divWad(currentShares + addedDepositShares)
+            .divWad(magnitude)
+            .divWad(uint256(ssf.getBeaconChainScalingFactor()));
+
+        return uint64(newStakerDepositScalingFactor);
+    }
+
+    // CONVERSION
+
+    function toDepositShares(
+        uint256 shares,
+        StakerScalingFactors memory ssf,
+        uint64 magnitude
+    ) internal pure returns (uint256 depositShares) {
+        depositShares = 
+            shares
+            .divWad(ssf.getDepositScalingFactor())
+            .divWad(uint256(ssf.getBeaconChainScalingFactor()))
+            .divWad(uint256(magnitude));
+    }
+
+    function toShares(uint256 depositShares, StakerScalingFactors memory ssf, uint64 magnitude) internal pure returns (uint256 shares) {
+        shares = 
+            depositShares                
+                .mulWad(ssf.getDepositScalingFactor())
+                .mulWad(uint256(ssf.getBeaconChainScalingFactor()))
+                .mulWad(uint256(magnitude));
+    }
+
 }

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -65,14 +65,15 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     // BEGIN STORAGE VARIABLES ADDED AFTER MAINNET DEPLOYMENT -- DO NOT SUGGEST REORDERING TO CONVENTIONAL ORDER
     /**
-     * @notice Mapping from Pod owner owner to the number of shares they have in the virtual beacon chain ETH strategy.
-     * @dev The share amount can become negative. This is necessary to accommodate the fact that a pod owner's virtual beacon chain ETH shares can
+     * // TODO: Update this comment
+     * @notice Mapping from Pod owner owner to the number of deposit shares they have in the virtual beacon chain ETH strategy.
+     * @dev The deposit share amount can become negative. This is necessary to accommodate the fact that a pod owner's virtual beacon chain ETH shares can
      * decrease between the pod owner queuing and completing a withdrawal.
      * When the pod owner's shares would otherwise increase, this "deficit" is decreased first _instead_.
      * Likewise, when a withdrawal is completed, this "deficit" is decreased and the withdrawal amount is decreased; We can think of this
      * as the withdrawal "paying off the deficit".
      */
-    mapping(address => int256) public podOwnerShares;
+    mapping(address => int256) public podOwnerDepositShares;
 
     uint64 internal __deprecated_denebForkTimestamp;
 

--- a/src/contracts/strategies/StrategyBase.sol
+++ b/src/contracts/strategies/StrategyBase.sol
@@ -302,7 +302,7 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
     function shares(
         address user
     ) public view virtual returns (uint256) {
-        return strategyManager.stakerStrategyShares(user, IStrategy(address(this))).unwrap();
+        return strategyManager.stakerDepositShares(user, IStrategy(address(this)));
     }
 
     /// @notice Internal function used to fetch this contract's current balance of `underlyingToken`.


### PR DESCRIPTION
This PR updates the storage of the delegationManager to store the operator's magnitude as part of its shares. Thus, we essentially store $$b_n$$ in this [doc](https://www.notion.so/eigen-labs/Slashing-Accounting-70dde029a6bb40628bcd56d351bf7e54#4caca6e758ab47e9a5edf26a19679596)

In doing so, we only need two types of shares

1. DepositShares: shares that are deposited in strategyManager/EPM
2. Shares: A concept native to DM. For a staker, this is withdrawable shares as we need to take into account scaling factors. For an operator, this is the sum of its stakers withdrawable shares. This lives in storage for the operator.  

What I'm looking for feedback on:

- How do we feel about removing custom types and going for `depositShares` and `shares` everywhere
- Naming of depositShares/shares
- Any issues with updating `operatorShares` on slashOperator? 

Note: this only compiles for SM/DM, not EPM.

TODOs:

- [x] Fix EPM compilation
- [ ] Clean up naming upon feedback
- [x] Clean up refs to SlashingLib functions (add params when calling)
- [x] Update functions for beacon chain slashing & helper function for avs slashing