### PR TITLE
fix: rewards v2 audit fixes

### DIFF
--- a/src/test/unit/RewardsCoordinatorUnit.t.sol
+++ b/src/test/unit/RewardsCoordinatorUnit.t.sol
@@ -427,7 +427,7 @@ contract RewardsCoordinatorUnitTests_setOperatorAVSSplit is RewardsCoordinatorUn
         split = uint16(bound(split, ONE_HUNDRED_IN_BIPS + 1, type(uint16).max));
 
         cheats.prank(operator);
-        cheats.expectRevert("RewardsCoordinator.setOperatorAVSSplit: split must be <= 10000 bips");
+        cheats.expectRevert("RewardsCoordinator._setOperatorSplit: split must be <= 10000 bips");
         rewardsCoordinator.setOperatorAVSSplit(operator, avs, split);
     }
 
@@ -566,7 +566,7 @@ contract RewardsCoordinatorUnitTests_setOperatorPISplit is RewardsCoordinatorUni
         split = uint16(bound(split, ONE_HUNDRED_IN_BIPS + 1, type(uint16).max));
 
         cheats.prank(operator);
-        cheats.expectRevert("RewardsCoordinator.setOperatorPISplit: split must be <= 10000 bips");
+        cheats.expectRevert("RewardsCoordinator._setOperatorSplit: split must be <= 10000 bips");
         rewardsCoordinator.setOperatorPISplit(operator, split);
     }
 

--- a/src/test/unit/RewardsCoordinatorUnit.t.sol
+++ b/src/test/unit/RewardsCoordinatorUnit.t.sol
@@ -461,14 +461,28 @@ contract RewardsCoordinatorUnitTests_setOperatorAVSSplit is RewardsCoordinatorUn
         split = uint16(bound(split, 0, ONE_HUNDRED_IN_BIPS));
         uint32 activatedAt = uint32(block.timestamp) + activationDelay;
         uint16 oldSplit = rewardsCoordinator.getOperatorAVSSplit(operator, avs);
-        assertEq(oldSplit, defaultSplitBips, "Operator split is not Default split before Initialization");
+        // Check that the split returns the default split before initialization for the first time.
+        assertEq(
+            oldSplit,
+            rewardsCoordinator.defaultOperatorSplitBips(),
+            "Operator split is not Default split before Initialization"
+        );
 
         cheats.expectEmit(true, true, true, true, address(rewardsCoordinator));
         emit OperatorAVSSplitBipsSet(operator, operator, avs, activatedAt, oldSplit, split);
         cheats.prank(operator);
         rewardsCoordinator.setOperatorAVSSplit(operator, avs, split);
 
-        assertEq(oldSplit, rewardsCoordinator.getOperatorAVSSplit(operator, avs), "Incorrect Operator split");
+        cheats.prank(address(this)); // Owner of RewardsCoordinator
+        // Change default split to check if it is returned before activation
+        rewardsCoordinator.setDefaultOperatorSplit(5000);
+        // Check that the split returns the default split before activation for the first time.
+        assertEq(
+            rewardsCoordinator.defaultOperatorSplitBips(),
+            rewardsCoordinator.getOperatorAVSSplit(operator, avs),
+            "Operator split is not Default split before Activation for first time"
+        );
+
         cheats.warp(activatedAt);
         assertEq(split, rewardsCoordinator.getOperatorAVSSplit(operator, avs), "Incorrect Operator split");
     }
@@ -595,14 +609,28 @@ contract RewardsCoordinatorUnitTests_setOperatorPISplit is RewardsCoordinatorUni
         split = uint16(bound(split, 0, ONE_HUNDRED_IN_BIPS));
         uint32 activatedAt = uint32(block.timestamp) + activationDelay;
         uint16 oldSplit = rewardsCoordinator.getOperatorPISplit(operator);
-        assertEq(oldSplit, defaultSplitBips, "Operator split is not Default split before Initialization");
+        // Check that the split returns the default split before initialization for the first time.
+        assertEq(
+            oldSplit,
+            rewardsCoordinator.defaultOperatorSplitBips(),
+            "Operator split is not Default split before Initialization"
+        );
 
         cheats.expectEmit(true, true, true, true, address(rewardsCoordinator));
         emit OperatorPISplitBipsSet(operator, operator, activatedAt, oldSplit, split);
         cheats.prank(operator);
         rewardsCoordinator.setOperatorPISplit(operator, split);
 
-        assertEq(oldSplit, rewardsCoordinator.getOperatorPISplit(operator), "Incorrect Operator split");
+        cheats.prank(address(this)); // Owner of RewardsCoordinator
+        // Change default split to check if it is returned before activation
+        rewardsCoordinator.setDefaultOperatorSplit(5000);
+        // Check that the split returns the default split before activation for the first time.
+        assertEq(
+            rewardsCoordinator.defaultOperatorSplitBips(),
+            rewardsCoordinator.getOperatorPISplit(operator),
+            "Operator split is not Default split before Activation for first time"
+        );
+
         cheats.warp(activatedAt);
         assertEq(split, rewardsCoordinator.getOperatorPISplit(operator), "Incorrect Operator split");
     }


### PR DESCRIPTION
# Motivation

As part of the Rewards v2 SigmaPrime audit, we need to tackle issue `ELSC2-07: Operators Can Lock In Current Default Split By Front-Running Changes`

# Modifications

* Moved `split <= ONE_HUNDRED_IN_BIPS` logic into common internal function : `_setOperatorSplit`
* Updated `_setOperatorSplit` and `_getOperatorSplit` for edge case of time after first split initialization, but before activation. 
* Updated tests.

# Result

Rewards v2 audit fixes. 