### PR TITLE
feat: prevent beacon chain allocs

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -147,7 +147,7 @@ contract AllocationManager is
 
             for (uint256 j = 0; j < params[i].strategies.length; j++) {
                 IStrategy strategy = params[i].strategies[j];
-                
+
                 // Cannot allocate to the beacon chain strategy.
                 if (strategy == beaconChainETHStrategy) {
                     continue;

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -147,6 +147,11 @@ contract AllocationManager is
 
             for (uint256 j = 0; j < params[i].strategies.length; j++) {
                 IStrategy strategy = params[i].strategies[j];
+                
+                // Cannot allocate to the beacon chain strategy.
+                if (strategy == beaconChainETHStrategy) {
+                    continue;
+                }
 
                 // 1. If the operator has any pending deallocations for this strategy, clear them
                 // to free up magnitude for allocation. Fetch the operator's up to date allocation
@@ -309,10 +314,6 @@ contract AllocationManager is
             bytes32 operatorSetKey = operatorSet.key();
             for (uint256 j = 0; j < params[i].strategies.length; j++) {
                 IStrategy strategy = params[i].strategies[j];
-
-                // Cannot add the beacon chain strategy to an operator set.
-                require(strategy != beaconChainETHStrategy, InvalidStrategy());
-
                 _operatorSetStrategies[operatorSetKey].add(address(strategy));
 
                 emit StrategyAddedToOperatorSet(operatorSet, strategy);
@@ -328,11 +329,8 @@ contract AllocationManager is
         bytes32 operatorSetKey = operatorSet.key();
         for (uint256 i = 0; i < strategies.length; i++) {
             IStrategy strategy = strategies[i];
-            // Cannot add the beacon chain strategy to an operator set.
-            require(strategy != beaconChainETHStrategy, InvalidStrategy());
             // Add the strategy to the operator set, while confirming it is not already present.
             require(_operatorSetStrategies[operatorSetKey].add(address(strategy)), StrategyAlreadyInOperatorSet());
-
             emit StrategyAddedToOperatorSet(operatorSet, strategy);
         }
     }
@@ -347,7 +345,6 @@ contract AllocationManager is
             IStrategy strategy = strategies[i];
             // Remove the strategy from the operator set, while confirming it is present.
             require(_operatorSetStrategies[operatorSetKey].remove(address(strategy)), StrategyNotInOperatorSet());
-
             emit StrategyRemovedFromOperatorSet(operatorSet, strategy);
         }
     }

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -23,6 +23,9 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @dev Index for flag that pauses operator register/deregister to operator sets when set.
     uint8 internal constant PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION = 2;
 
+    /// @notice Canonical, virtual beacon chain ETH strategy
+    IStrategy public constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
+
     // Immutables
 
     /// @notice The DelegationManager contract for EigenLayer

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -235,6 +235,7 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @param params array of magnitude adjustments for one or more operator sets
      * @dev Updates encumberedMagnitude for the updated strategies
      * @dev msg.sender is used as operator
+     * @dev Cannot allocate to `beaconChainETHStrategy`.
      */
     function modifyAllocations(
         AllocateParams[] calldata params
@@ -321,7 +322,6 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
 
     /**
      * @notice Allows an AVS to create new operator sets, defining strategies that the operator set uses.
-     * @dev Operator sets cannot include the beacon chain ETH strategy `beaconChainETHStrategy`.
      */
     function createOperatorSets(
         CreateSetParams[] calldata params
@@ -332,7 +332,6 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @dev Strategies MUST NOT already exist in the operator set
      * @param operatorSetId the operator set to add strategies to
      * @param strategies the strategies to add
-     * @dev Operator sets cannot include the beacon chain ETH strategy `beaconChainETHStrategy`.
      */
     function addStrategiesToOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) external;
 

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -43,7 +43,7 @@ interface IAllocationManagerErrors {
 
     /// @dev Thrown when an invalid operator set is provided.
     error InvalidOperatorSet();
-    /// @dev Thrown when a strategy is referenced that does not belong to an operator set.
+    /// @dev Thrown when a strategy is referenced that does not belong to an operator set or is not allowed to be added.
     error InvalidStrategy();
     /// @dev Thrown when trying to add a strategy to an operator set that already contains it.
     error StrategyAlreadyInOperatorSet();
@@ -320,7 +320,8 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
     ) external;
 
     /**
-     * @notice Allows an AVS to create new operator sets, defining strategies that the operator set uses
+     * @notice Allows an AVS to create new operator sets, defining strategies that the operator set uses.
+     * @dev Operator sets cannot include the beacon chain ETH strategy `beaconChainETHStrategy`.
      */
     function createOperatorSets(
         CreateSetParams[] calldata params
@@ -331,6 +332,7 @@ interface IAllocationManager is ISignatureUtils, IAllocationManagerErrors, IAllo
      * @dev Strategies MUST NOT already exist in the operator set
      * @param operatorSetId the operator set to add strategies to
      * @param strategies the strategies to add
+     * @dev Operator sets cannot include the beacon chain ETH strategy `beaconChainETHStrategy`.
      */
     function addStrategiesToOperatorSet(uint32 operatorSetId, IStrategy[] calldata strategies) external;
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -2858,6 +2858,15 @@ contract AllocationManagerUnitTests_removeStrategiesFromOperatorSet is Allocatio
 
 contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitTests {
     using SingleItemArrayLib for *;
+    
+    function test_CannotIncludeBeaconChainETHStrategy() public {
+        IStrategy strategy = IStrategy(allocationManager.beaconChainETHStrategy());
+        cheats.prank(defaultAVS);
+        cheats.expectRevert(InvalidStrategy.selector);
+        allocationManager.createOperatorSets(
+            CreateSetParams(1, strategy.toArray()).toArray()
+        );
+    }
 
     function test_createOperatorSets_InvalidOperatorSet() public {
         cheats.prank(defaultAVS);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -417,17 +417,20 @@ contract AllocationManagerUnitTests_SlashOperator is AllocationManagerUnitTests 
         cheats.prank(defaultAVS);
         allocationManager.addStrategiesToOperatorSet(defaultOperatorSet.id, strategies);
 
+        cheats.expectEmit(true, false, false, false, address(allocationManager));
+        emit OperatorSlashed(defaultOperator, defaultOperatorSet, new IStrategy[](0), new uint256[](0), "");
+
         cheats.prank(defaultAVS);
         allocationManager.slashOperator(SlashingParams(defaultOperator, defaultOperatorSet.id, WAD, ""));
 
-        // assertEq(
-        //     0,
-        //     allocationManager.encumberedMagnitude(defaultOperator, strategyMock),
-        //     "encumberedMagnitude was updated"
-        // );
-        // assertEq(
-        //     WAD, allocationManager.getMaxMagnitudes(defaultOperator, defaultStrategies)[0], "maxMagnitude was updated"
-        // );
+        assertEq(
+            0,
+            allocationManager.encumberedMagnitude(defaultOperator, strategyMock),
+            "encumberedMagnitude was updated"
+        );
+        assertEq(
+            WAD, allocationManager.getMaxMagnitudes(defaultOperator, defaultStrategies)[0], "maxMagnitude was updated"
+        );
     }
 
     function test_revert_operatorAllocated_notActive() public {

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -411,6 +411,25 @@ contract AllocationManagerUnitTests_SlashOperator is AllocationManagerUnitTests 
         allocationManager.slashOperator(_randSlashingParams(random().Address(), 0));
     }
 
+    function test_revert_CannotSlashBeaconChainETHStrategy() public {
+        IStrategy[] memory strategies = allocationManager.beaconChainETHStrategy().toArray();
+
+        cheats.prank(defaultAVS);
+        allocationManager.addStrategiesToOperatorSet(defaultOperatorSet.id, strategies);
+
+        cheats.prank(defaultAVS);
+        allocationManager.slashOperator(SlashingParams(defaultOperator, defaultOperatorSet.id, WAD, ""));
+
+        // assertEq(
+        //     0,
+        //     allocationManager.encumberedMagnitude(defaultOperator, strategyMock),
+        //     "encumberedMagnitude was updated"
+        // );
+        // assertEq(
+        //     WAD, allocationManager.getMaxMagnitudes(defaultOperator, defaultStrategies)[0], "maxMagnitude was updated"
+        // );
+    }
+
     function test_revert_operatorAllocated_notActive() public {
         AllocateParams[] memory allocateParams = _newAllocateParams(defaultOperatorSet, WAD);
 
@@ -1729,7 +1748,7 @@ contract AllocationManagerUnitTests_ModifyAllocations is AllocationManagerUnitTe
         }
     }
 
-    function test_CannotIncludeBeaconChainETHStrategy() public {
+    function test_CannotAllocateToBeaconChainETHStrategy() public {
         IStrategy[] memory strategies = allocationManager.beaconChainETHStrategy().toArray();
 
         cheats.prank(defaultAVS);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -1729,6 +1729,31 @@ contract AllocationManagerUnitTests_ModifyAllocations is AllocationManagerUnitTe
         }
     }
 
+    function test_CannotIncludeBeaconChainETHStrategy() public {
+        IStrategy[] memory strategies = allocationManager.beaconChainETHStrategy().toArray();
+
+        cheats.prank(defaultAVS);
+        allocationManager.addStrategiesToOperatorSet(defaultOperatorSet.id, strategies);
+
+        AllocateParams[] memory allocateParams = new AllocateParams[](1);
+        allocateParams[0] = AllocateParams({
+            operatorSet: defaultOperatorSet,
+            strategies: strategies,
+            newMagnitudes: uint64(1 ether).toArrayU64()
+        });
+
+        cheats.prank(defaultOperator);
+        allocationManager.modifyAllocations(allocateParams);
+
+        // Assert the allocation did not occur.
+        _checkAllocation(
+            allocationManager.getAllocation(defaultOperator, defaultOperatorSet, strategies[0]),
+            0,
+            0,
+            0
+        );
+    }
+
     /**
      * Allocates to `firstMod` magnitude and then deallocate to `secondMod` magnitude
      * Validates the storage
@@ -2858,15 +2883,6 @@ contract AllocationManagerUnitTests_removeStrategiesFromOperatorSet is Allocatio
 
 contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitTests {
     using SingleItemArrayLib for *;
-    
-    function test_CannotIncludeBeaconChainETHStrategy() public {
-        IStrategy strategy = IStrategy(allocationManager.beaconChainETHStrategy());
-        cheats.prank(defaultAVS);
-        cheats.expectRevert(InvalidStrategy.selector);
-        allocationManager.createOperatorSets(
-            CreateSetParams(1, strategy.toArray()).toArray()
-        );
-    }
 
     function test_createOperatorSets_InvalidOperatorSet() public {
         cheats.prank(defaultAVS);


### PR DESCRIPTION
### Changes

- ~~`require(strategies[i] != beaconChainETHStrategy)` check to `addStrategiesToOperatorSet` and `createOperatorSets`.~~ 

- `if(strategy == beaconChainETHStrategy) continue;` added to `modifyAllocations`. This prevents allocating to the beacon-chain ETH strategy, but does not revert if it's provided. Can alternatively modify this to a `require` statement.

- Test to ensure no storage is mutated if `beaconChainETHStrategy` is provided.
