### PR TITLE
refactor: `PermissionController` cleanup

### DIFF
--- a/script/deploy/devnet/deploy_from_scratch.s.sol
+++ b/script/deploy/devnet/deploy_from_scratch.s.sol
@@ -319,12 +319,9 @@ contract DeployFromScratch is Script, Test {
             )
         );
 
-        eigenLayerProxyAdmin.upgradeAndCall(
+        eigenLayerProxyAdmin.upgrade(
             ITransparentUpgradeableProxy(payable(address(permissionController))),
-            address(permissionControllerImplementation),
-            abi.encodeWithSelector(
-                PermissionController.initialize.selector
-            )
+            address(permissionControllerImplementation)
         );
 
         // Deploy strategyFactory & base

--- a/script/deploy/local/Deploy_From_Scratch.s.sol
+++ b/script/deploy/local/Deploy_From_Scratch.s.sol
@@ -335,12 +335,9 @@ contract DeployFromScratch is Script, Test {
             )
         );
 
-        eigenLayerProxyAdmin.upgradeAndCall(
+        eigenLayerProxyAdmin.upgrade(
             ITransparentUpgradeableProxy(payable(address(permissionController))),
-            address(permissionControllerImplementation),
-            abi.encodeWithSelector(
-                PermissionController.initialize.selector
-            )
+            address(permissionControllerImplementation)
         );
 
         // deploy StrategyBaseTVLLimits contract implementation

--- a/script/deploy/local/deploy_from_scratch.slashing.s.sol
+++ b/script/deploy/local/deploy_from_scratch.slashing.s.sol
@@ -330,10 +330,9 @@ contract DeployFromScratch is Script, Test {
             )
         );
 
-        eigenLayerProxyAdmin.upgradeAndCall(
+        eigenLayerProxyAdmin.upgrade(
             ITransparentUpgradeableProxy(payable(address(permissionController))),
-            address(permissionControllerImplementation),
-            abi.encodeWithSelector(PermissionController.initialize.selector)
+            address(permissionControllerImplementation)
         );
 
         // deploy StrategyBaseTVLLimits contract implementation

--- a/src/contracts/permissions/PermissionController.sol
+++ b/src/contracts/permissions/PermissionController.sol
@@ -23,8 +23,6 @@ contract PermissionController is Initializable, PermissionControllerStorage {
         _disableInitializers();
     }
 
-    function initialize() external initializer {}
-
     /**
      *
      *                         EXTERNAL FUNCTIONS
@@ -214,10 +212,8 @@ contract PermissionController is Initializable, PermissionControllerStorage {
         address[] memory targets = new address[](length);
         bytes4[] memory selectors = new bytes4[](length);
 
-        for (uint256 i = 0; i < length; i++) {
-            (address target, bytes4 selector) = _decodeTargetSelector(appointeePermissions.at(i));
-            targets[i] = target;
-            selectors[i] = selector;
+        for (uint256 i = 0; i < length; ++i) {
+            (targets[i], selectors[i]) = _decodeTargetSelector(appointeePermissions.at(i));
         }
 
         return (targets, selectors);

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -263,12 +263,9 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser, Logger {
             )
         );
         //PermissionController
-        eigenLayerProxyAdmin.upgradeAndCall(
+        eigenLayerProxyAdmin.upgrade(
             ITransparentUpgradeableProxy(payable(address(permissionController))),
-            address(permissionControllerImplementation),
-            abi.encodeWithSelector(
-                PermissionController.initialize.selector
-            )
+            address(permissionControllerImplementation)
         );
         // Create base strategy implementation and deploy a few strategies
         baseStrategyImplementation = new StrategyBase(strategyManager, eigenLayerPauserReg);

--- a/src/test/utils/EigenLayerUnitTestSetup.sol
+++ b/src/test/utils/EigenLayerUnitTestSetup.sol
@@ -75,9 +75,7 @@ abstract contract EigenLayerUnitTestSetup is Test {
         permissionController = PermissionController(address(new TransparentUpgradeableProxy(
             address(permissionControllerImplementation),
             address(eigenLayerProxyAdmin),
-            abi.encodeWithSelector(
-                PermissionController.initialize.selector
-            )
+            ""
         )));
 
         avsDirectoryMock = AVSDirectoryMock(payable(address(new AVSDirectoryMock())));


### PR DESCRIPTION
### Changes
- Removes `permissionController.initialize()` (was previously unimplemented).
- Small syntax nit