### PR TITLE
fix: complete withdrawals

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -944,16 +944,13 @@ contract DelegationManager is
             // still possible however for the slashing factors to change before the withdrawal is completable
             // and the shares withdrawn to be less
             if (completableBlock > uint32(block.number)) {
-                slashingFactors = _getSlashingFactors({
-                    staker: staker,
-                    operator: operator,
-                    strategies: withdrawals[i].strategies
-                });
-            // Read slashing factors at the completable block
+                slashingFactors =
+                    _getSlashingFactors({staker: staker, operator: operator, strategies: withdrawals[i].strategies});
+                // Read slashing factors at the completable block
             } else {
                 slashingFactors = _getSlashingFactorsAtBlock({
-                    staker: staker, 
-                    operator: operator, 
+                    staker: staker,
+                    operator: operator,
                     strategies: withdrawals[i].strategies,
                     blockNumber: completableBlock - 1
                 });

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -289,20 +289,6 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external returns (bytes32[] memory);
 
     /**
-     * @notice Used to complete the all queued withdrawals.
-     * Used to complete the specified `withdrawals`. The function caller must match `withdrawals[...].withdrawer`
-     * @param tokens Array of tokens for each Withdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
-     * @param receiveAsTokens Whether or not to complete each withdrawal as tokens. See `completeQueuedWithdrawal` for the usage of a single boolean.
-     * @param numToComplete The number of withdrawals to complete. This must be less than or equal to the number of queued withdrawals.
-     * @dev See `completeQueuedWithdrawal` for relevant dev tags
-     */
-    function completeQueuedWithdrawals(
-        IERC20[][] calldata tokens,
-        bool[] calldata receiveAsTokens,
-        uint256 numToComplete
-    ) external;
-
-    /**
      * @notice Used to complete the lastest queued withdrawal.
      * @param withdrawal The withdrawal to complete.
      * @param tokens Array in which the i-th entry specifies the `token` input to the 'withdraw' function of the i-th Strategy in the `withdrawal.strategies` array.


### PR DESCRIPTION
Decided on removing numToComplete interface and this PR also fixes some broken tests.

Also fixes a race condition bug where a staker's withdrawal is still slashable in the same block that the withdrawal is completable, leading to possible race conditions. The regression test `test_getQueuedWithdrawals_SlashAfterWithdrawalCompletion` on the view function found this and passes as a result of the fix.