### PR TITLE
refactor: EigenPods and beacon chain slashing

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -331,8 +331,9 @@ contract DelegationManager is
         uint256 sharesToRemove = dsf.calcWithdrawable({
             depositShares: curDepositShares,
             slashingFactor: prevSlashingFactor
-        }).mulWad(uint256(WAD) - wadSlashed); // ? TODO verify
+        }).mulWad(wadSlashed);
 
+        // Decrease the operator's shares
         _decreaseDelegation({
             operator: operator,
             staker: staker,

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -349,8 +349,6 @@ contract DelegationManager is
         uint64 prevMaxMagnitude,
         uint64 newMaxMagnitude
     ) external onlyAllocationManager {
-        require(newMaxMagnitude < prevMaxMagnitude, MaxMagnitudeCantIncrease());
-
         /// forgefmt: disable-next-item
         uint256 sharesToDecrement = SlashingLib.calcSlashedAmount({
             operatorShares: operatorShares[operator][strategy],

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -106,10 +106,6 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// @notice Returns the scaling factor applied to a `staker` for a given `strategy`
     mapping(address staker => mapping(IStrategy strategy => DepositScalingFactor)) internal _depositScalingFactor;
 
-    /// @notice Returns the slashing factor applied to the `staker` for the `beaconChainETHStrategy`
-    /// Note: this is specifically updated when the staker's beacon chain balance decreases
-    mapping(address staker => BeaconChainSlashingFactor) internal _beaconChainSlashingFactor;
-
     /// @notice Returns a list of queued withdrawals for a given `staker`.
     /// @dev Entrys are removed when the withdrawal is completed.
     /// @dev This variable only reflects withdrawals that were made after the slashing release.
@@ -146,5 +142,5 @@ abstract contract DelegationManagerStorage is IDelegationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[34] private __gap;
+    uint256[35] private __gap;
 }

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -246,7 +246,7 @@ contract StrategyManager is
         delegation.increaseDelegatedShares({
             staker: staker,
             strategy: strategy,
-            existingDepositShares: existingShares,
+            curDepositShares: existingShares,
             addedShares: addedShares
         });
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -43,8 +43,6 @@ interface IDelegationManagerErrors {
     /// @dev Thrown when an operator has been fully slashed(maxMagnitude is 0) for a strategy.
     /// or if the staker has had been natively slashed to the point of their beaconChainScalingFactor equalling 0.
     error FullySlashed();
-    /// @dev Thrown when burnOperatorShares is called and newMaxMagnitude is greater than or equal to the previous maxMagnitude
-    error MaxMagnitudeCantIncrease();
 
     /// Signatures
 
@@ -351,24 +349,6 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external;
 
     /**
-     * @notice Decreases the operators shares in storage after a slash and burns the corresponding Strategy shares
-     * by calling into the StrategyManager or EigenPodManager to burn the shares.
-     * @param operator The operator to decrease shares for
-     * @param strategy The strategy to decrease shares for
-     * @param prevMaxMagnitude the previous maxMagnitude of the operator
-     * @param newMaxMagnitude the new maxMagnitude of the operator
-     * @dev Callable only by the AllocationManager
-     * @dev Reverts if the newMaxMagnitude is >= the previous maxMagnitude. Shares can only decrease
-     * if the newMaxMagnitude has decreased.
-     */
-    function burnOperatorShares(
-        address operator,
-        IStrategy strategy,
-        uint64 prevMaxMagnitude,
-        uint64 newMaxMagnitude
-    ) external;
-
-    /**
      * @notice If the staker is delegated, decreases its operator's shares in response to
      * a decrease in balance in the beaconChainETHStrategy
      * @param staker the staker whose operator's balance will be decreased
@@ -383,6 +363,24 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         uint256 curDepositShares,
         uint64 prevBeaconChainSlashingFactor,
         uint256 wadSlashed
+    ) external;
+
+    /**
+     * @notice Decreases the operators shares in storage after a slash and burns the corresponding Strategy shares
+     * by calling into the StrategyManager or EigenPodManager to burn the shares.
+     * @param operator The operator to decrease shares for
+     * @param strategy The strategy to decrease shares for
+     * @param prevMaxMagnitude the previous maxMagnitude of the operator
+     * @param newMaxMagnitude the new maxMagnitude of the operator
+     * @dev Callable only by the AllocationManager
+     * @dev Note: Assumes `prevMaxMagnitude <= newMaxMagnitude`. This invariant is maintained in
+     * the AllocationManager.
+     */
+    function burnOperatorShares(
+        address operator,
+        IStrategy strategy,
+        uint64 prevMaxMagnitude,
+        uint64 newMaxMagnitude
     ) external;
 
     /**

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -374,7 +374,9 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @param staker the staker whose operator's balance will be decreased
      * @param curDepositShares the current deposit shares held by the staker
      * @param prevBeaconChainSlashingFactor the amount of beacon chain slashing experienced before the balance decrease
-     * @param wadSlashed the proportion that the staker's balance decreased
+     * @param wadSlashed the additional slashing experienced by the staker
+     * @dev Note: `wadSlashed` and `prevBeaconChainSlashingFactor` are assumed to ALWAYS be < 1 WAD.
+     * These invariants are maintained in the EigenPodManager.
      */
     function decreaseDelegatedShares(
         address staker,

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -135,11 +135,6 @@ interface IDelegationManagerTypes {
         // The address of the withdrawer
         address withdrawer;
     }
-
-    struct BeaconChainSlashingFactor {
-        bool isSet;
-        uint64 slashingFactor;
-    }
 }
 
 interface IDelegationManagerEvents is IDelegationManagerTypes {
@@ -175,9 +170,6 @@ interface IDelegationManagerEvents is IDelegationManagerTypes {
 
     /// @notice Emitted when a staker's depositScalingFactor is updated
     event DepositScalingFactorUpdated(address staker, IStrategy strategy, uint256 newDepositScalingFactor);
-
-    /// @notice Emitted when a staker's beaconChainScalingFactor is updated
-    event BeaconChainScalingFactorDecreased(address staker, uint64 newBeaconChainScalingFactor);
 
     /**
      * @notice Emitted when a new withdrawal is queued.
@@ -342,7 +334,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * the delegated delegatedShares. The staker's depositScalingFactor is updated here.
      * @param staker The address to increase the delegated shares for their operator.
      * @param strategy The strategy in which to increase the delegated shares.
-     * @param existingDepositShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
+     * @param curDepositShares The number of deposit shares the staker already has in the strategy. This is the shares amount stored in the
      * StrategyManager/EigenPodManager for the staker's shares.
      * @param addedShares The number of shares added to the staker's shares in the strategy
      *
@@ -354,24 +346,8 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     function increaseDelegatedShares(
         address staker,
         IStrategy strategy,
-        uint256 existingDepositShares,
+        uint256 curDepositShares,
         uint256 addedShares
-    ) external;
-
-    /**
-     * @notice Decreases a native restaker's delegated share balance in a strategy due to beacon chain slashing. This updates their beaconChainScalingFactor.
-     * Their operator's stakeShares are also updated (if they are delegated).
-     * @param staker The address to increase the delegated stakeShares for their operator.
-     * @param existingShares The number of shares the staker already has in the EPM. This does not change upon decreasing shares.
-     * @param proportionOfOldBalance The current pod owner shares proportion of the previous pod owner shares
-     *
-     * @dev *If the staker is actively delegated*, then decreases the `staker`'s delegated stakeShares in `strategy` by `proportionPodBalanceDecrease` proportion. Otherwise does nothing.
-     * @dev Callable only by the EigenPodManager.
-     */
-    function decreaseBeaconChainScalingFactor(
-        address staker,
-        uint256 existingShares,
-        uint64 proportionOfOldBalance
     ) external;
 
     /**
@@ -390,6 +366,21 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         IStrategy strategy,
         uint64 prevMaxMagnitude,
         uint64 newMaxMagnitude
+    ) external;
+
+    /**
+     * @notice If the staker is delegated, decreases its operator's shares in response to
+     * a decrease in balance in the beaconChainETHStrategy
+     * @param staker the staker whose operator's balance will be decreased
+     * @param curDepositShares the current deposit shares held by the staker
+     * @param prevBeaconChainSlashingFactor the amount of beacon chain slashing experienced before the balance decrease
+     * @param wadSlashed the proportion that the staker's balance decreased
+     */
+    function decreaseDelegatedShares(
+        address staker,
+        uint256 curDepositShares,
+        uint64 prevBeaconChainSlashingFactor,
+        uint256 wadSlashed
     ) external;
 
     /**
@@ -526,13 +517,6 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @notice Returns the scaling factor applied to a staker's deposits for a given strategy
      */
     function depositScalingFactor(address staker, IStrategy strategy) external view returns (uint256);
-
-    /**
-     * @notice Returns the slashing factor applied to the staker's beacon chain ETH shares
-     */
-    function getBeaconChainSlashingFactor(
-        address staker
-    ) external view returns (uint64);
 
     /**
      * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.

--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -40,7 +40,7 @@ interface IEigenPodErrors {
 
     /// Withdrawing
 
-    /// @dev Thrown when amount exceeds `withdrawableRestakedExecutionLayerGwei`.
+    /// @dev Thrown when amount exceeds `restakedExecutionLayerGwei`.
     error InsufficientWithdrawableBalance();
     /// @dev Thrown when provided `amountGwei` is not a multiple of gwei.
     error AmountMustBeMultipleOfGwei();
@@ -93,10 +93,8 @@ interface IEigenPodTypes {
         bytes32 beaconBlockRoot;
         uint24 proofsRemaining;
         uint64 podBalanceGwei;
-        // this used to be an int128 before the slashing release
-        // now it is an int64. (2^63 - 1) gwei * 1e-9 eth/gwei = 9_223_372_036.85 eth = 9 billion eth
         int64 balanceDeltasGwei;
-        uint64 beaconChainBalanceBeforeGwei;
+        uint64 prevBeaconBalanceGwei;
     }
 }
 
@@ -154,7 +152,7 @@ interface IEigenPod is IEigenPodErrors, IEigenPodEvents {
     /**
      * @notice Transfers `amountWei` in ether from this contract to the specified `recipient` address
      * @notice Called by EigenPodManager to withdrawBeaconChainETH that has been added to the EigenPod's balance due to a withdrawal from the beacon chain.
-     * @dev The podOwner must have already proved sufficient withdrawals, so that this pod's `withdrawableRestakedExecutionLayerGwei` exceeds the
+     * @dev The podOwner must have already proved sufficient withdrawals, so that this pod's `restakedExecutionLayerGwei` exceeds the
      * `amountWei` input (when converted to GWEI).
      * @dev Reverts if `amountWei` is not a whole Gwei amount
      */

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -51,7 +51,7 @@ interface IEigenPodManagerEvents {
     );
 
     /// @notice Emitted when a staker's beaconChainSlashingFactor is updated
-    event BeaconChainSlashingFactorUpdated(address staker, uint64 newBeaconChainSlashingFactor);
+    event BeaconChainSlashingFactorDecreased(address staker, uint256 wadSlashed, uint64 newBeaconChainSlashingFactor);
 }
 
 interface IEigenPodManagerTypes {

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -102,12 +102,16 @@ interface IEigenPodManager is
      * @notice Changes the `podOwner`'s shares by `sharesDelta` and performs a call to the DelegationManager
      * to ensure that delegated shares are also tracked correctly
      * @param podOwner is the pod owner whose balance is being updated.
-     * @param sharesDelta is the change in podOwner's beaconChainETHStrategy shares
-     * @param wadSlashed is the proportion (of WAD) of the podOwner's balance that has changed
+     * @param prevRestakedBalanceWei is the total amount restaked through the pod before the balance update
+     * @param balanceDeltaWei is the amount the balance changed
      * @dev Callable only by the podOwner's EigenPod contract.
      * @dev Reverts if `sharesDelta` is not a whole Gwei amount
      */
-    function recordBeaconChainETHBalanceUpdate(address podOwner, int256 sharesDelta, uint256 wadSlashed) external;
+    function recordBeaconChainETHBalanceUpdate(
+        address podOwner,
+        uint256 prevRestakedBalanceWei,
+        int256 balanceDeltaWei
+    ) external;
 
     /// @notice Returns the address of the `podOwner`'s EigenPod if it has been deployed.
     function ownerToPod(

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -51,7 +51,7 @@ interface IEigenPodManagerEvents {
     );
 
     /// @notice Emitted when a staker's beaconChainSlashingFactor is updated
-    event BeaconChainSlashingFactorDecreased(address staker, uint64 newBeaconChainSlashingFactor);
+    event BeaconChainSlashingFactorUpdated(address staker, uint64 newBeaconChainSlashingFactor);
 }
 
 interface IEigenPodManagerTypes {
@@ -156,8 +156,8 @@ interface IEigenPodManager is
     function beaconChainETHStrategy() external view returns (IStrategy);
 
     /**
-     * @notice Returns the amount of reported slashing a staker has experienced on the
-     * beacon chain.
+     * @notice Returns the historical sum of proportional balance decreases a pod owner has experienced when
+     * updating their pod's balance.
      */
     function beaconChainSlashingFactor(
         address staker

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -93,13 +93,13 @@ library SlashingLib {
 
     function update(
         DepositScalingFactor storage dsf,
-        uint256 existingDepositShares,
+        uint256 curDepositShares,
         uint256 addedShares,
         uint256 slashingFactor
     ) internal {
         // If this is the staker's first deposit for this operator, set the scaling factor to
         // the inverse of slashingFactor
-        if (existingDepositShares == 0) {
+        if (curDepositShares == 0) {
             dsf._scalingFactor = uint256(WAD).divWad(slashingFactor);
             return;
         }
@@ -107,7 +107,7 @@ library SlashingLib {
         /**
          * Base Equations:
          * (1) newShares = currentShares + addedShares
-         * (2) newDepositShares = existingDepositShares + addedShares
+         * (2) newDepositShares = curDepositShares + addedShares
          * (3) newShares = newDepositShares * newDepositScalingFactor * slashingFactor
          *
          * Plugging (1) into (3):
@@ -117,15 +117,15 @@ library SlashingLib {
          * (5) newDepositScalingFactor = (currentShares + addedShares) / (newDepositShares * slashingFactor)
          *
          * Plugging in (2) into (5):
-         * (7) newDepositScalingFactor = (currentShares + addedShares) / ((existingDepositShares + addedShares) * slashingFactor)
+         * (7) newDepositScalingFactor = (currentShares + addedShares) / ((curDepositShares + addedShares) * slashingFactor)
          * Note that magnitudes must be divided by WAD for precision. Thus,
          *
-         * (8) newDepositScalingFactor = WAD * (currentShares + addedShares) / ((existingDepositShares + addedShares) * slashingFactor / WAD)
-         * (9) newDepositScalingFactor = (currentShares + addedShares) * WAD / (existingDepositShares + addedShares) * WAD / slashingFactor
+         * (8) newDepositScalingFactor = WAD * (currentShares + addedShares) / ((curDepositShares + addedShares) * slashingFactor / WAD)
+         * (9) newDepositScalingFactor = (currentShares + addedShares) * WAD / (curDepositShares + addedShares) * WAD / slashingFactor
          */
 
         // Step 1: Calculate Numerator
-        uint256 currentShares = dsf.calcWithdrawable(existingDepositShares, slashingFactor);
+        uint256 currentShares = dsf.calcWithdrawable(curDepositShares, slashingFactor);
 
         // Step 2: Compute currentShares + addedShares
         uint256 newShares = currentShares + addedShares;
@@ -133,7 +133,7 @@ library SlashingLib {
         // Step 3: Calculate newDepositScalingFactor
         /// forgefmt: disable-next-item
         uint256 newDepositScalingFactor = newShares
-            .divWad(existingDepositShares + addedShares)
+            .divWad(curDepositShares + addedShares)
             .divWad(slashingFactor);
 
         dsf._scalingFactor = newDepositScalingFactor;

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -54,6 +54,13 @@ library SlashingLib {
         return x.mulDiv(y, WAD, Math.Rounding.Up);
     }
 
+    /**
+     * @notice Used as part of calculating wadSlashed in the EPM to ensure that we don't overslash
+     */
+    function divWadRoundUp(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x.mulDiv(WAD, y, Math.Rounding.Up);
+    }
+
     // GETTERS
 
     function scalingFactor(

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -271,14 +271,14 @@ contract EigenPodManager is
         // balance that remains. Note that underflow here should be impossible given
         // the invariants pods use to calculate these values.
         uint256 newRestakedBalanceWei = prevRestakedBalanceWei - balanceDecreasedWei;
-        uint256 balanceRemainingWad = newRestakedBalanceWei.divWadRoundUp(prevRestakedBalanceWei);
+        uint256 proportionRemainingWad = newRestakedBalanceWei.divWadRoundUp(prevRestakedBalanceWei);
 
         // Update pod owner's beacon chain slashing factor. Note that `newBeaconSlashingFactor`
-        // should be less than `prevBeaconSlashingFactor` because `balanceRemainingWad` is
+        // should be less than `prevBeaconSlashingFactor` because `proportionRemainingWad` is
         // guaranteed to be less than WAD.
         uint64 prevBeaconSlashingFactor = beaconChainSlashingFactor(podOwner);
-        uint64 newBeaconSlashingFactor = uint64(prevBeaconSlashingFactor.mulWad(balanceRemainingWad));
-        emit BeaconChainSlashingFactorDecreased(podOwner, newBeaconSlashingFactor);
+        uint64 newBeaconSlashingFactor = uint64(prevBeaconSlashingFactor.mulWad(proportionRemainingWad));
+        emit BeaconChainSlashingFactorUpdated(podOwner, newBeaconSlashingFactor);
         /// forgefmt: disable-next-item
         _beaconChainSlashingFactor[podOwner] = BeaconChainSlashingFactor({
             slashingFactor: newBeaconSlashingFactor,
@@ -287,8 +287,8 @@ contract EigenPodManager is
 
         uint256 curDepositShares = uint256(podOwnerDepositShares[podOwner]);
         // Note that underflow here should be impossible given
-        // `balanceRemainingWad` is guaranteed to be less than WAD.
-        uint256 wadSlashed = uint256(WAD) - balanceRemainingWad;
+        // `proportionRemainingWad` is guaranteed to be less than WAD.
+        uint256 wadSlashed = uint256(WAD) - proportionRemainingWad;
         return (curDepositShares, prevBeaconSlashingFactor, wadSlashed);
     }
 

--- a/src/contracts/pods/EigenPodManager.sol
+++ b/src/contracts/pods/EigenPodManager.sol
@@ -271,7 +271,7 @@ contract EigenPodManager is
         // balance that remains. Note that underflow here should be impossible given
         // the invariants pods use to calculate these values.
         uint256 newRestakedBalanceWei = prevRestakedBalanceWei - balanceDecreasedWei;
-        uint256 balanceRemainingWad = newRestakedBalanceWei.divWad(prevRestakedBalanceWei);
+        uint256 balanceRemainingWad = newRestakedBalanceWei.divWadRoundUp(prevRestakedBalanceWei);
 
         // Update pod owner's beacon chain slashing factor. Note that `newBeaconSlashingFactor`
         // should be less than `prevBeaconSlashingFactor` because `balanceRemainingWad` is

--- a/src/contracts/pods/EigenPodManagerStorage.sol
+++ b/src/contracts/pods/EigenPodManagerStorage.sol
@@ -77,6 +77,10 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
 
     uint64 internal __deprecated_denebForkTimestamp;
 
+    /// @notice Returns the slashing factor applied to the `staker` for the `beaconChainETHStrategy`
+    /// Note: this is specifically updated when the staker's beacon chain balance decreases
+    mapping(address staker => BeaconChainSlashingFactor) internal _beaconChainSlashingFactor;
+
     constructor(
         IETHPOSDeposit _ethPOS,
         IBeacon _eigenPodBeacon,
@@ -94,5 +98,5 @@ abstract contract EigenPodManagerStorage is IEigenPodManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[44] private __gap;
+    uint256[43] private __gap;
 }

--- a/src/contracts/pods/EigenPodStorage.sol
+++ b/src/contracts/pods/EigenPodStorage.sol
@@ -11,7 +11,7 @@ abstract contract EigenPodStorage is IEigenPod {
     uint64 internal __deprecated_mostRecentWithdrawalTimestamp;
 
     /// @notice the amount of execution layer ETH in this contract that is staked in EigenLayer (i.e. withdrawn from the Beacon Chain but not from EigenLayer),
-    uint64 public withdrawableRestakedExecutionLayerGwei;
+    uint64 internal restakedExecutionLayerGwei;
 
     /// @notice DEPRECATED: previously used to track whether a pod had activated restaking
     bool internal __deprecated_hasRestaked;

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1194,7 +1194,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
 
     /// @dev Looks up the staker's beacon chain scaling factor
     function _getBeaconChainSlashingFactor(User staker) internal view returns (uint64) {
-        return delegationManager.getBeaconChainSlashingFactor(address(staker));
+        return eigenPodManager.beaconChainSlashingFactor(address(staker));
     }
 
     function _getPrevCumulativeWithdrawals(User staker) internal timewarp() returns (uint) {

--- a/src/test/integration/tests/eigenpod/VerifyWC_StartCP_CompleteCP.t.sol
+++ b/src/test/integration/tests/eigenpod/VerifyWC_StartCP_CompleteCP.t.sol
@@ -726,7 +726,7 @@ contract Integration_VerifyWC_StartCP_CompleteCP is IntegrationCheckUtils {
         check_StartCheckpoint_WithPodBalance_State(staker, gweiSent);
 
         staker.completeCheckpoint();
-        // check that `pod.balance == withdrawableRestakedExecutionLayerGwei + remainderSent
+        // check that `pod.balance == restakedExecutionLayerGwei + remainderSent
         assert_PodBalance_Eq(staker, (gweiSent * GWEI_TO_WEI) + remainderSent, "pod balance should equal expected");
         check_CompleteCheckpoint_WithPodBalance_State(staker, gweiSent);
     }
@@ -754,7 +754,7 @@ contract Integration_VerifyWC_StartCP_CompleteCP is IntegrationCheckUtils {
         check_StartCheckpoint_WithPodBalance_State(staker, gweiSent);
 
         staker.completeCheckpoint();
-        // check that `pod.balance == withdrawableRestakedExecutionLayerGwei + remainderSent
+        // check that `pod.balance == restakedExecutionLayerGwei + remainderSent
         assert_PodBalance_Eq(staker, (gweiSent * GWEI_TO_WEI) + remainderSent, "pod balance should equal expected");
         check_CompleteCheckpoint_WithPodBalance_State(staker, gweiSent);
     }

--- a/src/test/mocks/EigenPodManagerMock.sol
+++ b/src/test/mocks/EigenPodManagerMock.sol
@@ -13,6 +13,13 @@ contract EigenPodManagerMock is Test, Pausable {
 
     mapping(address => uint256) public podOwnerSharesWithdrawn;
 
+    struct BeaconChainSlashingFactor {
+        bool isSet;
+        uint64 slashingFactor;
+    }
+
+    mapping(address => BeaconChainSlashingFactor) _beaconChainSlashingFactor;
+
     constructor(IPauserRegistry _pauserRegistry) Pausable(_pauserRegistry) {
         _setPausedStatus(0);
     }
@@ -54,5 +61,17 @@ contract EigenPodManagerMock is Test, Pausable {
 
     function withdrawSharesAsTokens(address podOwner, address /** strategy */, address /** token */, uint256 shares) external {
         podOwnerSharesWithdrawn[podOwner] += shares;
+    }
+
+    function setBeaconChainSlashingFactor(address staker, uint64 bcsf) external {
+        _beaconChainSlashingFactor[staker] = BeaconChainSlashingFactor({
+            isSet: true,
+            slashingFactor: bcsf
+        });
+    }
+
+    function beaconChainSlashingFactor(address staker) external view returns (uint64) {
+        BeaconChainSlashingFactor memory bsf = _beaconChainSlashingFactor[staker];
+        return bsf.isSet ? bsf.slashingFactor : WAD;
     }
 }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -2878,17 +2878,6 @@ contract DelegationManagerUnitTests_ShareAdjustment is DelegationManagerUnitTest
         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
     }
 
-    /// @notice Verifies that `DelegationManager.burnOperatorShares` reverts if the newMaxMagnitude
-    /// is less than prevMaxMagnitude.
-    function testFuzz_Revert_burnOperatorShares_InvalidNewMaxMagnitude(Randomness r) public {
-        uint64 prevMaxMagnitude = r.Uint64(1, WAD);
-        uint64 newMaxMagnitude = r.Uint64(prevMaxMagnitude, WAD);
-
-        cheats.prank(address(allocationManagerMock));
-        cheats.expectRevert(IDelegationManagerErrors.MaxMagnitudeCantIncrease.selector);
-        delegationManager.burnOperatorShares(defaultOperator, strategyMock, prevMaxMagnitude, newMaxMagnitude);        
-    }
-
     /**
      * @notice Verifies that `DelegationManager.burnOperatorShares` properly decreases the delegated `shares` that the operator
      * who the `defaultStaker` is delegated to has in the strategies

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -494,7 +494,7 @@ contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodMa
 
         // Not checking the new slashing factor - just checking the invariant that new <= prev
         cheats.expectEmit(true, true, true, false);
-        emit BeaconChainSlashingFactorDecreased(defaultStaker, 0);
+        emit BeaconChainSlashingFactorUpdated(defaultStaker, 0);
 
         cheats.prank(address(defaultPod));
         eigenPodManager.recordBeaconChainETHBalanceUpdate(defaultStaker, prevRestakedBalanceWei, -int(sharesDelta));

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -494,7 +494,7 @@ contract EigenPodManagerUnitTests_BeaconChainETHBalanceUpdateTests is EigenPodMa
 
         // Not checking the new slashing factor - just checking the invariant that new <= prev
         cheats.expectEmit(true, true, true, false);
-        emit BeaconChainSlashingFactorUpdated(defaultStaker, 0);
+        emit BeaconChainSlashingFactorDecreased(defaultStaker, 0, 0);
 
         cheats.prank(address(defaultPod));
         eigenPodManager.recordBeaconChainETHBalanceUpdate(defaultStaker, prevRestakedBalanceWei, -int(sharesDelta));


### PR DESCRIPTION
Changes:
* Removed `_beaconChainSlashingFactor` from `DelegationManager` and placed in `EigenPodManager`
* Altered equation used to decrease operator shares when beacon chain scaling factor is reduced (see `DM.decreaseDelegatedShares`)
* EigenPod checkpoints no longer deleted when complete. Checkpoint timestamps are reset to 0, but the struct itself is no longer deleted. This saves gas when creating a new checkpoint, because the state slot is not zeroed out.
  * Removed slashing math calculation from EigenPod in favor of implementing this in `EPM._reduceSlashingFactor`. This removes a branch from EigenPods.
* `EPM.recordBeaconChainETHBalanceUpdate` branches cleaned up:
  * Fixed bug where no update would occur when `podOwnerDepositShares == 0`
  * Explicitly follow `_addShares` path when `balanceDeltaWei == 0`