### PR TITLE
slashing: revert timestamps delegation

### DIFF
--- a/script/deploy/devnet/deploy_from_scratch.s.sol
+++ b/script/deploy/devnet/deploy_from_scratch.s.sol
@@ -365,10 +365,11 @@ contract DeployFromScratch is Script, Test {
         _verifyInitializationParams();
 
         // Check DM and AM have same withdrawa/deallocation delay
-        require(
-            delegation.MIN_WITHDRAWAL_DELAY() == allocationManager.DEALLOCATION_DELAY(),
-            "DelegationManager and AllocationManager have different withdrawal/deallocation delays"
-        );
+        // TODO: Update after AllocationManager is converted to timestamps as well
+        // require(
+        //     delegation.MIN_WITHDRAWAL_DELAY_BLOCKS() == allocationManager.DEALLOCATION_DELAY(),
+        //     "DelegationManager and AllocationManager have different withdrawal/deallocation delays"
+        // );
         require(
             allocationManager.DEALLOCATION_DELAY() == 1 days
         );

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -34,9 +34,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @dev Index for flag that pauses completing existing withdrawals when set.
     uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
 
-    /// @notice The minimum number of blocks to complete a legacy pre-slashing upgrade withdrawal of a strategy. 50400 * 12 seconds = 1 week
-    uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50_400;
-
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
@@ -58,10 +55,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
 
     /// @notice Minimum withdrawal delay in blocks until a queued withdrawal can be completed.
     uint32 public immutable MIN_WITHDRAWAL_DELAY_BLOCKS;
-
-    /// @notice The block number at which the slashing upgrade was activated.
-    /// This is needed to determine if a withdrawal is a legacy or slashing withdrawal and the delays they are subject to.
-    uint32 public immutable SLASHING_UPGRADE_BLOCK;
 
     // Mutatables
 
@@ -125,7 +118,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
         eigenPodManager = _eigenPodManager;
         allocationManager = _allocationManager;
         MIN_WITHDRAWAL_DELAY_BLOCKS = _MIN_WITHDRAWAL_DELAY_BLOCKS;
-        SLASHING_UPGRADE_BLOCK = uint32(block.number);
     }
 
     /**

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -34,15 +34,8 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @dev Index for flag that pauses completing existing withdrawals when set.
     uint8 internal constant PAUSED_EXIT_WITHDRAWAL_QUEUE = 2;
 
-    /// @notice The minimum number of blocks to complete a withdrawal of a strategy. 50400 * 12 seconds = 1 week
+    /// @notice The minimum number of blocks to complete a legacy pre-slashing upgrade withdrawal of a strategy. 50400 * 12 seconds = 1 week
     uint256 public constant LEGACY_MIN_WITHDRAWAL_DELAY_BLOCKS = 50_400;
-
-    /// @notice Check against the blockNumber/timestamps to determine if the withdrawal is a legacy or slashing withdrawl.
-    // Legacy withdrawals use block numbers. We expect block number 1 billion in ~370 years
-    // Slashing withdrawals use timestamps. The UTC timestmap as of Jan 1st, 2024 is 1_704_067_200 . Thus, when deployed, all
-    // withdrawal timestamps are AFTER the `LEGACY_WITHDRAWAL_CHECK_VALUE` timestamp.
-    // This below value is the UTC timestamp at Sunday, September 9th, 2001.
-    uint32 public constant LEGACY_WITHDRAWAL_CHECK_VALUE = 1_000_000_000;
 
     /// @notice Canonical, virtual beacon chain ETH strategy
     IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
@@ -63,8 +56,12 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @notice The AllocationManager contract for EigenLayer
     IAllocationManager public immutable allocationManager;
 
-    /// @notice Minimum withdrawal delay in seconds until a queued withdrawal can be completed.
-    uint32 public immutable MIN_WITHDRAWAL_DELAY;
+    /// @notice Minimum withdrawal delay in blocks until a queued withdrawal can be completed.
+    uint32 public immutable MIN_WITHDRAWAL_DELAY_BLOCKS;
+
+    /// @notice The block number at which the slashing upgrade was activated.
+    /// This is needed to determine if a withdrawal is a legacy or slashing withdrawal and the delays they are subject to.
+    uint32 public immutable SLASHING_UPGRADE_BLOCK;
 
     // Mutatables
 
@@ -121,13 +118,14 @@ abstract contract DelegationManagerStorage is IDelegationManager {
         IStrategyManager _strategyManager,
         IEigenPodManager _eigenPodManager,
         IAllocationManager _allocationManager,
-        uint32 _MIN_WITHDRAWAL_DELAY
+        uint32 _MIN_WITHDRAWAL_DELAY_BLOCKS
     ) {
         avsDirectory = _avsDirectory;
         strategyManager = _strategyManager;
         eigenPodManager = _eigenPodManager;
         allocationManager = _allocationManager;
-        MIN_WITHDRAWAL_DELAY = _MIN_WITHDRAWAL_DELAY;
+        MIN_WITHDRAWAL_DELAY_BLOCKS = _MIN_WITHDRAWAL_DELAY_BLOCKS;
+        SLASHING_UPGRADE_BLOCK = uint32(block.number);
     }
 
     /**

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -29,8 +29,6 @@ interface IDelegationManagerErrors {
 
     /// @dev Thrown when attempting to execute an action that was not queued.
     error WithdrawalNotQueued();
-    /// @dev Thrown when provided delay exceeds maximum.
-    error AllocationDelaySet();
     /// @dev Thrown when caller cannot undelegate on behalf of a staker.
     error CallerCannotUndelegate();
     /// @dev Thrown when two array parameters have mismatching lengths.
@@ -536,19 +534,12 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         address staker
     ) external view returns (IStrategy[] memory, uint256[] memory);
 
-    /// @notice Returns a completable timestamp given a start timestamp for a withdrawal
-    /// @dev check whether the withdrawal delay has elapsed (handles both legacy and post-slashing-release withdrawals) and returns the completable timestamp
-    function getCompletableTimestamp(
-        uint32 startTimestamp
-    ) external view returns (uint32 completableTimestamp);
-
-    /// @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
-    /// Applies to withdrawals queued at a blocknumber >= SLASHING_UPGRADE_BLOCK.
+    /**
+     * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
+     * Also applies to legacy withdrawals so any withdrawals not completed prior to the slashing upgrade will be subject
+     * to this longer delay.
+     */
     function MIN_WITHDRAWAL_DELAY_BLOCKS() external view returns (uint32);
-
-    /// @notice Return the M2 minimum withdrawal delay in blocks for backwards compatability.
-    /// NOT to be confused with the current minimum withdrawal delay for withdrawals queued at a blocknumber >= SLASHING_UPGRADE_BLOCK.
-    function minWithdrawalDelayBlocks() external view returns (uint256);
 
     /// @notice Returns the keccak256 hash of `withdrawal`.
     function calculateWithdrawalRoot(

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -40,9 +40,6 @@ interface IDelegationManagerErrors {
     /// @dev Thrown when caller is neither the StrategyManager or EigenPodManager contract.
     error OnlyStrategyManagerOrEigenPodManager();
 
-    /// @dev Thrown when provided delay exceeds maximum.
-    error WithdrawalDelayExceedsMax();
-
     /// Slashing
 
     /// @dev Thrown when an operator has been fully slashed(maxMagnitude is 0) for a strategy.
@@ -133,11 +130,8 @@ interface IDelegationManagerTypes {
         address withdrawer;
         // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
         uint256 nonce;
-        // Timestamp when the Withdrawal was created.
-        // NOTE this used to be `startBlock` but changedto timestamps in the Slashing release. This has no effect
-        // on the hash of this struct but we do need to know when to handle blocknumbers vs timestamps depending on
-        // if the withdrawal was created before or after the Slashing release.
-        uint32 startTimestamp;
+        // Blocknumber when the Withdrawal was created.
+        uint32 startBlock;
         // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
         // Array containing the amount of staker's scaledShares for withdrawal in each Strategy in the `strategies` array
@@ -548,7 +542,12 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         uint32 startTimestamp
     ) external view returns (uint32 completableTimestamp);
 
-    /// @notice Return the M2 minimum withdrawal delay in blocks for backwards compatability
+    /// @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
+    /// Applies to withdrawals queued at a blocknumber >= SLASHING_UPGRADE_BLOCK.
+    function MIN_WITHDRAWAL_DELAY_BLOCKS() external view returns (uint32);
+
+    /// @notice Return the M2 minimum withdrawal delay in blocks for backwards compatability.
+    /// NOT to be confused with the current minimum withdrawal delay for withdrawals queued at a blocknumber >= SLASHING_UPGRADE_BLOCK.
     function minWithdrawalDelayBlocks() external view returns (uint256);
 
     /// @notice Returns the keccak256 hash of `withdrawal`.

--- a/src/test/DepositWithdraw.t.sol
+++ b/src/test/DepositWithdraw.t.sol
@@ -141,7 +141,7 @@ contract DepositWithdrawTests is EigenLayerTestHelper {
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
             delegatedTo: delegation.delegatedTo(staker),
-            startTimestamp: uint32(block.timestamp),
+            startBlock: uint32(block.number),
             scaledShares: shareAmounts
         });
 

--- a/src/test/DevnetLifecycle.t.sol
+++ b/src/test/DevnetLifecycle.t.sol
@@ -115,7 +115,7 @@ contract Devnet_Lifecycle_Test is Test {
         cheats.prank(operator);
         delegationManager.registerAsOperator(operatorDetails, 1, emptyStringForMetadataURI);
         // Warp passed configuration delay
-        cheats.warp(block.timestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
 
         // Validate storage
         assertTrue(delegationManager.isOperator(operator));
@@ -202,10 +202,10 @@ contract Devnet_Lifecycle_Test is Test {
         IAllocationManagerTypes.MagnitudeInfo[] memory infos = allocationManager.getAllocationInfo(operator, wethStrategy, _getOperatorSetsArray());
         assertEq(infos[0].currentMagnitude, 0);
         assertEq(infos[0].pendingDiff, int128(uint128(magnitudeToSet)));
-        assertEq(infos[0].effectTimestamp, block.timestamp + 1);
+        assertEq(infos[0].effectTimestamp, block.number + 1);
 
         // Warp to effect timestamp
-        cheats.warp(block.timestamp + 1);
+        cheats.roll(block.number + 1);
 
         // Check allocation
         infos = allocationManager.getAllocationInfo(operator, wethStrategy, _getOperatorSetsArray());
@@ -253,7 +253,7 @@ contract Devnet_Lifecycle_Test is Test {
             delegatedTo: operator,
             withdrawer: staker,
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-            startTimestamp: uint32(block.timestamp),
+            startBlock: uint32(block.number),
             strategies: strategies,
             scaledShares: scaledShares
         });
@@ -264,7 +264,7 @@ contract Devnet_Lifecycle_Test is Test {
         delegationManager.queueWithdrawals(queuedWithdrawals);
 
         // Roll passed withdrawal delay
-        cheats.warp(block.timestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
 
         // Complete withdrawal
         IERC20[] memory tokens = new IERC20[](1);

--- a/src/test/EigenLayerTestHelper.t.sol
+++ b/src/test/EigenLayerTestHelper.t.sol
@@ -291,7 +291,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             withdrawer: withdrawer,
             nonce: delegation.cumulativeWithdrawalsQueued(staker),
             delegatedTo: delegation.delegatedTo(staker),
-            startTimestamp: uint32(block.timestamp)
+            startBlock: uint32(block.number)
         });
 
         {
@@ -402,7 +402,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             staker: depositor,
             withdrawer: withdrawer,
             nonce: nonce,
-            startTimestamp: withdrawalStartTimestamp,
+            startBlock: withdrawalStartTimestamp,
             delegatedTo: delegatedTo
         });
 
@@ -452,7 +452,7 @@ contract EigenLayerTestHelper is EigenLayerDeployer {
             staker: depositor,
             withdrawer: withdrawer,
             nonce: nonce,
-            startTimestamp: withdrawalStartTimestamp,
+            startBlock: withdrawalStartTimestamp,
             delegatedTo: delegatedTo,
             scaledShares: shareAmounts
         });

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -367,11 +367,9 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
 
         // Create time machine and beacon chain. Set block time to beacon chain genesis time
         // TODO: update if needed to sane timestamp
-        // cheats.warp(GENESIS_TIME_LOCAL);
-        cheats.warp(delegationManager.SLASHING_UPGRADE_BLOCK());
+        cheats.warp(GENESIS_TIME_LOCAL);
         timeMachine = new TimeMachine();
-        // beaconChain = new BeaconChainMock(eigenPodManager, GENESIS_TIME_LOCAL);
-        beaconChain = new BeaconChainMock(eigenPodManager, delegationManager.SLASHING_UPGRADE_BLOCK());
+        beaconChain = new BeaconChainMock(eigenPodManager, GENESIS_TIME_LOCAL);
     }
 
     /**

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -368,10 +368,10 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         // Create time machine and beacon chain. Set block time to beacon chain genesis time
         // TODO: update if needed to sane timestamp
         // cheats.warp(GENESIS_TIME_LOCAL);
-        cheats.warp(delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
+        cheats.warp(delegationManager.SLASHING_UPGRADE_BLOCK());
         timeMachine = new TimeMachine();
         // beaconChain = new BeaconChainMock(eigenPodManager, GENESIS_TIME_LOCAL);
-        beaconChain = new BeaconChainMock(eigenPodManager, delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
+        beaconChain = new BeaconChainMock(eigenPodManager, delegationManager.SLASHING_UPGRADE_BLOCK());
     }
 
     /**

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -150,7 +150,7 @@ contract User is PrintUtils {
             delegatedTo: operator,
             withdrawer: withdrawer,
             nonce: nonce,
-            startTimestamp: uint32(block.timestamp),
+            startBlock: uint32(block.number),
             strategies: strategies,
             scaledShares: shares
         });
@@ -486,7 +486,7 @@ contract User is PrintUtils {
                 delegatedTo: delegatedTo,
                 withdrawer: staker,
                 nonce: (nonce + i),
-                startTimestamp: uint32(block.timestamp),
+                startBlock: uint32(block.number),
                 strategies: singleStrategy,
                 scaledShares: singleShares
             });

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -32,7 +32,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     IERC20 mockToken;
     uint256 mockTokenInitialSupply = 10e50;
 
-    uint32 constant MIN_WITHDRAWAL_DELAY = 17.5 days;
+    uint32 constant MIN_WITHDRAWAL_DELAY_BLOCKS = 126_000; // 17.5 days in blocks
 
     // Delegation signer
     uint256 delegationSignerPrivateKey = uint256(0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
@@ -86,7 +86,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             IStrategyManager(address(strategyManagerMock)), 
             IEigenPodManager(address(eigenPodManagerMock)), 
             IAllocationManager(address(allocationManagerMock)), 
-            MIN_WITHDRAWAL_DELAY
+            MIN_WITHDRAWAL_DELAY_BLOCKS
         );
         delegationManager = DelegationManager(
             address(
@@ -371,7 +371,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             delegatedTo: delegationManager.delegatedTo(staker),
             withdrawer: withdrawer,
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-            startTimestamp: uint32(block.timestamp),
+            startBlock: uint32(block.number),
             strategies: strategyArray,
             scaledShares: scaledSharesArray
         });
@@ -410,7 +410,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             delegatedTo: delegationManager.delegatedTo(staker),
             withdrawer: withdrawer,
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
-            startTimestamp: uint32(block.timestamp),
+            startBlock: uint32(block.number),
             strategies: strategies,
             scaledShares: scaledSharesArray
         });
@@ -544,8 +544,8 @@ contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerU
             "constructor / initializer incorrect, allocationManager set wrong"
         );
         assertEq(
-            delegationManager.MIN_WITHDRAWAL_DELAY(),
-            MIN_WITHDRAWAL_DELAY,
+            delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS(),
+            MIN_WITHDRAWAL_DELAY_BLOCKS,
             "constructor / initializer incorrect, MIN_WITHDRAWAL_DELAY set wrong"
         );
         assertEq(delegationManager.owner(), address(this), "constructor / initializer incorrect, owner set wrong");
@@ -3920,7 +3920,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
     // TODO: add upgrade tests for completing withdrawals queued before upgrade in integration tests
     function setUp() public override {
         DelegationManagerUnitTests.setUp();
-        cheats.warp(delegationManager.LEGACY_WITHDRAWAL_CHECK_VALUE());
+        cheats.roll(delegationManager.SLASHING_UPGRADE_BLOCK());
     }
 
     function test_Revert_WhenExitWithdrawalQueuePaused() public {
@@ -4000,7 +4000,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens,  true);
         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
@@ -4035,7 +4035,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         });
 
         // prank as withdrawer address
-        cheats.warp(withdrawal.startTimestamp + minWithdrawalDelayBlocks - 1);
+        cheats.roll(withdrawal.startBlock + minWithdrawalDelayBlocks - 1);
         cheats.expectRevert(IDelegationManagerErrors.WithdrawalDelayNotElapsed.selector);
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens,  receiveAsTokens);
@@ -4071,7 +4071,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
 
         // completeQueuedWithdrawal
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(staker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit SlashingWithdrawalCompleted(withdrawalRoot);
@@ -4141,7 +4141,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         // Complete queue withdrawal
         IERC20[] memory tokens = new IERC20[](1);
         tokens[0] = IERC20(strategies[0].underlyingToken());
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(defaultStaker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit SlashingWithdrawalCompleted(withdrawalRoot);
@@ -4210,7 +4210,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
 
         // Complete queue withdrawal
         IERC20[] memory tokens = new IERC20[](1);
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(defaultStaker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit SlashingWithdrawalCompleted(withdrawalRoot);
@@ -4292,7 +4292,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
 
         // Complete queue withdrawal
         IERC20[] memory tokens = new IERC20[](1);
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(defaultStaker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit SlashingWithdrawalCompleted(withdrawalRoot);
@@ -4345,7 +4345,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         strategyManagerMock.setDelegationManager(delegationManager);
 
         // completeQueuedWithdrawal
-        cheats.warp(withdrawal.startTimestamp + delegationManager.MIN_WITHDRAWAL_DELAY());
+        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
         cheats.prank(staker);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit SlashingWithdrawalCompleted(withdrawalRoot);

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -3918,10 +3918,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
 
 contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManagerUnitTests {
     // TODO: add upgrade tests for completing withdrawals queued before upgrade in integration tests
-    function setUp() public override {
-        DelegationManagerUnitTests.setUp();
-        cheats.roll(delegationManager.SLASHING_UPGRADE_BLOCK());
-    }
 
     function test_Revert_WhenExitWithdrawalQueuePaused() public {
         cheats.prank(pauser);


### PR DESCRIPTION
Decided on keeping `struct Withdrawal` as using blocknumbers as opposed to converting to timestamps.


<s> However because the delay is going to change in the upcoming release to align with DEALLOCATION_DELAY in the AllocationManager, the withdrawal startBlock will need to be checked against the blocknumber of the Slashing upgrade. See `getCompletableTimestamp()` for details.
</s>
All legacy withdrawals queued prior to the upgrade will actually have their withdrawal delay extended by however long the new withdrawal delay period (17.5 day delay so extended by 10.5 days). Thus removing any branching logic for handling withdrawals and their timestamps. 

Additionally, `minWithdrawalDelayBlocks` will still be deprecated as having this lie in storage with a setter function is not practical. Any changes to this delay will require deeper consideration and likely an upgrade to the AllocationManager. Using the constant `MIN_WITHDRAWAL_DELAY_BLOCKS` for post-slashing queue withdrawals seems most reasonable here.