### PR TITLE
feat: explicit multisig syntax on zeus scripts

### DIFF
--- a/script/releases/v0.5.1-rewardsv2/2-multisig.s.sol
+++ b/script/releases/v0.5.1-rewardsv2/2-multisig.s.sol
@@ -27,6 +27,13 @@ contract Queue is MultisigBuilder, Deploy {
     MultisigCall[] private _executorCalls;
     MultisigCall[] private _opsCalls;
 
+    function options() internal virtual override view returns (MultisigOptions memory) {
+        return MultisigOptions(
+            this._operationsMultisig(),
+            Operation.Call
+        );
+    }
+
     function _getMultisigTransactionCalldata() internal view returns (bytes memory) {
         ProxyAdmin pa = ProxyAdmin(this._proxyAdmin());
 
@@ -47,7 +54,7 @@ contract Queue is MultisigBuilder, Deploy {
         return (executorMultisigCalldata);
     }
 
-    function _runAsMultisig() internal virtual override {
+    function runAsMultisig() internal virtual override {
         bytes memory executorMultisigCalldata = _getMultisigTransactionCalldata();
 
         TimelockController timelock = TimelockController(payable(this._timelock()));
@@ -64,7 +71,6 @@ contract Queue is MultisigBuilder, Deploy {
     function testDeploy() public virtual override {
         runAsEOA();
 
-        zSetMultisigContext(this._operationsMultisig()); // this test will run as if the ops multisig ran the step
         execute();
         TimelockController timelock = TimelockController(payable(this._timelock()));
 


### PR DESCRIPTION
# What's changed

- Zeus scripts now explicitly state the multisig that they intend to run from.
- zSetMultisigContext is no longer needed, as the script implies its runner.
- Zeus 0.4.0 can now communicate with this standard.

NOTE:
- Will be supported in `zeus 0.4.0` (https://github.com/Layr-Labs/zeus/pull/5)
- We'll re-pin the upgrade to this commit.

# Testing 
- I redid the rewards V2 deploy from today here: ([final commit](https://github.com/jbrower95/eigenlayer-contracts-metadata/commit/33161b5545e6781d68d1606d2182ff0ea18585e5))
- Tenderly of redeploy: https://dashboard.tenderly.co/layrlabs/eigenlayer/testnet/cfd65c84-9ab2-4d4c-a175-fb725956b5fa