### PR TITLE
fix: change to sharesToWithdraw

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -614,6 +614,7 @@ contract DelegationManager is
         require(strategies.length != 0, InputArrayLengthZero());
 
         uint256[] memory scaledShares = new uint256[](strategies.length);
+        uint256[] memory sharesToWithdraw = new uint256[](strategies.length);
 
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
@@ -631,7 +632,7 @@ contract DelegationManager is
             );
 
             // Calculate the shares to withdraw
-            uint256 sharesToWithdraw = depositSharesToWithdraw[i].toShares(ssf, maxMagnitudes[i]);
+            sharesToWithdraw[i] = depositSharesToWithdraw[i].toShares(ssf, maxMagnitudes[i]);
 
             // Remove delegated shares from the operator
             if (operator != address(0)) {
@@ -640,11 +641,11 @@ contract DelegationManager is
                     operator: operator,
                     staker: staker,
                     strategy: strategies[i],
-                    sharesToDecrease: sharesToWithdraw
+                    sharesToDecrease: sharesToWithdraw[i]
                 });
             }
 
-            scaledShares[i] = sharesToWithdraw.scaleSharesForQueuedWithdrawal(ssf, maxMagnitudes[i]);
+            scaledShares[i] = sharesToWithdraw[i].scaleSharesForQueuedWithdrawal(ssf, maxMagnitudes[i]);
 
             // Remove active shares from EigenPodManager/StrategyManager
             shareManager.removeDepositShares(staker, strategies[i], depositSharesToWithdraw[i]);
@@ -672,7 +673,7 @@ contract DelegationManager is
 
         queuedWithdrawals[withdrawalRoot] = withdrawal;
 
-        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, depositSharesToWithdraw);
+        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, sharesToWithdraw);
         return withdrawalRoot;
     }
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -173,9 +173,9 @@ interface IDelegationManagerEvents is IDelegationManagerTypes {
      * @notice Emitted when a new withdrawal is queued.
      * @param withdrawalRoot Is the hash of the `withdrawal`.
      * @param withdrawal Is the withdrawal itself.
-     * @param depositSharesToWithdraw Is an array of the depositShares that were queued for withdrawal corresponding to the strategies in the `withdrawal`.
+     * @param sharesToWithdraw Is an array of the expected shares that were queued for withdrawal corresponding to the strategies in the `withdrawal`.
      */
-    event SlashingWithdrawalQueued(bytes32 withdrawalRoot, Withdrawal withdrawal, uint256[] depositSharesToWithdraw);
+    event SlashingWithdrawalQueued(bytes32 withdrawalRoot, Withdrawal withdrawal, uint256[] sharesToWithdraw);
 
     /// @notice Emitted when a queued withdrawal is completed
     event SlashingWithdrawalCompleted(bytes32 withdrawalRoot);

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -3215,6 +3215,9 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             depositSharesToWithdraw: withdrawalAmount
         });
 
+        uint256[] memory sharesToWithdraw = new uint256[](1);
+        sharesToWithdraw[0] = withdrawalAmount / 2;
+
         assertEq(delegationManager.delegatedTo(defaultStaker), defaultOperator, "staker should be delegated to operator");
         uint256 nonceBefore = delegationManager.cumulativeWithdrawalsQueued(defaultStaker);
         uint256 delegatedSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[0]);
@@ -3222,7 +3225,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
 
         // queueWithdrawals
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, queuedWithdrawalParams[0].depositShares);
+        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, sharesToWithdraw);
         cheats.prank(defaultStaker);
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
 

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -2787,13 +2787,16 @@ contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
             depositSharesToWithdraw: shares
         });
 
+        uint256[] memory sharesToWithdraw = new uint256[](1);
+        sharesToWithdraw[0] = shares / 2;
+
         // Undelegate the staker
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerUndelegated(defaultStaker, defaultOperator);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit OperatorSharesDecreased(defaultOperator, defaultStaker, strategyMock, operatorSharesAfterSlash);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, depositShares);
+        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, sharesToWithdraw);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit DepositScalingFactorUpdated(defaultStaker, strategyMock, WAD);
         cheats.prank(defaultStaker);
@@ -2928,13 +2931,16 @@ contract DelegationManagerUnitTests_Undelegate is DelegationManagerUnitTests {
 
         uint256 operatorSharesDecreased = uint256(shares).toShares(ssf, operatorMagnitude);
 
+        uint256[] memory sharesToWithdraw = new uint256[](1);
+        sharesToWithdraw[0] = operatorSharesDecreased;
+
         // Undelegate the staker
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit StakerUndelegated(defaultStaker, defaultOperator);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit OperatorSharesDecreased(defaultOperator, defaultStaker, strategyMock, operatorSharesDecreased);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, queuedWithdrawalParams[0].depositShares);
+        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, sharesToWithdraw);
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit DepositScalingFactorUpdated(defaultStaker, strategyMock, WAD);
         cheats.prank(defaultStaker);


### PR DESCRIPTION
Changes the `SlashingWithdrawalQueued` event to emit the shares attempted for withdrawal, rather than deposit shares