### PR TITLE
chore: log rather than comment final coverage output

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,18 +68,5 @@ jobs:
         echo "comment_contents<<$EOF" >> $GITHUB_OUTPUT
         echo "$(lcov --list ./lcov.info.pruned --ignore-errors inconsistent)" >> $GITHUB_OUTPUT
         echo "$EOF" >> $GITHUB_OUTPUT
-    - name: Comment the full report
-      uses: actions/github-script@v7
-      with:
-        script: |
-          let body = `${{ steps.print_coverage.outputs.comment_contents }}`;
-          github.rest.issues.createComment({
-            issue_number: ${{ steps.get_issue_number.outputs.result }},
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `
-            \`\`\`
-            ${body}
-            \`\`\`
-            `
-          })
+    - name: Log Coverage Report
+      run: echo "${{ steps.print_coverage.outputs.comment_contents }}"


### PR DESCRIPTION
Currently, we comment the coverage report frequently on every PR, taking up a lot of space on every PR but not providing much value. This PR logs the coverage report rather than comment it so that those seeking out this information can access it, while generally keeping PRs clean of this information.