### PR TITLE
Feat: Update legacy withdrawal timestamp param to legacy withdrawal check

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -754,9 +754,9 @@ contract DelegationManager is
     function getCompletableTimestamp(
         uint32 startTimestamp
     ) public view returns (uint32 completableTimestamp) {
-        if (startTimestamp < LEGACY_WITHDRAWALS_TIMESTAMP) {
+        if (startTimestamp < LEGACY_WITHDRAWAL_CHECK_VALUE) {
             // this is a legacy M2 withdrawal using blocknumbers.
-            // It would take up to 600+ years for the blocknumber to reach the LEGACY_WITHDRAWALS_TIMESTAMP, so this is a safe check.
+            // It would take 370+ years for the blockNumber to reach the LEGACY_WITHDRAWAL_CHECK_VALUE, so this is a safe check.
             require(startTimestamp + LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS <= block.number, WithdrawalDelayNotElapsed());
             // sourcing the magnitudes from time=0, will always give us WAD, which doesn't factor in slashing
             completableTimestamp = 0;

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -37,9 +37,12 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @notice The minimum number of blocks to complete a withdrawal of a strategy. 50400 * 12 seconds = 1 week
     uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50_400;
 
-    /// @notice Wed Jan 01 2025 17:00:00 GMT+0000, timestamp used to check whether a pending withdrawal
-    /// should be processed as legacy M2 or with slashing considered.
-    uint32 public constant LEGACY_WITHDRAWALS_TIMESTAMP = 1_735_750_800;
+    /// @notice Check against the blockNumber/timestamps to determine if the withdrawal is a legacy or slashing withdrawl.
+    // Legacy withdrawals use block numbers. We expect block number 1 billion in ~370 years
+    // Slashing withdrawals use timestamps. The UTC timestmap as of Jan 1st, 2024 is 1_704_067_200 . Thus, when deployed, all
+    // withdrawal timestamps are AFTER the `LEGACY_WITHDRAWAL_CHECK_VALUE` timestamp.
+    // This below value is the UTC timestamp at Sunday, September 9th, 2001. 
+    uint32 public constant LEGACY_WITHDRAWAL_CHECK_VALUE = 1_000_000_000;
 
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -41,7 +41,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     // Legacy withdrawals use block numbers. We expect block number 1 billion in ~370 years
     // Slashing withdrawals use timestamps. The UTC timestmap as of Jan 1st, 2024 is 1_704_067_200 . Thus, when deployed, all
     // withdrawal timestamps are AFTER the `LEGACY_WITHDRAWAL_CHECK_VALUE` timestamp.
-    // This below value is the UTC timestamp at Sunday, September 9th, 2001. 
+    // This below value is the UTC timestamp at Sunday, September 9th, 2001.
     uint32 public constant LEGACY_WITHDRAWAL_CHECK_VALUE = 1_000_000_000;
 
     /// @notice Canonical, virtual beacon chain ETH strategy

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -368,10 +368,10 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         // Create time machine and beacon chain. Set block time to beacon chain genesis time
         // TODO: update if needed to sane timestamp
         // cheats.warp(GENESIS_TIME_LOCAL);
-        cheats.warp(delegationManager.LEGACY_WITHDRAWALS_TIMESTAMP());
+        cheats.warp(delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
         timeMachine = new TimeMachine();
         // beaconChain = new BeaconChainMock(eigenPodManager, GENESIS_TIME_LOCAL);
-        beaconChain = new BeaconChainMock(eigenPodManager, delegationManager.LEGACY_WITHDRAWALS_TIMESTAMP());
+        beaconChain = new BeaconChainMock(eigenPodManager, delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
     }
 
     /**

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -3518,7 +3518,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
     // TODO: add upgrade tests for completing withdrawals queued before upgrade in integration tests
     function setUp() public override {
         DelegationManagerUnitTests.setUp();
-        cheats.warp(delegationManager.LEGACY_WITHDRAWALS_TIMESTAMP());
+        cheats.warp(delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
     }
 
     function test_Revert_WhenExitWithdrawalQueuePaused() public {


### PR DESCRIPTION
Implements @MinisculeTarantula's suggestion to make this a bit clearer