### PR TITLE
Fix: Update coverage workflow job name

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-  run-tests:
+  run-coverage:
     needs: prepare
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Has the same name as the testing file, causing CI assertions for `run-tests` to also require coverage to pass