### PR TITLE
slashing: fully slashed strategies

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -218,7 +218,7 @@ contract DelegationManager is
             // Otherwise if the operator has been slashed 100% for the strategy, it implies
             // the staker has no available shares to withdraw and we simply decrement their entire depositShares amount.
             // Note the returned withdrawal root will be 0x0 in this scenario but is not actually a valid null root.
-            if (_verifyMaxMagnitudeAndScalingFactor(maxMagnitudes[i], ssf)) {
+            if (_hasNonZeroScalingFactors(maxMagnitudes[i], ssf)) {
                 IStrategy[] memory singleStrategy = new IStrategy[](1);
                 uint256[] memory singleShares = new uint256[](1);
                 uint64[] memory singleMaxMagnitude = new uint64[](1);
@@ -569,7 +569,7 @@ contract DelegationManager is
 
         // Ensure that the operator has not been fully slashed for a strategy
         // and that the staker has not been fully slashed if its the beaconChainStrategy
-        require(_verifyMaxMagnitudeAndScalingFactor(maxMagnitude, ssf), FullySlashed());
+        require(_hasNonZeroScalingFactors(maxMagnitude, ssf), FullySlashed());
 
         // Increment operator shares
         operatorShares[operator][strategy] += addedShares;
@@ -639,7 +639,7 @@ contract DelegationManager is
 
             // Ensure that the operator has not been fully slashed for a strategy
             // and that the staker has not been slashed fully if its the beaconChainStrategy
-            require(_verifyMaxMagnitudeAndScalingFactor(maxMagnitudes[i], ssf), FullySlashed());
+            require(_hasNonZeroScalingFactors(maxMagnitudes[i], ssf), FullySlashed());
 
             // Calculate the deposit shares
             uint256 depositSharesToRemove = sharesToWithdraw[i].toDepositShares(ssf, maxMagnitudes[i]);
@@ -694,7 +694,7 @@ contract DelegationManager is
      * if this is the beaconChain strategy
      * @return bool True if the maxMagnitude is not 0 and the staker's beaconChainScalingFactor is not 0
      */
-    function _verifyMaxMagnitudeAndScalingFactor(
+    function _hasNonZeroScalingFactors(
         uint64 maxMagnitude,
         StakerScalingFactors memory ssf
     ) internal view returns (bool) {

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -268,6 +268,8 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      *             or their delegationApprover is the `msg.sender`, then approval is assumed.
      * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
+     * @dev If the staker delegating has shares in a strategy that the operator was slashed 100% for (the operator's maxMagnitude = 0),
+     * then delegation is blocked and will revert.
      */
     function delegateTo(
         address operator,
@@ -291,6 +293,8 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @dev This function will revert if the current `block.timestamp` is equal to or exceeds the expiry
      * @dev In the case that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
+     * @dev If the staker delegating has shares in a strategy that the operator was slashed 100% for (the operator's maxMagnitude = 0),
+     * then delegation is blocked and will revert.
      */
     function delegateToBySignature(
         address staker,
@@ -373,6 +377,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      *
      * @dev *If the staker is actively delegated*, then increases the `staker`'s delegated delegatedShares in `strategy`.
      * Otherwise does nothing.
+     * @dev If the operator was slashed 100% for the strategy (the operator's maxMagnitude = 0), then increasing delegated shares is blocked and will revert.
      * @dev Callable only by the StrategyManager or EigenPodManager.
      */
     function increaseDelegatedShares(

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -43,6 +43,12 @@ interface IDelegationManagerErrors {
     /// @dev Thrown when provided delay exceeds maximum.
     error WithdrawalDelayExceedsMax();
 
+    /// Slashing
+
+    /// @dev Thrown when an operator has been fully slashed(maxMagnitude is 0) for a strategy.
+    /// or if the staker has had been natively slashed to the point of their beaconChainScalingFactor equalling 0.
+    error FullySlashed();
+
     /// Signatures
 
     /// @dev Thrown when attempting to spend a spent eip-712 salt.

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -2836,7 +2836,6 @@ contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTest
     /**
      * @notice Verifies that `DelegationManager.increaseDelegatedShares` reverts when operator slashed 100% for a strategy
      * and the staker has deposits in that strategy
-     * @dev Checks that there is no change if the staker is not delegated
      */
     function testFuzz_Revert_increaseDelegatedShares_slashedOperator100Percent(
         address staker,
@@ -2946,9 +2945,8 @@ contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTest
     }
 
     /**
-     * @notice Verifies that `DelegationManager.increaseDelegatedShares` doesn't when operator slashed 100% for a strategy
+     * @notice Verifies that `DelegationManager.increaseDelegatedShares` doesn't revert when operator slashed 100% for a strategy
      * and the staker has deposits in a separate strategy
-     * @dev Checks that there is no change if the staker is not delegated
      */
     function testFuzz_increaseDelegatedShares_slashedOperator100Percent(
         address staker,
@@ -3491,7 +3489,6 @@ contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
     /**
      * @notice Verifies that the `undelegate` function properly undelegates a staker even though their shares
      * were slashed entirely.
-     * @notice The operator should have its shares slashed prior to the staker's deposit
      */
     function testFuzz_undelegate_slashedOperator100PercentWhileStaked(uint128 shares) public {
         // register *this contract* as an operator
@@ -3800,13 +3797,11 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
     }
 
     /**
-     * @notice Verifies that `DelegationManager.queueWithdrawals` properly queues a withdrawal for the `withdrawer`
-     * from the `strategy` for the `sharesAmount`. Operator is slashed while the staker is deposited
-     * - Asserts that staker is delegated to the operator
-     * - Asserts that shares for delegatedTo operator are decreased by `sharesAmount`
-     * - Asserts that staker cumulativeWithdrawalsQueued nonce is incremented
+     * @notice Verifies that `DelegationManager.queueWithdrawals` reverts when queuing a withdrawal for the `withdrawer`
+     * from the `strategy` for the `sharesAmount` since the Operator is slashed 100% while the staker is deposited
+     * - Asserts that queuing a withdrawal reverts when the operator is slashed 100%
+     * - Asserts that staker withdrawableShares after is 0
      * - Checks that event was emitted with correct withdrawalRoot and withdrawal
-     * TODO: fuzz magnitude
      */
     function testFuzz_Revert_queueWithdrawal_SingleStrat_slashed100PercentWhileStaked(
         uint128 depositAmount,


### PR DESCRIPTION
This handles edge cases of 100% slashed scenarios where an operator is fully slashed for a strategy(maxMagnitude = 0)
and also when a native restaker has had enough accrued delta decreases in their beacon chain shares to the point where their beaconChainScalingFactor is 0. Either of these situations will result in a divide by 0 and has more transparent error revert checks when this occurs. 

Changes:
- Undelegation from a fully slashed operator is also fixed now as the queue withdrawal is ignored and deposit shares are fully decreased.
- Delegated deposits (`increaseDelegatedShares`) to an operator for a strategy that is fully slashed will revert
- Queue withdrawals for a strategy that is fully slashed will revert

Note: Complete queued withdrawals are unchanged but perhaps should revert if they were slashed during queue delay. It would avoid wasted gas for withdrawing 0 shares.

Tests:

- [x] As staker delegating to an operator who is slashed 100% for a strategy will revert
- [x] As existing staker delegated to an operator who is slashed 100% for a strategy, depositing more shares(`increaseDelegatedShares`) will revert
- [x] As existing staker with withdrawable shares delegated to an operator, after the operator was slashed 100%, the staker no longer has withdrawable shares
- [x] As staker delegated to operator who was slashed 100% for a strategy, the staker can still `increaseDelegatedShares` for other strategies with non-zero maxMagnitude for the operator.
- [x] Staker can undelegate even when slashed 100% (strategy that is 100% slashed is not queue withdrawn)
- [x] Staker cannot queue withdrawal for strategy slashed 100%