### PR TITLE
feat: remove max strategies list

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -330,8 +330,6 @@ contract AllocationManager is
     /// @inheritdoc IAllocationManager
     function createOperatorSets(address avs, CreateSetParams[] calldata params) external checkCanCall(avs) {
         for (uint256 i = 0; i < params.length; i++) {
-            require(params[i].strategies.length <= MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH, MaxStrategiesExceeded());
-
             OperatorSet memory operatorSet = OperatorSet(avs, params[i].operatorSetId);
 
             // Create the operator set, ensuring it does not already exist
@@ -355,11 +353,6 @@ contract AllocationManager is
     ) external checkCanCall(avs) {
         OperatorSet memory operatorSet = OperatorSet(avs, operatorSetId);
         bytes32 operatorSetKey = operatorSet.key();
-
-        require(
-            _operatorSetStrategies[operatorSetKey].length() + strategies.length <= MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH,
-            MaxStrategiesExceeded()
-        );
 
         require(_operatorSets[avs].contains(operatorSet.id), InvalidOperatorSet());
 

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -23,10 +23,6 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @dev Index for flag that pauses operator register/deregister to operator sets when set.
     uint8 internal constant PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION = 2;
 
-    /// @dev Returns the maximum number of strategies an operator set can support.
-    /// NOTE: 32 LST strategies + 1 beacon chain ETH strategy = 33 total strategies.
-    uint8 internal constant MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH = 33;
-
     // Immutables
 
     /// @notice The DelegationManager contract for EigenLayer

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -13,8 +13,6 @@ interface IAllocationManagerErrors {
     error InvalidWadToSlash();
     /// @dev Thrown when two array parameters have mismatching lengths.
     error InputArrayLengthMismatch();
-    /// @dev Thrown when creating an operator set with more than max strategies.
-    error MaxStrategiesExceeded();
 
     /// Caller
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -18,7 +18,6 @@ contract AllocationManagerUnitTests is EigenLayerUnitTestSetup, IAllocationManag
     uint256 internal constant FUZZ_MAX_STRATS = 8;
     uint256 internal constant FUZZ_MAX_OP_SETS = 8;
 
-    uint8 internal constant MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH = 33;
     uint8 internal constant PAUSED_MODIFY_ALLOCATIONS = 0;
     uint8 internal constant PAUSED_OPERATOR_SLASHING = 1;
     uint8 internal constant PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION = 2;
@@ -3481,29 +3480,6 @@ contract AllocationManagerUnitTests_addStrategiesToOperatorSet is AllocationMana
         allocationManager.addStrategiesToOperatorSet(defaultAVS, defaultOperatorSet.id, defaultStrategies);
     }
 
-    function test_addStrategiesToOperatorSet_MaxStrategiesExceeded() public {
-        cheats.startPrank(defaultAVS);
-        cheats.expectRevert(MaxStrategiesExceeded.selector);
-        allocationManager.addStrategiesToOperatorSet(
-            defaultAVS, defaultOperatorSet.id, new IStrategy[](MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH + 1)
-        );
-
-        for (uint256 i; i < MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH - 1; ++i) {
-            allocationManager.addStrategiesToOperatorSet(
-                defaultAVS, 
-                defaultOperatorSet.id, 
-                IStrategy(cheats.randomAddress()).toArray()
-            );
-        }
-
-        cheats.expectRevert(MaxStrategiesExceeded.selector);
-        allocationManager.addStrategiesToOperatorSet(
-            defaultAVS, 
-            defaultOperatorSet.id, 
-            IStrategy(cheats.randomAddress()).toArray()
-        );        
-    }
-
     function testFuzz_addStrategiesToOperatorSet_Correctness(
         Randomness r
     ) public rand(r) {
@@ -3580,18 +3556,6 @@ contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitT
         cheats.prank(defaultAVS);
         cheats.expectRevert(InvalidOperatorSet.selector);
         allocationManager.createOperatorSets(defaultAVS, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray());
-    }
-
-    function testRevert_createOperatorSets_MaxStrategiesExceeded() public {
-        cheats.prank(defaultAVS);
-        cheats.expectRevert(MaxStrategiesExceeded.selector);
-        allocationManager.createOperatorSets(
-            defaultAVS, 
-            CreateSetParams(
-                defaultOperatorSet.id, 
-                new IStrategy[](MAX_OPERATOR_SET_STRATEGY_LIST_LENGTH + 1)
-            ).toArray()
-        );
     }
 
     function testFuzz_createOperatorSets_Correctness(


### PR DESCRIPTION
We do not need this parameter any more since on `slashOperator` we don't loop through the list of strats in an opSet