### PR TITLE
feat: add redelegate

### DIFF
--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -263,6 +263,22 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external returns (bytes32[] memory withdrawalRoots);
 
     /**
+     * @notice Undelegates the staker from their current operator, and redelegates to `newOperator`
+     * Queues a withdrawal for all of the staker's withdrawable shares.
+     * @dev This method acts like a call to `undelegate`, then `delegateTo`
+     * @param newOperator the new operator that will be delegated all assets
+     * @dev NOTE: the following 2 params are ONLY checked if `newOperator` has a `delegationApprover`.
+     * If not, they can be left empty.
+     * @param newOperatorApproverSig A signature from the operator's `delegationApprover`
+     * @param approverSalt A unique single use value tied to the approver's signature
+     */
+    function redelegate(
+        address newOperator,
+        SignatureWithExpiry memory newOperatorApproverSig,
+        bytes32 approverSalt
+    ) external returns (bytes32[] memory withdrawalRoots);
+
+    /**
      * @notice Allows a staker to withdraw some shares. Withdrawn shares/strategies are immediately removed
      * from the staker. If the staker is delegated, withdrawn shares/strategies are also removed from
      * their operator.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -264,7 +264,8 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
 
     /**
      * @notice Undelegates the staker from their current operator, and redelegates to `newOperator`
-     * Queues a withdrawal for all of the staker's withdrawable shares.
+     * Queues a withdrawal for all of the staker's withdrawable shares. These shares will only be
+     * delegated to `newOperator` AFTER the withdrawal is completed.
      * @dev This method acts like a call to `undelegate`, then `delegateTo`
      * @param newOperator the new operator that will be delegated all assets
      * @dev NOTE: the following 2 params are ONLY checked if `newOperator` has a `delegationApprover`.


### PR DESCRIPTION
* add `redelegate`, a combination of `undelegate` and `delegateTo`
* refactors out common parts of each  method into helpers (`_undelegate` and `_checkApproverSignature`)
* reorders internal methods to make more sense (`queue` is now above `complete`)