### PR TITLE
fix: try catch on burning

### DIFF
--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -143,7 +143,7 @@ contract StrategyManager is
     /// @inheritdoc IStrategyManager
     function burnShares(IStrategy strategy, uint256 sharesToBurn) external onlyDelegationManager {
         // burning shares is functionally the same as withdrawing but with different destination address
-        strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn);
+        try strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn) {} catch {}
     }
 
     /// @inheritdoc IStrategyManager

--- a/src/contracts/core/StrategyManagerStorage.sol
+++ b/src/contracts/core/StrategyManagerStorage.sol
@@ -27,7 +27,7 @@ abstract contract StrategyManagerStorage is IStrategyManager {
     uint8 internal constant PAUSED_DEPOSITS = 0;
 
     /// @notice default address for burning slashed shares and transferring underlying tokens
-    address public constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000DeaDBeef;
+    address public constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000000E16E4;
 
     // Immutables
 


### PR DESCRIPTION
To prevent a DOS situation of slashing an operatorSet's strategies, any reverts on the underlyingToken's transfer function are wrapped in a try catch block. In such scenario, these slashed shares will simply just sit in the Strategy contract unable to be withdrawn.