### PR TITLE
POC: Key Rotation Integration

### DIFF
--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -151,7 +151,7 @@ contract AVSDirectory is
         ISignatureUtils.SignatureWithSaltAndExpiry memory adminSignature
     ) external override onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) {
         if (operatorSignature.signature.length == 0) {
-            _checkCanCall(operator, msg.sender);
+            _checkCanCall(operator);
         } else {
             address admin = permissionController.getAdmin(operator);
             // Assert operator's signature has not expired.
@@ -228,8 +228,7 @@ contract AVSDirectory is
     function cancelSalt(
         address operator,
         bytes32 salt
-    ) external override {
-        _checkCanCall(operator, msg.sender);
+    ) external override checkCanCall(operator) {
         // Mutate `operatorSaltIsSpent` to `true` to prevent future spending.
         operatorSaltIsSpent[operator][salt] = true;
     }

--- a/src/contracts/core/AVSDirectoryStorage.sol
+++ b/src/contracts/core/AVSDirectoryStorage.sol
@@ -52,8 +52,8 @@ abstract contract AVSDirectoryStorage is IAVSDirectory {
     /// @dev This storage will be deprecated once M2 based deregistration is deprecated.
     mapping(address => mapping(address => OperatorAVSRegistrationStatus)) public avsOperatorStatus;
 
-    /// @notice Mapping: operator => salt => Whether the salt has been used or not.
-    mapping(address => mapping(bytes32 => bool)) public operatorSaltIsSpent;
+    /// @notice Mapping: admin => salt => Whether the salt has been used or not.
+    mapping(address => mapping(bytes32 => bool)) public adminSaltIsSpent;
 
     /// @notice Mapping: avs => Whether it is a an operator set AVS or not.
     mapping(address => bool) public isOperatorSetAVS;

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -215,6 +215,7 @@ contract AllocationManager is
     function setAllocationDelay(address operator, uint32 delay) external {
         // TODO: fix error
         require(msg.sender == address(delegation) || _checkCanCall(operator), InvalidCaller());
+        require(delegation.isOperator(operator), OperatorNotRegistered());
         _setAllocationDelay(operator, delay);
     }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -134,8 +134,7 @@ contract AllocationManager is
     function modifyAllocations(
         address operator,
         MagnitudeAllocation[] calldata allocations
-    ) external onlyWhenNotPaused(PAUSED_MODIFY_ALLOCATIONS) {
-        _checkCanCall(operator, msg.sender);
+    ) external onlyWhenNotPaused(PAUSED_MODIFY_ALLOCATIONS) checkCanCall(operator) {
         (bool isSet, uint32 operatorAllocationDelay) = getAllocationDelay(operator);
         require(isSet, UninitializedAllocationDelay());
 
@@ -215,7 +214,7 @@ contract AllocationManager is
     /// @inheritdoc IAllocationManager
     function setAllocationDelay(address operator, uint32 delay) external {
         // TODO: fix error
-        require(msg.sender == address(delegation) || _checkCanCall(operator, msg.sender), OnlyDelegationManager());
+        require(msg.sender == address(delegation) || _checkCanCall(operator), InvalidCaller());
         _setAllocationDelay(operator, delay);
     }
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -120,8 +120,7 @@ contract DelegationManager is
     function modifyOperatorDetails(
         address operator,
         OperatorDetails calldata newOperatorDetails
-    ) external {
-        _checkCanCall(operator, msg.sender);        
+    ) external checkCanCall(operator) {
         require(isOperator(operator), OperatorNotRegistered());
         _setOperatorDetails(operator, newOperatorDetails);
     }
@@ -130,10 +129,9 @@ contract DelegationManager is
     function updateOperatorMetadataURI(
         address operator,
         string calldata metadataURI
-    ) external {
-        _checkCanCall(operator, msg.sender);
-        require(isOperator(msg.sender), OperatorNotRegistered());
-        emit OperatorMetadataURIUpdated(msg.sender, metadataURI);
+    ) external checkCanCall(operator) {
+        require(isOperator(operator), OperatorNotRegistered());
+        emit OperatorMetadataURIUpdated(operator, metadataURI);
     }
 
     /// @inheritdoc IDelegationManager

--- a/src/contracts/core/RewardsCoordinator.sol
+++ b/src/contracts/core/RewardsCoordinator.sol
@@ -222,10 +222,19 @@ contract RewardsCoordinator is
     function setClaimerFor(
         address claimer
     ) external {
+        // Use the setClaimerFor function for operators
+        require(!delegationManager.isOperator(msg.sender), InvalidOperator());
         address earner = msg.sender;
-        address prevClaimer = claimerFor[earner];
-        claimerFor[earner] = claimer;
-        emit ClaimerForSet(earner, prevClaimer, claimer);
+        _setClaimer(earner, claimer);
+    }
+
+    function setClaimerForOperator(
+        address operator,
+        address claimer
+    ) external {
+        require(delegationManager.isOperator(operator), InvalidOperator());
+        _checkCanCall(operator, msg.sender);
+        _setClaimer(operator, claimer);
     }
 
     /// @inheritdoc IRewardsCoordinator
@@ -400,6 +409,15 @@ contract RewardsCoordinator is
     ) internal {
         emit RewardsUpdaterSet(rewardsUpdater, _rewardsUpdater);
         rewardsUpdater = _rewardsUpdater;
+    }
+
+    function _setClaimer(
+        address earner,
+        address claimer
+    ) internal {
+        address prevClaimer = claimerFor[earner];
+        claimerFor[earner] = claimer;
+        emit ClaimerForSet(earner, prevClaimer, claimer);
     }
 
     /**

--- a/src/contracts/core/RewardsCoordinator.sol
+++ b/src/contracts/core/RewardsCoordinator.sol
@@ -231,9 +231,8 @@ contract RewardsCoordinator is
     function setClaimerForOperator(
         address operator,
         address claimer
-    ) external {
+    ) external checkCanCall(operator) {
         require(delegationManager.isOperator(operator), InvalidOperator());
-        _checkCanCall(operator, msg.sender);
         _setClaimer(operator, claimer);
     }
 

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -110,25 +110,30 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      * @notice Called by an AVS to create a list of new operatorSets.
      *
+     * @param avs The address of the AVS creating the operator sets.
      * @param operatorSetIds The IDs of the operator set to initialize.
      *
      * @dev msg.sender must be the AVS.
      * @dev The AVS may create operator sets before it becomes an operator set AVS.
      */
     function createOperatorSets(
+        address avs,
         uint32[] calldata operatorSetIds
     ) external;
 
     /**
      * @notice Sets the AVS as an operator set AVS, preventing legacy M2 operator registrations.
      *
+     * @param avs The address of the AVS to set as an operator set AVS.
+     * 
      * @dev msg.sender must be the AVS.
      */
-    function becomeOperatorSetAVS() external;
+    function becomeOperatorSetAVS(address avs) external;
 
     /**
      * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
      *
+     * @param avs The address of the AVS to migrate operators for
      * @param operators The list of operators to migrate
      * @param operatorSetIds The list of operatorSets to migrate the operators to
      *
@@ -138,6 +143,7 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
      * @dev The operator is deregistered from the M2 legacy AVS once migrated
      */
     function migrateOperatorsToOperatorSets(
+        address avs,
         address[] calldata operators,
         uint32[][] calldata operatorSetIds
     ) external;
@@ -145,6 +151,7 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      *  @notice Called by AVSs to add an operator to a list of operatorSets.
      *
+     *  @param avs The address of the AVS adding the operator to the operator sets.
      *  @param operator The address of the operator to be added to the operator set.
      *  @param operatorSetIds The IDs of the operator sets.
      *  @param operatorSignature The signature of the operator on their intent to register.
@@ -153,6 +160,7 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
      *  @dev The operator must not have a pending deregistration from the operator set.
      */
     function registerOperatorToOperatorSets(
+        address avs,
         address operator,
         uint32[] calldata operatorSetIds,
         ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
@@ -179,50 +187,57 @@ interface IAVSDirectory is IAVSDirectoryEvents, IAVSDirectoryErrors, ISignatureU
     /**
      *  @notice Called by AVSs to remove an operator from an operator set.
      *
+     *  @param avs The address of the AVS removing the operator from the operator sets.
      *  @param operator The address of the operator to be removed from the operator set.
      *  @param operatorSetIds The IDs of the operator sets.
      *
      *  @dev msg.sender is used as the AVS.
      */
-    function deregisterOperatorFromOperatorSets(address operator, uint32[] calldata operatorSetIds) external;
+    function deregisterOperatorFromOperatorSets(address avs, address operator, uint32[] calldata operatorSetIds) external;
 
     /**
      *  @notice Called by AVSs to add a set of strategies to an operator set.
      *
+     *  @param avs The address of the AVS adding the strategies to the operator set.
      *  @param operatorSetId The ID of the operator set.
      *  @param strategies The addresses of the strategies to be added to the operator set.
      *
      *  @dev msg.sender is used as the AVS.
      */
-    function addStrategiesToOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) external;
+    function addStrategiesToOperatorSet(address avs, uint32 operatorSetId, IStrategy[] calldata strategies) external;
 
     /**
      *  @notice Called by AVSs to remove a set of strategies from an operator set.
      *
+     *  @param avs The address of the AVS removing the strategies from the operator set.
      *  @param operatorSetId The ID of the operator set.
      *  @param strategies The addresses of the strategies to be removed from the operator set.
      *
      *  @dev msg.sender is used as the AVS.
      */
-    function removeStrategiesFromOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) external;
+    function removeStrategiesFromOperatorSet(address avs, uint32 operatorSetId, IStrategy[] calldata strategies) external;
 
     /**
      *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
      *
+     *  @param avs The address of the AVS updating the metadata URI.
      *  @param metadataURI The URI for metadata associated with an AVS.
      *
      *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
      */
     function updateAVSMetadataURI(
+        address avs,
         string calldata metadataURI
     ) external;
 
     /**
      * @notice Called by an operator to cancel a salt that has been used to register with an AVS.
      *
+     * @param operator The address of the operator to cancel the salt for.
      * @param salt A unique and single use value associated with the approver signature.
      */
     function cancelSalt(
+        address operator
         bytes32 salt
     ) external;
 

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -147,16 +147,19 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @notice Called by an AVS to slash an operator in a given operator set
      */
     function slashOperator(
+        address avs
         SlashingParams calldata params
     ) external;
 
     /**
      * @notice Modifies the propotions of slashable stake allocated to a list of operatorSets for a set of strategies
+     * @param operator the operator to modify the allocation for
      * @param allocations array of magnitude adjustments for multiple strategies and corresponding operator sets
      * @dev Updates encumberedMagnitude for the updated strategies
      * @dev msg.sender is used as operator
      */
     function modifyAllocations(
+        address operator,
         MagnitudeAllocation[] calldata allocations
     ) external;
 
@@ -177,7 +180,7 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
     ) external;
 
     /**
-     * @notice Called by the delegation manager to set an operator's allocation delay.
+     * @notice Called by the delegation manager or an operator to set an operator's allocation delay.
      * This is set when the operator first registers, and is the time between an operator
      * allocating magnitude to an operator set, and the magnitude becoming slashable.
      * @dev Note that if an operator's allocation delay is 0, it has not been set yet,
@@ -186,17 +189,6 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @param delay the allocation delay in seconds
      */
     function setAllocationDelay(address operator, uint32 delay) external;
-
-    /**
-     * @notice Called by an operator to set their allocation delay. This is the time between an operator
-     * allocating magnitude to an operator set, and the magnitude becoming slashable.
-     * @dev Note that if an operator's allocation delay is 0, it has not been set yet,
-     * and the operator will be unable to allocate magnitude to any operator set.
-     * @param delay the allocation delay in seconds
-     */
-    function setAllocationDelay(
-        uint32 delay
-    ) external;
 
     /**
      *

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -21,8 +21,6 @@ interface IAllocationManagerErrors {
     error InvalidOperatorSet();
     /// @dev Thrown when an invalid operator is provided.
     error InvalidOperator();
-    /// @dev Thrown when caller is not the delegation manager.
-    error OnlyDelegationManager();
     /// @dev Thrown when an operator attempts to set their allocation for an operatorSet to the same value
     error SameMagnitude();
     /// @dev Thrown when an allocation is attempted for a given operator when they have pending allocations or deallocations.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -230,20 +230,24 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
 
     /**
      * @notice Updates an operator's stored `OperatorDetails`.
+     * @param operator The operator to update details for.
      * @param newOperatorDetails is the updated `OperatorDetails` for the operator, to replace their current OperatorDetails`.
      *
      * @dev The caller must have previously registered as an operator in EigenLayer.
      */
     function modifyOperatorDetails(
+        address operator,
         OperatorDetails calldata newOperatorDetails
     ) external;
 
     /**
      * @notice Called by an operator to emit an `OperatorMetadataURIUpdated` event indicating the information has updated.
+     * @param operator The operator to update metadata for
      * @param metadataURI The URI for metadata associated with an operator
      * @dev Note that the `metadataURI` is *never stored * and is only emitted in the `OperatorMetadataURIUpdated` event
      */
     function updateOperatorMetadataURI(
+        address operator,
         string calldata metadataURI
     ) external;
 

--- a/src/contracts/interfaces/IRewardsCoordinator.sol
+++ b/src/contracts/interfaces/IRewardsCoordinator.sol
@@ -269,6 +269,7 @@ interface IRewardsCoordinator is IRewardsCoordinatorErrors, IRewardsCoordinatorE
     /**
      * @notice Creates a new rewards submission on behalf of an AVS, to be split amongst the
      * set of stakers delegated to operators who are registered to the `avs`
+     * @param avs The AVS on behalf of which the rewards submission is being made. It is assumed to be the msg.sender
      * @param rewardsSubmissions The rewards submissions being created
      * @dev Expected to be called by the ServiceManager of the AVS on behalf of which the submission is being made
      * @dev The duration of the `rewardsSubmission` cannot exceed `MAX_REWARDS_DURATION`
@@ -278,6 +279,7 @@ interface IRewardsCoordinator is IRewardsCoordinatorErrors, IRewardsCoordinatorE
      * e.g. if the `strategies` and `weights` arrays are of non-equal lengths
      */
     function createAVSRewardsSubmission(
+        address avs,
         RewardsSubmission[] calldata rewardsSubmissions
     ) external;
 

--- a/src/contracts/permissions/PermissionControllerStorage.sol
+++ b/src/contracts/permissions/PermissionControllerStorage.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.27;
 import "../interfaces/IPermissionController.sol";
 
 abstract contract PermissionControllerStorage is IPermissionController {
-    /// @notice Mapping (account => admin)
-    mapping(address => address) accountToAdmin;
+    /// @notice Mapping of account to admin
+    mapping(address account => address admin) accountToAdmin;
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new


### PR DESCRIPTION
Examples of what the core protocol functions would look to satisfy:

1. Key rotation for operators
2. Forward-compatible delegated account interfaces 

See #843 for only the implementation


Breaking Interfaces:

1. `modifyOperatorDetails` - DM
2. `setMetadataURI` - DM
3. `createAVSRewardsSubmission` - RC. _Note: we likely can leave this the same as this reward type will be deprecated long term_
4. `cancelSalt` - AVSD
5. `setMetadataURI` - AVSD.  _Note: We may want to not break this interface for AVSs_

I specifically chose to leave out `setClaimer` in the RC and `undelegate` in the DM as they already have delegation enabled. An argument can be made to add `setClaimer`, but then this feature becomes usable by stakers too, which is not in scope.   

Core contracts without changes are: `EigenPodManager`, `StrategyManager`, `StrategyFactory`