### PR TITLE
feat: async burning of shares

### DIFF
--- a/docs/release/slashing/AVSDirectory.md
+++ b/docs/release/slashing/AVSDirectory.md
@@ -1,0 +1,145 @@
+# AVSDirectory
+
+## Overview
+
+The AVSDirectory contract is where registration relationships are defined between AVSs, operatorSets, and operators. Registration and deregistration are used in the protocol to activate and deactivate slashable stake allocations. They're also used to make the protocol more legible to external integrations.
+
+The slashing release introduces the concept of operatorSets, which are simply an (address, uint32) pair that the define an AVS and an operator set ID. OperatorSets are used to group operators by different tasks and sets of tokens. For example, EigenDA has an ETH/LST operatorSet and an Eigen operatorSet. A bridge may have on operatorSet for all operators that serve a particular chain. Overall, operatorSets are mainly used for protocol legibility.
+
+Functionality is provided for AVSs to migrate from an pre-operatorSet registration model to an operatorSet model. Direct to AVS registration is still supported for AVSs that have not migrated to the operatorSet model, but is slated to be deprecated soon in the future.
+
+## `becomeOperatorSetAVS`
+```solidity
+/**
+ * @notice Sets the AVS as an operator set AVS, preventing legacy M2 operator registrations.
+ *
+ * @dev msg.sender must be the AVS.
+ */
+function becomeOperatorSetAVS() external;
+```
+
+AVSs call this to become an operator set AVS. Once an AVS becomes an operator set AVS, they can no longer register operators via the legacy M2 registration path. This is a seperate function to help avoid accidental migrations to the operator set AVS model.
+
+## `createOperatorSets`
+```solidity
+/**
+ * @notice Called by an AVS to create a list of new operatorSets.
+ *
+ * @param operatorSetIds The IDs of the operator set to initialize.
+ *
+ * @dev msg.sender must be the AVS.
+ */
+function createOperatorSets(
+    uint32[] calldata operatorSetIds
+) external;
+```
+
+AVSs use this function to create a list of new operator sets.They must call this function before they add any operators to the operator sets. The operator set IDs must be not already exist.
+
+This can be called before the AVS becomes an operator set AVS. (TODO: we should make this so that it can only be called after the AVS becomes an operator set AVS?)
+
+## `migrateOperatorsToOperatorSets`
+```solidity
+/**
+ * @notice Called by an AVS to migrate operators that have a legacy M2 registration to operator sets.
+ *
+ * @param operators The list of operators to migrate
+ * @param operatorSetIds The list of operatorSets to migrate the operators to
+ *
+ * @dev The msg.sender used is the AVS
+ * @dev The operator can only be migrated at most once per AVS
+ * @dev The AVS can no longer register operators via the legacy M2 registration path once it begins migration
+ * @dev The operator is deregistered from the M2 legacy AVS once migrated
+ */
+function migrateOperatorsToOperatorSets(
+    address[] calldata operators,
+    uint32[][] calldata operatorSetIds
+) external;
+```
+
+AVSs that launched before the slashing release can use this function to migrate operators that have a legacy M2 registration to operator sets. Each operator can only be migrated once for the AVS and the AVS can no longer register operators via the legacy M2 registration path once it begins migration.
+
+## `registerOperatorToOperatorSets`
+```solidity
+/**
+ *  @notice Called by AVSs to add an operator to list of operatorSets.
+ *
+ *  @param operator The address of the operator to be added to the operator set.
+ *  @param operatorSetIds The IDs of the operator sets.
+ *  @param operatorSignature The signature of the operator on their intent to register.
+ *
+ *  @dev msg.sender is used as the AVS.
+ */
+function registerOperatorToOperatorSets(
+    address operator,
+    uint32[] calldata operatorSetIds,
+    ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+) external;
+```
+
+AVSs use this function to add an operator to a list of operator sets. The operator's signature is required to confirm their intent to register.  If the operator has a slashable stake allocation to the AVS, it takes effect when the operator is registered (and up to `DEALLOCATION_DELAY` seconds after the operator is deregistered).
+
+The operator set must exist before the operator can be added to it and the AVS must be an operator set AVS.
+
+## `deregisterOperatorFromOperatorSets`
+```solidity
+/**
+ *  @notice Called by AVSs to remove an operator from an operator set.
+ *
+ *  @param operator The address of the operator to be removed from the operator set.
+ *  @param operatorSetIds The IDs of the operator sets.
+ *
+ *  @dev msg.sender is used as the AVS.
+ */
+function deregisterOperatorFromOperatorSets(address operator, uint32[] calldata operatorSetIds) external;
+```
+
+AVSs use this function to remove an operator from an operator set. The operator is still slashable for its slashable stake allocation to the AVS until `DEALLOCATION_DELAY` seconds after the operator is deregistered.
+
+The operator must be registered to the operator set before they can be deregistered from it.
+
+
+## `forceDeregisterFromOperatorSets`
+```solidity
+/**
+ * @notice Called by an operator to deregister from an operator set
+ *
+ * @param operator The operator to deregister from the operatorSets.
+ * @param avs The address of the AVS to deregister the operator from.
+ * @param operatorSetIds The IDs of the operator sets.
+ * @param operatorSignature the signature of the operator on their intent to deregister or empty if the operator itself is calling
+ *
+ * @dev if the operatorSignature is empty, the caller must be the operator
+ * @dev this will likely only be called in case the AVS contracts are in a state that prevents operators from deregistering
+ */
+function forceDeregisterFromOperatorSets(
+    address operator,
+    address avs,
+    uint32[] calldata operatorSetIds,
+    ISignatureUtils.SignatureWithSaltAndExpiry memory operatorSignature
+) external;
+```
+
+Operators can use this function to deregister from an operator set without requiring the AVS to sign off on the deregistration. This function is intended to be used in cases where the AVS contracts are in a state that prevents operators from deregistering (either malicious or unintentional).
+
+Operators can also deallocate their slashable stake allocation seperately to avoid slashing risk, so this function is mainly for external integrations to interpret the correct state of the protocol.
+
+## `updateAVSMetadataURI`
+```solidity
+/**
+ *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+ *
+ *  @param metadataURI The URI for metadata associated with an AVS.
+ *
+ *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
+ */
+function updateAVSMetadataURI(
+    string calldata metadataURI
+) external;
+```
+
+This function allows an AVS to update the metadata URI associated with the AVS. The metadata URI is never stored on-chain and is only emitted in the `AVSMetadataURIUpdated` event.
+
+## View Functions
+
+See the [AVS Directory Inteface](../../../src/contracts/interfaces/IAVSDirectory.sol) for view functions. 

--- a/docs/release/slashing/AllocationManager.md
+++ b/docs/release/slashing/AllocationManager.md
@@ -1,0 +1,169 @@
+# AllocationManager
+
+## Prerequisites
+
+- [The Mechanics of Allocating and Slashing Unique Stake](https://forum.eigenlayer.xyz/t/the-mechanics-of-allocating-and-slashing-unique-stake/13870)
+
+## Overview
+The AllocationManager contract manages the allocation and reallocation of operators' slashable stake across various strategies and operator sets. It enforces allocation and deallocation delays and handles the slashing process initiated by AVSs.
+
+## Parameterization
+
+- `ALLOCATION_CONFIGURATION_DELAY`: The delay in seconds before allocations take effect.
+    - Mainnet: `21 days`. Very TBD
+    - Testnet: `1 hour`. Very TBD
+    - Public Devnet: `10 minutes`
+- `DEALLOCATION_DELAY`: The delay in seconds before deallocations take effect.
+    - Mainnet: `17.5 days`. Slightly TBD
+    - Testnet: `3 days`. Very TBD
+    - Public Devnet: `1 days` 
+
+## `setAllocationDelay` 
+
+```solidity
+/**
+ * @notice Called by operators or the delegation manager to set their allocation delay.
+ * @param operator The operator to set the delay on behalf of.
+ * @param delay The allocation delay in seconds.
+ */
+function setAllocationDelay(address operator, uint32 delay) external;
+
+These functions allow operators to set their allocation delay. The first variant is called by the DelegationManager upon operator registration for all new operators created after the slashing release. The second variant is called by operators themselves to update their allocation delay or set it for the first time if they joined before the slashing release.
+
+The allocation delay takes effect in `ALLOCATION_CONFIGURATION_DELAY` seconds.
+
+The allocation delay can be any positive uint32.
+
+The allocation delay's primary purpose is to give stakers delegated to an operator the chance to withdraw their stake before the operator can change the risk profile to something they're not comfortable with.
+
+## `modifyAllocations`
+
+```solidity
+/**
+ * @notice struct used to modify the allocation of slashable magnitude to list of operatorSets
+ * @param strategy the strategy to allocate magnitude for
+ * @param expectedMaxMagnitude the expected max magnitude of the operator used to combat against race conditions with slashing
+ * @param operatorSets the operatorSets to allocate magnitude for
+ * @param magnitudes the magnitudes to allocate for each operatorSet
+ */
+struct MagnitudeAllocation {
+    IStrategy strategy;
+    uint64 expectedMaxMagnitude;
+    OperatorSet[] operatorSets;
+    uint64[] magnitudes;
+}
+
+/**
+ * @notice Modifies the propotions of slashable stake allocated to a list of operatorSets for a set of strategies
+ * @param allocations array of magnitude adjustments for multiple strategies and corresponding operator sets
+ * @dev Updates encumberedMagnitude for the updated strategies
+ * @dev msg.sender is used as operator
+ */
+function modifyAllocations(MagnitudeAllocation[] calldata allocations) external
+```
+
+This function is called by operators to adjust the proportions of their slashable stake allocated to different operator sets for different strategies.
+
+The operator provides their expected max magnitude for each strategy they're adjusting the allocation for. This is used to combat race conditions with slashings for the strategy, which may result in larger than expected slashable proportions allocated to operator sets.
+
+Each `(operator, operatorSet, strategy)` tuple can have at most 1 pending modification at a time. The function will revert is there is a pending modification for any of the tuples in the input. 
+
+The contract keeps track of the total magnitude in pending allocations, active allocations, and pending deallocations. This is called the **_encumbered magnitude_** for a strategy. The contract verifies that the allocations made in this call do not make the encumbered magnitude exceed the operator's max magnitude for the strategy. If the encumbered magnitude exceeds the max magnitude, the function reverts.
+
+Any _allocations_ (i.e. increases in the proportion of slashable stake allocated to an AVS) take effect after the operator's allocation delay. The allocation delay must be set for the operator before they can call this function.
+
+Any _deallocations_ (i.e. decreases in the proportion of slashable stake allocated to an AVS) take effect after `DEALLOCATION_DELAY` seconds. This enables AVSs enough time to update their view of stakes to the new proportions and have any tasks created against previous stakes to expire.
+
+## `clearDeallocationQueue`
+
+```solidity
+/**
+ * @notice This function takes a list of strategies and adds all completable deallocations for each strategy,
+ * updating the encumberedMagnitude of the operator as needed.
+ *
+ * @param operator address to complete deallocations for
+ * @param strategies a list of strategies to complete deallocations for
+ * @param numToComplete a list of number of pending deallocations to complete for each strategy
+ *
+ * @dev can be called permissionlessly by anyone
+ */
+function clearDeallocationQueue(
+    address operator,
+    IStrategy[] calldata strategies,
+    uint16[] calldata numToComplete
+) external;
+```
+
+This function is used to complete pending deallocations for a list of strategies for an operator. The function takes a list of strategies and the number of pending deallocations to complete for each strategy. For each strategy, the function completes pending deallocations if their effect timestamps have passed. 
+
+Completing a deallocation decreases the encumbered magnitude for the strategy, allowing them to make allocations with that magnitude. Encumbered magnitude must be decreased only upon completion because pending deallocations can be slashed before they are completable.
+
+## `slashOperator`
+
+```solidity
+/**
+ * @notice Struct containing parameters to slashing
+ * @param operator the address to slash
+ * @param operatorSetId the ID of the operatorSet the operator is being slashed on behalf of
+ * @param strategies the set of strategies to slash
+ * @param wadsToSlash the parts in 1e18 to slash, this will be proportional to the operator's
+ * slashable stake allocation for the operatorSet
+ * @param description the description of the slashing provided by the AVS for legibility
+ */
+struct SlashingParams {
+    address operator;
+    uint32 operatorSetId;
+    IStrategy[] strategies;
+    uint256[] wadsToSlash;
+    string description;
+}
+
+/**
+ * @notice Called by an AVS to slash an operator for given operatorSetId, list of strategies, and wadToSlash.
+ * For each given (operator, operatorSetId, strategy) tuple, bipsToSlash
+ * bips of the operatorSet's slashable stake allocation will be slashed
+ *
+ * @param operator the address to slash
+ * @param operatorSetId the ID of the operatorSet the operator is being slashed on behalf of
+ * @param strategies the set of strategies to slash
+ * @param wadToSlash the parts in 1e18 to slash, this will be proportional to the
+ * operator's slashable stake allocation for the operatorSet
+ * @param description the description of the slashing provided by the AVS for legibility
+ */
+function slashOperator(
+    SlashingParams calldata params
+) external
+```
+
+This function is called by AVSs to slash an operator for a given operator set and list of strategies. The AVS provides the proportion of the operator's slashable stake allocation to slash for each strategy. The proportion is given in parts in 1e18 and is with respect to the operator's _current_ slashable stake allocation for the operator set (i.e. `wadsToSlash=5e17` means 50% of the operator's slashable stake allocation for the operator set will be slashed). The AVS also provides a description of the slashing for legibility by outside integrations.
+
+Slashing is instant and irreversable. Slashed funds remain unrecoverable in the protocol but will be burned/redistributed in a future release. Slashing by one operatorSet does not effect the slashable stake allocation of other operatorSets for the same operator and strategy.
+
+Slashing updates storage in a way that instantly updates all view functions to reflect the correct values.
+
+## View Functions 
+
+### `getMinDelegatedAndSlashableOperatorSharesBefore`
+
+```solidity
+/**
+ * @notice returns the minimum operatorShares and the slashableOperatorShares for an operator, list of strategies, 
+ * and an operatorSet before a given timestamp. This is used to get the shares to weight operators by given ones slashing window.
+ * @param operatorSet the operatorSet to get the shares for
+ * @param operators the operators to get the shares for
+ * @param strategies the strategies to get the shares for
+ * @param beforeTimestamp the timestamp to get the shares at
+ */
+function getMinDelegatedAndSlashableOperatorSharesBefore(
+    OperatorSet calldata operatorSet,
+    address[] calldata operators,
+    IStrategy[] calldata strategies,
+    uint32 beforeTimestamp
+) external view returns (uint256[][] memory, uint256[][] memory)
+```
+
+This function returns the minimum operator shares and the slashable operator shares for an operator, list of strategies, and an operator set before a given timestamp. This is used by AVSs to pessimistically estimate the operator's slashable stake allocation for a given strategy and operator set within their slashability windows. If an AVS calls this function every week and creates tasks that are slashable for a week after they're created, then `beforeTimestamp` should be 2 weeks in the future to account for the latest task that may be created against stale stakes. More on this in new docs soon.
+
+### Additional View Functions
+
+See the [AllocationManager Interface](../../../src/contracts/interfaces/IAllocationManager.sol) for additional view functions.

--- a/docs/release/slashing/MetdataURI.md
+++ b/docs/release/slashing/MetdataURI.md
@@ -1,0 +1,51 @@
+# Metadata URI Standard
+
+Below is the new metadataURI standard for AVSs that call `setMetadataURI` in the `AllocationManager`
+
+```plaintext
+ {
+  "name": "AVS",
+  "website": "https.avs.xyz/",
+  "description": "Some description about",
+  "logo": "http://github.com/logo.png",
+  "twitter": "https://twitter.com/avs"
+  "operatorSets": [
+        {
+          "name":"ETH Set",
+          "id":"1", // Note: we use this param to match the opSet id in the Allocation Manager
+          "description":"The ETH operatorSet for AVS",
+          "software":[
+              {
+              "name": "NetworkMonitor",
+              "description": "",
+              "url": "https://link-to-binary-or-github.com"
+              },
+              {
+              "name": "ValidatorClient",
+              "description": "",
+              "url": "https://link-to-binary-or-github.com"
+              }
+            ],
+            "slashingConditions: ["Condition A", "Condition B"]
+        },
+        {
+          "name":"EIGEN Set",
+          "id":"2", // Note: we use this param to match the opSet id in the Allocation Manager
+          "description":"The EIGEN operatorSet for AVS",
+          "software":[
+              {
+              "name": "NetworkMonitor",
+              "description": "",
+              "url": "https://link-to-binary-or-github.com"
+              },
+              {
+              "name": "ValidatorClient",
+              "description": "",
+              "url": "https://link-to-binary-or-github.com"
+              }
+            ],
+            "slashingConditions: ["Condition A", "Condition B"]
+        }
+   ]
+}
+```

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -283,7 +283,7 @@ contract DelegationManager is
     ) external onlyAllocationManager {
         /// forgefmt: disable-next-item
         uint256 operatorSharesSlashed = SlashingLib.calcSlashedAmount({
-            operatorShares: operatorShares[operator][strategy],
+            shares: operatorShares[operator][strategy],
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });
@@ -752,8 +752,8 @@ contract DelegationManager is
         // less than or equal to MIN_WITHDRAWAL_DELAY_BLOCKS ago. These shares are still slashable.
         uint256 scaledSharesAdded = curQueuedScaledShares - prevQueuedScaledShares;
 
-        return SlashingLib.scaleForBurning({
-            scaledShares: scaledSharesAdded,
+        return SlashingLib.calcSlashedAmount({
+            shares: scaledSharesAdded,
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -283,7 +283,7 @@ contract DelegationManager is
     ) external onlyAllocationManager {
         /// forgefmt: disable-next-item
         uint256 operatorSharesSlashed = SlashingLib.calcSlashedAmount({
-            shares: operatorShares[operator][strategy],
+            operatorShares: operatorShares[operator][strategy],
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });
@@ -752,8 +752,8 @@ contract DelegationManager is
         // less than or equal to MIN_WITHDRAWAL_DELAY_BLOCKS ago. These shares are still slashable.
         uint256 scaledSharesAdded = curQueuedScaledShares - prevQueuedScaledShares;
 
-        return SlashingLib.calcSlashedAmount({
-            shares: scaledSharesAdded,
+        return SlashingLib.scaleForBurning({
+            scaledShares: scaledSharesAdded,
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -124,7 +124,7 @@ contract DelegationManager is
         address operator,
         SignatureWithExpiry memory approverSignatureAndExpiry,
         bytes32 approverSalt
-    ) external {
+    ) public {
         require(!isDelegated(msg.sender), ActivelyDelegated());
         require(isOperator(operator), OperatorNotRegistered());
 
@@ -143,22 +143,17 @@ contract DelegationManager is
     /// @inheritdoc IDelegationManager
     function undelegate(
         address staker
-    ) external returns (bytes32[] memory withdrawalRoots) {
+    ) public returns (bytes32[] memory withdrawalRoots) {
         // Check that the `staker` can undelegate
         require(isDelegated(staker), NotActivelyDelegated());
         require(!isOperator(staker), OperatorsCannotUndelegate());
 
-        // Validate caller is the staker, the operator, or the operator's `delegationApprover`
-        require(staker != address(0), InputAddressZero());
-        address operator = delegatedTo[staker];
-        require(
-            msg.sender == staker || _checkCanCall(operator)
-                || msg.sender == _operatorDetails[operator].delegationApprover,
-            CallerCannotUndelegate()
-        );
-
-        // Emit an event if this action was not initiated by the staker themselves
+        // If the action is not being initiated by the staker, validate that it is initiated
+        // by the operator or their delegationApprover.
         if (msg.sender != staker) {
+            address operator = delegatedTo[staker];
+
+            require(_checkCanCall(operator) || msg.sender == delegationApprover(operator), CallerCannotUndelegate());
             emit StakerForceUndelegated(staker, operator);
         }
 
@@ -171,24 +166,9 @@ contract DelegationManager is
         SignatureWithExpiry memory newOperatorApproverSig,
         bytes32 approverSalt
     ) external returns (bytes32[] memory withdrawalRoots) {
-        // Check that the staker can undelegate, and `newOperator` can be delegated to
-        require(isDelegated(msg.sender), NotActivelyDelegated());
-        require(!isOperator(msg.sender), OperatorsCannotUndelegate());
-        require(isOperator(newOperator), OperatorNotRegistered());
-
-        // Undelegate the staker and queue any deposited assets for withdrawal
-        withdrawalRoots = _undelegate(msg.sender);
-
-        // If the operator has a `delegationApprover`, check the provided signature
-        _checkApproverSignature({
-            staker: msg.sender,
-            operator: newOperator,
-            signature: newOperatorApproverSig,
-            salt: approverSalt
-        });
-
-        // Delegate to the new operator
-        _delegate(msg.sender, newOperator);
+        withdrawalRoots = undelegate(msg.sender);
+        // delegateTo uses msg.sender as staker
+        delegateTo(newOperator, newOperatorApproverSig, approverSalt);
     }
 
     /// @inheritdoc IDelegationManager
@@ -200,7 +180,6 @@ contract DelegationManager is
 
         for (uint256 i = 0; i < params.length; i++) {
             require(params[i].strategies.length == params[i].depositShares.length, InputArrayLengthMismatch());
-            require(params[i].withdrawer == msg.sender, WithdrawerNotStaker());
 
             uint256[] memory slashingFactors = _getSlashingFactors(msg.sender, operator, params[i].strategies);
 
@@ -242,34 +221,15 @@ contract DelegationManager is
     }
 
     /// @inheritdoc IDelegationManager
-    function completeQueuedWithdrawals(
-        IERC20[][] calldata tokens,
-        bool[] calldata receiveAsTokens,
-        uint256 numToComplete
-    ) external onlyWhenNotPaused(PAUSED_EXIT_WITHDRAWAL_QUEUE) nonReentrant {
-        EnumerableSet.Bytes32Set storage withdrawalRoots = _stakerQueuedWithdrawalRoots[msg.sender];
-        uint256 length = withdrawalRoots.length();
-        numToComplete = numToComplete > length ? length : numToComplete;
-
-        // Read withdrawals to complete. We use 2 seperate loops here because the second
-        // loop will remove elements by index from `withdrawalRoots`.
-        Withdrawal[] memory withdrawals = new Withdrawal[](numToComplete);
-        for (uint256 i; i < withdrawals.length; ++i) {
-            withdrawals[i] = queuedWithdrawals[withdrawalRoots.at(i)];
-        }
-
-        for (uint256 i; i < withdrawals.length; ++i) {
-            _completeQueuedWithdrawal(withdrawals[i], tokens[i], receiveAsTokens[i]);
-        }
-    }
-
-    /// @inheritdoc IDelegationManager
     function increaseDelegatedShares(
         address staker,
         IStrategy strategy,
         uint256 prevDepositShares,
         uint256 addedShares
     ) external onlyStrategyManagerOrEigenPodManager {
+        /// Note: Unlike `decreaseDelegatedShares`, we don't return early if the staker has no operator.
+        /// This is because `_increaseDelegation` updates the staker's deposit scaling factor, which we
+        /// need to do even if not delegated.
         address operator = delegatedTo[staker];
         uint64 maxMagnitude = allocationManager.getMaxMagnitude(operator, strategy);
         uint256 slashingFactor = _getSlashingFactor(staker, strategy, maxMagnitude);
@@ -322,30 +282,34 @@ contract DelegationManager is
         uint64 newMaxMagnitude
     ) external onlyAllocationManager {
         /// forgefmt: disable-next-item
-        uint256 sharesToDecrement = SlashingLib.calcSlashedAmount({
+        uint256 operatorSharesSlashed = SlashingLib.calcSlashedAmount({
             operatorShares: operatorShares[operator][strategy],
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });
 
-        // While `sharesToDecrement` describes the amount we should directly remove from the operator's delegated
-        // shares, `sharesToBurn` also includes any shares that have been queued for withdrawal and are still
-        // slashable given the withdrawal delay.
-        uint256 sharesToBurn =
-            sharesToDecrement + _getSlashedSharesInQueue(operator, strategy, prevMaxMagnitude, newMaxMagnitude);
+        uint256 scaledSharesSlashedFromQueue = _getSlashableSharesInQueue({
+            operator: operator,
+            strategy: strategy,
+            prevMaxMagnitude: prevMaxMagnitude,
+            newMaxMagnitude: newMaxMagnitude
+        });
+
+        // Calculate the total deposit shares to burn - slashed operator shares plus still-slashable
+        // shares sitting in the withdrawal queue.
+        uint256 totalDepositSharesToBurn = operatorSharesSlashed + scaledSharesSlashedFromQueue;
 
         // Remove shares from operator
         _decreaseDelegation({
             operator: operator,
-            staker: address(0), // we treat this as a decrease for the zero address staker
+            staker: address(0), // we treat this as a decrease for the 0-staker (only used for events)
             strategy: strategy,
-            sharesToDecrease: sharesToDecrement
+            sharesToDecrease: operatorSharesSlashed
         });
 
         // NOTE: native ETH shares will be burned by a different mechanism in a future release
         if (strategy != beaconChainETHStrategy) {
-            strategyManager.burnShares(strategy, sharesToBurn);
-            emit OperatorSharesBurned(operator, strategy, sharesToBurn);
+            strategyManager.increaseBurnableShares(strategy, totalDepositSharesToBurn);
         }
     }
 
@@ -484,7 +448,7 @@ contract DelegationManager is
         require(strategies.length != 0, InputArrayLengthZero());
 
         uint256[] memory scaledShares = new uint256[](strategies.length);
-        uint256[] memory sharesToWithdraw = new uint256[](strategies.length);
+        uint256[] memory withdrawableShares = new uint256[](strategies.length);
 
         // Remove shares from staker and operator
         // Each of these operations fail if we attempt to remove more shares than exist
@@ -492,20 +456,11 @@ contract DelegationManager is
             IShareManager shareManager = _getShareManager(strategies[i]);
             DepositScalingFactor memory dsf = _depositScalingFactor[staker][strategies[i]];
 
-            // Check withdrawing deposit shares amount doesn't exceed balance
-            require(
-                depositSharesToWithdraw[i] <= shareManager.stakerDepositShares(staker, strategies[i]),
-                WithdrawalExceedsMax()
-            );
-
             // Calculate how many shares can be withdrawn after factoring in slashing
-            sharesToWithdraw[i] = dsf.calcWithdrawable(depositSharesToWithdraw[i], slashingFactors[i]);
+            withdrawableShares[i] = dsf.calcWithdrawable(depositSharesToWithdraw[i], slashingFactors[i]);
 
-            // Apply slashing. If the staker or operator has been fully slashed, this will return 0
-            scaledShares[i] = SlashingLib.scaleForQueueWithdrawal({
-                sharesToWithdraw: sharesToWithdraw[i],
-                slashingFactor: slashingFactors[i]
-            });
+            // Scale shares for queue withdrawal
+            scaledShares[i] = dsf.scaleForQueueWithdrawal(depositSharesToWithdraw[i]);
 
             // Remove delegated shares from the operator
             if (operator != address(0)) {
@@ -519,7 +474,7 @@ contract DelegationManager is
                     operator: operator,
                     staker: staker,
                     strategy: strategies[i],
-                    sharesToDecrease: sharesToWithdraw[i]
+                    sharesToDecrease: withdrawableShares[i]
                 });
             }
 
@@ -547,7 +502,7 @@ contract DelegationManager is
         queuedWithdrawals[withdrawalRoot] = withdrawal;
         _stakerQueuedWithdrawalRoots[staker].add(withdrawalRoot);
 
-        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, sharesToWithdraw);
+        emit SlashingWithdrawalQueued(withdrawalRoot, withdrawal, withdrawableShares);
         return withdrawalRoot;
     }
 
@@ -555,7 +510,7 @@ contract DelegationManager is
      * @dev This function completes a queued withdrawal for a staker.
      * This will apply any slashing that has occurred since the the withdrawal was queued by multiplying the withdrawal's
      * scaledShares by the operator's maxMagnitude for each strategy. This ensures that any slashing that has occurred
-     * during the period the withdrawal was queued until its completable timestamp is applied to the withdrawal amount.
+     * during the period the withdrawal was queued until its slashableUntil block is applied to the withdrawal amount.
      * If receiveAsTokens is true, then these shares will be withdrawn as tokens.
      * If receiveAsTokens is false, then they will be redeposited according to the current operator the staker is delegated to,
      * and added back to the operator's delegatedShares.
@@ -572,8 +527,10 @@ contract DelegationManager is
 
         uint256[] memory prevSlashingFactors;
         {
-            uint32 completableBlock = withdrawal.startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS;
-            require(completableBlock <= uint32(block.number), WithdrawalDelayNotElapsed());
+            // slashableUntil is block inclusive so we need to check if the current block is strictly greater than the slashableUntil block
+            // meaning the withdrawal can be completed.
+            uint32 slashableUntil = withdrawal.startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS;
+            require(uint32(block.number) > slashableUntil, WithdrawalDelayNotElapsed());
 
             // Given the max magnitudes of the operator the staker was originally delegated to, calculate
             // the slashing factors for each of the withdrawal's strategies.
@@ -581,9 +538,16 @@ contract DelegationManager is
                 staker: withdrawal.staker,
                 operator: withdrawal.delegatedTo,
                 strategies: withdrawal.strategies,
-                blockNumber: completableBlock
+                blockNumber: slashableUntil
             });
         }
+
+        // Remove the withdrawal from the queue. Note that for legacy withdrawals, the removals
+        // from `_stakerQueuedWithdrawalRoots` and `queuedWithdrawals` will no-op.
+        _stakerQueuedWithdrawalRoots[withdrawal.staker].remove(withdrawalRoot);
+        delete queuedWithdrawals[withdrawalRoot];
+        delete pendingWithdrawals[withdrawalRoot];
+        emit SlashingWithdrawalCompleted(withdrawalRoot);
 
         // Given the max magnitudes of the operator the staker is now delegated to, calculate the current
         // slashing factors to apply to each withdrawal if it is received as shares.
@@ -629,13 +593,6 @@ contract DelegationManager is
                 });
             }
         }
-
-        _stakerQueuedWithdrawalRoots[withdrawal.staker].remove(withdrawalRoot);
-
-        delete queuedWithdrawals[withdrawalRoot];
-        delete pendingWithdrawals[withdrawalRoot];
-
-        emit SlashingWithdrawalCompleted(withdrawalRoot);
     }
 
     /**
@@ -658,6 +615,7 @@ contract DelegationManager is
     ) internal {
         // Ensure that the operator has not been fully slashed for a strategy
         // and that the staker has not been fully slashed if it is the beaconChainStrategy
+        // This is to prevent a divWad by 0 when updating the depositScalingFactor
         require(slashingFactor != 0, FullySlashed());
 
         // Update the staker's depositScalingFactor. This only results in an update
@@ -775,26 +733,27 @@ contract DelegationManager is
      * Note: To get the total amount of slashable shares in the queue withdrawable, set newMaxMagnitude to 0 and prevMaxMagnitude
      * is the current maxMagnitude of the operator.
      */
-    function _getSlashedSharesInQueue(
+    function _getSlashableSharesInQueue(
         address operator,
         IStrategy strategy,
         uint64 prevMaxMagnitude,
         uint64 newMaxMagnitude
     ) internal view returns (uint256) {
-        // Fetch the cumulative scaled shares sitting in the withdrawal queue both now and before
-        // the withdrawal delay.
-        uint256 curCumulativeScaledShares = _cumulativeScaledSharesHistory[operator][strategy].latest();
-        uint256 prevCumulativeScaledShares = _cumulativeScaledSharesHistory[operator][strategy].upperLookup({
-            key: uint32(block.number) - MIN_WITHDRAWAL_DELAY_BLOCKS
+        // We want ALL shares added to the withdrawal queue in the window [block.number - MIN_WITHDRAWAL_DELAY_BLOCKS, block.number]
+        //
+        // To get this, we take the current shares in the withdrawal queue and subtract the number of shares
+        // that were in the queue before MIN_WITHDRAWAL_DELAY_BLOCKS.
+        uint256 curQueuedScaledShares = _cumulativeScaledSharesHistory[operator][strategy].latest();
+        uint256 prevQueuedScaledShares = _cumulativeScaledSharesHistory[operator][strategy].upperLookup({
+            key: uint32(block.number) - MIN_WITHDRAWAL_DELAY_BLOCKS - 1
         });
 
-        // The difference between these values represents the number of scaled shares that entered the
-        // withdrawal queue less than `MIN_WITHDRAWAL_DELAY_BLOCKS` ago. These shares are still slashable,
-        // so we use them to calculate the number of slashable shares in the withdrawal queue.
-        uint256 slashableScaledShares = curCumulativeScaledShares - prevCumulativeScaledShares;
+        // The difference between these values is the number of scaled shares that entered the withdrawal queue
+        // less than or equal to MIN_WITHDRAWAL_DELAY_BLOCKS ago. These shares are still slashable.
+        uint256 scaledSharesAdded = curQueuedScaledShares - prevQueuedScaledShares;
 
         return SlashingLib.scaleForBurning({
-            scaledShares: slashableScaledShares,
+            scaledShares: scaledSharesAdded,
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });
@@ -843,12 +802,12 @@ contract DelegationManager is
     /// @inheritdoc IDelegationManager
     function delegationApprover(
         address operator
-    ) external view returns (address) {
+    ) public view returns (address) {
         return _operatorDetails[operator].delegationApprover;
     }
 
     /// @inheritdoc IDelegationManager
-    function depositScalingFactor(address staker, IStrategy strategy) public view returns (uint256) {
+    function depositScalingFactor(address staker, IStrategy strategy) external view returns (uint256) {
         return _depositScalingFactor[staker][strategy].scalingFactor();
     }
 
@@ -878,11 +837,10 @@ contract DelegationManager is
 
     /// @inheritdoc IDelegationManager
     function getSlashableSharesInQueue(address operator, IStrategy strategy) public view returns (uint256) {
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategy;
-        uint64 maxMagnitude = allocationManager.getMaxMagnitudes(operator, strategies)[0];
-        // Return amount of shares slashed if all remaining magnitude were to be slashed
-        return _getSlashedSharesInQueue({
+        uint64 maxMagnitude = allocationManager.getMaxMagnitude(operator, strategy);
+
+        // Return amount of slashable scaled shares remaining
+        return _getSlashableSharesInQueue({
             operator: operator,
             strategy: strategy,
             prevMaxMagnitude: maxMagnitude,
@@ -944,10 +902,17 @@ contract DelegationManager is
     }
 
     /// @inheritdoc IDelegationManager
+    function getQueuedWithdrawal(
+        bytes32 withdrawalRoot
+    ) external view returns (Withdrawal memory) {
+        return queuedWithdrawals[withdrawalRoot];
+    }
+
+    /// @inheritdoc IDelegationManager
     function getQueuedWithdrawals(
         address staker
     ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares) {
-        bytes32[] memory withdrawalRoots = _stakerQueuedWithdrawalRoots[staker].values();
+        bytes32[] memory withdrawalRoots = getQueuedWithdrawalRoots(staker);
 
         uint256 totalQueued = withdrawalRoots.length;
         withdrawals = new Withdrawal[](totalQueued);
@@ -959,15 +924,58 @@ contract DelegationManager is
             withdrawals[i] = queuedWithdrawals[withdrawalRoots[i]];
             shares[i] = new uint256[](withdrawals[i].strategies.length);
 
-            uint256[] memory slashingFactors = _getSlashingFactors(staker, operator, withdrawals[i].strategies);
+            uint32 slashableUntil = withdrawals[i].startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS;
+
+            uint256[] memory slashingFactors;
+            // If slashableUntil block is in the past, read the slashing factors at that block
+            // Otherwise read the current slashing factors. Note that if the slashableUntil block is the current block
+            // or in the future then the slashing factors are still subject to change before the withdrawal is completable
+            // and the shares withdrawn to be less
+            if (slashableUntil < uint32(block.number)) {
+                slashingFactors = _getSlashingFactorsAtBlock({
+                    staker: staker,
+                    operator: operator,
+                    strategies: withdrawals[i].strategies,
+                    blockNumber: slashableUntil
+                });
+            } else {
+                slashingFactors =
+                    _getSlashingFactors({staker: staker, operator: operator, strategies: withdrawals[i].strategies});
+            }
 
             for (uint256 j; j < withdrawals[i].strategies.length; ++j) {
                 shares[i][j] = SlashingLib.scaleForCompleteWithdrawal({
                     scaledShares: withdrawals[i].scaledShares[j],
-                    slashingFactor: slashingFactors[i]
+                    slashingFactor: slashingFactors[j]
                 });
             }
         }
+    }
+
+    /// @inheritdoc IDelegationManager
+    function getQueuedWithdrawalRoots(
+        address staker
+    ) public view returns (bytes32[] memory) {
+        return _stakerQueuedWithdrawalRoots[staker].values();
+    }
+
+    /// @inheritdoc IDelegationManager
+    function convertToDepositShares(
+        address staker,
+        IStrategy[] memory strategies,
+        uint256[] memory withdrawableShares
+    ) external view returns (uint256[] memory) {
+        // Get the slashing factors for the staker/operator/strategies
+        address operator = delegatedTo[staker];
+        uint256[] memory slashingFactors = _getSlashingFactors(staker, operator, strategies);
+
+        // Calculate the deposit shares based on the slashing factor
+        uint256[] memory depositShares = new uint256[](strategies.length);
+        for (uint256 i = 0; i < strategies.length; ++i) {
+            DepositScalingFactor memory dsf = _depositScalingFactor[staker][strategies[i]];
+            depositShares[i] = dsf.calcDepositShares(withdrawableShares[i], slashingFactors[i]);
+        }
+        return depositShares;
     }
 
     /// @inheritdoc IDelegationManager

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -143,7 +143,7 @@ contract StrategyManager is
     /// @inheritdoc IStrategyManager
     function burnShares(IStrategy strategy, uint256 sharesToBurn) external onlyDelegationManager {
         // burning shares is functionally the same as withdrawing but with different destination address
-        strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn);
+        try strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn) {} catch {}
     }
 
     /// @inheritdoc IStrategyManager

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -149,7 +149,6 @@ contract StrategyManager is
 
     /// @inheritdoc IStrategyManager
     function burnShares(IStrategy strategy, uint256 sharesToBurn) external nonReentrant {
-        require(strategyIsWhitelistedForDeposit[strategy], StrategyNotWhitelisted());
         require(sharesToBurn <= burnableShares[strategy], BurnSharesAmountTooHigh());
         burnableShares[strategy] -= sharesToBurn;
         emit BurnableSharesDecreased(strategy, sharesToBurn);

--- a/src/contracts/core/StrategyManagerStorage.sol
+++ b/src/contracts/core/StrategyManagerStorage.sol
@@ -69,6 +69,9 @@ abstract contract StrategyManagerStorage is IStrategyManager {
     /// @dev Do not remove, deprecated storage.
     mapping(IStrategy strategy => bool) private __deprecated_thirdPartyTransfersForbidden;
 
+    /// @notice Returns the amount of `shares` that have been slashed on EigenLayer but not burned yet.
+    mapping(IStrategy strategy => uint256) public burnableShares;
+
     // Construction
 
     /**
@@ -85,5 +88,5 @@ abstract contract StrategyManagerStorage is IStrategyManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[39] private __gap;
+    uint256[38] private __gap;
 }

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -148,9 +148,6 @@ interface IDelegationManagerEvents is IDelegationManagerTypes {
     /// @notice Emitted whenever an operator's shares are decreased for a given strategy. Note that shares is the delta in the operator's shares.
     event OperatorSharesDecreased(address indexed operator, address staker, IStrategy strategy, uint256 shares);
 
-    /// @notice Emitted whenever an operator's shares are burned for a given strategy
-    event OperatorSharesBurned(address indexed operator, IStrategy strategy, uint256 shares);
-
     /// @notice Emitted when @param staker delegates to @param operator.
     event StakerDelegated(address indexed staker, address indexed operator);
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -51,8 +51,12 @@ interface IDelegationManagerErrors {
 
     /// @dev Thrown when attempting to withdraw before delay has elapsed.
     error WithdrawalDelayNotElapsed();
+    /// @dev Thrown when a withdraw amount larger than max is attempted.
+    error WithdrawalExceedsMax();
     /// @dev Thrown when withdrawer is not the current caller.
     error WithdrawerNotCaller();
+    /// @dev Thrown when `withdrawer` is not staker.
+    error WithdrawerNotStaker();
 }
 
 interface IDelegationManagerTypes {
@@ -88,44 +92,40 @@ interface IDelegationManagerTypes {
     }
 
     /**
-     * @dev A struct representing an existing queued withdrawal. After the withdrawal delay has elapsed, this withdrawal can be completed via `completeQueuedWithdrawal`.
-     * A `Withdrawal` is created by the `DelegationManager` when `queueWithdrawals` is called. The `withdrawalRoots` hashes returned by `queueWithdrawals` can be used
-     * to fetch the corresponding `Withdrawal` from storage (via `getQueuedWithdrawal`).
-     *
-     * @param staker The address that queued the withdrawal
-     * @param delegatedTo The address that the staker was delegated to at the time the withdrawal was queued. Used to determine if additional slashing occurred before
-     * this withdrawal became completeable.
-     * @param withdrawer The address that will call the contract to complete the withdrawal. Note that this will always equal `staker`; alternate withdrawers are not
-     * supported at this time.
-     * @param nonce The staker's `cumulativeWithdrawalsQueued` at time of queuing. Used to ensure withdrawals have unique hashes.
-     * @param startBlock The block number when the withdrawal was queued.
-     * @param strategies The strategies requested for withdrawal when the withdrawal was queued
-     * @param scaledShares The staker's deposit shares requested for withdrawal, scaled by the staker's `depositScalingFactor`. Upon completion, these will be
-     * scaled by the appropriate slashing factor as of the withdrawal's completable block. The result is what is actually withdrawable.
+     * Struct type used to specify an existing queued withdrawal. Rather than storing the entire struct, only a hash is stored.
+     * In functions that operate on existing queued withdrawals -- e.g. completeQueuedWithdrawal`, the data is resubmitted and the hash of the submitted
+     * data is computed by `calculateWithdrawalRoot` and checked against the stored hash in order to confirm the integrity of the submitted data.
      */
     struct Withdrawal {
+        // The address that originated the Withdrawal
         address staker;
+        // The address that the staker was delegated to at the time that the Withdrawal was created
         address delegatedTo;
+        // The address that can complete the Withdrawal + will receive funds when completing the withdrawal
         address withdrawer;
+        // Nonce used to guarantee that otherwise identical withdrawals have unique hashes
         uint256 nonce;
+        // Blocknumber when the Withdrawal was created.
         uint32 startBlock;
+        // Array of strategies that the Withdrawal contains
         IStrategy[] strategies;
+        // Array containing the amount of staker's scaledShares for withdrawal in each Strategy in the `strategies` array
+        // Note that these scaledShares need to be multiplied by the operator's maxMagnitude and beaconChainScalingFactor at completion to include
+        // slashing occurring during the queue withdrawal delay. This is because scaledShares = sharesToWithdraw / (maxMagnitude * beaconChainScalingFactor)
+        // at queue time. beaconChainScalingFactor is simply equal to 1 if the strategy is not the beaconChainStrategy.
+        // To account for slashing, we later multiply scaledShares * maxMagnitude * beaconChainScalingFactor at the earliest possible completion time
+        // to get the withdrawn shares after applying slashing during the delay period.
         uint256[] scaledShares;
     }
 
-    /**
-     * @param strategies The strategies to withdraw from
-     * @param depositShares For each strategy, the number of deposit shares to withdraw. Deposit shares can
-     * be queried via `getDepositedShares`.
-     * NOTE: The number of shares ultimately received when a withdrawal is completed may be lower depositShares
-     * if the staker or their delegated operator has experienced slashing.
-     * @param __deprecated_withdrawer This field is ignored. The only party that may complete a withdrawal
-     * is the staker that originally queued it. Alternate withdrawers are not supported.
-     */
     struct QueuedWithdrawalParams {
+        // Array of strategies that the QueuedWithdrawal contains
         IStrategy[] strategies;
+        // Array containing the amount of depositShares for withdrawal in each Strategy in the `strategies` array
+        // Note that the actual shares received on completing withdrawal may be less than the depositShares if slashing occurred
         uint256[] depositShares;
-        address __deprecated_withdrawer;
+        // The address of the withdrawer
+        address withdrawer;
     }
 }
 
@@ -228,10 +228,13 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     /**
      * @notice Caller delegates their stake to an operator.
      * @param operator The account (`msg.sender`) is delegating its assets to for use in serving applications built on EigenLayer.
-     * @param approverSignatureAndExpiry (optional) Verifies the operator approves of this delegation
-     * @param approverSalt (optional) A unique single use value tied to an individual signature.
-     * @dev The signature/salt are used ONLY if the operator has configured a delegationApprover.
-     * If they have not, these params can be left empty.
+     * @param approverSignatureAndExpiry Verifies the operator approves of this delegation
+     * @param approverSalt A unique single use value tied to an individual signature.
+     * @dev The approverSignatureAndExpiry is used in the event that the operator's `delegationApprover` address is set to a non-zero value.
+     * @dev In the event that `approverSignatureAndExpiry` is not checked, its content is ignored entirely; it's recommended to use an empty input
+     * in this case to save on complexity + gas costs
+     * @dev If the staker delegating has shares in a strategy that the operator was slashed 100% for (the operator's maxMagnitude = 0),
+     * then delegation is blocked and will revert.
      */
     function delegateTo(
         address operator,
@@ -240,14 +243,14 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external;
 
     /**
-     * @notice Undelegates the staker from their operator and queues a withdrawal for all of their shares
-     * @param staker The account to be undelegated
-     * @return withdrawalRoots The roots of the newly queued withdrawals, if a withdrawal was queued. Returns
-     * an empty array if none was queued.
+     * @notice Undelegates the staker from the operator who they are delegated to.
+     * Queues withdrawals of all of the staker's withdrawable shares in the StrategyManager (to the staker) and/or EigenPodManager, if necessary.
+     * @param staker The account to be undelegated.
+     * @return withdrawalRoots The roots of the newly queued withdrawals, if a withdrawal was queued. Otherwise just bytes32(0).
      *
      * @dev Reverts if the `staker` is also an operator, since operators are not allowed to undelegate from themselves.
      * @dev Reverts if the caller is not the staker, nor the operator who the staker is delegated to, nor the operator's specified "delegationApprover"
-     * @dev Reverts if the `staker` is not delegated to an operator
+     * @dev Reverts if the `staker` is already undelegated.
      */
     function undelegate(
         address staker
@@ -271,19 +274,33 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external returns (bytes32[] memory withdrawalRoots);
 
     /**
-     * @notice Allows a staker to queue a withdrawal of their deposit shares. The withdrawal can be
-     * completed after the MIN_WITHDRAWAL_DELAY_BLOCKS via either of the completeQueuedWithdrawal methods.
+     * @notice Allows a staker to withdraw some shares. Withdrawn shares/strategies are immediately removed
+     * from the staker. If the staker is delegated, withdrawn shares/strategies are also removed from
+     * their operator.
      *
-     * While in the queue, these shares are removed from the staker's balance, as well as from their operator's
-     * delegated share balance (if applicable). Note that while in the queue, deposit shares are still subject
-     * to slashing. If any slashing has occurred, the shares received may be less than the queued deposit shares.
+     * All withdrawn shares/strategies are placed in a queue and can be withdrawn after a delay. Withdrawals
+     * are still subject to slashing during the delay period so the amount withdrawn on completion may actually be less
+     * than what was queued if slashing has occurred in that period.
      *
-     * @dev To view all the staker's strategies/deposit shares that can be queued for withdrawal, see `getDepositedShares`
-     * @dev To view the current coversion between a staker's deposit shares and withdrawable shares, see `getWithdrawableShares`
+     * @dev To view what the staker is able to queue withdraw, see `getWithdrawableShares()`
      */
     function queueWithdrawals(
         QueuedWithdrawalParams[] calldata params
     ) external returns (bytes32[] memory);
+
+    /**
+     * @notice Used to complete the all queued withdrawals.
+     * Used to complete the specified `withdrawals`. The function caller must match `withdrawals[...].withdrawer`
+     * @param tokens Array of tokens for each Withdrawal. See `completeQueuedWithdrawal` for the usage of a single array.
+     * @param receiveAsTokens Whether or not to complete each withdrawal as tokens. See `completeQueuedWithdrawal` for the usage of a single boolean.
+     * @param numToComplete The number of withdrawals to complete. This must be less than or equal to the number of queued withdrawals.
+     * @dev See `completeQueuedWithdrawal` for relevant dev tags
+     */
+    function completeQueuedWithdrawals(
+        IERC20[][] calldata tokens,
+        bool[] calldata receiveAsTokens,
+        uint256 numToComplete
+    ) external;
 
     /**
      * @notice Used to complete the lastest queued withdrawal.
@@ -473,36 +490,10 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      */
     function depositScalingFactor(address staker, IStrategy strategy) external view returns (uint256);
 
-    /// @notice Returns the Withdrawal associated with a `withdrawalRoot`, if it exists. NOTE that
-    /// withdrawals queued before the slashing release can NOT be queried with this method.
-    function getQueuedWithdrawal(
-        bytes32 withdrawalRoot
-    ) external view returns (Withdrawal memory);
-
     /// @notice Returns a list of pending queued withdrawals for a `staker`, and the `shares` to be withdrawn.
     function getQueuedWithdrawals(
         address staker
     ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares);
-
-    /// @notice Returns a list of queued withdrawal roots for the `staker`.
-    /// NOTE that this only returns withdrawals queued AFTER the slashing release.
-    function getQueuedWithdrawalRoots(
-        address staker
-    ) external view returns (bytes32[] memory);
-
-    /**
-     * @notice Converts shares for a set of strategies to deposit shares, likely in order to input into `queueWithdrawals`
-     * @param staker the staker to convert shares for
-     * @param strategies the strategies to convert shares for
-     * @param withdrawableShares the shares to convert
-     * @return the deposit shares
-     * @dev will be a few wei off due to rounding errors
-     */
-    function convertToDepositShares(
-        address staker,
-        IStrategy[] memory strategies,
-        uint256[] memory withdrawableShares
-    ) external view returns (uint256[] memory);
 
     /// @notice Returns the keccak256 hash of `withdrawal`.
     function calculateWithdrawalRoot(

--- a/src/contracts/libraries/SlashingLib.sol
+++ b/src/contracts/libraries/SlashingLib.sol
@@ -168,17 +168,15 @@ library SlashingLib {
     }
 
     /**
-     * @notice Used for calculating amount of operatorShares that were slashed to decrement
-     * operatorShares. This is also used for calculating the amount of shares that are slashed
-     * from the withdrawal queue for a given (strategy, operator) tuple.
+     * @notice Used for calculating amount of operatorShares that were slashed and need to be decremented. 
      * NOTE: max magnitude is guaranteed to only ever decrease.
      */
     function calcSlashedAmount(
-        uint256 shares,
+        uint256 operatorShares,
         uint256 prevMaxMagnitude,
         uint256 newMaxMagnitude
     ) internal pure returns (uint256) {
         // round up mulDiv so we don't overslash
-        return shares - shares.mulDiv(newMaxMagnitude, prevMaxMagnitude, Math.Rounding.Up);
+        return operatorShares - operatorShares.mulDiv(newMaxMagnitude, prevMaxMagnitude, Math.Rounding.Up);
     }
 }

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -32,7 +32,7 @@ contract DelegationManagerMock is Test {
         uint64 newMaxMagnitude
     ) external {
         uint256 amountSlashed = SlashingLib.calcSlashedAmount({
-            operatorShares: operatorShares[operator][strategy],
+            shares: operatorShares[operator][strategy],
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -32,7 +32,7 @@ contract DelegationManagerMock is Test {
         uint64 newMaxMagnitude
     ) external {
         uint256 amountSlashed = SlashingLib.calcSlashedAmount({
-            shares: operatorShares[operator][strategy],
+            operatorShares: operatorShares[operator][strategy],
             prevMaxMagnitude: prevMaxMagnitude,
             newMaxMagnitude: newMaxMagnitude
         });

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -6683,7 +6683,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             for (uint256 i = 0; i < strategies.length; ++i) {
                 uint256 currentShares = delegationManager.operatorShares(defaultOperator, strategies[i]);
                 uint256 sharesToDecrease = SlashingLib.calcSlashedAmount({
-                    operatorShares: currentShares,
+                    shares: currentShares,
                     prevMaxMagnitude: prevMaxMagnitude,
                     newMaxMagnitude: newMaxMagnitude
                 });

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -68,7 +68,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     // Helper to use in storage
     DepositScalingFactor dsf;
     uint256 stakerDSF;
-    uint256 slashingFactor;
 
     /// @notice mappings used to handle duplicate entries in fuzzed address array input
     mapping(address => uint256) public totalSharesForStrategyInArray;
@@ -124,7 +123,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
 
         // Roll blocks forward so that block.number - MIN_WITHDRAWAL_DELAY_BLOCKS doesn't revert
         // in _getSlashableSharesInQueue
-        cheats.roll(MIN_WITHDRAWAL_DELAY_BLOCKS);
+        cheats.roll(MIN_WITHDRAWAL_DELAY_BLOCKS + 1);
 
         // Exclude delegation manager from fuzzed tests
         isExcludedFuzzAddress[address(delegationManager)] = true;
@@ -307,7 +306,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
 
     function _setUpQueueWithdrawalsSingleStrat(
         address staker,
-        address withdrawer,
         IStrategy strategy,
         uint256 depositSharesToWithdraw
     ) internal view returns (
@@ -322,7 +320,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             queuedWithdrawalParams[0] = QueuedWithdrawalParams({
                 strategies: strategyArray,
                 depositShares: withdrawalAmounts,
-                withdrawer: withdrawer
+                __deprecated_withdrawer: address(0)
             });
         }
 
@@ -332,7 +330,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         Withdrawal memory withdrawal = Withdrawal({
             staker: staker,
             delegatedTo: delegationManager.delegatedTo(staker),
-            withdrawer: withdrawer,
+            withdrawer: staker,
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
             startBlock: uint32(block.number),
             strategies: strategyArray,
@@ -345,7 +343,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
 
     function _setUpQueueWithdrawals(
         address staker,
-        address withdrawer,
         IStrategy[] memory strategies,
         uint256[] memory depositWithdrawalAmounts
     ) internal view returns (
@@ -358,7 +355,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             queuedWithdrawalParams[0] = QueuedWithdrawalParams({
                 strategies: strategies,
                 depositShares: depositWithdrawalAmounts,
-                withdrawer: withdrawer
+                __deprecated_withdrawer: address(0)
             });
         }
 
@@ -371,7 +368,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         Withdrawal memory withdrawal = Withdrawal({
             staker: staker,
             delegatedTo: delegationManager.delegatedTo(staker),
-            withdrawer: withdrawer,
+            withdrawer: staker,
             nonce: delegationManager.cumulativeWithdrawalsQueued(staker),
             startBlock: uint32(block.number),
             strategies: strategies,
@@ -395,27 +392,9 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     }
 
     function _getScaledShares(address staker, IStrategy strategy, uint256 depositSharesToWithdraw) internal view returns (uint256) {
-        // Setup vars
-        address operator = delegationManager.delegatedTo(staker);
-        IStrategy[] memory strategyArray = new IStrategy[](1);
-        strategyArray[0] = strategy;
-
-        // Calculate the amount of slashing to apply
-        uint64 maxMagnitude = allocationManagerMock.getMaxMagnitudes(operator, strategyArray)[0];
-        uint256 slashingFactor = _getSlashingFactor(staker, strategy, maxMagnitude);
-
-        uint256 sharesToWithdraw = _calcWithdrawableShares(
-            depositSharesToWithdraw,
-            delegationManager.depositScalingFactor(staker, strategy),
-            slashingFactor
-        );
-
-        uint256 scaledShares = SlashingLib.scaleForQueueWithdrawal({
-            sharesToWithdraw: sharesToWithdraw,
-            slashingFactor: slashingFactor
-        });
-
-        return scaledShares;
+        DepositScalingFactor memory _dsf = DepositScalingFactor(delegationManager.depositScalingFactor(staker, strategy));
+        
+        return _dsf.scaleForQueueWithdrawal(depositSharesToWithdraw);
     }
 
     /// @notice get the shares expected to be withdrawn given the staker, strategy, maxMagnitude, and depositSharesToWithdraw
@@ -459,7 +438,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
      */
     function _setUpCompleteQueuedWithdrawalSingleStrat(
         address staker,
-        address withdrawer,
         uint256 depositAmount,
         uint256 withdrawalAmount,
         bool isBeaconChainStrategy
@@ -473,7 +451,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: staker,
-            withdrawer: withdrawer,
             strategy: strategies[0],
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -501,7 +478,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
      */
     function _setUpCompleteQueuedWithdrawalsSingleStrat(
         address staker,
-        address withdrawer,
         uint256 depositAmount,
         uint256 numWithdrawals
     ) internal returns (
@@ -524,7 +500,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: withdrawer,
                 strategy: strategies[0],
                 depositSharesToWithdraw: depositAmount
             });
@@ -557,7 +532,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
      */
     function _setUpCompleteQueuedWithdrawal(
         address staker,
-        address withdrawer,
         uint256[] memory depositAmounts,
         uint256[] memory withdrawalAmounts,
         bool depositBeaconChainShares
@@ -575,7 +549,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawals({
             staker: staker,
-            withdrawer: withdrawer,
             strategies: strategies,
             depositWithdrawalAmounts: withdrawalAmounts
         });
@@ -866,8 +839,6 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
     function _burnOperatorShares_expectEmit(BurnOperatorSharesEmitStruct memory params) internal {
         cheats.expectEmit(true, true, true, true, address(delegationManager));
         emit OperatorSharesDecreased(params.operator, address(0), params.strategy, params.sharesToDecrease);
-        cheats.expectEmit(true, true, true, true, address(delegationManager));
-        emit OperatorSharesBurned(params.operator, params.strategy, params.sharesToBurn);
     }
 
     /// -----------------------------------------------------------------------
@@ -1399,6 +1370,8 @@ contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerU
 }
 
 contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerUnitTests {
+    using ArrayLib for *;
+    
     function test_registerAsOperator_revert_paused() public {
         // set the pausing flag
         cheats.prank(pauser);
@@ -1521,8 +1494,7 @@ contract DelegationManagerUnitTests_RegisterModifyOperator is DelegationManagerU
     function testFuzz_registerAsOperator_withDeposits(Randomness r) public rand(r) {
         uint256 shares = r.Uint256(1, MAX_STRATEGY_SHARES);
         // Set staker shares in StrategyManager
-        IStrategy[] memory strategiesToReturn = new IStrategy[](1);
-        strategiesToReturn[0] = strategyMock;
+        IStrategy[] memory strategiesToReturn = strategyMock.toArray();
         uint256[] memory sharesToReturn = new uint256[](1);
         sharesToReturn[0] = shares;
         strategyManagerMock.setDeposits(defaultOperator, strategiesToReturn, sharesToReturn);
@@ -3563,8 +3535,7 @@ contract DelegationManagerUnitTests_increaseDelegatedShares is DelegationManager
         _setOperatorMagnitude(defaultOperator, strategyMock, initialMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         strategyManagerMock.addDeposit(defaultStaker, strategyMock, shares);
 
         // delegate from the `defaultStaker` to the operator
@@ -3947,15 +3918,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
         delegationManager.undelegate(defaultOperator);
     }
 
-    function test_Revert_undelegate_zeroAddress() public {
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(address(0), defaultOperator);
-
-        cheats.prank(address(0));
-        cheats.expectRevert(IPausable.InputAddressZero.selector);
-        delegationManager.undelegate(address(0));
-    }
-
     /**
      * @notice Verifies that the `undelegate` function has proper access controls (can only be called by the operator who the `staker` has delegated
      * to or the operator's `delegationApprover`), or the staker themselves
@@ -4077,7 +4039,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategy,
             depositSharesToWithdraw: shares
         });
@@ -4155,7 +4116,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategy,
             depositSharesToWithdraw: shares
         });
@@ -4296,7 +4256,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: defaultStaker,
-                withdrawer: defaultStaker,
                 strategy: strategy,
                 depositSharesToWithdraw: shares
             });
@@ -4389,7 +4348,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategy,
             depositSharesToWithdraw: shares
         });
@@ -4534,7 +4492,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: stakers[i],
-                withdrawer: stakers[i],
                 strategy: strategyMock,
                 depositSharesToWithdraw: stakerDepositShares[stakers[i]]
             });
@@ -4617,7 +4574,6 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategyMock,
             depositSharesToWithdraw: shares
         });
@@ -4672,7 +4628,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
         // complete withdrawal as shares, should add back delegated shares to operator due to delegating again
         IERC20[] memory tokens = new IERC20[](1);
         tokens[0] = IERC20(strategyMock.underlyingToken());
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, false);
 
@@ -4682,6 +4638,8 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
 }
 
 contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {    
+    using ArrayLib for *;
+    
     // @notice Verifies that redelegating is not possible when the "delegation paused" switch is flipped
     function testFuzz_Revert_redelegate_delegatePaused(Randomness r) public {
         address staker = r.Address();
@@ -4862,7 +4820,6 @@ contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategy,
             depositSharesToWithdraw: shares
         });
@@ -4956,7 +4913,6 @@ contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {
             Withdrawal memory strategyWithdrawal,
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: staker,
-            withdrawer: staker,
             strategy: strategyMock,
             depositSharesToWithdraw: strategyShares
         });
@@ -4965,7 +4921,6 @@ contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {
             Withdrawal memory beaconWithdrawal,
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: staker,
-            withdrawer: staker,
             strategy: IStrategy(address(beaconChainETHStrategy)),
             depositSharesToWithdraw: uint256(beaconShares)
         });
@@ -4974,7 +4929,7 @@ contract DelegationManagerUnitTests_redelegate is DelegationManagerUnitTests {
         delegationManager.undelegate(staker);
         // 4. Delegate to operator again with shares added back
         {
-            cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
+            cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks() + 1);
             IERC20[] memory strategyTokens = new IERC20[](1);
             strategyTokens[0] = IERC20(strategyMock.underlyingToken());
             IERC20[] memory beaconTokens = new IERC20[](1);
@@ -5029,7 +4984,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         delegationManager.pause(2 ** PAUSED_ENTER_WITHDRAWAL_QUEUE);
         (QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategyMock,
             depositSharesToWithdraw: 100
         });
@@ -5047,37 +5001,41 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         queuedWithdrawalParams[0] = QueuedWithdrawalParams({
             strategies: strategyArray,
             depositShares: shareAmounts,
-            withdrawer: defaultStaker
+            __deprecated_withdrawer: address(0)
         });
 
         cheats.expectRevert(InputArrayLengthMismatch.selector);
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
     }
 
-    function testFuzz_Revert_WhenNotStakerWithdrawer(address withdrawer) public {
-        cheats.assume(withdrawer != defaultStaker);
-
+    function testFuzz_IgnoresWithdrawerField(address withdrawer) public {
+        _depositIntoStrategies(defaultStaker, strategyMock.toArray(), uint(100).toArrayU256());
         (QueuedWithdrawalParams[] memory queuedWithdrawalParams, , ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: withdrawer,
             strategy: strategyMock,
             depositSharesToWithdraw: 100
         });
-        cheats.expectRevert(WithdrawerNotStaker.selector);
+
+        // set the ignored field to a different address. the dm should ignore this.
+        queuedWithdrawalParams[0].__deprecated_withdrawer = withdrawer;
+
         cheats.prank(defaultStaker);
-        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+        bytes32 withdrawalRoot = delegationManager.queueWithdrawals(queuedWithdrawalParams)[0];
+
+        Withdrawal memory withdrawal = delegationManager.getQueuedWithdrawal(withdrawalRoot);
+        assertEq(withdrawal.staker, defaultStaker, "staker should be msg.sender");
+        assertEq(withdrawal.withdrawer, defaultStaker, "withdrawer should be msg.sender");
     }
 
     function test_Revert_WhenEmptyStrategiesArray() public {
         IStrategy[] memory strategyArray = new IStrategy[](0);
         uint256[] memory shareAmounts = new uint256[](0);
-        address withdrawer = defaultOperator;
 
         QueuedWithdrawalParams[] memory queuedWithdrawalParams = new QueuedWithdrawalParams[](1);
         queuedWithdrawalParams[0] = QueuedWithdrawalParams({
             strategies: strategyArray,
             depositShares: shareAmounts,
-            withdrawer: withdrawer
+            __deprecated_withdrawer: address(0)
         });
 
         cheats.expectRevert(InputArrayLengthZero.selector);
@@ -5116,7 +5074,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategies[0],
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -5189,7 +5146,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategyMock,
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -5281,7 +5237,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: defaultStaker,
-                withdrawer: defaultStaker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: withdrawalAmount
             });
@@ -5352,7 +5307,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategyMock,
             depositSharesToWithdraw: 0 // expected 0 since slashed 100%
         });
@@ -5447,7 +5401,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawals({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategies: strategies,
             depositWithdrawalAmounts: withdrawalAmounts
         });
@@ -5549,7 +5502,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawals({
                 staker: defaultStaker,
-                withdrawer: defaultStaker,
                 strategies: strategies,
                 depositWithdrawalAmounts: withdrawalAmounts
             });
@@ -5667,7 +5619,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawals({
                 staker: defaultStaker,
-                withdrawer: defaultStaker,
                 strategies: strategies,
                 depositWithdrawalAmounts: withdrawalAmounts
             });
@@ -5797,7 +5748,6 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
                 bytes32 withdrawalRoot
             ) = _setUpQueueWithdrawals({
                 staker: defaultStaker,
-                withdrawer: defaultStaker,
                 strategies: strategies,
                 depositWithdrawalAmounts: withdrawalAmounts
             });
@@ -5864,7 +5814,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             /* bytes32 withdrawalRoot */
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100,
             isBeaconChainStrategy: false
@@ -5887,10 +5836,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         // multiple Withdrawal interface
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         delegationManager.completeQueuedWithdrawals(withdrawals, tokensArray,  receiveAsTokens);
-
-        // numToComplete interface
-        cheats.expectRevert(IPausable.CurrentlyPaused.selector);
-        delegationManager.completeQueuedWithdrawals(tokensArray,  receiveAsTokens, 1);
     }
 
     function test_Revert_WhenInputArrayLengthMismatch() public {
@@ -5901,7 +5846,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             /* bytes32 withdrawalRoot */
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100,
             isBeaconChainStrategy: false
@@ -5909,7 +5853,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         // Roll to completion block
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
 
         // resize tokens array
         IERC20[] memory newTokens = new IERC20[](0);
@@ -5917,16 +5861,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         cheats.prank(defaultStaker);
         cheats.expectRevert(InputArrayLengthMismatch.selector);
         delegationManager.completeQueuedWithdrawal(withdrawal, newTokens,  false);
-
-        IERC20[][] memory tokensArray = new IERC20[][](1);
-        tokensArray[0] = newTokens;
-
-        bool[] memory receiveAsTokens = new bool[](1);
-        receiveAsTokens[0] = true;
-
-        cheats.prank(defaultStaker);
-        cheats.expectRevert(InputArrayLengthMismatch.selector);
-        delegationManager.completeQueuedWithdrawals(tokensArray,  receiveAsTokens, 1);
 
         // check that the withdrawal completes otherwise
         cheats.prank(defaultStaker);
@@ -5942,7 +5876,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             IERC20[] memory tokens,
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100,
             isBeaconChainStrategy: false
@@ -5962,7 +5895,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmount: 100,
             withdrawalAmount: 100,
             isBeaconChainStrategy: false
@@ -5970,7 +5902,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens,  true);
         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
@@ -6001,27 +5933,56 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             /* bytes32 withdrawalRoot */
         ) = _setUpCompleteQueuedWithdrawal({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmounts: depositAmounts,
             withdrawalAmounts: withdrawalAmounts,
             depositBeaconChainShares: false
         });
 
         // prank as withdrawer address
-        cheats.roll(withdrawal.startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS - 1);
+        cheats.roll(withdrawal.startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS);
         cheats.expectRevert(WithdrawalDelayNotElapsed.selector);
         cheats.prank(defaultStaker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokens, receiveAsTokens);
+    }
 
-        IERC20[][] memory tokensArray = new IERC20[][](1);
-        tokensArray[0] = tokens;
+    /// @notice Verifies that when we complete a withdrawal as shares after a full slash, we revert
+    function test_revert_fullySlashed() public {
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _setOperatorMagnitude(defaultOperator, strategyMock, WAD);
 
-        bool[] memory receiveAsTokensArray = new bool[](1);
-        receiveAsTokensArray[0] = false;
+        // Set the staker deposits in the strategies
+        uint256 depositAmount = 100e18;
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, depositAmount);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
-        cheats.expectRevert(WithdrawalDelayNotElapsed.selector);
+        // Queue withdrawal
+        uint256 withdrawalAmount = depositAmount;
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            Withdrawal memory withdrawal,
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw: withdrawalAmount
+        });
         cheats.prank(defaultStaker);
-        delegationManager.completeQueuedWithdrawals(tokensArray,  receiveAsTokensArray, 1);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        // Warp to just before the MIN_WITHDRAWAL_DELAY_BLOCKS
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+
+        // Slash all of operator's shares
+        _setOperatorMagnitude(defaultOperator, strategyMock, 0);
+        cheats.prank(address(allocationManagerMock));
+        delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, 0);
+
+        // Complete withdrawal as shares and assert that operator has no shares increased
+        cheats.roll(block.number + 1);
+        IERC20[] memory tokens = strategyMock.underlyingToken().toArray();
+        cheats.expectRevert(FullySlashed.selector);
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, false);
     }
 
     /**
@@ -6039,7 +6000,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32[] memory withdrawalRoots
         ) = _setUpCompleteQueuedWithdrawalsSingleStrat({
             staker: staker,
-            withdrawer: staker,
             depositAmount: depositAmount,
             numWithdrawals: numWithdrawals
         });
@@ -6054,7 +6014,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         bool[] memory receiveAsTokensArray = receiveAsTokens.toArray(numWithdrawals);
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawals[0].startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawals[0].startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         _completeQueuedWithdrawals_expectEmit(
             CompleteQueuedWithdrawalsEmitStruct({
                 withdrawals: withdrawals,
@@ -6102,67 +6062,10 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         }
         _assertWithdrawalRootsComplete(staker, withdrawals);
         assertEq(
-            delegationManager.getDepositScalingFactor(staker, withdrawals[0].strategies[0]),
+            delegationManager.depositScalingFactor(staker, withdrawals[0].strategies[0]),
             uint256(WAD),
             "deposit scaling factor should be WAD"
         );
-    }
-
-    /**
-     * Test completing multiple queued withdrawals for a single strategy without passing in the withdrawals
-     */
-    function test_completeQueuedWithdrawals_NumToComplete(Randomness r) public rand(r) {
-        address staker = r.Address();
-        uint256 depositAmount = r.Uint256(1, MAX_STRATEGY_SHARES);
-        uint256 numWithdrawals = r.Uint256(2, 20);
-        uint256 numToComplete = r.Uint256(2, numWithdrawals);
-
-        (
-            Withdrawal[] memory withdrawals,
-            IERC20[][] memory tokens,
-            bytes32[] memory withdrawalRoots
-        ) = _setUpCompleteQueuedWithdrawalsSingleStrat({
-            staker: staker,
-            withdrawer: staker,
-            depositAmount: depositAmount,
-            numWithdrawals: numWithdrawals
-        });
-
-        _registerOperatorWithBaseDetails(defaultOperator);
-        _delegateToOperatorWhoAcceptsAllStakers(staker, defaultOperator);
-        uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, withdrawals[0].strategies[0]);
-
-        for (uint i = 0; i < withdrawalRoots.length; i++) {
-            assertTrue(delegationManager.pendingWithdrawals(withdrawalRoots[i]), "withdrawalRoots should be pending");
-        }
-
-        bool[] memory receiveAsTokens = new bool[](withdrawals.length);
-        for (uint i = 0; i < withdrawals.length; i++) {
-            receiveAsTokens[i] = true;
-        }
-
-        // completeQueuedWithdrawal
-        cheats.roll(withdrawals[0].startBlock + delegationManager.minWithdrawalDelayBlocks());
-        _completeQueuedWithdrawals_expectEmit(
-            CompleteQueuedWithdrawalsEmitStruct({
-                withdrawals: withdrawals,
-                tokens: tokens,
-                receiveAsTokens: receiveAsTokens
-            })
-        );
-        cheats.prank(staker);
-        delegationManager.completeQueuedWithdrawals(tokens, receiveAsTokens, numToComplete);
-
-        uint256 operatorSharesAfter = delegationManager.operatorShares(defaultOperator, withdrawals[0].strategies[0]);
-        assertEq(operatorSharesAfter, operatorSharesBefore, "operator shares should be unchanged");
-
-        for (uint i = 0; i < numToComplete; i++) {
-            assertFalse(delegationManager.pendingWithdrawals(withdrawalRoots[i]), "withdrawalRoot should be completed and marked false now");
-        }
-
-        for (uint i = numToComplete; i < numWithdrawals; i++) {
-            assertTrue(delegationManager.pendingWithdrawals(withdrawalRoots[i]), "withdrawalRoot should still be pending");
-        }
     }
 
     /**
@@ -6191,7 +6094,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             depositAmount: depositAmount,
             withdrawalAmount: withdrawalAmount,
             isBeaconChainStrategy: false
@@ -6201,7 +6103,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6260,7 +6162,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategyMock,
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -6311,7 +6212,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         {
             IERC20[] memory tokens = new IERC20[](1);
             tokens[0] = IERC20(strategyMock.underlyingToken());
-            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
             _completeQueuedWithdrawal_expectEmit(
                 CompleteQueuedWithdrawalEmitStruct({
                     withdrawal: withdrawal,
@@ -6371,7 +6272,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: beaconChainETHStrategy,
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -6418,7 +6318,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
 
         {
             IERC20[] memory tokens = new IERC20[](1);
-            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
             _completeQueuedWithdrawal_expectEmit(
                 CompleteQueuedWithdrawalEmitStruct({
                     withdrawal: withdrawal,
@@ -6476,7 +6376,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: beaconChainETHStrategy,
             depositSharesToWithdraw: withdrawalAmount
         });
@@ -6515,7 +6414,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         ) = delegationManager.getWithdrawableShares(defaultStaker, beaconChainETHStrategy.toArray());
         uint256 operatorSharesBefore = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
         IERC20[] memory tokens = new IERC20[](1);
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6566,7 +6465,6 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             bytes32 withdrawalRoot
         ) = _setUpCompleteQueuedWithdrawalSingleStrat({
             staker: staker,
-            withdrawer: staker,
             depositAmount: depositAmount,
             withdrawalAmount: withdrawalAmount,
             isBeaconChainStrategy: false
@@ -6579,7 +6477,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         strategyManagerMock.setDelegationManager(delegationManager);
 
         // completeQueuedWithdrawal
-        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         _completeQueuedWithdrawal_expectEmit(
             CompleteQueuedWithdrawalEmitStruct({
                 withdrawal: withdrawal,
@@ -6594,6 +6492,82 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         // Since staker is delegated, operatorShares get incremented
         assertEq(operatorSharesAfter, operatorSharesBefore + withdrawalAmount, "operator shares not increased correctly");
         assertFalse(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be completed and marked false now");
+    }
+
+    function testFuzz_completeQueuedWithdrawals_OutOfOrderBlocking(Randomness r) public {
+        uint256 totalDepositShares = r.Uint256(4, 100 ether);
+        uint256 depositSharesPerWithdrawal = totalDepositShares / 4;
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, totalDepositShares);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        QueuedWithdrawalParams[] memory queuedParams = new QueuedWithdrawalParams[](4);
+        Withdrawal[] memory withdrawals = new Withdrawal[](4);
+        
+        uint256 startBlock = block.number;
+
+        uint256 nonce = delegationManager.cumulativeWithdrawalsQueued(defaultStaker);
+        for (uint256 i; i < 4; ++i) {
+            cheats.roll(startBlock + i);
+            (
+                QueuedWithdrawalParams[] memory params, 
+                Withdrawal memory withdrawal,
+            ) = _setUpQueueWithdrawalsSingleStrat(
+                defaultStaker, 
+                strategyMock, 
+                depositSharesPerWithdrawal
+            );
+            withdrawal.nonce = nonce;
+            nonce += 1;
+
+            (queuedParams[i], withdrawals[i]) = (params[0], withdrawal);
+        }
+
+        uint256 delay = delegationManager.minWithdrawalDelayBlocks();
+
+        cheats.startPrank(defaultStaker);
+        cheats.roll(startBlock);
+        
+        delegationManager.queueWithdrawals(queuedParams[0].toArray());
+        cheats.roll(startBlock + 1);
+        delegationManager.queueWithdrawals(queuedParams[1].toArray());
+        
+        (Withdrawal[] memory firstWithdrawals, ) = delegationManager.getQueuedWithdrawals(defaultStaker);
+
+        cheats.roll(startBlock + 2);
+        delegationManager.queueWithdrawals(queuedParams[2].toArray());
+        cheats.roll(startBlock + 3);
+        delegationManager.queueWithdrawals(queuedParams[3].toArray());
+
+        IERC20[][] memory tokens = new IERC20[][](2);
+        for (uint256 i; i < 2; ++i) {
+            tokens[i] = strategyMock.underlyingToken().toArray();
+        }
+
+        bytes32 root1 = delegationManager.calculateWithdrawalRoot(withdrawals[0]);
+        bytes32 root2 = delegationManager.calculateWithdrawalRoot(withdrawals[1]);
+        
+        bytes32 root1_view = delegationManager.calculateWithdrawalRoot(firstWithdrawals[0]);
+        bytes32 root2_view = delegationManager.calculateWithdrawalRoot(firstWithdrawals[1]);
+
+        assertEq(
+            root1, root1_view,
+            "withdrawal root should be the same"
+        );
+
+        assertEq(
+            root2, root2_view,
+            "withdrawal root should be the same"
+        );
+
+        cheats.roll(startBlock + delay + 2);
+        delegationManager.completeQueuedWithdrawals(firstWithdrawals, tokens, true.toArray(2));
+        
+        // Throws `WithdrawalNotQueued`.
+        cheats.roll(startBlock + delay + 3);
+        delegationManager.completeQueuedWithdrawals(withdrawals[2].toArray(), tokens, true.toArray());
+        cheats.stopPrank();
     }
 }
 
@@ -6618,6 +6592,174 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
         cheats.prank(address(allocationManagerMock));
         delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, WAD/2);
         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
+    }
+
+    /// @notice Verifies that shares are burnable for a withdrawal slashed just before the MIN_WITHDRAWAL_DELAY_BLOCKS is hit
+    function test_sharesBurnableAtMinDelayBlocks() public {
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _setOperatorMagnitude(defaultOperator, strategyMock, WAD);
+
+        // Set the staker deposits in the strategies
+        uint256 depositAmount = 100e18;
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, depositAmount);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        // Queue withdrawal
+        uint256 withdrawalAmount = depositAmount;
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            Withdrawal memory withdrawal,
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw: withdrawalAmount
+        });
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        // Warp to just before the MIN_WITHDRAWAL_DELAY_BLOCKS
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+
+        uint256 slashableSharesInQueue = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
+
+        // Slash all of operator's shares
+        _setOperatorMagnitude(defaultOperator, strategyMock, 0);
+        cheats.prank(address(allocationManagerMock));
+        delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, 0);
+
+        uint256 slashableSharesInQueueAfter = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
+
+        // Complete withdrawal as tokens and assert that nothing is returned
+        cheats.roll(block.number + 1);
+        IERC20[] memory tokens = strategyMock.underlyingToken().toArray();
+        cheats.expectCall(
+            address(strategyManagerMock),
+            abi.encodeWithSelector(
+                IShareManager.withdrawSharesAsTokens.selector,
+                defaultStaker,
+                strategyMock,
+                strategyMock.underlyingToken(),
+                0
+            )
+        );
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, true);
+
+        assertEq(
+            slashableSharesInQueue,
+            depositAmount,
+            "the withdrawal in queue from block.number - minWithdrawalDelayBlocks should still be included"
+        );
+        assertEq(
+            slashableSharesInQueueAfter,
+            0,
+            "slashable shares in queue should be 0 after burning"
+        );
+    }
+
+    /// @notice Verifies that shares are NOT burnable for a withdrawal queued just before the MIN_WITHDRAWAL_DELAY_BLOCKS
+    function test_sharesNotBurnableWhenWithdrawalCompletable() public {
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _setOperatorMagnitude(defaultOperator, strategyMock, WAD);
+
+        // Set the staker deposits in the strategies
+        uint256 depositAmount = 100e18;
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, depositAmount);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        // Queue withdrawal
+        uint256 withdrawalAmount = depositAmount;
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            Withdrawal memory withdrawal,
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw: withdrawalAmount
+        });
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        // Warp to completion time
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
+        uint256 slashableShares = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
+        assertEq(slashableShares, 0, "shares should not be slashable");
+
+        // Slash all of operator's shares
+        _setOperatorMagnitude(defaultOperator, strategyMock, 0);
+        cheats.prank(address(allocationManagerMock));
+        delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, 0);
+
+        // Complete withdrawal as tokens and assert that we call back into teh SM with 100 tokens
+        IERC20[] memory tokens = strategyMock.underlyingToken().toArray();
+        cheats.expectCall(
+            address(strategyManagerMock),
+            abi.encodeWithSelector(
+                IShareManager.withdrawSharesAsTokens.selector,
+                defaultStaker,
+                strategyMock,
+                strategyMock.underlyingToken(),
+                100e18
+            )
+        );
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokens, true);        
+    }
+
+    /**
+     * @notice Queues 5 withdrawals at different blocks. Then, warps such that the first 2 are completable. Validates the slashable shares
+     */
+    function test_slashableSharesInQueue() public {
+        // Register operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _setOperatorMagnitude(defaultOperator, strategyMock, WAD);
+
+        // Set the staker deposits in the strategies
+        uint256 depositAmount = 120e18;
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, depositAmount);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        // Queue 5 withdrawals
+        uint256 startBlock = block.number;
+        uint256 withdrawalAmount = depositAmount / 6;
+        for(uint256 i = 0; i < 5; i++) {
+            (
+                QueuedWithdrawalParams[] memory queuedWithdrawalParams,,
+            ) = _setUpQueueWithdrawalsSingleStrat({
+                staker: defaultStaker,
+                strategy: strategyMock,
+                depositSharesToWithdraw: withdrawalAmount
+            });
+            cheats.prank(defaultStaker);
+            delegationManager.queueWithdrawals(queuedWithdrawalParams);
+            cheats.roll(startBlock + i + 1);
+        }
+
+        // Warp to completion time for the first 2 withdrawals
+        // First withdrawal queued at startBlock. Second queued at startBlock + 1
+        cheats.roll(startBlock + 1 + delegationManager.minWithdrawalDelayBlocks() + 1);
+
+        // Get slashable shares
+        uint256 slashableSharesInQueue = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
+        assertEq(slashableSharesInQueue, depositAmount/6 * 3, "slashable shares in queue should be 3/6 of the deposit amount");
+
+        // Slash all of operator's shares
+        _setOperatorMagnitude(defaultOperator, strategyMock, 0);
+        cheats.prank(address(allocationManagerMock));
+        cheats.expectEmit(true, true, true, true, address(delegationManager));
+        emit OperatorSharesDecreased(
+            defaultOperator,
+            address(0),
+            strategyMock,
+            depositAmount / 6 // 1 withdrawal not queued so decreased
+        );
+        delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, 0);
+        
+        // Assert slashable shares
+        slashableSharesInQueue = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
+        assertEq(slashableSharesInQueue, 0);
     }
 
     /**
@@ -6682,8 +6824,8 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             cheats.startPrank(address(allocationManagerMock));
             for (uint256 i = 0; i < strategies.length; ++i) {
                 uint256 currentShares = delegationManager.operatorShares(defaultOperator, strategies[i]);
-                uint256 sharesToDecrease = SlashingLib.calcSlashedAmount({
-                    shares: currentShares,
+                (uint256 sharesToDecrease, ) = _calcSlashedAmount({
+                    operatorShares: currentShares,
                     prevMaxMagnitude: prevMaxMagnitude,
                     newMaxMagnitude: newMaxMagnitude
                 });
@@ -6813,7 +6955,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 Withdrawal memory withdrawal,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker2,
-                withdrawer: staker2,
                 strategy: strategyMock,
                 depositSharesToWithdraw: withdrawAmount
             });
@@ -6824,7 +6965,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 withdrawAmount,
                 "there should be withdrawAmount slashable shares in queue"
             );
-            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks());
+            cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
         }
 
         uint256 operatorSharesBefore = delegationManager.operatorShares(operator, strategyMock);
@@ -6892,7 +7033,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 QueuedWithdrawalParams[] memory queuedWithdrawalParams,,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker2,
-                withdrawer: staker2,
                 strategy: strategyMock,
                 depositSharesToWithdraw: withdrawAmount
             });
@@ -6970,7 +7110,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 Withdrawal memory withdrawal,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: staker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: withdrawAmount1
             });
@@ -6987,7 +7126,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 withdrawal,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: staker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: withdrawAmount2
             });
@@ -7056,7 +7194,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
         uint256 depositSharesToWithdraw1 = r.Uint256(1, depositAmount);
         uint256 depositSharesToWithdraw2 = r.Uint256(1, depositAmount - depositSharesToWithdraw1);
 
-        uint64 newMagnitude = 5e17;
+        uint64 newMagnitude = 50e16;
 
         // 2. Register the operator, set the staker deposits, and delegate the 2 stakers to them
         _registerOperatorWithBaseDetails(operator);
@@ -7069,7 +7207,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 QueuedWithdrawalParams[] memory queuedWithdrawalParams,,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: staker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: depositSharesToWithdraw1
             });
@@ -7119,20 +7256,17 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             );
         }
 
-        // 4. Queue withdrawal for staker and slash operator for 50% again
-        newMagnitude = newMagnitude/2;
+        // 4. Queue withdrawal for staker and slash operator for 60% again
+        newMagnitude = 25e16;
         {
             (
                 QueuedWithdrawalParams[] memory queuedWithdrawalParams,,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: staker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: depositSharesToWithdraw2
             });
 
-            // actual withdrawn shares are half of the deposit shares because of first slashing
-            uint256 withdrawAmount2 = depositSharesToWithdraw2 / 2;
 
             // 4.1 queue a withdrawal for the staker
             cheats.prank(staker);
@@ -7141,7 +7275,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             uint256 queuedSlashableSharesBefore = delegationManager.getSlashableSharesInQueue(operator, strategyMock);
 
             uint256 sharesToDecrease = operatorSharesBefore / 2;
-            uint256 sharesToBurn = sharesToDecrease + (withdrawAmount2 + depositSharesToWithdraw1/2)/2;
+            uint256 sharesToBurn = sharesToDecrease + (depositSharesToWithdraw1 + depositSharesToWithdraw2) / 4;
 
             // 4.2 Burn shares
             _setOperatorMagnitude(operator, strategyMock, newMagnitude);
@@ -7164,13 +7298,13 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             // 4.3 Assert slashable shares and operator shares
             assertEq(
                 queuedSlashableSharesBefore,
-                withdrawAmount2 + depositSharesToWithdraw1/2,
-                "Slashable shares in queue before should be withdrawAmount1 / 2 + withdrawAmount2"
+                (depositSharesToWithdraw1 + depositSharesToWithdraw2)/2,
+                "Slashable shares in queue before should be both queued withdrawal amounts halved"
             );
             assertEq(
                 delegationManager.getSlashableSharesInQueue(operator, strategyMock),
-                (withdrawAmount2 + depositSharesToWithdraw1/2)/2,
-                "Slashable shares in queue should be (withdrawAmount2 + depositSharesToWithdraw1/2)/2 after slashing"
+                queuedSlashableSharesBefore / 2,
+                "Slashable shares in queue should be halved again after slashing"
             );
             assertEq(
                 delegationManager.operatorShares(operator, strategyMock),
@@ -7207,7 +7341,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 Withdrawal memory withdrawal,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker,
-                withdrawer: staker,
                 strategy: strategyMock,
                 depositSharesToWithdraw: depositAmount
             });
@@ -7220,7 +7353,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 "there should be depositAmount slashable shares in queue"
             );
             // Check slashable shares in queue before and when the withdrawal is completable
-            completableBlock = withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks();
+            completableBlock = withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1;
             IERC20[] memory tokenArray = strategyMock.underlyingToken().toArray();
 
             // 3.2 roll to right before withdrawal is completable, check that slashable shares are still there
@@ -7309,7 +7442,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
                 QueuedWithdrawalParams[] memory queuedWithdrawalParams,,
             ) = _setUpQueueWithdrawalsSingleStrat({
                 staker: staker2,
-                withdrawer: staker2,
                 strategy: beaconChainETHStrategy,
                 depositSharesToWithdraw: withdrawAmount
             });
@@ -7366,8 +7498,6 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
         _setOperatorMagnitude(defaultOperator, strategyMock, initialMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
         strategyManagerMock.addDeposit(defaultStaker, strategyMock, shares);
 
         // delegate from the `defaultStaker` to the operator
@@ -7393,7 +7523,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
             (
                 uint256[] memory withdrawableShares,
                 uint256[] memory depositShares
-            ) = delegationManager.getWithdrawableShares(defaultStaker, strategies);
+            ) = delegationManager.getWithdrawableShares(defaultStaker, strategyMock.toArray());
             assertEq(depositShares[0], shares, "staker deposit shares not reset correctly");
             assertLe(
                 withdrawableShares[0],
@@ -7600,6 +7730,7 @@ contract DelegationManagerUnitTests_burningShares is DelegationManagerUnitTests 
 /// @notice Fuzzed Unit tests to compare totalWitdrawable shares for an operator vs their actual operatorShares.
 /// Requires the WRITE_CSV_TESTS env variable to be set to true to output to a test file
 contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUnitTests {
+    using ArrayLib for *;
     using SlashingLib for *;
 
     /**
@@ -7621,8 +7752,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         {
             uint256[] memory sharesToSet = new uint256[](1);
             sharesToSet[0] = shares;
@@ -7706,8 +7836,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         {
             uint256[] memory sharesToSet = new uint256[](1);
             sharesToSet[0] = shares;
@@ -7791,8 +7920,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         uint256[] memory sharesToSet = new uint256[](1);
         sharesToSet[0] = shares;
 
@@ -7868,8 +7996,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         uint256[] memory sharesToSet = new uint256[](1);
         sharesToSet[0] = shares;
 
@@ -7944,8 +8071,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         uint256[] memory sharesToSet = new uint256[](1);
         sharesToSet[0] = shares;
 
@@ -8020,8 +8146,7 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
         _setOperatorMagnitude(defaultOperator, strategyMock, initMagnitude);
     
         // Set the staker deposits in the strategies
-        IStrategy[] memory strategies = new IStrategy[](1);
-        strategies[0] = strategyMock;
+        IStrategy[] memory strategies = strategyMock.toArray();
         uint256[] memory sharesToSet = new uint256[](1);
         sharesToSet[0] = shares;
 
@@ -8125,7 +8250,7 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
         queuedWithdrawalParams[0] = QueuedWithdrawalParams({
             strategies: strategies,
             depositShares: depositShares,
-            withdrawer: staker
+            __deprecated_withdrawer: address(0)
         });
         cheats.prank(staker);
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
@@ -8143,7 +8268,7 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
 
         bytes32 withdrawalRoot = keccak256(abi.encode(withdrawal));
         assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
-        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks());
+        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks() + 1);
 
         cheats.prank(staker);
         delegationManager.completeQueuedWithdrawal(withdrawal, tokenMock.toArray(),  false);
@@ -8195,7 +8320,6 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
             bytes32 withdrawalRoot
         ) = _setUpQueueWithdrawalsSingleStrat({
             staker: defaultStaker,
-            withdrawer: defaultStaker,
             strategy: strategy,
             depositSharesToWithdraw: shares
         });
@@ -8263,14 +8387,379 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
         assertEq(stakerWithdrawableShares[0], 0, "staker withdrawable shares not calculated correctly");
         assertEq(depositShares[0], 0, "staker deposit shares not reset correctly");
 
-        bool[] memory receiveAsTokens = new bool[](1);
-        receiveAsTokens[0] = false;
-        IERC20[][] memory tokens = new IERC20[][](1);
-        delegationManager.completeQueuedWithdrawals(tokens, receiveAsTokens, 1);
+        cheats.roll(withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1);
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokenMock.toArray(), false);
 
         (stakerWithdrawableShares, depositShares) = delegationManager.getWithdrawableShares(defaultStaker, strategyArray);
         assertEq(stakerWithdrawableShares[0], 0, "staker withdrawable shares not calculated correctly");
         assertEq(depositShares[0], 0, "staker deposit shares not reset correctly");
         assertEq(delegationManager.operatorShares(newOperator, strategy), 0, "new operator shares should be unchanged");
+    }
+}
+
+contract DelegationManagerUnitTests_ConvertToDepositShares is DelegationManagerUnitTests {
+    using ArrayLib for *;
+
+    function test_convertToDepositShares_noSlashing() public {
+        uint shares = 100 ether;
+
+        // Set the staker deposits in the strategies
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, shares);
+        _checkDepositSharesConvertCorrectly(strategyMock.toArray(), shares.toArrayU256());
+    }
+
+    function test_convertToDepositShares_withSlashing() public {
+        IStrategy[] memory strategies = strategyMock.toArray();
+        uint256[] memory shares = uint256(100 ether).toArrayU256();
+
+        // Set the staker deposits in the strategies
+        strategyManagerMock.addDeposit(defaultStaker, strategies[0], shares[0]);
+
+        // register *this contract* as an operator
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+        _setOperatorMagnitude(defaultOperator, strategyMock, WAD/3);
+
+        _checkDepositSharesConvertCorrectly(strategies, shares);   
+
+        // queue and complete a withdrawal for half the deposit shares
+        (uint256[] memory withdrawableShares,) = delegationManager.getWithdrawableShares(defaultStaker, strategies);
+        _queueAndCompleteWithdrawalForSingleStrategy(strategies[0], shares[0] / 2);
+
+        // queued a withdrawal for half the deposit shares, and added back as withdrawable shares
+        shares[0] = shares[0] / 2 + withdrawableShares[0] / 2;
+        _checkDepositSharesConvertCorrectly(strategies, shares);
+    }
+
+    function test_convertToDepositShares_beaconChainETH() public {
+        IStrategy[] memory strategies = beaconChainETHStrategy.toArray();
+        uint256[] memory shares = uint256(100 ether).toArrayU256();
+
+        // Set the staker deposits in the strategies
+        eigenPodManagerMock.setPodOwnerShares(defaultStaker, int256(shares[0]));
+
+        uint256[] memory depositShares = delegationManager.convertToDepositShares(defaultStaker, strategies, shares);
+        assertEq(depositShares[0], shares[0], "deposit shares not converted correctly");
+
+        // delegate to an operator and slash
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+        _setOperatorMagnitude(defaultOperator, beaconChainETHStrategy, WAD/3);
+
+        _checkDepositSharesConvertCorrectly(strategies, shares);
+
+        // slash on beacon chain by 1/3
+        _decreaseBeaconChainShares(defaultStaker, int256(shares[0]), shares[0]/3);
+
+        _checkDepositSharesConvertCorrectly(strategies, shares);
+
+        // queue and complete a withdrawal for half the deposit shares
+        (uint256[] memory withdrawableShares,) = delegationManager.getWithdrawableShares(defaultStaker, strategies);
+        _queueAndCompleteWithdrawalForSingleStrategy(strategies[0], shares[0] / 2);
+
+        // queued a withdrawal for half the deposit shares, and added back as withdrawable shares
+        shares[0] = shares[0] / 2 + withdrawableShares[0] / 2;
+        _checkDepositSharesConvertCorrectly(strategies, shares);
+    }
+
+    function _checkDepositSharesConvertCorrectly(IStrategy[] memory strategies, uint256[] memory expectedDepositShares) public view {
+        (uint256[] memory withdrawableShares,) = delegationManager.getWithdrawableShares(defaultStaker, strategies);
+        // get the deposit shares
+        uint256[] memory depositShares = delegationManager.convertToDepositShares(defaultStaker, strategies, withdrawableShares);
+
+        for (uint256 i = 0; i < strategies.length; i++) {
+            assertApproxEqRel(
+                expectedDepositShares[i],
+                depositShares[i],
+                APPROX_REL_DIFF,
+                "deposit shares not converted correctly"
+            );
+
+            // make sure that the deposit shares are less than or equal to the shares, 
+            // so this value is sane to input into `completeQueuedWithdrawals`
+            assertLe(
+                depositShares[i],
+                expectedDepositShares[i],
+                "deposit shares should be less than or equal to expected deposit shares"
+            );
+        }
+
+        // get the deposit shares
+        uint256[] memory oneThirdWithdrawableShares = new uint256[](strategies.length);
+        for (uint256 i = 0; i < strategies.length; i++) {
+            oneThirdWithdrawableShares[i] = withdrawableShares[i]/3;
+        }
+        uint256[] memory oneThirdDepositShares = delegationManager.convertToDepositShares(defaultStaker, strategies, oneThirdWithdrawableShares);
+        for (uint256 i = 0; i < strategies.length; i++) {
+            assertApproxEqRel(
+                expectedDepositShares[i]/3,
+                oneThirdDepositShares[i],
+                APPROX_REL_DIFF,
+                "deposit shares not converted correctly"
+            );
+        }
+    }
+
+    function _queueAndCompleteWithdrawalForSingleStrategy(IStrategy strategy, uint256 shares) public {
+        (QueuedWithdrawalParams[] memory queuedWithdrawalParams, Withdrawal memory withdrawal,) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategy,
+            depositSharesToWithdraw: shares
+        });
+
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+        cheats.roll(block.number + delegationManager.minWithdrawalDelayBlocks() + 1);
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokenMock.toArray(), false);
+    }
+}
+
+contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUnitTests {
+    using ArrayLib for *;
+    using SlashingLib for *;
+
+    function _withdrawalRoot(Withdrawal memory withdrawal) internal pure returns (bytes32) {
+        return keccak256(abi.encode(withdrawal));
+    }
+
+    function test_getQueuedWithdrawals_Correctness(Randomness r) public rand(r) {
+        uint256 numStrategies = r.Uint256(2, 8);
+        uint256[] memory depositShares = r.Uint256Array({
+            len: numStrategies, 
+            min: 2, 
+            max: 100 ether
+        });
+
+        IStrategy[] memory strategies = _deployAndDepositIntoStrategies(defaultStaker, depositShares, false);
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        for (uint256 i; i < numStrategies; ++i) {
+            uint256 newStakerShares = depositShares[i] / 2;
+            _setOperatorMagnitude(defaultOperator, strategies[i], 0.5 ether);
+            cheats.prank(address(allocationManagerMock));
+            delegationManager.burnOperatorShares(defaultOperator, strategies[i], WAD, 0.5 ether);
+            uint256 afterSlash = delegationManager.operatorShares(defaultOperator, strategies[i]);
+            assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
+        }
+
+        // Queue withdrawals.
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawals({
+            staker: defaultStaker,
+            strategies: strategies,
+            depositWithdrawalAmounts: depositShares
+        });
+
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams);
+        
+        // Get queued withdrawals.
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+        // Checks
+        for (uint256 i; i < strategies.length; ++i) {
+            uint256 newStakerShares = depositShares[i] / 2;
+            assertApproxEqAbs(shares[0][i], newStakerShares, 1, "staker shares should be decreased by half +- 1");
+        }
+        
+        assertEq(_withdrawalRoot(withdrawal), _withdrawalRoot(withdrawals[0]), "_withdrawalRoot(withdrawal) != _withdrawalRoot(withdrawals[0])");
+        assertEq(_withdrawalRoot(withdrawal), withdrawalRoot, "_withdrawalRoot(withdrawal) != withdrawalRoot");
+    }
+
+    function test_getQueuedWithdrawals_TotalQueuedGreaterThanTotalStrategies(
+        Randomness r
+    ) public rand(r) {
+        uint256 totalDepositShares = r.Uint256(2, 100 ether);
+
+        _registerOperatorWithBaseDetails(defaultOperator);
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, totalDepositShares);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+        
+        uint256 newStakerShares = totalDepositShares / 2;
+        _setOperatorMagnitude(defaultOperator, strategyMock, 0.5 ether);
+        cheats.prank(address(allocationManagerMock));
+        delegationManager.burnOperatorShares(defaultOperator, strategyMock, WAD, 0.5 ether);
+        uint256 afterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
+        assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
+
+        // Queue withdrawals.
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams0,
+            Withdrawal memory withdrawal0,
+            bytes32 withdrawalRoot0
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw: totalDepositShares / 2
+        });
+
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams0);
+
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams1,
+            Withdrawal memory withdrawal1,
+            bytes32 withdrawalRoot1
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw:  totalDepositShares / 2
+        });
+
+        cheats.prank(defaultStaker);
+        delegationManager.queueWithdrawals(queuedWithdrawalParams1);
+
+        // Get queued withdrawals.
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+
+        // Sanity
+        assertEq(withdrawals.length, 2, "withdrawal.length != 2");
+        assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");
+        assertEq(withdrawals[1].strategies.length, 1, "withdrawals[1].strategies.length != 1");
+
+        // Checks
+        assertApproxEqAbs(shares[0][0], newStakerShares / 2, 1, "shares[0][0] != newStakerShares");
+        assertApproxEqAbs(shares[1][0], newStakerShares / 2, 1, "shares[1][0] != newStakerShares");
+        assertEq(_withdrawalRoot(withdrawal0), _withdrawalRoot(withdrawals[0]), "withdrawal0 != withdrawals[0]");
+        assertEq(_withdrawalRoot(withdrawal1), _withdrawalRoot(withdrawals[1]), "withdrawal1 != withdrawals[1]");
+        assertEq(_withdrawalRoot(withdrawal0), withdrawalRoot0, "_withdrawalRoot(withdrawal0) != withdrawalRoot0");
+        assertEq(_withdrawalRoot(withdrawal1), withdrawalRoot1, "_withdrawalRoot(withdrawal1) != withdrawalRoot1");
+    }
+
+    /**
+     * @notice Assert that the shares returned in the view function `getQueuedWithdrawals` are unaffected from a
+     * slash that occurs after the withdrawal is completed. Also assert that completing the withdrawal matches the
+     * expected withdrawn shares from the view function.
+     * Slashing on the completableBlock of the withdrawal should have no affect on the withdrawn shares.
+     */
+    function test_getQueuedWithdrawals_SlashAfterWithdrawalCompletion(Randomness r) public rand(r) {
+        uint256 depositAmount = r.Uint256(1, MAX_STRATEGY_SHARES);
+
+        // Deposit Staker
+        strategyManagerMock.addDeposit(defaultStaker, strategyMock, depositAmount);
+
+        // Register operator and delegate to it
+        _registerOperatorWithBaseDetails(defaultOperator);
+        _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
+
+        // Queue withdrawal
+        (
+            QueuedWithdrawalParams[] memory queuedWithdrawalParams,
+            Withdrawal memory withdrawal,
+            bytes32 withdrawalRoot
+        ) = _setUpQueueWithdrawalsSingleStrat({
+            staker: defaultStaker,
+            strategy: strategyMock,
+            depositSharesToWithdraw: depositAmount
+        });
+        {
+            uint256 operatorSharesBeforeQueue = delegationManager.operatorShares(defaultOperator, strategyMock);
+            cheats.prank(defaultStaker);
+            delegationManager.queueWithdrawals(queuedWithdrawalParams);
+
+            assertTrue(delegationManager.pendingWithdrawals(withdrawalRoot), "withdrawalRoot should be pending");
+            uint256 operatorSharesAfterQueue = delegationManager.operatorShares(defaultOperator, strategyMock);
+            uint256 sharesWithdrawn = _calcWithdrawableShares({
+                depositShares: depositAmount,
+                depositScalingFactor: uint256(WAD),
+                slashingFactor: uint256(WAD)
+            });
+            assertEq(
+                operatorSharesAfterQueue,
+                operatorSharesBeforeQueue - sharesWithdrawn,
+                "operator shares should be decreased after queue"
+            );
+        }
+
+        // Slash operator 50% while staker has queued withdrawal
+        {
+            uint256 operatorSharesAfterQueue = delegationManager.operatorShares(defaultOperator, strategyMock);
+            (uint256 sharesToDecrement, ) = _calcSlashedAmount({
+                operatorShares: operatorSharesAfterQueue,
+                prevMaxMagnitude: uint64(WAD),
+                newMaxMagnitude: 50e16
+            });
+            _setOperatorMagnitude(defaultOperator, strategyMock, 50e16);
+            cheats.prank(address(allocationManagerMock));
+            delegationManager.burnOperatorShares(defaultOperator, withdrawal.strategies[0], uint64(WAD), 50e16);
+            uint256 operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
+            assertEq(
+                operatorSharesAfterSlash,
+                operatorSharesAfterQueue - sharesToDecrement,
+                "operator shares should be decreased after slash"
+            );
+        }
+
+        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50%
+        {
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+            assertEq(withdrawals.length, 1, "withdrawals.length != 1");
+            assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");
+            assertEq(shares[0][0], depositAmount / 2, "shares[0][0] != depositAmount / 2");
+        }
+
+        // Roll blocks to after withdrawal completion
+        uint32 completableBlock = withdrawal.startBlock + delegationManager.minWithdrawalDelayBlocks() + 1;
+        cheats.roll(completableBlock);
+
+        // slash operator 50% again
+        {
+            uint256 operatorShares = delegationManager.operatorShares(defaultOperator, strategyMock);
+            (uint256 sharesToDecrement, ) = _calcSlashedAmount({
+                operatorShares: operatorShares,
+                prevMaxMagnitude: 50e16,
+                newMaxMagnitude: 25e16
+            });
+            _setOperatorMagnitude(defaultOperator, strategyMock, 25e16);
+            cheats.prank(address(allocationManagerMock));
+            delegationManager.burnOperatorShares(defaultOperator, withdrawal.strategies[0], 50e16, 25e16);
+            uint256 operatorSharesAfterSecondSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
+            assertEq(
+                operatorSharesAfterSecondSlash,
+                operatorShares - sharesToDecrement,
+                "operator shares should be decreased after slash"
+            );
+        }
+
+        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50% and hasn't been
+        // affected by the second slash
+        uint256 expectedSharesIncrease = depositAmount / 2;
+        uint256 queuedWithdrawableShares;
+        {
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+            queuedWithdrawableShares = shares[0][0];
+            assertEq(withdrawals.length, 1, "withdrawals.length != 1");
+            assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");
+            assertEq(queuedWithdrawableShares, depositAmount / 2, "queuedWithdrawableShares != withdrawalAmount / 2");
+        }
+
+        // Complete queued Withdrawal with shares added back. Since total deposit slashed by 50% and not 75%
+        (uint256[] memory withdrawableSharesBefore, ) = delegationManager.getWithdrawableShares(defaultStaker, withdrawal.strategies);
+        cheats.prank(defaultStaker);
+        delegationManager.completeQueuedWithdrawal(withdrawal, tokenMock.toArray(), false);
+        (uint256[] memory withdrawableSharesAfter, ) = delegationManager.getWithdrawableShares(defaultStaker, withdrawal.strategies);
+
+        // Added shares
+        assertEq(
+            withdrawableSharesAfter[0],
+            withdrawableSharesBefore[0] + expectedSharesIncrease,
+            "withdrawableShares should be increased by expectedSharesIncrease"
+        );
+        assertEq(
+            expectedSharesIncrease,
+            queuedWithdrawableShares,
+            "expectedSharesIncrease should be equal to queuedWithdrawableShares"
+        );
+        assertEq(
+            block.number,
+            completableBlock,
+            "block.number should be the completableBlock"
+        );
     }
 }


### PR DESCRIPTION
### Description
This PR removes synchronous burning and adding a separate permissionless function that can clear `burnableShares` for all the accumulated slashed shares for a StrategyManager Strategy. 
This implies that when AVSs slash by calling `AllocationManager.slashOperator`, the call stack no longer has the underlying ERC20 token transfer included and we avoid some of the edge cases revolving around the previous try/catch design.

Additionally:
~Removes the function `SlashingLib.scaleSharesForBurning` which is used for calculating the amount of shares to slash in the withdrawal queue. This was removed as its logic is equivalent to `calcSlashedAmount` and cleans up some of the code.~ This is actually not correct, operatorShares and scaledShares are not used equivalently because operatorShares decreases over time upon each slash so do a mulWad(maxMagnitude) is not equivalent to calculating the amount slashed. 
TL;DR the original implementation should remain as-is