### PR TITLE
slashing: cleanup

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,6 +53,9 @@ jobs:
         version: nightly
     - name: Run coverage
       run: forge coverage --report lcov
+      env:
+        RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+        RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
     - name: Prune coverage report
       run: lcov --remove ./lcov.info -o ./lcov.info.pruned 'src/test/*' 'script/*' '*Storage.sol' --ignore-errors inconsistent
     - name: Generate reports

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This document provides an overview of system components, contracts, and user rol
     * [Depositing Into EigenLayer](#depositing-into-eigenlayer)
     * [Delegating to an Operator](#delegating-to-an-operator)
     * [Undelegating or Queueing a Withdrawal](#undelegating-or-queueing-a-withdrawal)
-    * [Completing a Withdrawal as OwnedShares](#completing-a-withdrawal-as-shares)
+    * [Completing a Withdrawal as Shares](#completing-a-withdrawal-as-shares)
     * [Completing a Withdrawal as Tokens](#completing-a-withdrawal-as-tokens)
     * [Withdrawal Processing: Validator Exits](#withdrawal-processing-validator-exits)
     * [Withdrawal Processing: Partial Beacon Chain Withdrawals](#withdrawal-processing-partial-beacon-chain-withdrawals)
@@ -156,7 +156,7 @@ Undelegating from an Operator automatically queues a withdrawal that needs to go
 
 ![.](./images/Staker%20Flow%20Diagrams/Queue%20Withdrawal.png)
 
-##### Completing a Withdrawal as OwnedShares
+##### Completing a Withdrawal as Shares
 
 This flow is mostly useful if a Staker wants to change which Operator they are delegated to. The Staker first needs to undelegate (see above). At this point, they can delegate to a different Operator. However, the new Operator will only be awarded shares once the Staker completes their queued withdrawal "as shares":
 

--- a/docs/release/slashing/AllocationManager.md
+++ b/docs/release/slashing/AllocationManager.md
@@ -103,7 +103,7 @@ function clearDeallocationQueue(
 ) external;
 ```
 
-This function is used to complete pending deallocations for a list of strategies for an operator. The function takes a list of strategies and the number of pending deallocations to complete for each strategy. For each strategy, the function completes pending modifications if their effect timestamps have passed. 
+This function is used to complete pending deallocations for a list of strategies for an operator. The function takes a list of strategies and the number of pending deallocations to complete for each strategy. For each strategy, the function completes pending deallocations if their effect timestamps have passed. 
 
 Completing a deallocation decreases the encumbered magnitude for the strategy, allowing them to make allocations with that magnitude. Encumbered magnitude must be decreased only upon completion because pending deallocations can be slashed before they are completable.
 

--- a/docs/release/slashing/AllocationManager.md
+++ b/docs/release/slashing/AllocationManager.md
@@ -51,13 +51,13 @@ The allocation delay's primary purpose is to give stakers delegated to an operat
 /**
  * @notice struct used to modify the allocation of slashable magnitude to list of operatorSets
  * @param strategy the strategy to allocate magnitude for
- * @param expectedTotalMagnitude the expected total magnitude of the operator used to combat against race conditions with slashing
+ * @param expectedMaxMagnitude the expected max magnitude of the operator used to combat against race conditions with slashing
  * @param operatorSets the operatorSets to allocate magnitude for
  * @param magnitudes the magnitudes to allocate for each operatorSet
  */
 struct MagnitudeAllocation {
     IStrategy strategy;
-    uint64 expectedTotalMagnitude;
+    uint64 expectedMaxMagnitude;
     OperatorSet[] operatorSets;
     uint64[] magnitudes;
 }
@@ -73,15 +73,15 @@ function modifyAllocations(MagnitudeAllocation[] calldata allocations) external
 
 This function is called by operators to adjust the proportions of their slashable stake allocated to different operator sets for different strategies.
 
-The operator provides their expected total magnitude for each strategy they're adjusting the allocation for. This is used to combat race conditions with slashings for the strategy, which may result in larger than expected slashable proportions allocated to operator sets.
+The operator provides their expected max magnitude for each strategy they're adjusting the allocation for. This is used to combat race conditions with slashings for the strategy, which may result in larger than expected slashable proportions allocated to operator sets.
 
 Each `(operator, operatorSet, strategy)` tuple can have at most 1 pending modification at a time. The function will revert is there is a pending modification for any of the tuples in the input. 
 
-The contract limits keeps track of the total magnitude in pending allocations, active allocations, and pending deallocations. This is called the **_encumbered magnitude_** for a strategy. The contract verifies that the allocations made in this call do not make the encumbered magnitude exceed the operator's total magnitude for the strategy. If the encumbered magnitude exceeds the total magnitude, the function reverts.
+The contract keeps track of the total magnitude in pending allocations, active allocations, and pending deallocations. This is called the **_encumbered magnitude_** for a strategy. The contract verifies that the allocations made in this call do not make the encumbered magnitude exceed the operator's max magnitude for the strategy. If the encumbered magnitude exceeds the max magnitude, the function reverts.
 
 Any _allocations_ (i.e. increases in the proportion of slashable stake allocated to an AVS) take effect after the operator's allocation delay. The allocation delay must be set for the operator before they can call this function.
 
-Any _deallocations_ (i.e. decreases in the proportion of slashable stake allocated to an AVS) take after `DEALLOCATION_DELAY` seconds. This enables AVSs enough time to update their view of stakes to the new proportions and have any tasks created against previous stakes to expire.
+Any _deallocations_ (i.e. decreases in the proportion of slashable stake allocated to an AVS) take effect after `DEALLOCATION_DELAY` seconds. This enables AVSs enough time to update their view of stakes to the new proportions and have any tasks created against previous stakes to expire.
 
 ## `clearDeallocationQueue`
 
@@ -103,7 +103,7 @@ function clearDeallocationQueue(
 ) external;
 ```
 
-This function is used to complete pending deallocations for a list of strategies for an operator. The function takes a list of strategies and the number of pending deallocations to complete for each strategy. For each strategy, the function completes a modification if its effect timestamp has passed. 
+This function is used to complete pending deallocations for a list of strategies for an operator. The function takes a list of strategies and the number of pending deallocations to complete for each strategy. For each strategy, the function completes pending modifications if their effect timestamps have passed. 
 
 Completing a deallocation decreases the encumbered magnitude for the strategy, allowing them to make allocations with that magnitude. Encumbered magnitude must be decreased only upon completion because pending deallocations can be slashed before they are completable.
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -220,6 +220,12 @@ contract AllocationManager is
     }
 
     /**
+     *
+     *                         INTERNAL FUNCTIONS
+     *
+     */
+
+    /**
      * @dev Clear one or more pending deallocations to a strategy's allocated magnitude
      * @param operator the operator whose pending deallocations will be cleared
      * @param strategy the strategy to update
@@ -356,12 +362,22 @@ contract AllocationManager is
         });
     }
 
+    /**
+     *
+     *                         VIEW FUNCTIONS
+     *
+     */
+
     /// @inheritdoc IAllocationManager
     function getAllocationInfo(
         address operator,
         IStrategy strategy
     ) external view returns (OperatorSet[] memory, MagnitudeInfo[] memory) {
-        OperatorSet[] memory operatorSets = avsDirectory.getOperatorSetsOfOperator(operator, 0, type(uint256).max);
+        OperatorSet[] memory operatorSets = avsDirectory.getOperatorSetsOfOperator({
+            operator: operator,
+            start: 0,
+            length: type(uint256).max
+        });
         MagnitudeInfo[] memory infos = getAllocationInfo(operator, strategy, operatorSets);
         return (operatorSets, infos);
     }

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -70,14 +70,14 @@ contract AllocationManager is
             require(info.currentMagnitude > 0, OperatorNotAllocated());
 
             // 1. Calculate slashing amount and update current/encumbered magnitude
-            uint64 slashedMagnitude = uint64(uint256(info.currentMagnitude).mulWad(params.wadToSlash));
+            uint64 slashedMagnitude = uint64(uint256(info.currentMagnitude).mulWadRoundUp(params.wadToSlash));
             info.currentMagnitude -= slashedMagnitude;
             info.encumberedMagnitude -= slashedMagnitude;
 
             // 2. If there is a pending deallocation, reduce pending deallocation proportionally.
             // This ensures that when the deallocation is cleared, less magnitude is freed.
             if (info.pendingDiff < 0) {
-                uint64 slashedPending = uint64(uint256(uint128(-info.pendingDiff)).mulWad(params.wadToSlash));
+                uint64 slashedPending = uint64(uint256(uint128(-info.pendingDiff)).mulWadRoundUp(params.wadToSlash));
                 info.pendingDiff += int128(uint128(slashedPending));
 
                 emit OperatorSetMagnitudeUpdated(

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -137,14 +137,14 @@ contract AllocationManager is
             require(allocation.operatorSets.length == allocation.magnitudes.length, InputArrayLengthMismatch());
             require(avsDirectory.isOperatorSetBatch(allocation.operatorSets), InvalidOperatorSet());
 
-            // 1. For the given (operator,strategy) clear any clearable pending deallocations to free up encumberedMagnitude
-            _clearDeallocationQueue({operator: msg.sender, strategy: allocation.strategy, numToClear: type(uint16).max});
-
-            // 2. Check current maxMagnitude matches expected value. This is to check for slashing race conditions
+            // 1. Check current maxMagnitude matches expected value. This is to check for slashing race conditions
             // where an operator gets slashed from an operatorSet and as a result all the configured allocations have larger
             // proprtional magnitudes relative to each other.
             uint64 maxMagnitude = _maxMagnitudeHistory[msg.sender][allocation.strategy].latest();
             require(maxMagnitude == allocation.expectedMaxMagnitude, InvalidExpectedMaxMagnitude());
+
+            // 2. For the given (operator,strategy) clear any clearable pending deallocations to free up encumberedMagnitude
+            _clearDeallocationQueue({operator: msg.sender, strategy: allocation.strategy, numToClear: type(uint16).max});
 
             for (uint256 j = 0; j < allocation.operatorSets.length; ++j) {
                 bytes32 operatorSetKey = _encodeOperatorSet(allocation.operatorSets[j]);

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -114,8 +114,8 @@ contract AllocationManager is
             delegation.decreaseOperatorShares({
                 operator: params.operator,
                 strategy: params.strategies[i],
-                previousTotalMagnitude: maxMagnitudeBeforeSlash,
-                newTotalMagnitude: maxMagnitudeAfterSlash
+                previousMaxMagnitude: maxMagnitudeBeforeSlash,
+                newMaxMagnitude: maxMagnitudeAfterSlash
             });
 
             // 6. Record the proportion of shares slashed
@@ -140,11 +140,11 @@ contract AllocationManager is
             // 1. For the given (operator,strategy) complete any pending deallocation to free up encumberedMagnitude
             _clearDeallocationQueue({operator: msg.sender, strategy: allocation.strategy, numToClear: type(uint16).max});
 
-            // 2. Check current totalMagnitude matches expected value. This is to check for slashing race conditions
+            // 2. Check current maxMagnitude matches expected value. This is to check for slashing race conditions
             // where an operator gets slashed from an operatorSet and as a result all the configured allocations have larger
             // proprtional magnitudes relative to each other.
             uint64 maxMagnitude = _maxMagnitudeHistory[msg.sender][allocation.strategy].latest();
-            require(maxMagnitude == allocation.expectedMaxMagnitude, InvalidExpectedTotalMagnitude());
+            require(maxMagnitude == allocation.expectedMaxMagnitude, InvalidExpectedMaxMagnitude());
 
             for (uint256 j = 0; j < allocation.operatorSets.length; ++j) {
                 bytes32 operatorSetKey = _encodeOperatorSet(allocation.operatorSets[j]);
@@ -311,6 +311,7 @@ contract AllocationManager is
         return info;
     }
 
+    /// @notice Update the operator's magnitude info in storage and their encumbered magnitude.
     function _updateMagnitudeInfo(
         address operator,
         IStrategy strategy,

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -373,11 +373,8 @@ contract AllocationManager is
         address operator,
         IStrategy strategy
     ) external view returns (OperatorSet[] memory, MagnitudeInfo[] memory) {
-        OperatorSet[] memory operatorSets = avsDirectory.getOperatorSetsOfOperator({
-            operator: operator,
-            start: 0,
-            length: type(uint256).max
-        });
+        OperatorSet[] memory operatorSets =
+            avsDirectory.getOperatorSetsOfOperator({operator: operator, start: 0, length: type(uint256).max});
         MagnitudeInfo[] memory infos = getAllocationInfo(operator, strategy, operatorSets);
         return (operatorSets, infos);
     }

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -32,7 +32,7 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @notice The AVSDirectory contract for EigenLayer
     IAVSDirectory public immutable avsDirectory;
 
-    /// @notice Delay before deallocations are completable and can be added back into freeMagnitude
+    /// @notice Delay before deallocations are clearable and can be added back into freeMagnitude
     /// In this window, deallocations still remain slashable by the operatorSet they were allocated to.
     uint32 public immutable DEALLOCATION_DELAY;
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -228,8 +228,10 @@ contract DelegationManager is
                 maxMagnitudes: singleMaxMagnitude
             });
 
-            // all shares and queued withdrawn and no delegated operator
-            // reset staker's depositScalingFactor to default
+            // all shares are queued withdrawn with no delegated operator, so
+            // reset staker's depositScalingFactor back to WAD default.
+            // If this is not reset, the depositScalingFactor would be incorrect
+            // when the staker deposits and queue withdraws in the future.
             ssf.depositScalingFactor = WAD;
             emit DepositScalingFactorUpdated(staker, strategies[i], WAD);
         }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -591,7 +591,7 @@ contract DelegationManager is
      * out of the amount withdrawable for the staker has to also be decremented from the staker's deposit shares.
      * Ex. Suppose as a staker, I have 100 depositShares for a strategy thats sitting in the StrategyManager in the `stakerDepositShares` mapping but I actually have been slashed 50%
      * and my real withdrawable amount is 50 shares.
-     * Now when I go to withdraw 20 shares, I'm propotionally withdrawing 40% of my withdrawable shares. We calculate below via the `toDepositShares()` function to
+     * Now when I go to withdraw 20 shares, I'm proportionally withdrawing 40% of my withdrawable shares. We calculate below via the `toDepositShares()` function to
      * decrement 40 shares from my 100 depositShares in storage. The end state is that I have 30 withdrawable shares now and 60 depositShares, this still accurately reflects a 50% slashing
      * that has occurred on my existing stake.
      * @dev sharesToWithdraw are divided by the current maxMagnitude of the operator (at queue time) and this value is stored in the Withdrawal struct as `scaledShares`.

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -787,6 +787,11 @@ contract DelegationManager is
     }
 
     /// @inheritdoc IDelegationManager
+    function minWithdrawalDelayBlocks() public view returns (uint256) {
+        return LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS;
+    }
+
+    /// @inheritdoc IDelegationManager
     function calculateWithdrawalRoot(
         Withdrawal memory withdrawal
     ) public pure returns (bytes32) {

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -76,6 +76,7 @@ contract DelegationManager is
         _disableInitializers();
     }
 
+    /// @inheritdoc IDelegationManager
     function initialize(
         address initialOwner,
         IPauserRegistry _pauserRegistry,
@@ -210,12 +211,13 @@ contract DelegationManager is
         uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
 
         for (uint256 i = 0; i < strategies.length; i++) {
+            StakerScalingFactors storage ssf = stakerScalingFactor[staker][strategies[i]];
             IStrategy[] memory singleStrategy = new IStrategy[](1);
             uint256[] memory singleShares = new uint256[](1);
             uint64[] memory singleMaxMagnitude = new uint64[](1);
             singleStrategy[0] = strategies[i];
             // TODO: this part is a bit gross, can we make it better?
-            singleShares[0] = depositedShares[i].toShares(stakerScalingFactor[staker][strategies[i]], maxMagnitudes[i]);
+            singleShares[0] = depositedShares[i].toShares(ssf, maxMagnitudes[i]);
             singleMaxMagnitude[0] = maxMagnitudes[i];
 
             withdrawalRoots[i] = _removeSharesAndQueueWithdrawal({
@@ -228,7 +230,7 @@ contract DelegationManager is
 
             // all shares and queued withdrawn and no delegated operator
             // reset staker's depositScalingFactor to default
-            stakerScalingFactor[staker][strategies[i]].depositScalingFactor = WAD;
+            ssf.depositScalingFactor = WAD;
             emit DepositScalingFactorUpdated(staker, strategies[i], WAD);
         }
 
@@ -250,7 +252,8 @@ contract DelegationManager is
 
             // Remove shares from staker's strategies and place strategies/shares in queue.
             // If the staker is delegated to an operator, the operator's delegated shares are also reduced
-            // NOTE: This will fail if the staker doesn't have the shares implied by the input parameters
+            // NOTE: This will fail if the staker doesn't have the shares implied by the input parameters.
+            // The view function getWithdrawableShares() can be used to check what shares are available for withdrawal.
             withdrawalRoots[i] = _removeSharesAndQueueWithdrawal({
                 staker: msg.sender,
                 operator: operator,
@@ -295,7 +298,7 @@ contract DelegationManager is
             address operator = delegatedTo[staker];
             IStrategy[] memory strategies = new IStrategy[](1);
             strategies[0] = strategy;
-            uint64[] memory totalMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
+            uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
 
             // add deposit shares to operator's stake shares and update the staker's depositScalingFactor
             _increaseDelegation({
@@ -304,7 +307,7 @@ contract DelegationManager is
                 strategy: strategy,
                 existingDepositShares: existingDepositShares,
                 addedShares: addedShares,
-                totalMagnitude: totalMagnitudes[0]
+                maxMagnitude: maxMagnitudes[0]
             });
         }
     }
@@ -319,15 +322,13 @@ contract DelegationManager is
         address operator = delegatedTo[staker];
         IStrategy[] memory strategies = new IStrategy[](1);
         strategies[0] = beaconChainETHStrategy;
-        uint64[] memory totalMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
+        uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
 
-        uint256 sharesBefore =
-            existingDepositShares.toShares(stakerScalingFactor[staker][beaconChainETHStrategy], totalMagnitudes[0]);
         StakerScalingFactors storage ssf = stakerScalingFactor[staker][beaconChainETHStrategy];
+        uint256 sharesBefore = existingDepositShares.toShares(ssf, maxMagnitudes[0]);
         ssf.decreaseBeaconChainScalingFactor(proportionOfOldBalance);
         emit BeaconChainScalingFactorDecreased(staker, ssf.beaconChainScalingFactor);
-        uint256 sharesAfter =
-            existingDepositShares.toShares(stakerScalingFactor[staker][beaconChainETHStrategy], totalMagnitudes[0]);
+        uint256 sharesAfter = existingDepositShares.toShares(ssf, maxMagnitudes[0]);
 
         // if the staker is delegated to an operators
         if (isDelegated(staker)) {
@@ -336,7 +337,6 @@ contract DelegationManager is
                 operator: operator,
                 staker: staker,
                 strategy: beaconChainETHStrategy,
-                // TODO: fix this
                 sharesToDecrease: sharesBefore - sharesAfter
             });
         }
@@ -346,11 +346,11 @@ contract DelegationManager is
     function decreaseOperatorShares(
         address operator,
         IStrategy strategy,
-        uint64 previousTotalMagnitude,
-        uint64 newTotalMagnitude
+        uint64 previousMaxMagnitude,
+        uint64 newMaxMagnitude
     ) external onlyAllocationManager {
         uint256 sharesToDecrease =
-            operatorShares[operator][strategy].getOperatorSharesToDecrease(previousTotalMagnitude, newTotalMagnitude);
+            operatorShares[operator][strategy].getOperatorSharesToDecrease(previousMaxMagnitude, newMaxMagnitude);
 
         _decreaseDelegation({
             operator: operator,
@@ -426,7 +426,7 @@ contract DelegationManager is
         // read staker's deposited shares and strategies to add to operator's shares
         // and also update the staker depositScalingFactor for each strategy
         (IStrategy[] memory strategies, uint256[] memory depositedShares) = getDepositedShares(staker);
-        uint64[] memory totalMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
+        uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
 
         for (uint256 i = 0; i < strategies.length; ++i) {
             // forgefmt: disable-next-item
@@ -436,15 +436,16 @@ contract DelegationManager is
                 strategy: strategies[i],
                 existingDepositShares: uint256(0),
                 addedShares: depositedShares[i],
-                totalMagnitude: totalMagnitudes[i]
+                maxMagnitude: maxMagnitudes[i]
             });
         }
     }
 
     /**
      * @dev This function completes a queued withdrawal for a staker.
-     * This will apply any slashing that has occurred since the the withdrawal was queued. By multiplying the withdrawl's
-     * delegatedShares by the operator's total magnitude for each strategy
+     * This will apply any slashing that has occurred since the the withdrawal was queued. By multiplying the withdrawal's
+     * scaledShares by the operator's maxMagnitude for each strategy. This ensures that any slashing that has occurred
+     * during the period the withdrawal was queued until its completable timestamp is applied to the withdrawal amount.
      * If receiveAsTokens is true, then these shares will be withdrawn as tokens.
      * If receiveAsTokens is false, then they will be redeposited according to the current operator the staker is delegated to,
      * and added back to the operator's delegatedShares.
@@ -459,11 +460,10 @@ contract DelegationManager is
         bytes32 withdrawalRoot = calculateWithdrawalRoot(withdrawal);
         require(pendingWithdrawals[withdrawalRoot], WithdrawalNotQueued());
 
-        // TODO: is there a cleaner way to do this?
         uint32 completableTimestamp = getCompletableTimestamp(withdrawal.startTimestamp);
-        // read delegated operator's totalMagnitudes at time of withdrawal to convert the delegatedShares to shared
+        // read delegated operator's maxMagnitudes at time of withdrawal to convert the delegatedShares to shared
         // factoring in slashing that occured during withdrawal delay
-        uint64[] memory totalMagnitudes = allocationManager.getMaxMagnitudesAtTimestamp({
+        uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudesAtTimestamp({
             operator: withdrawal.delegatedTo,
             strategies: withdrawal.strategies,
             timestamp: completableTimestamp
@@ -471,8 +471,8 @@ contract DelegationManager is
 
         for (uint256 i = 0; i < withdrawal.strategies.length; i++) {
             IShareManager shareManager = _getShareManager(withdrawal.strategies[i]);
-            uint256 sharesToWithdraw = withdrawal.scaledSharesToWithdraw[i].scaleSharesForCompleteWithdrawal(
-                stakerScalingFactor[withdrawal.staker][withdrawal.strategies[i]], totalMagnitudes[i]
+            uint256 sharesToWithdraw = withdrawal.scaledShares[i].scaleSharesForCompleteWithdrawal(
+                stakerScalingFactor[withdrawal.staker][withdrawal.strategies[i]], maxMagnitudes[i]
             );
 
             if (receiveAsTokens) {
@@ -503,13 +503,13 @@ contract DelegationManager is
 
     /**
      * @notice Increases `operator`s depositedShares in `strategy` based on staker's addedDepositShares
-     * and increases the staker's depositScalingFactor for the strategy.
+     * and updates the staker's depositScalingFactor for the strategy.
      * @param operator The operator to increase the delegated delegatedShares for
      * @param staker The staker to increase the depositScalingFactor for
      * @param strategy The strategy to increase the delegated delegatedShares and the depositScalingFactor for
      * @param existingDepositShares The number of deposit shares the staker already has in the strategy.
      * @param addedShares The shares added to the staker in the StrategyManager/EigenPodManager
-     * @param totalMagnitude The current total magnitude of the operator for the strategy
+     * @param maxMagnitude The current max magnitude of the operator for the strategy
      */
     function _increaseDelegation(
         address operator,
@@ -517,20 +517,20 @@ contract DelegationManager is
         IStrategy strategy,
         uint256 existingDepositShares,
         uint256 addedShares,
-        uint64 totalMagnitude
+        uint64 maxMagnitude
     ) internal {
-        //TODO: double check ordering here
+        // Increment operator shares
         operatorShares[operator][strategy] += addedShares;
         emit OperatorSharesIncreased(operator, staker, strategy, addedShares);
 
         // update the staker's depositScalingFactor
         StakerScalingFactors storage ssf = stakerScalingFactor[staker][strategy];
-        ssf.updateDepositScalingFactor(existingDepositShares, addedShares, totalMagnitude);
+        ssf.updateDepositScalingFactor(existingDepositShares, addedShares, maxMagnitude);
         emit DepositScalingFactorUpdated(staker, strategy, ssf.depositScalingFactor);
     }
 
     /**
-     * @notice Decreases `operator`s shares in `strategy` based on staker's removed shares and operator's totalMagnitude
+     * @notice Decreases `operator`s shares in `strategy` based on staker's removed shares
      * @param operator The operator to decrease the delegated delegated shares for
      * @param staker The staker to decrease the delegated delegated shares for
      * @param strategy The strategy to decrease the delegated delegated shares for
@@ -544,12 +544,28 @@ contract DelegationManager is
     ) internal {
         // Decrement operator shares
         operatorShares[operator][strategy] -= sharesToDecrease;
-
         emit OperatorSharesDecreased(operator, staker, strategy, sharesToDecrease);
     }
 
     /**
      * @notice Removes `sharesToWithdraw` in `strategies` from `staker` who is currently delegated to `operator` and queues a withdrawal to the `withdrawer`.
+     * @param staker The staker queuing a withdrawal
+     * @param operator The operator the staker is delegated to
+     * @param strategies The strategies to queue a withdrawal for
+     * @param sharesToWithdraw The amount of shares the staker wishes to withdraw, must be less than staker's withdrawable shares
+     * @param maxMagnitudes The corresponding maxMagnitudes of the operator for the respective strategies
+     *
+     * @dev The amount withdrawable by the staker may not actually be the same as the depositShares that are in storage in the StrategyManager/EigenPodManager.
+     * This is a result of any slashing that has occurred during the time the staker has been delegated to an operator. So the proportional amount that is withdrawn
+     * out of the amount withdrawable for the staker has to also be decremented from the staker's deposit shares.
+     * Ex. Suppose as a staker, I have 100 depositShares for a strategy thats sitting in the StrategyManager in the `stakerDepositShares` mapping but I actually have been slashed 50%
+     * and my real withdrawable amount is 50 shares.
+     * Now when I go to withdraw 20 shares, I'm propotionally withdrawing 40% of my withdrawable shares. We calculate below via the `toDepositShares()` function to
+     * decrement 40 shares from my 100 depositShares in storage. The end state is that I have 30 withdrawable shares now and 60 depositShares, this still accurately reflects a 50% slashing
+     * that has occurred on my existing stake.
+     * @dev sharesToWithdraw are divided by the current maxMagnitude of the operator (at queue time) and this value is stored in the Withdrawal struct as `scaledShares`.
+     * Upon completion the `scaledShares` are then multiplied by the maxMagnitude of the operator at completion time. This is how we factor in any slashing events
+     * that occurred during the withdrawal delay period. Shares in a withdrawal are no longer slashable once the withdrawal is completable.
      * @dev If the `operator` is indeed an operator, then the operator's delegated shares in the `strategies` are also decreased appropriately.
      * @dev If `withdrawer` is not the same address as `staker`
      */
@@ -563,7 +579,7 @@ contract DelegationManager is
         require(staker != address(0), InputAddressZero());
         require(strategies.length != 0, InputArrayLengthZero());
 
-        uint256[] memory scaledSharesToWithdraw = new uint256[](strategies.length);
+        uint256[] memory scaledShares = new uint256[](strategies.length);
 
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
@@ -587,7 +603,7 @@ contract DelegationManager is
                 });
             }
 
-            scaledSharesToWithdraw[i] = sharesToWithdraw[i].scaleSharesForQueuedWithdrawal(ssf, maxMagnitudes[i]);
+            scaledShares[i] = sharesToWithdraw[i].scaleSharesForQueuedWithdrawal(ssf, maxMagnitudes[i]);
 
             // Remove active shares from EigenPodManager/StrategyManager
             // EigenPodManager: this call will revert if it would reduce the Staker's virtual beacon chain ETH shares below zero
@@ -606,7 +622,7 @@ contract DelegationManager is
             nonce: nonce,
             startTimestamp: uint32(block.timestamp),
             strategies: strategies,
-            scaledSharesToWithdraw: scaledSharesToWithdraw
+            scaledShares: scaledShares
         });
 
         bytes32 withdrawalRoot = calculateWithdrawalRoot(withdrawal);
@@ -620,9 +636,11 @@ contract DelegationManager is
 
     /**
      *
-     *                              SHARES CONVERSION FUNCTIONS
+     *                         SHARES CONVERSION FUNCTIONS
      *
      */
+
+    /// @notice Depending on the strategy used, determine which ShareManager contract to make external calls to
     function _getShareManager(
         IStrategy strategy
     ) internal view returns (IShareManager) {
@@ -695,7 +713,7 @@ contract DelegationManager is
         IStrategy[] memory strategies
     ) public view returns (uint256[] memory withdrawableShares) {
         address operator = delegatedTo[staker];
-        uint64[] memory totalMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
+        uint64[] memory maxMagnitudes = allocationManager.getMaxMagnitudes(operator, strategies);
         withdrawableShares = new uint256[](strategies.length);
 
         for (uint256 i = 0; i < strategies.length; ++i) {
@@ -712,7 +730,7 @@ contract DelegationManager is
                 // forgefmt: disable-next-item
                 withdrawableShares[i] = depositShares.toShares(
                     stakerScalingFactor[staker][strategies[i]],
-                    totalMagnitudes[i]
+                    maxMagnitudes[i]
                 );
             } else {
                 withdrawableShares[i] = depositShares;

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -263,8 +263,9 @@ contract StrategyManager is
         //check that the user has sufficient shares
         uint256 userDepositShares = stakerDepositShares[staker][strategy];
 
+        // This check technically shouldn't actually ever revert because depositSharesToRemove is already
+        // checked to not exceed max amount of shares when the withdrawal was queued in the DelegationManager
         require(depositSharesToRemove <= userDepositShares, SharesAmountTooHigh());
-
         userDepositShares = userDepositShares - depositSharesToRemove;
 
         // subtract the shares from the staker's existing shares for this strategy

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -272,14 +272,14 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      * @notice Returns operator set an operator is registered to in the order they were registered.
      * @param operator The operator address to query.
-     * @param index The index of the enumerated list of operator sets.
+     * @param index The index in the enumerated list of operator sets.
      */
     function operatorSetsMemberOfAtIndex(address operator, uint256 index) external view returns (OperatorSet memory);
 
     /**
      * @notice Retursn the operator registered to an operatorSet in the order that it was registered.
      *  @param operatorSet The operatorSet to query.
-     *  @param index The index of the enumerated list of operators.
+     *  @param index The index in the enumerated list of operators.
      */
     function operatorSetMemberAtIndex(OperatorSet memory operatorSet, uint256 index) external view returns (address);
 
@@ -294,7 +294,7 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      * @notice Returns an array of operator sets an operator is registered to.
      * @param operator The operator address to query.
-     * @param start The starting index of the array to query.
+     * @param start The starting index in the array to query.
      *  @param length The amount of items of the array to return.
      */
     function getOperatorSetsOfOperator(
@@ -306,7 +306,7 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      * @notice Returns an array of operators registered to the operatorSet.
      * @param operatorSet The operatorSet to query.
-     * @param start The starting index of the array to query.
+     * @param start The starting index in the array to query.
      * @param length The amount of items of the array to return.
      */
     function getOperatorsInOperatorSet(

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -151,7 +151,9 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
     ) external;
 
     /**
-     * @notice Modifies the propotions of slashable stake allocated to a list of operatorSets for a set of strategies
+     * @notice Modifies the proportions of slashable stake allocated to a list of operatorSets for a set of strategies.
+     * Note that deallocations remain slashable for DEALLOCATION_DELAY amount of time therefore when they are cleared they may
+     * free up less allocatable magnitude than initially deallocated.
      * @param allocations array of magnitude adjustments for multiple strategies and corresponding operator sets
      * @dev Updates encumberedMagnitude for the updated strategies
      * @dev msg.sender is used as operator

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -73,11 +73,14 @@ interface IAllocationManagerTypes {
     /**
      * @notice Struct containing allocation delay metadata for a given operator.
      * @param delay Current allocation delay if `pendingDelay` is non-zero and `pendingDelayEffectTimestamp` has elapsed.
+     * @param isSet Whether the operator has initially set an allocation delay. Note that this could be false but the
+     * block.timestamp >= effectTimestamp in which we consider their delay to be configured and active.
      * @param pendingDelay Current allocation delay if it's non-zero and `pendingDelayEffectTimestamp` has elapsed.
      * @param effectTimestamp The timestamp for which `pendingDelay` becomes the curren allocation delay.
      */
     struct AllocationDelayInfo {
         uint32 delay;
+        bool isSet;
         uint32 pendingDelay;
         uint32 effectTimestamp;
     }
@@ -183,8 +186,6 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @notice Called by the delegation manager to set an operator's allocation delay.
      * This is set when the operator first registers, and is the time between an operator
      * allocating magnitude to an operator set, and the magnitude becoming slashable.
-     * @dev Note that if an operator's allocation delay is 0, it has not been set yet,
-     * and the operator will be unable to allocate magnitude to any operator set.
      * @param operator The operator to set the delay on behalf of.
      * @param delay the allocation delay in seconds
      */

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -15,8 +15,8 @@ interface IAllocationManagerErrors {
     error InputArrayLengthMismatch();
     /// @dev Thrown when an operator's allocation delay has yet to be set.
     error UninitializedAllocationDelay();
-    /// @dev Thrown when provided `expectedTotalMagnitude` for a given allocation does not match `currentTotalMagnitude`.
-    error InvalidExpectedTotalMagnitude();
+    /// @dev Thrown when provided `expectedMaxMagnitude` for a given allocation does not match`currentMaxMagnitude`.
+    error InvalidExpectedMaxMagnitude();
     /// @dev Thrown when an invalid operator set is provided.
     error InvalidOperatorSet();
     /// @dev Thrown when an invalid operator is provided.
@@ -127,8 +127,8 @@ interface IAllocationManagerEvents is IAllocationManagerTypes {
     /// @notice Emitted when operator's encumbered magnitude is updated for a given strategy
     event EncumberedMagnitudeUpdated(address operator, IStrategy strategy, uint64 encumberedMagnitude);
 
-    /// @notice Emitted when an operator's total magnitude is updated for a given strategy
-    event MaxMagnitudeUpdated(address operator, IStrategy strategy, uint64 totalMagnitude);
+    /// @notice Emitted when an operator's max magnitude is updated for a given strategy
+    event MaxMagnitudeUpdated(address operator, IStrategy strategy, uint64 maxMagnitude);
 
     /// @notice Emitted when an operator is slashed by an operator set for a strategy
     /// `wadSlashed` is the proportion of the operator's total delegated stake that was slashed
@@ -260,7 +260,7 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
     /**
      * @notice Returns the maximum magnitude an operator can allocate for the given strategies
      * @dev The max magnitude of an operator starts at WAD (1e18), and is decreased anytime
-     * the operator is slashed. This value acts as a cap on the total magnitude of the operator.
+     * the operator is slashed. This value acts as a cap on the max magnitude of the operator.
      * @param operator the operator to query
      * @param strategies the strategies to get the max magnitudes for
      * @return the max magnitudes for each strategy
@@ -274,7 +274,7 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @notice Returns the maximum magnitude an operator can allocate for the given strategies
      * at a given timestamp
      * @dev The max magnitude of an operator starts at WAD (1e18), and is decreased anytime
-     * the operator is slashed. This value acts as a cap on the total magnitude of the operator.
+     * the operator is slashed. This value acts as a cap on the max magnitude of the operator.
      * @param operator the operator to query
      * @param strategies the strategies to get the max magnitudes for
      * @param timestamp the timestamp at which to check the max magnitudes

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -37,8 +37,6 @@ interface IAllocationManagerErrors {
     error AlreadySlashedForTimestamp();
     /// @dev Thrown when calling a view function that requires a valid timestamp.
     error InvalidTimestamp();
-    /// @dev Thrown when an invalid allocation delay is set
-    error InvalidAllocationDelay();
     /// @dev Thrown when a slash is attempted on an operator who has not allocated to the strategy, operatorSet pair
     error OperatorNotAllocated();
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -161,19 +161,20 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
     ) external;
 
     /**
-     * @notice This function takes a list of strategies and adds all completable deallocations for each strategy,
-     * updating the encumberedMagnitude of the operator as needed.
+     * @notice This function takes a list of strategies and for each strategy, removes from the deallocationQueue
+     * all clearable deallocations up to max `numToClear` number of deallocations, updating the encumberedMagnitude
+     * of the operator as needed.
      *
-     * @param operator address to complete deallocations for
-     * @param strategies a list of strategies to complete deallocations for
-     * @param numToComplete a list of number of pending deallocations to complete for each strategy
+     * @param operator address to clear deallocations for
+     * @param strategies a list of strategies to clear deallocations for
+     * @param numToClear a list of number of pending deallocations to clear for each strategy
      *
      * @dev can be called permissionlessly by anyone
      */
     function clearDeallocationQueue(
         address operator,
         IStrategy[] calldata strategies,
-        uint16[] calldata numToComplete
+        uint16[] calldata numToClear
     ) external;
 
     /**

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -135,10 +135,11 @@ interface IDelegationManagerTypes {
         // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
         // Array containing the amount of staker's scaledShares for withdrawal in each Strategy in the `strategies` array
-        // Note that these scaledShares need to be multiplied by the operator's maxMagnitude at completion to include
-        // slashing occurring during the queue withdrawal delay. This is because scaledShares = sharesToWithdraw / maxMagnitude at queue time.
-        // to account for slashing, we later multiply scaledShares * maxMagnitude at completion time to get the withdrawn shares
-        // after applying slashing during the delay period.
+        // Note that these scaledShares need to be multiplied by the operator's maxMagnitude and beaconChainScalingFactor at completion to include
+        // slashing occurring during the queue withdrawal delay. This is because scaledShares = sharesToWithdraw / (maxMagnitude * beaconChainScalingFactor)
+        // at queue time. beaconChainScalingFactor is simply equal to 1 if the strategy is not the beaconChainStrategy.
+        // To account for slashing, we later multiply scaledShares * maxMagnitude * beaconChainScalingFactor at the earliest possible completion time
+        // to get the withdrawn shares after applying slashing during the delay period.
         uint256[] scaledShares;
     }
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -408,6 +408,31 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
 
     /**
      *
+     *                         BACKWARDS COMPATIBLE LEGACY FUNCTIONS
+     *                         TO BE DEPRECATED IN FUTURE
+     *
+     */
+
+    /// @notice Overloaded version of `completeQueuedWithdrawal` that includes a `middlewareTimesIndex` parameter
+    /// for backwards compatibility with the M2 release. To be deprecated in a future release.
+    function completeQueuedWithdrawal(
+        Withdrawal calldata withdrawal,
+        IERC20[] calldata tokens,
+        uint256 middlewareTimesIndex,
+        bool receiveAsTokens
+    ) external;
+
+    /// @notice Overloaded version of `completeQueuedWithdrawals` that includes a `middlewareTimesIndexes` parameter
+    /// for backwards compatibility with the M2 release. To be deprecated in a future release.
+    function completeQueuedWithdrawals(
+        Withdrawal[] calldata withdrawals,
+        IERC20[][] calldata tokens,
+        uint256[] calldata middlewareTimesIndexes,
+        bool[] calldata receiveAsTokens
+    ) external;
+
+    /**
+     *
      *                         VIEW FUNCTIONS
      *
      */

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -134,11 +134,12 @@ interface IDelegationManagerTypes {
         uint32 startTimestamp;
         // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
-        // TODO: Find a better name for this
-        // Array containing the amount of staker's scaledSharesToWithdraw for withdrawal in each Strategy in the `strategies` array
-        // Note that these shares need to be multiplied by the operator's totalMagnitude at completion to include
-        // slashing occurring during the queue withdrawal delay
-        uint256[] scaledSharesToWithdraw;
+        // Array containing the amount of staker's scaledShares for withdrawal in each Strategy in the `strategies` array
+        // Note that these scaledShares need to be multiplied by the operator's maxMagnitude at completion to include
+        // slashing occurring during the queue withdrawal delay. This is because scaledShares = sharesToWithdraw / maxMagnitude at queue time.
+        // to account for slashing, we later multiply scaledShares * maxMagnitude at completion time to get the withdrawn shares
+        // after applying slashing during the delay period.
+        uint256[] scaledShares;
     }
 
     struct QueuedWithdrawalParams {
@@ -293,10 +294,10 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external;
 
     /**
-     * @notice Undelegates the staker from the operator who they are delegated to. Puts the staker into the "undelegation limbo" mode of the EigenPodManager
-     * and queues a withdrawal of all of the staker's shares in the StrategyManager (to the staker), if necessary.
+     * @notice Undelegates the staker from the operator who they are delegated to.
+     * Queues withdrawals of all of the staker's withdrawable shares in the StrategyManager (to the staker) and/or EigenPodManager, if necessary.
      * @param staker The account to be undelegated.
-     * @return withdrawalRoot The root of the newly queued withdrawal, if a withdrawal was queued. Otherwise just bytes32(0).
+     * @return withdrawalRoots The roots of the newly queued withdrawals, if a withdrawal was queued. Otherwise just bytes32(0).
      *
      * @dev Reverts if the `staker` is also an operator, since operators are not allowed to undelegate from themselves.
      * @dev Reverts if the caller is not the staker, nor the operator who the staker is delegated to, nor the operator's specified "delegationApprover"
@@ -304,14 +305,18 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      */
     function undelegate(
         address staker
-    ) external returns (bytes32[] memory withdrawalRoot);
+    ) external returns (bytes32[] memory withdrawalRoots);
 
     /**
-     * Allows a staker to withdraw some shares. Withdrawn shares/strategies are immediately removed
+     * @notice Allows a staker to withdraw some shares. Withdrawn shares/strategies are immediately removed
      * from the staker. If the staker is delegated, withdrawn shares/strategies are also removed from
      * their operator.
      *
-     * All withdrawn shares/strategies are placed in a queue and can be fully withdrawn after a delay.
+     * All withdrawn shares/strategies are placed in a queue and can be withdrawn after a delay. Withdrawals
+     * are still subject to slashing during the delay period so the amount withdrawn on completion may actually be less
+     * than what was queued if slashing has occurred in that period.
+     *
+     * @dev To view what the staker is able to queue withdraw, see `getWithdrawableShares()`
      */
     function queueWithdrawals(
         QueuedWithdrawalParams[] calldata params
@@ -319,9 +324,11 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
 
     /**
      * @notice Used to complete the specified `withdrawal`. The caller must match `withdrawal.withdrawer`
+     * Withdrawals remain slashable during the withdrawal delay period and the actual withdrawn shares are calculated
+     * based off the scaledShares.
      * @param withdrawal The Withdrawal to complete.
      * @param tokens Array in which the i-th entry specifies the `token` input to the 'withdraw' function of the i-th Strategy in the `withdrawal.strategies` array.
-     * @param receiveAsTokens If true, the shares specified in the withdrawal will be withdrawn from the specified strategies themselves
+     * @param receiveAsTokens If true, the shares calculated to be withdrawn will be withdrawn from the specified strategies themselves
      * and sent to the caller, through calls to `withdrawal.strategies[i].withdraw`. If false, then the shares in the specified strategies
      * will simply be transferred to the caller directly.
      * @dev beaconChainETHStrategy shares are non-transferrable, so if `receiveAsTokens = false` and `withdrawal.withdrawer != withdrawal.staker`, note that
@@ -388,15 +395,15 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @notice Decreases the operators shares in storage after a slash
      * @param operator The operator to decrease shares for
      * @param strategy The strategy to decrease shares for
-     * @param previousTotalMagnitude The total magnitude before the slash
-     * @param newTotalMagnitude The total magnitude after the slash
+     * @param previousMaxMagnitude The max magnitude before the slash
+     * @param newMaxMagnitude The max magnitude after the slash
      * @dev Callable only by the AllocationManager
      */
     function decreaseOperatorShares(
         address operator,
         IStrategy strategy,
-        uint64 previousTotalMagnitude,
-        uint64 newTotalMagnitude
+        uint64 previousMaxMagnitude,
+        uint64 newMaxMagnitude
     ) external;
 
     /**
@@ -498,7 +505,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         address staker
     ) external view returns (IStrategy[] memory, uint256[] memory);
 
-    /// @notice Returns a completable timestamp given a start timestamp.
+    /// @notice Returns a completable timestamp given a start timestamp for a withdrawal
     /// @dev check whether the withdrawal delay has elapsed (handles both legacy and post-slashing-release withdrawals) and returns the completable timestamp
     function getCompletableTimestamp(
         uint32 startTimestamp

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -511,6 +511,9 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         uint32 startTimestamp
     ) external view returns (uint32 completableTimestamp);
 
+    /// @notice Return the M2 minimum withdrawal delay in blocks for backwards compatability
+    function minWithdrawalDelayBlocks() external view returns (uint256);
+
     /// @notice Returns the keccak256 hash of `withdrawal`.
     function calculateWithdrawalRoot(
         Withdrawal memory withdrawal

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -69,7 +69,7 @@ interface IDelegationManagerErrors {
 interface IDelegationManagerTypes {
     // @notice Struct used for storing information about a single operator who has registered with EigenLayer
     struct OperatorDetails {
-        /// @notice DEPRECATED -- this field is no longer used, payments are handled in PaymentCoordinator.sol
+        /// @notice DEPRECATED -- this field is no longer used, payments are handled in RewardsCoordinator.sol
         address __deprecated_earningsReceiver;
         /**
          * @notice Address to verify signatures when a staker wishes to delegate to the operator, as well as controlling "forced undelegations".

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -47,6 +47,15 @@ library SlashingLib {
         return x.mulDiv(WAD, y);
     }
 
+    /**
+     * @notice Used explicitly for calculating slashed magnitude, we want to ensure even in the
+     * situation where an operator is slashed several times and precision has been lost over time,
+     * an incoming slashing request isn't rounded down to 0 and an operator is able to avoided slashing penalties.
+     */
+    function mulWadRoundUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x.mulDiv(y, WAD, Math.Rounding.Up);
+    }
+
     // GETTERS
 
     function getDepositScalingFactor(

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -19,7 +19,7 @@ uint64 constant WAD = 1e18;
  *          - For a staker, this is the amount of shares that they can withdraw
  *          - For an operator, this is the sum of its staker's withdrawable shares       
  * 
- * Note that `withdrawal.scaledSharesToWithdraw` is scaled for the beaconChainETHStrategy to divide by the beaconChainScalingFactor upon queueing
+ * Note that `withdrawal.scaledShares` is scaled for the beaconChainETHStrategy to divide by the beaconChainScalingFactor upon queueing
  * and multiply by the beaconChainScalingFactor upon withdrawal
  */
 
@@ -73,22 +73,22 @@ library SlashingLib {
     }
 
     function scaleSharesForCompleteWithdrawal(
-        uint256 scaledSharesToWithdraw,
+        uint256 scaledShares,
         StakerScalingFactors memory ssf,
         uint64 operatorMagnitude
     ) internal pure returns (uint256) {
         /// forgefmt: disable-next-item
-        return scaledSharesToWithdraw
+        return scaledShares
             .mulWad(uint256(ssf.getBeaconChainScalingFactor()))
             .mulWad(uint256(operatorMagnitude));
     }
 
     function getOperatorSharesToDecrease(
         uint256 operatorShares,
-        uint64 previousTotalMagnitude,
-        uint64 newTotalMagnitude
+        uint64 previousMaxMagnitude,
+        uint64 newMaxMagnitude
     ) internal pure returns (uint256) {
-        return operatorShares - operatorShares.divWad(previousTotalMagnitude).mulWad(newTotalMagnitude);
+        return operatorShares - operatorShares.divWad(previousMaxMagnitude).mulWad(newMaxMagnitude);
     }
 
     function decreaseBeaconChainScalingFactor(
@@ -103,38 +103,38 @@ library SlashingLib {
         StakerScalingFactors storage ssf,
         uint256 existingDepositShares,
         uint256 addedShares,
-        uint64 totalMagnitude
+        uint64 maxMagnitude
     ) internal {
         if (existingDepositShares == 0) {
-            // if this is their first deposit for the operator, set the scaling factor to inverse of totalMagnitude
+            // if this is their first deposit for the operator, set the scaling factor to inverse of maxMagnitude
             /// forgefmt: disable-next-item
             ssf.depositScalingFactor = uint256(WAD)
                 .divWad(ssf.getBeaconChainScalingFactor())
-                .divWad(totalMagnitude);
+                .divWad(maxMagnitude);
             return;
         }
         /**
          * Base Equations:
          * (1) newShares = currentShares + addedShares
          * (2) newDepositShares = existingDepositShares + addedShares
-         * (3) newShares = newDepositShares * newStakerDepositScalingFactor * beaconChainScalingFactor * totalMagnitude
+         * (3) newShares = newDepositShares * newStakerDepositScalingFactor * beaconChainScalingFactor * maxMagnitude
          *
          * Plugging (1) into (3):
-         * (4) newDepositShares * newStakerDepositScalingFactor * beaconChainScalingFactor * totalMagnitude = currentShares + addedShares
+         * (4) newDepositShares * newStakerDepositScalingFactor * beaconChainScalingFactor * maxMagnitude = currentShares + addedShares
          *
          * Solving for newStakerDepositScalingFactor
-         * (5) newStakerDepositScalingFactor = (currentShares + addedShares) / (newDepositShares * beaconChainScalingFactor * totalMagnitude)
+         * (5) newStakerDepositScalingFactor = (currentShares + addedShares) / (newDepositShares * beaconChainScalingFactor * maxMagnitude)
          *
          * Plugging in (2) into (5):
-         * (7) newStakerDepositScalingFactor = (currentShares + addedShares) / ((existingDepositShares + addedShares) * beaconChainScalingFactor * totalMagnitude)
+         * (7) newStakerDepositScalingFactor = (currentShares + addedShares) / ((existingDepositShares + addedShares) * beaconChainScalingFactor * maxMagnitude)
          * Note that magnitudes must be divided by WAD for precision. Thus,
          *
-         * (8) newStakerDepositScalingFactor = WAD * (currentShares + addedShares) / ((existingDepositShares + addedShares) * beaconChainScalingFactor / WAD * totalMagnitude / WAD)
-         * (9) newStakerDepositScalingFactor = (currentShares + addedShares) * WAD / (existingDepositShares + addedShares) * WAD / beaconChainScalingFactor * WAD / totalMagnitude
+         * (8) newStakerDepositScalingFactor = WAD * (currentShares + addedShares) / ((existingDepositShares + addedShares) * beaconChainScalingFactor / WAD * maxMagnitude / WAD)
+         * (9) newStakerDepositScalingFactor = (currentShares + addedShares) * WAD / (existingDepositShares + addedShares) * WAD / beaconChainScalingFactor * WAD / maxMagnitude
          */
 
         // Step 1: Calculate Numerator
-        uint256 currentShares = existingDepositShares.toShares(ssf, totalMagnitude);
+        uint256 currentShares = existingDepositShares.toShares(ssf, maxMagnitude);
 
         // Step 2: Compute currentShares + addedShares
         uint256 newShares = currentShares + addedShares;
@@ -143,7 +143,7 @@ library SlashingLib {
         /// forgefmt: disable-next-item
         uint256 newStakerDepositScalingFactor = newShares
             .divWad(existingDepositShares + addedShares)
-            .divWad(totalMagnitude)
+            .divWad(maxMagnitude)
             .divWad(uint256(ssf.getBeaconChainScalingFactor()));
 
         ssf.depositScalingFactor = newStakerDepositScalingFactor;

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -50,7 +50,7 @@ library SlashingLib {
     /**
      * @notice Used explicitly for calculating slashed magnitude, we want to ensure even in the
      * situation where an operator is slashed several times and precision has been lost over time,
-     * an incoming slashing request isn't rounded down to 0 and an operator is able to avoided slashing penalties.
+     * an incoming slashing request isn't rounded down to 0 and an operator is able to avoid slashing penalties.
      */
     function mulWadRoundUp(uint256 x, uint256 y) internal pure returns (uint256) {
         return x.mulDiv(y, WAD, Math.Rounding.Up);

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -142,7 +142,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
             delegatedTo: delegation.delegatedTo(staker),
             startTimestamp: uint32(block.timestamp),
-            scaledSharesToWithdraw: shareAmounts
+            scaledShares: shareAmounts
         });
 
 

--- a/src/test/DevnetLifecycle.t.sol
+++ b/src/test/DevnetLifecycle.t.sol
@@ -255,7 +255,7 @@ contract Devnet_Lifecycle_Test is Test {
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
             startTimestamp: uint32(block.timestamp),
             strategies: strategies,
-            scaledSharesToWithdraw: scaledShares
+            scaledShares: scaledShares
         });
         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         // Generate complete withdrawal params

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -286,7 +286,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
 
         queuedWithdrawal = IDelegationManagerTypes.Withdrawal({
             strategies: strategyArray,
-            scaledSharesToWithdraw: shareAmounts,
+            scaledShares: shareAmounts,
             staker: staker,
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
@@ -398,7 +398,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
 
         IDelegationManagerTypes.Withdrawal memory queuedWithdrawal = IDelegationManagerTypes.Withdrawal({
             strategies: strategyArray,
-            scaledSharesToWithdraw: shareAmounts,
+            scaledShares: shareAmounts,
             staker: depositor,
             withdrawer: withdrawer,
             nonce: nonce,
@@ -454,7 +454,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             nonce: nonce,
             startTimestamp: withdrawalStartTimestamp,
             delegatedTo: delegatedTo,
-            scaledSharesToWithdraw: shareAmounts
+            scaledShares: shareAmounts
         });
         // complete the queued withdrawal
         delegation.completeQueuedWithdrawal(queuedWithdrawal, tokensArray, true);

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -266,7 +266,7 @@ contract IntegrationCheckUtils is IntegrationBase {
             if (operator != staker) {
                 assert_Snap_Unchanged_TokenBalances(User(operator), "operator should not have any change in underlying token balances");
             }
-            assert_Snap_Added_OperatorShares(User(operator), withdrawal.strategies, withdrawal.scaledSharesToWithdraw, "operator should have received shares");
+            assert_Snap_Added_OperatorShares(User(operator), withdrawal.strategies, withdrawal.scaledShares, "operator should have received shares");
         }
     }
 

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -61,7 +61,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
     //     _rollBlocksForCompleteWithdrawals(strategies);
 
     //     for (uint256 i = 0; i < withdrawals.length; i++) {
-    //         uint256[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint256[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
     //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
     //     }
@@ -195,7 +195,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
     //     // Fast forward to when we can complete the withdrawal
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; i++) {
-    //         uint256[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint256[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
     //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawStrats, withdrawShares, tokens, expectedTokens);
     //     }

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -61,7 +61,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
     //         staker.completeWithdrawalAsShares(withdrawals[i]);
-    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //     }
 
     //     // 5. Delegate to a new operator
@@ -80,9 +80,9 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
     //     // Complete withdrawals
     //     for (uint i = 0; i < withdrawals.length; i++) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-    //         check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw, tokens, expectedTokens);
+    //         check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares, tokens, expectedTokens);
     //     }
     // }
 
@@ -134,7 +134,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
     //         staker.completeWithdrawalAsShares(withdrawals[i]);
-    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //     }
 
     //     // 5. Delegate to a new operator
@@ -230,7 +230,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //         _rollBlocksForCompleteWithdrawals(strategies);
     //         for (uint256 i = 0; i < withdrawals.length; ++i) {
     //             staker.completeWithdrawalAsShares(withdrawals[i]);
-    //             check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //             check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         }
 
     //         // 5. Delegate to a new operator
@@ -258,7 +258,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
     //         // Complete withdrawals
     //         for (uint i = 0; i < newWithdrawals.length; i++) {
-    //             uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledSharesToWithdraw);
+    //             uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledShares);
     //             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(newWithdrawals[i]);
     //             check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, shares, tokens, expectedTokens);
     //         }
@@ -323,7 +323,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //         _rollBlocksForCompleteWithdrawals(strategies);
     //         for (uint256 i = 0; i < withdrawals.length; ++i) {
     //             staker.completeWithdrawalAsShares(withdrawals[i]);
-    //             check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //             check_Withdrawal_AsShares_Undelegated_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         }
 
     //         // 5. Deposit into Strategies
@@ -351,7 +351,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
     //         // Complete withdrawals
     //         for (uint i = 0; i < newWithdrawals.length; i++) {
-    //             uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledSharesToWithdraw);
+    //             uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledShares);
     //             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(newWithdrawals[i]);
     //             check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, shares, tokens, expectedTokens);
     //         }
@@ -401,9 +401,9 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //     // Fast forward to when we can complete the withdrawal
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-    //         check_Withdrawal_AsTokens_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw, tokens, expectedTokens);
+    //         check_Withdrawal_AsTokens_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares, tokens, expectedTokens);
     //     }
 
     //     //5. Deposit into Strategies
@@ -427,7 +427,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
     //     // Complete withdrawals as tokens
     //     for (uint i = 0; i < withdrawals.length; i++) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
     //         check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], strategies, shares, tokens, expectedTokens);
     //     }
@@ -476,9 +476,9 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
     //     // Fast forward to when we can complete the withdrawal
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-    //         check_Withdrawal_AsTokens_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw, tokens, expectedTokens);
+    //         check_Withdrawal_AsTokens_State(staker, operator1, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares, tokens, expectedTokens);
     //     }
 
     //     //5. Deposit into Strategies

--- a/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
@@ -59,9 +59,9 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
 
     //     // Complete withdrawal
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-    //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw, tokens, expectedTokens);
+    //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares, tokens, expectedTokens);
     //     }
 
     //     // Check Final State
@@ -123,7 +123,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
     //         staker.completeWithdrawalAsShares(withdrawals[i]);
 
-    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //     }
 
     //     // Check final state:
@@ -179,9 +179,9 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
     //     _rollBlocksForCompleteWithdrawals(strategies);
 
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
-    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
     //         IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-    //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw, tokens, expectedTokens);
+    //         check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares, tokens, expectedTokens);
     //     }
 
     //     // Check Final State
@@ -237,7 +237,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
     //     _rollBlocksForCompleteWithdrawals(strategies);
     //     for (uint256 i = 0; i < withdrawals.length; ++i) {
     //         staker.completeWithdrawalAsShares(withdrawals[i]);
-    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledSharesToWithdraw);
+    //         check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawals[i].scaledShares);
     //     }
 
     //     // Check final state:

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -109,7 +109,7 @@ contract User is PrintUtils {
             emit log("expecting withdrawal:");
             emit log_named_uint("nonce: ", expectedWithdrawals[i].nonce);
             emit log_named_address("strat: ", address(expectedWithdrawals[i].strategies[0]));
-            emit log_named_uint("shares: ", expectedWithdrawals[i].scaledSharesToWithdraw[0]);
+            emit log_named_uint("shares: ", expectedWithdrawals[i].scaledShares[0]);
         }
         
         return expectedWithdrawals;
@@ -152,7 +152,7 @@ contract User is PrintUtils {
             nonce: nonce,
             startTimestamp: uint32(block.timestamp),
             strategies: strategies,
-            scaledSharesToWithdraw: shares
+            scaledShares: shares
         });
 
         bytes32[] memory withdrawalRoots = delegationManager.queueWithdrawals(params);
@@ -488,7 +488,7 @@ contract User is PrintUtils {
                 nonce: (nonce + i),
                 startTimestamp: uint32(block.timestamp),
                 strategies: singleStrategy,
-                scaledSharesToWithdraw: singleShares
+                scaledShares: singleShares
             });
         }
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -931,7 +931,7 @@ contract AllocationManagerUnitTests_SlashOperator is AllocationManagerUnitTests 
      * Slashes the operator after deallocation, even if the deallocation has not been cleared. Validates that:
      * 1. Even if we do not clear deallocation queue, the deallocation is NOT slashed from since we're passed the deallocationEffectTimestamp
      * 2. Validates storage post slash & post clearing deallocation queue
-     * 3. Total magnitude only decreased proportionally by the magnitude set after deallocation
+     * 3. Max magnitude only decreased proportionally by the magnitude set after deallocation
      */
     function test_allocate_deallocate_slashAfterDeallocation() public {
         // Allocate all magnitude
@@ -1275,12 +1275,12 @@ contract AllocationManagerUnitTests_ModifyAllocations is AllocationManagerUnitTe
         allocationManager.modifyAllocations(allocations);
     }
 
-    function test_revert_invalidExpectedTotalMagnitude() public {
+    function test_revert_invalidExpectedMaxMagnitude() public {
         IAllocationManagerTypes.MagnitudeAllocation[] memory allocations =
             _randomMagnitudeAllocation_singleStrat_singleOpSet(0, 0);
         allocations[0].expectedMaxMagnitude = 1e18 + 1;
 
-        cheats.expectRevert(IAllocationManagerErrors.InvalidExpectedTotalMagnitude.selector);
+        cheats.expectRevert(IAllocationManagerErrors.InvalidExpectedMaxMagnitude.selector);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(allocations);
     }
@@ -1920,7 +1920,7 @@ contract AllocationManagerUnitTests_ClearDeallocationQueue is AllocationManagerU
         cheats.warp(allocationEffectTimestamp);
         allocationManager.clearDeallocationQueue(defaultOperator, _strategyMockArray(), _maxNumToClear());
 
-        // Validate `getAllocatableMagnitude`. Allocatable magnitude should be the difference between the total magnitude and the encumbered magnitude
+        // Validate `getAllocatableMagnitude`. Allocatable magnitude should be the difference between the max magnitude and the encumbered magnitude
         uint64 allocatableMagnitude = allocationManager.getAllocatableMagnitude(defaultOperator, strategyMock);
         assertEq(WAD - 33e16 - 5e17, allocatableMagnitude, "allocatableMagnitude not correct");
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -768,6 +768,130 @@ contract AllocationManagerUnitTests_SlashOperator is AllocationManagerUnitTests 
     }
 
     /**
+     * Allocates 100% magnitude for a single strategy to an operatorSet.
+     * First slashes 99% from the operatorSet, slashes 99.99% a second time, and on the third slash, slashes
+     * 99.9999999999999% which should get rounded up to 100% or 1e18 wadSlashed leaving the operator with no magnitude
+     * in the operatorSet, 0 encumbered magnitude, and 0 max magnitude.
+     * 
+     * Asserts that:
+     * 1. Events are emitted
+     * 2. Encumbered mag is updated
+     * 3. Max mag is updated
+     * 4. Calculations for `getAllocatableMagnitude` and `getAllocationInfo` are correct
+     * 5. Slashed amounts are rounded up to ensure magnitude is always slashed
+     */
+    function test_slashTwoOperatorSets() public {
+        // Generate allocation for `strategyMock`, we allocate 100% to opSet 0
+        IAllocationManagerTypes.MagnitudeAllocation[] memory allocations = _generateMagnitudeAllocationCalldataForOpSet({
+            avsToSet: defaultAVS,
+            operatorSetId: 0,
+            magnitudeToSet: 1e18,
+            expectedMaxMagnitude: 1e18
+        });
+
+        cheats.prank(defaultOperator);
+        allocationManager.modifyAllocations(allocations);
+        cheats.warp(block.timestamp + DEFAULT_OPERATOR_ALLOCATION_DELAY);
+
+        // 1. Slash operator for 99% in opSet 0 bringing their magnitude to 1e16
+        SlashingParams memory slashingParams = SlashingParams({
+            operator: defaultOperator,
+            operatorSetId: allocations[0].operatorSets[0].operatorSetId,
+            strategies: _strategyMockArray(),
+            wadToSlash: 99e16,
+            description: "test"
+        });
+        avsDirectoryMock.setIsOperatorSlashable(slashingParams.operator, defaultAVS, slashingParams.operatorSetId, true);
+        uint64 expectedEncumberedMagnitude = 1e16; // After slashing 99%, only 1% expected encumberedMagnitude
+        uint64 magnitudeAfterSlash = 1e16;
+        uint64 maxMagnitudeAfterSlash = 1e16; // 1e15 is maxMagnitude
+        uint256[] memory wadSlashed = new uint256[](1);
+        wadSlashed[0] = 99e16;
+
+        // Slash Operator
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit EncumberedMagnitudeUpdated(defaultOperator, strategyMock, expectedEncumberedMagnitude);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSetMagnitudeUpdated(defaultOperator, allocations[0].operatorSets[0], strategyMock, magnitudeAfterSlash, uint32(block.timestamp));
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit MaxMagnitudeUpdated(defaultOperator, strategyMock, maxMagnitudeAfterSlash);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSlashed(slashingParams.operator, _operatorSet(defaultAVS, slashingParams.operatorSetId), slashingParams.strategies, wadSlashed, slashingParams.description);
+        cheats.prank(defaultAVS);
+        allocationManager.slashOperator(slashingParams);
+
+        // Check storage
+        assertEq(expectedEncumberedMagnitude, allocationManager.encumberedMagnitude(defaultOperator, strategyMock), "encumberedMagnitude not updated");
+        assertEq(maxMagnitudeAfterSlash, allocationManager.getMaxMagnitudes(defaultOperator, _strategyMockArray())[0], "maxMagnitude not updated");
+        MagnitudeInfo[] memory mInfos = allocationManager.getAllocationInfo(defaultOperator, strategyMock, allocations[0].operatorSets);
+        assertEq(magnitudeAfterSlash, mInfos[0].currentMagnitude, "currentMagnitude not updated");
+
+        // 2. Slash operator again for 99.99% in opSet 0 bringing their magnitude to 1e14
+        slashingParams = SlashingParams({
+            operator: defaultOperator,
+            operatorSetId: allocations[0].operatorSets[0].operatorSetId,
+            strategies: _strategyMockArray(),
+            wadToSlash: 9999e14,
+            description: "test"
+        });
+        expectedEncumberedMagnitude = 1e12; // After slashing 99.99%, only 0.01% expected encumberedMagnitude
+        magnitudeAfterSlash = 1e12;
+        maxMagnitudeAfterSlash = 1e12;
+        wadSlashed[0] = 9999e14;
+
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit EncumberedMagnitudeUpdated(defaultOperator, strategyMock, expectedEncumberedMagnitude);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSetMagnitudeUpdated(defaultOperator, allocations[0].operatorSets[0], strategyMock, magnitudeAfterSlash, uint32(block.timestamp));
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit MaxMagnitudeUpdated(defaultOperator, strategyMock, maxMagnitudeAfterSlash);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSlashed(slashingParams.operator, _operatorSet(defaultAVS, slashingParams.operatorSetId), slashingParams.strategies, wadSlashed, slashingParams.description);
+        cheats.prank(defaultAVS);
+        allocationManager.slashOperator(slashingParams);
+
+        // Check storage
+        assertEq(expectedEncumberedMagnitude, allocationManager.encumberedMagnitude(defaultOperator, strategyMock), "encumberedMagnitude not updated");
+        assertEq(maxMagnitudeAfterSlash, allocationManager.getMaxMagnitudes(defaultOperator, _strategyMockArray())[0], "maxMagnitude not updated");
+        mInfos = allocationManager.getAllocationInfo(defaultOperator, strategyMock, allocations[0].operatorSets);
+        assertEq(magnitudeAfterSlash, mInfos[0].currentMagnitude, "currentMagnitude not updated");
+
+        // 3. Slash operator again for 99.9999999999999% in opSet 0
+        slashingParams = SlashingParams({
+            operator: defaultOperator,
+            operatorSetId: allocations[0].operatorSets[0].operatorSetId,
+            strategies: _strategyMockArray(),
+            wadToSlash: 1e18 - 1e3,
+            description: "test"
+        });
+        // Should technically be 1e3 remaining but with rounding error and rounding up slashed amounts
+        // the remaining magnitude is 0
+        expectedEncumberedMagnitude = 0; // Should technically be 1e3 remaining but with rounding error and rounding up slashed amounts.
+        magnitudeAfterSlash = 0;
+        maxMagnitudeAfterSlash = 0;
+        // wadSlashed is rounded up from the 1e18 - 1e3 amount
+        wadSlashed[0] = 1e18;
+
+        // Slash Operator
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit EncumberedMagnitudeUpdated(defaultOperator, strategyMock, expectedEncumberedMagnitude);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSetMagnitudeUpdated(defaultOperator, allocations[0].operatorSets[0], strategyMock, magnitudeAfterSlash, uint32(block.timestamp));
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit MaxMagnitudeUpdated(defaultOperator, strategyMock, maxMagnitudeAfterSlash);
+        cheats.expectEmit(true, true, true, true, address(allocationManager));
+        emit OperatorSlashed(slashingParams.operator, _operatorSet(defaultAVS, slashingParams.operatorSetId), slashingParams.strategies, wadSlashed, slashingParams.description);
+        cheats.prank(defaultAVS);
+        allocationManager.slashOperator(slashingParams);
+
+        // Check storage
+        assertEq(expectedEncumberedMagnitude, allocationManager.encumberedMagnitude(defaultOperator, strategyMock), "encumberedMagnitude not updated");
+        assertEq(maxMagnitudeAfterSlash, allocationManager.getMaxMagnitudes(defaultOperator, _strategyMockArray())[0], "maxMagnitude not updated");
+        mInfos = allocationManager.getAllocationInfo(defaultOperator, strategyMock, allocations[0].operatorSets);
+        assertEq(magnitudeAfterSlash, mInfos[0].currentMagnitude, "currentMagnitude not updated");
+    }
+
+    /**
      * Allocates all of magnitude to a single strategy to an operatorSet. Deallocate half. Finally, slash while deallocation is pending
      * Asserts that:
      * 1. Events are emitted, including for deallocation

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -363,8 +363,8 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         }
 
         // Get scaled shares to withdraw
-        uint256[] memory scaledSharesToWithdrawArray = new uint256[](1);
-        scaledSharesToWithdrawArray[0] = _getScaledSharesToWithdraw(staker, strategy, sharesToWithdraw);
+        uint256[] memory scaledSharesArray = new uint256[](1);
+        scaledSharesArray[0] = _getScaledShares(staker, strategy, sharesToWithdraw);
 
         IDelegationManagerTypes.Withdrawal memory withdrawal = IDelegationManagerTypes.Withdrawal({
             staker: staker,
@@ -373,7 +373,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
             startTimestamp: uint32(block.timestamp),
             strategies: strategyArray,
-            scaledSharesToWithdraw: scaledSharesToWithdrawArray
+            scaledShares: scaledSharesArray
         });
         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
@@ -400,9 +400,9 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         }
 
         // Get scaled shares to withdraw
-        uint256[] memory scaledSharesToWithdrawArray = new uint256[](strategies.length);
+        uint256[] memory scaledSharesArray = new uint256[](strategies.length);
         for (uint256 i = 0; i < strategies.length; i++) {
-            scaledSharesToWithdrawArray[i] = _getScaledSharesToWithdraw(staker, strategies[i], withdrawalAmounts[i]);
+            scaledSharesArray[i] = _getScaledShares(staker, strategies[i], withdrawalAmounts[i]);
         }
         
         IDelegationManagerTypes.Withdrawal memory withdrawal = IDelegationManagerTypes.Withdrawal({
@@ -412,14 +412,14 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
             startTimestamp: uint32(block.timestamp),
             strategies: strategies,
-            scaledSharesToWithdraw: scaledSharesToWithdrawArray
+            scaledShares: scaledSharesArray
         });
         bytes32 withdrawalRoot = delegationManager.calculateWithdrawalRoot(withdrawal);
         
         return (queuedWithdrawalParams, withdrawal, withdrawalRoot);
     }
 
-    function _getScaledSharesToWithdraw(address staker, IStrategy strategy, uint256 sharesToWithdraw) internal view returns (uint256) {
+    function _getScaledShares(address staker, IStrategy strategy, uint256 sharesToWithdraw) internal view returns (uint256) {
         // Setup vars
         address operator = delegationManager.delegatedTo(staker);
         IStrategy[] memory strategyArray = new IStrategy[](1);
@@ -433,13 +433,13 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             beaconChainScalingFactor: beaconChainScalingFactor
         });
 
-        uint256 scaledSharesToWithdraw = SlashingLib.scaleSharesForQueuedWithdrawal(
+        uint256 scaledShares = SlashingLib.scaleSharesForQueuedWithdrawal(
             sharesToWithdraw,
             stakerScalingFactor,
             allocationManagerMock.getMaxMagnitudes(operator, strategyArray)[0]
         );
 
-        return scaledSharesToWithdraw;
+        return scaledShares;
     }
 
     /**


### PR DESCRIPTION
PR Fixes:
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1769243035
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1769256480 added legacy minWithdrawalDelayBlocks interfaces
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1769370145 fixed interface to "numToClear" and added to natspec description
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1769374303 addressed, see `modifyAllocations`
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1769375520 added helpers using `Rounding.Up` in the OZ Math lib
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772293939 Allow for allocationDelays of 0 now https://github.com/Layr-Labs/eigenlayer-contracts/pull/842/commits/86845acb8da47dc1a69fb8a77a90a93a7dc93d51
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772294865
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772320029 https://github.com/Layr-Labs/eigenlayer-contracts/pull/842/commits/664f9cd076abde998e9d89e31fb5336a85ceb762
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772321327 https://github.com/Layr-Labs/eigenlayer-contracts/pull/842/commits/4d9580f1a0cc95cd9453b3fd6eab9e18720e7768
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772326774
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772326774 fixed natspec
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772327394 nit comment
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1772327394
- https://github.com/Layr-Labs/eigenlayer-contracts/pull/679#discussion_r1773850362

Additional Changes:

- totalMagnitude -> maxMagnitude
- renamed `scaledSharesToWithdraw` to `scaledShares`. Previous name indicates that its the actual shares to withdraw which is a bit misleading
- added some clarification to comments and natspec
- IDelegationManager still had description of undelegation limbo in its natspec. This was removed
- fixed `run-coverage` CI due to RPC_MAINNET env not being set
