### PR TITLE
chore: remove unnecessary delegate checks

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -137,7 +137,7 @@ contract DelegationManager is
 
         // Checking the `approverSignatureAndExpiry` if applicable
         address approver = _operatorDetails[operator].delegationApprover;
-        if (approver != address(0) && msg.sender != approver && msg.sender != operator) {
+        if (approver != address(0)) {
             // check that the salt hasn't been used previously, then mark the salt as spent
             require(!delegationApproverSaltIsSpent[approver][approverSalt], SaltSpent());
             // actually check that the signature is valid

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -238,11 +238,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @param operator The account (`msg.sender`) is delegating its assets to for use in serving applications built on EigenLayer.
      * @param approverSignatureAndExpiry Verifies the operator approves of this delegation
      * @param approverSalt A unique single use value tied to an individual signature.
-     * @dev The approverSignatureAndExpiry is used in the event that:
-     *          1) the operator's `delegationApprover` address is set to a non-zero value.
-     *                  AND
-     *          2) neither the operator nor their `delegationApprover` is the `msg.sender`, since in the event that the operator
-     *             or their delegationApprover is the `msg.sender`, then approval is assumed.
+     * @dev The approverSignatureAndExpiry is used in the event that the operator's `delegationApprover` address is set to a non-zero value.
      * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
      * in this case to save on complexity + gas costs
      * @dev If the staker delegating has shares in a strategy that the operator was slashed 100% for (the operator's maxMagnitude = 0),


### PR DESCRIPTION
Remove checks on `delegateTo` for validating the `msg.sender` is not the operator or delegationApprover when there is an approver. not needed since this function is called by stakers