### PR TITLE
fix: update alloc config delay bound

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -432,7 +432,7 @@ contract AllocationManager is
         }
 
         info.pendingDelay = delay;
-        info.effectBlock = uint32(block.number) + ALLOCATION_CONFIGURATION_DELAY;
+        info.effectBlock = uint32(block.number) + ALLOCATION_CONFIGURATION_DELAY + 1;
 
         _allocationDelayInfo[operator] = info;
         emit AllocationDelaySet(operator, delay, info.effectBlock);

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -204,6 +204,7 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
         print.method("registerAsOperator");
         delegationManager.registerAsOperator(address(0), withdrawalDelay, "metadata");
         print.gasUsed();
+        rollForward({blocks: allocationManager().ALLOCATION_CONFIGURATION_DELAY() + 1});
     }
 
     /// @dev Delegate to the operator without a signature

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -204,7 +204,6 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
         print.method("registerAsOperator");
         delegationManager.registerAsOperator(address(0), withdrawalDelay, "metadata");
         print.gasUsed();
-        rollForward({blocks: allocationManager().ALLOCATION_CONFIGURATION_DELAY() + 1});
     }
 
     /// @dev Delegate to the operator without a signature


### PR DESCRIPTION
This matches the effect block behavior to be similar to that of the allocation delay. Allocation configs updates are activated on the `17.5th day + 1 block`