### PR TITLE
fix(slashing): fix upgrade script phase 4

### DIFF
--- a/script/releases/v1.0.0-slashing/cleanup/start.sh
+++ b/script/releases/v1.0.0-slashing/cleanup/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+go run script.go

--- a/script/releases/v1.0.0-slashing/upgrade.json
+++ b/script/releases/v1.0.0-slashing/upgrade.json
@@ -1,6 +1,6 @@
 {
     "name": "slashing",
-    "from": "0.5.2",
+    "from": "~0.5.3",
     "to": "1.0.0",
     "phases": [
         {
@@ -17,7 +17,12 @@
         },
         {
             "type": "script",
-            "filename": "4-podCleanup.sh"
+            "filename": "cleanup/start.sh",
+            "arguments": [
+                {"type": "url", "passBy": "env", "inputType": "text", "name": "RPC_URL", "prompt": "Enter an ETH RPC URL"},
+                {"type": "url", "passBy": "env", "inputType": "text", "name": "BEACON_URL", "prompt": "Enter an ETH2 Beacon RPC URL"},
+                {"type": "privateKey", "passBy": "env", "inputType": "password", "name": "SENDER_PK", "prompt": "Enter an ETH wallet private key to complete checkpoints from:"}
+            ]
         },
         {
             "type": "multisig",


### PR DESCRIPTION
- Adds a harness script `start.sh` for invoking the go binary. (must be executable).
- Expresses the arguments of the script -- a beacon node, an RPC node, and a privateKey.

Will be running this upgrade on a tenderly fork, through the script phase, to test this rollout. (For the final phase, we'll just provide a beacon holesky ETH2 node against the tenderly fork).
