### PR TITLE
feat: add back minWithdrawalDelayBlocks for introspection

### DIFF
--- a/script/deploy/devnet/deploy_from_scratch.s.sol
+++ b/script/deploy/devnet/deploy_from_scratch.s.sol
@@ -378,7 +378,7 @@ contract DeployFromScratch is Script, Test {
         // Check DM and AM have same withdrawa/deallocation delay
         // TODO: Update after AllocationManager is converted to timestamps as well
         // require(
-        //     delegation.MIN_WITHDRAWAL_DELAY_BLOCKS() == allocationManager.DEALLOCATION_DELAY(),
+        //     delegation.minWithdrawalDelayBlocks() == allocationManager.DEALLOCATION_DELAY(),
         //     "DelegationManager and AllocationManager have different withdrawal/deallocation delays"
         // );
         require(

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -978,6 +978,11 @@ contract DelegationManager is
     }
 
     /// @inheritdoc IDelegationManager
+    function minWithdrawalDelayBlocks() external view returns (uint32) {
+        return MIN_WITHDRAWAL_DELAY_BLOCKS;
+    }
+
+    /// @inheritdoc IDelegationManager
     function calculateDelegationApprovalDigestHash(
         address staker,
         address operator,

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -50,7 +50,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     IAllocationManager public immutable allocationManager;
 
     /// @notice Minimum withdrawal delay in blocks until a queued withdrawal can be completed.
-    uint32 public immutable MIN_WITHDRAWAL_DELAY_BLOCKS;
+    uint32 internal immutable MIN_WITHDRAWAL_DELAY_BLOCKS;
 
     // Mutatables
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -526,6 +526,9 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     /// @notice return address of the beaconChainETHStrategy
     function beaconChainETHStrategy() external view returns (IStrategy);
 
+    /// @notice Backwards-compatible interface to return the `MIN_WITHDRAWAL_DELAY_BLOCKS` value
+    function minWithdrawalDelayBlocks() external view returns (uint32);
+
     /// @notice The EIP-712 typehash for the DelegationApproval struct used by the contract
     function DELEGATION_APPROVAL_TYPEHASH() external view returns (bytes32);
 }

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -523,7 +523,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
      * Also applies to legacy withdrawals so any withdrawals not completed prior to the slashing upgrade will be subject
      * to this longer delay.
-     * @dev Backwards-compatible interface to return the `MIN_WITHDRAWAL_DELAY_BLOCKS` value
+     * @dev Backwards-compatible interface to return the internal `MIN_WITHDRAWAL_DELAY_BLOCKS` value
      * @dev Previous value in storage was deprecated. See `__deprecated_minWithdrawalDelayBlocks`
      */
     function minWithdrawalDelayBlocks() external view returns (uint32);

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -490,13 +490,6 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      */
     function depositScalingFactor(address staker, IStrategy strategy) external view returns (uint256);
 
-    /**
-     * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
-     * Also applies to legacy withdrawals so any withdrawals not completed prior to the slashing upgrade will be subject
-     * to this longer delay.
-     */
-    function MIN_WITHDRAWAL_DELAY_BLOCKS() external view returns (uint32);
-
     /// @notice Returns a list of pending queued withdrawals for a `staker`, and the `shares` to be withdrawn.
     function getQueuedWithdrawals(
         address staker
@@ -526,8 +519,13 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     /// @notice return address of the beaconChainETHStrategy
     function beaconChainETHStrategy() external view returns (IStrategy);
 
-    /// @notice Backwards-compatible interface to return the `MIN_WITHDRAWAL_DELAY_BLOCKS` value
-    /// @dev Previous value in storage was deprecated. See `__deprecated_minWithdrawalDelayBlocks`
+    /**
+     * @notice Returns the minimum withdrawal delay in blocks to pass for withdrawals queued to be completable.
+     * Also applies to legacy withdrawals so any withdrawals not completed prior to the slashing upgrade will be subject
+     * to this longer delay.
+     * @dev Backwards-compatible interface to return the `MIN_WITHDRAWAL_DELAY_BLOCKS` value
+     * @dev Previous value in storage was deprecated. See `__deprecated_minWithdrawalDelayBlocks`
+     */
     function minWithdrawalDelayBlocks() external view returns (uint32);
 
     /// @notice The EIP-712 typehash for the DelegationApproval struct used by the contract

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -527,6 +527,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     function beaconChainETHStrategy() external view returns (IStrategy);
 
     /// @notice Backwards-compatible interface to return the `MIN_WITHDRAWAL_DELAY_BLOCKS` value
+    /// @dev Previous value in storage was deprecated. See `__deprecated_minWithdrawalDelayBlocks`
     function minWithdrawalDelayBlocks() external view returns (uint32);
 
     /// @notice The EIP-712 typehash for the DelegationApproval struct used by the contract

--- a/src/test/DevnetLifecycle.t.sol
+++ b/src/test/DevnetLifecycle.t.sol
@@ -111,7 +111,7 @@ contract Devnet_Lifecycle_Test is Test, IAllocationManagerTypes {
         cheats.prank(operator);
         delegationManager.registerAsOperator(address(0), 1, emptyStringForMetadataURI);
         // Warp passed configuration delay
-        cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
 
         // Validate storage
         assertTrue(delegationManager.isOperator(operator));
@@ -221,7 +221,7 @@ contract Devnet_Lifecycle_Test is Test, IAllocationManagerTypes {
         delegationManager.queueWithdrawals(queuedWithdrawals);
 
         // Roll passed withdrawal delay
-        cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
 
         // Complete withdrawal
         IERC20[] memory tokens = new IERC20[](1);

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1317,7 +1317,7 @@ abstract contract IntegrationBase is IntegrationDeployer {
         for (uint i = 0; i < withdrawals.length; ++i) {
             if (withdrawals[i].startBlock > latest) latest = withdrawals[i].startBlock;
         }
-        cheats.roll(latest + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(latest + delegationManager.minWithdrawalDelayBlocks());
     }
 
     /// @dev Rolls forward by the default allocation delay blocks.

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1383,7 +1383,7 @@ contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerU
             "constructor / initializer incorrect, allocationManager set wrong"
         );
         assertEq(
-            delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS(),
+            delegationManager.minWithdrawalDelayBlocks(),
             MIN_WITHDRAWAL_DELAY_BLOCKS,
             "constructor / initializer incorrect, MIN_WITHDRAWAL_DELAY set wrong"
         );
@@ -4672,7 +4672,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
         // complete withdrawal as shares, should add back delegated shares to operator due to delegating again
         IERC20[] memory tokens = new IERC20[](1);
         tokens[0] = IERC20(strategyMock.underlyingToken());
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, false);
 
@@ -4974,7 +4974,7 @@ contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {
         delegationManager.undelegate(staker);
         // 4. Delegate to operator again with shares added back
         {
-            cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+            cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
             IERC20[] memory strategyTokens = new IERC20[](1);
             strategyTokens[0] = IERC20(strategyMock.underlyingToken());
             IERC20[] memory beaconTokens = new IERC20[](1);
@@ -5909,7 +5909,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         // Roll to completion block
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
 
         // resize tokens array
         IERC20[] memory newTokens = new IERC20[](0);
@@ -5970,7 +5970,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens,  true);
         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
@@ -6054,7 +6054,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         bool[] memory receiveAsTokensArray = receiveAsTokens.toArray(numWithdrawals);
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawals[0].startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawals[0].startBlock + delegationManager.minWithdrawalDelayBlocks());
         _completeQueuedWithdrawals_expectEmit(
             CompleteQueuedWithdrawalsEmitStruct({
                 withdrawals: withdrawals,
@@ -6142,7 +6142,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         }
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawals[0].startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawals[0].startBlock + delegationManager.minWithdrawalDelayBlocks());
         _completeQueuedWithdrawals_expectEmit(
             CompleteQueuedWithdrawalsEmitStruct({
                 withdrawals: withdrawals,
@@ -6201,7 +6201,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6311,7 +6311,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         {
             IERC20[] memory tokens = new IERC20[](1);
             tokens[0] = IERC20(strategyMock.underlyingToken());
-            cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
             _completeQueuedWithdrawal_expectEmit(
                 CompleteQueuedWithdrawalEmitStruct({
                     withdrawal: withdrawal,
@@ -6418,7 +6418,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
 
         {
             IERC20[] memory tokens = new IERC20[](1);
-            cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
             _completeQueuedWithdrawal_expectEmit(
                 CompleteQueuedWithdrawalEmitStruct({
                     withdrawal: withdrawal,
@@ -6515,7 +6515,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         ) = delegationManager.getWithdrawableShares(defaultStaker, beaconChainETHStrategy.toArray());
         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
         IERC20[] memory tokens = new IERC20[](1);
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6579,7 +6579,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         strategyManagerMock.setDelegationManager(delegationManager);
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6824,7 +6824,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 withdrawAmount,
                 "there should be withdrawAmount slashable shares in queue"
             );
-            cheats.roll(withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
         }
 
         uint256 operatorSharesBefore = delegationManager.operatorShares(operator, strategyMock);
@@ -7220,7 +7220,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 "there should be depositAmount slashable shares in queue"
             );
             // Check slashable shares in queue before and when the withdrawal is completable
-            completableBlock = withdrawal.startBlock + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS();
+            completableBlock = withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks();
             IERC20[] memory tokenArray = strategyMock.underlyingToken().toArray();
 
             // 3.2 roll to right before withdrawal is completable, check that slashable shares are still there
@@ -8143,7 +8143,7 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
 
         bytes32 withdrawalRoot = keccak256(abi.encode(withdrawal));
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.roll(block.number + delegationManager.MIN_WITHDRAWAL_DELAY_BLOCKS());
+        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
 
         cheats.prank(staker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokenMock.toArray(),  false);

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -1436,6 +1436,7 @@ contract StrategyManagerUnitTests_withdrawSharesAsTokens is StrategyManagerUnitT
     ) external filterFuzzedAddressInputs(staker) {
         cheats.assume(staker != address(this));
         cheats.assume(staker != address(0));
+        cheats.assume(staker != address(dummyStrat));
         cheats.assume(sharesAmount > 0 && sharesAmount < dummyToken.totalSupply() && depositAmount >= sharesAmount);
         IStrategy strategy = dummyStrat;
         IERC20 token = dummyToken;
@@ -1487,6 +1488,7 @@ contract StrategyManagerUnitTests_burnShares is StrategyManagerUnitTests {
         uint256 sharesToBurn
     ) external filterFuzzedAddressInputs(staker) {
         cheats.assume(staker != address(0));
+        cheats.assume(staker != address(dummyStrat));
         cheats.assume(sharesToBurn > 0 && sharesToBurn < dummyToken.totalSupply() && depositAmount >= sharesToBurn);
         IStrategy strategy = dummyStrat;
         IERC20 token = dummyToken;


### PR DESCRIPTION
This is so we don't break the BLSSigChecker on preprod/testnet 