### PR TITLE
fix: add missing params

### DIFF
--- a/script/configs/local/deploy_from_scratch.anvil.config.json
+++ b/script/configs/local/deploy_from_scratch.anvil.config.json
@@ -48,6 +48,7 @@
           "activation_delay": 7200,
           "calculation_interval_seconds": 604800,
           "global_operator_commission_bips": 1000,
+          "default_operator_split_bips":1000,
           "OPERATOR_SET_GENESIS_REWARDS_TIMESTAMP": 1720656000,
           "OPERATOR_SET_MAX_RETROACTIVE_LENGTH": 2592000
      },


### PR DESCRIPTION
add `.rewardsCoordinator.default_operator_split_bips`