### PR TITLE
refactor: require "name" to be populated for deployments

### DIFF
--- a/script/releases/release-template/2-multisig.s.sol
+++ b/script/releases/release-template/2-multisig.s.sol
@@ -11,6 +11,13 @@ contract Queue is MultisigBuilder {
     MultisigCall[] private _opsCalls;
 
     function _queue() internal returns (MultisigCall[] memory) {
+
+        // Example of a call to a contract - remove this
+        _executorCalls.append({
+            to: address(0),
+            data: abi.encodeWithSelector(bytes4(keccak256("test(uint256)")), uint256(0))
+        });
+
         //////////////////////////
         // construct executor data here
         //////////////////////////

--- a/script/releases/v0.1-eigenpod-example/1-eoa.s.sol
+++ b/script/releases/v0.1-eigenpod-example/1-eoa.s.sol
@@ -29,7 +29,7 @@ contract DeployEigenPodAndManager is EOADeployer {
             )
         );
 
-        _deployments.push(singleton(newEigenPodManager));
+        _deployments.push(singleton(newEigenPodManager, type(EigenPodManager).name));
 
         address newEigenPod = address(
             new EigenPod(
@@ -40,7 +40,7 @@ contract DeployEigenPodAndManager is EOADeployer {
         );
 
         // create and record new EigenPod pointing to defunct EigenPodManager
-        _deployments.push(singleton(newEigenPod));
+        _deployments.push(singleton(newEigenPod, type(EigenPod).name));
 
         vm.stopBroadcast();
 


### PR DESCRIPTION
This change introduces the requirement for users to explicitly title their contract when performing deployments. This name will be used by Zeus for tracking.