### PR TITLE
fix: remove token param from withdrawal api

### DIFF
--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -134,10 +134,9 @@ contract StrategyManager is
     function withdrawSharesAsTokens(
         address staker,
         IStrategy strategy,
-        IERC20 token,
         uint256 shares
     ) external onlyDelegationManager {
-        strategy.withdraw(staker, token, shares);
+        strategy.withdraw(staker, shares);
     }
 
     /// @inheritdoc IShareManager
@@ -154,7 +153,7 @@ contract StrategyManager is
         burnableShares[strategy] = 0;
         emit BurnableSharesDecreased(strategy, sharesToBurn);
         // burning shares is functionally the same as withdrawing but with different destination address
-        strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn);
+        strategy.withdraw(DEFAULT_BURN_ADDRESS,  sharesToBurn);
     }
 
     /// @inheritdoc IStrategyManager

--- a/src/contracts/interfaces/IShareManager.sol
+++ b/src/contracts/interfaces/IShareManager.sol
@@ -30,8 +30,7 @@ interface IShareManager {
 
     /// @notice Used by the DelegationManager to convert withdrawn descaled shares to tokens and send them to a staker
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager
-    /// @dev token is not validated when talking to the EigenPodManager
-    function withdrawSharesAsTokens(address staker, IStrategy strategy, IERC20 token, uint256 shares) external;
+    function withdrawSharesAsTokens(address staker, IStrategy strategy, uint256 shares) external;
 
     /// @notice Returns the current shares of `user` in `strategy`
     /// @dev strategy must be beaconChainETH when talking to the EigenPodManager

--- a/src/contracts/interfaces/IStrategy.sol
+++ b/src/contracts/interfaces/IStrategy.sol
@@ -61,12 +61,11 @@ interface IStrategy is IStrategyErrors, IStrategyEvents {
     /**
      * @notice Used to withdraw tokens from this Strategy, to the `recipient`'s address
      * @param recipient is the address to receive the withdrawn funds
-     * @param token is the ERC20 token being transferred out
      * @param amountShares is the amount of shares being withdrawn
      * @dev This function is only callable by the strategyManager contract. It is invoked inside of the strategyManager's
      * other functions, and individual share balances are recorded in the strategyManager as well.
      */
-    function withdraw(address recipient, IERC20 token, uint256 amountShares) external;
+    function withdraw(address recipient, uint256 amountShares) external;
 
     /**
      * @notice Used to convert a number of shares to the equivalent amount of underlying tokens for this strategy.

--- a/src/contracts/strategies/EigenStrategy.sol
+++ b/src/contracts/strategies/EigenStrategy.sol
@@ -64,20 +64,6 @@ contract EigenStrategy is StrategyBase {
     }
 
     /**
-     * @notice This function hook is called in EigenStrategy.withdraw() before withdrawn shares are calculated and is
-     * overridden here to allow for withdrawing shares either into EIGEN or bEIGEN tokens. If wrapping bEIGEN into EIGEN is needed,
-     * it is performed in _afterWithdrawal(). This hook just checks the token paramater is either EIGEN or bEIGEN.
-     * @param token token to be withdrawn, can be either EIGEN or bEIGEN. If EIGEN, then bEIGEN is wrapped into EIGEN
-     */
-    function _beforeWithdrawal(
-        address, /*recipient*/
-        IERC20 token,
-        uint256 /*amountShares*/
-    ) internal virtual override {
-        require(token == underlyingToken || token == EIGEN, OnlyUnderlyingToken());
-    }
-
-    /**
      * @notice This function hook is called in EigenStrategy.withdraw() after withdrawn shares are calculated and is
      * overridden here to allow for withdrawing shares either into EIGEN or bEIGEN tokens. If token is bEIGEN aka the underlyingToken,
      * then the contract functions exactly the same as the StrategyBase contract and transfers out bEIGEN to the recipient.
@@ -86,13 +72,12 @@ contract EigenStrategy is StrategyBase {
      * @param token token to be withdrawn, can be either EIGEN or bEIGEN. If EIGEN, then bEIGEN is wrapped into EIGEN
      * @param amountToSend amount of tokens to transfer
      */
-    function _afterWithdrawal(address recipient, IERC20 token, uint256 amountToSend) internal virtual override {
-        if (token == EIGEN) {
-            // wrap bEIGEN into EIGEN assuming a 1-1 wrapping amount
-            // the strategy will then hold `amountToSend` of EIGEN
-            underlyingToken.approve(address(token), amountToSend);
-            EIGEN.wrap(amountToSend);
-        }
+    function _afterWithdrawal(address recipient, uint256 amountToSend) internal virtual override {
+
+        // wrap bEIGEN into EIGEN assuming a 1-1 wrapping amount
+        // the strategy will then hold `amountToSend` of EIGEN
+        underlyingToken.approve(address(token), amountToSend);
+        EIGEN.wrap(amountToSend);
 
         // Whether the withdrawal specified EIGEN or bEIGEN, the strategy
         // holds the correct balance and can transfer to the recipient here

--- a/src/contracts/strategies/StrategyBase.sol
+++ b/src/contracts/strategies/StrategyBase.sol
@@ -142,7 +142,6 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
      * @param amountShares is the amount of shares being withdrawn
      * @dev This function is only callable by the strategyManager contract. It is invoked inside of the strategyManager's
      * other functions, and individual share balances are recorded in the strategyManager as well.
-     * @dev Note that any validation of `token` is done inside `_beforeWithdrawal`. This can be overridden if needed.
      */
     function withdraw(
         address recipient,
@@ -179,18 +178,6 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
     function _beforeDeposit(
         IERC20 token,
         uint256 // amount
-    ) internal virtual {
-        require(token == underlyingToken, OnlyUnderlyingToken());
-    }
-
-    /**
-     * @notice Called in the external `withdraw` function, before any logic is executed.  Expected to be overridden if strategies want such logic.
-     * @param token The token being withdrawn
-     */
-    function _beforeWithdrawal(
-        address, // recipient
-        IERC20 token,
-        uint256 // amountShares
     ) internal virtual {
         require(token == underlyingToken, OnlyUnderlyingToken());
     }

--- a/src/contracts/strategies/StrategyBase.sol
+++ b/src/contracts/strategies/StrategyBase.sol
@@ -139,7 +139,6 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
     /**
      * @notice Used to withdraw tokens from this Strategy, to the `recipient`'s address
      * @param recipient is the address to receive the withdrawn funds
-     * @param token is the ERC20 token being transferred out
      * @param amountShares is the amount of shares being withdrawn
      * @dev This function is only callable by the strategyManager contract. It is invoked inside of the strategyManager's
      * other functions, and individual share balances are recorded in the strategyManager as well.
@@ -147,11 +146,8 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
      */
     function withdraw(
         address recipient,
-        IERC20 token,
         uint256 amountShares
     ) external virtual override onlyWhenNotPaused(PAUSED_WITHDRAWALS) onlyStrategyManager {
-        // call hook to allow for any pre-withdrawal logic
-        _beforeWithdrawal(recipient, token, amountShares);
 
         // copy `totalShares` value to memory, prior to any change
         uint256 priorTotalShares = totalShares;
@@ -173,7 +169,7 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
         // emit exchange rate
         _emitExchangeRate(virtualTokenBalance - amountToSend, totalShares + SHARES_OFFSET);
 
-        _afterWithdrawal(recipient, token, amountToSend);
+        _afterWithdrawal(recipient, amountToSend);
     }
 
     /**
@@ -203,11 +199,10 @@ contract StrategyBase is Initializable, Pausable, IStrategy {
      * @notice Transfers tokens to the recipient after a withdrawal is processed
      * @dev Called in the external `withdraw` function after all logic is executed
      * @param recipient The destination of the tokens
-     * @param token The ERC20 being transferred
      * @param amountToSend The amount of `token` to transfer
      */
-    function _afterWithdrawal(address recipient, IERC20 token, uint256 amountToSend) internal virtual {
-        token.safeTransfer(recipient, amountToSend);
+    function _afterWithdrawal(address recipient, uint256 amountToSend) internal virtual {
+        underlyingToken.safeTransfer(recipient, amountToSend);
     }
 
     /**

--- a/src/test/unit/StrategyBaseUnit.t.sol
+++ b/src/test/unit/StrategyBaseUnit.t.sol
@@ -195,7 +195,7 @@ contract StrategyBaseUnitTests is Test {
         cheats.prank(address(strategyManager));
         cheats.expectEmit(true, true, true, true, address(strategy));
         emit ExchangeRateEmitted(1e18);
-        strategy.withdraw(address(this), underlyingToken, sharesToWithdraw);
+        strategy.withdraw(address(this), sharesToWithdraw);
 
         uint256 tokenBalanceAfter = underlyingToken.balanceOf(address(this));
         uint256 totalSharesAfter = strategy.totalShares();
@@ -215,7 +215,7 @@ contract StrategyBaseUnitTests is Test {
 
 
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, sharesToWithdraw);
+        strategy.withdraw(address(this), sharesToWithdraw);
 
         uint256 tokenBalanceAfter = underlyingToken.balanceOf(address(this));
         uint256 totalSharesAfter = strategy.totalShares();
@@ -234,7 +234,7 @@ contract StrategyBaseUnitTests is Test {
         uint256 sharesBefore = strategy.totalShares();
         uint256 tokenBalanceBefore = underlyingToken.balanceOf(address(this));
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, amountToWithdraw);
+        strategy.withdraw(address(this), amountToWithdraw);
 
         require(sharesBefore == strategy.totalShares(), "shares changed");
         require(tokenBalanceBefore == underlyingToken.balanceOf(address(this)), "token balance changed");
@@ -252,7 +252,7 @@ contract StrategyBaseUnitTests is Test {
 
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, amountToWithdraw);
+        strategy.withdraw(address(this), amountToWithdraw);
     }
 
     function testWithdrawalFailsWhenCallingFromNotStrategyManager(address caller) public {
@@ -265,17 +265,7 @@ contract StrategyBaseUnitTests is Test {
 
         cheats.expectRevert(IStrategyErrors.OnlyStrategyManager.selector);
         cheats.prank(caller);
-        strategy.withdraw(address(this), underlyingToken, amountToWithdraw);
-    }
-
-    function testWithdrawalFailsWhenNotUsingUnderlyingToken(address notUnderlyingToken) public {
-        cheats.assume(notUnderlyingToken != address(underlyingToken));
-
-        uint256 amountToWithdraw = 1e18;
-
-        cheats.expectRevert(IStrategyErrors.OnlyUnderlyingToken.selector);
-        cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), IERC20(notUnderlyingToken), amountToWithdraw);
+        strategy.withdraw(address(this), amountToWithdraw);
     }
 
     function testWithdrawFailsWhenSharesGreaterThanTotalShares(uint256 amountToDeposit, uint256 sharesToWithdraw) public virtual {
@@ -289,7 +279,7 @@ contract StrategyBaseUnitTests is Test {
 
         cheats.expectRevert(IStrategyErrors.WithdrawalAmountExceedsTotalDeposits.selector);
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, sharesToWithdraw);
+        strategy.withdraw(address(this), sharesToWithdraw);
     }
 
     function testWithdrawalFailsWhenTokenTransferFails() public {
@@ -313,7 +303,7 @@ contract StrategyBaseUnitTests is Test {
 
         cheats.expectRevert();
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, amountToWithdraw);
+        strategy.withdraw(address(this), amountToWithdraw);
     }
 
     // uint240 input to prevent overflow
@@ -389,6 +379,6 @@ contract StrategyBaseUnitTests is Test {
         uint256 sharesToWithdraw = totalSharesBefore - sharesToLeave;
 
         cheats.prank(address(strategyManager));
-        strategy.withdraw(address(this), underlyingToken, sharesToWithdraw);
+        strategy.withdraw(address(this), sharesToWithdraw);
     }
 }


### PR DESCRIPTION
`token` param does not seem to be required in withdraw, currently creating lots of validation overhead and verbose api

it's passed in and is only used to validate if it's the same as `underlying_token` of the strategy. We can simplify it by just removing `token` param and use `underlying_token` directly
