### PR TITLE
feat: require avs register metadata in allocation manager

### DIFF
--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -22,7 +22,9 @@ Libraries and Mixins:
 
 ## Overview
 
-The `AllocationManager` manages registration and deregistration of operators to operator sets, handles allocation and slashing of operators' slashable stake, and is the entry point an AVS uses to slash an operator. The `AllocationManager's` responsibilities are broken down into the following concepts:
+The `AllocationManager` manages AVS metadata registration, registration and deregistration of operators to operator sets, handles allocation and slashing of operators' slashable stake, and is the entry point an AVS uses to slash an operator. The `AllocationManager's` responsibilities are broken down into the following concepts:
+
+* [AVS Metadata](#avs-metadata)
 * [Operator Sets](#operator-sets)
 * [Allocations and Slashing](#allocations-and-slashing)
 * [Config](#config)
@@ -37,6 +39,91 @@ The `AllocationManager` manages registration and deregistration of operators to 
     * Testnet: `50 blocks` (10 minutes).
 
 ---
+
+## AVS Metadata
+
+AVSs must register their metadata to declare themselves who they are as the first step, before they can create operator sets or register operators into operator sets. `AllocationManager` keeps track of AVSs that have registered metadata.
+
+**Methods:**
+* [`updateAVSMetadataURI`](#updateavsmetadatauri)
+
+
+#### `updateAVSMetadataURI`
+
+```solidity
+/**
+ *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
+ *
+ *  @param metadataURI The URI for metadata associated with an AVS.
+ *
+ *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
+ */
+function updateAVSMetadataURI(
+    address avs, 
+    string calldata metadataURI
+) 
+    external
+    checkCanCall(avs)
+```
+
+_Note: this method can be called directly by an AVS, or by a caller authorized by the AVS. See [`PermissionController.md`](../permissions/PermissionController.md) for details._
+
+Below is the format AVSs should use when updating their metadata URI. This is not validated onchain.
+
+```json
+{
+    "name": "AVS",
+    "website": "https.avs.xyz/",
+    "description": "Some description about",
+    "logo": "http://github.com/logo.png",
+    "twitter": "https://twitter.com/avs",
+    "operatorSets": [
+        {
+            "name": "ETH Set",
+            "id": "1", // Note: we use this param to match the opSet id in the Allocation Manager
+            "description": "The ETH operatorSet for AVS",
+            "software": [
+                {
+                    "name": "NetworkMonitor",
+                    "description": "",
+                    "url": "https://link-to-binary-or-github.com"
+                },
+                {
+                    "name": "ValidatorClient",
+                    "description": "",
+                    "url": "https://link-to-binary-or-github.com"
+                }
+            ],
+            "slashingConditions": ["Condition A", "Condition B"]
+        },
+        {
+            "name": "EIGEN Set",
+            "id": "2", // Note: we use this param to match the opSet id in the Allocation Manager
+            "description": "The EIGEN operatorSet for AVS",
+            "software": [
+                {
+                    "name": "NetworkMonitor",
+                    "description": "",
+                    "url": "https://link-to-binary-or-github.com"
+                },
+                {
+                    "name": "ValidatorClient",
+                    "description": "",
+                    "url": "https://link-to-binary-or-github.com"
+                }
+            ],
+            "slashingConditions": ["Condition A", "Condition B"]
+        }
+    ]
+}
+```
+
+*Effects*:
+* Emits an `AVSMetadataURIUpdated` event for use in offchain services
+
+*Requirements*:
+* Caller MUST be authorized, either as the AVS itself or an admin/appointee (see [`PermissionController.md`](../permissions/PermissionController.md))
+
 
 ## Operator Sets
 
@@ -665,7 +752,6 @@ Once slashing is processed for a strategy, [slashed stake is burned via the `Del
 **Methods:**
 * [`setAllocationDelay`](#setallocationdelay)
 * [`setAVSRegistrar`](#setavsregistrar)
-* [`updateAVSMetadataURI`](#updateavsmetadatauri)
 
 #### `setAllocationDelay`
 
@@ -753,82 +839,6 @@ Note that when an operator registers, registration will FAIL if the call to `IAV
 *Effects*:
 * Sets `_avsRegistrar[avs]` to `registrar`
 * Emits an `AVSRegistrarSet` event
-
-*Requirements*:
-* Caller MUST be authorized, either as the AVS itself or an admin/appointee (see [`PermissionController.md`](../permissions/PermissionController.md))
-
-#### `updateAVSMetadataURI`
-
-```solidity
-/**
- *  @notice Called by an AVS to emit an `AVSMetadataURIUpdated` event indicating the information has updated.
- *
- *  @param metadataURI The URI for metadata associated with an AVS.
- *
- *  @dev Note that the `metadataURI` is *never stored* and is only emitted in the `AVSMetadataURIUpdated` event.
- */
-function updateAVSMetadataURI(
-    address avs, 
-    string calldata metadataURI
-) 
-    external
-    checkCanCall(avs)
-```
-
-_Note: this method can be called directly by an AVS, or by a caller authorized by the AVS. See [`PermissionController.md`](../permissions/PermissionController.md) for details._
-
-Below is the format AVSs should use when updating their metadata URI. This is not validated onchain.
-
-```json
-{
-    "name": "AVS",
-    "website": "https.avs.xyz/",
-    "description": "Some description about",
-    "logo": "http://github.com/logo.png",
-    "twitter": "https://twitter.com/avs",
-    "operatorSets": [
-        {
-            "name": "ETH Set",
-            "id": "1", // Note: we use this param to match the opSet id in the Allocation Manager
-            "description": "The ETH operatorSet for AVS",
-            "software": [
-                {
-                    "name": "NetworkMonitor",
-                    "description": "",
-                    "url": "https://link-to-binary-or-github.com"
-                },
-                {
-                    "name": "ValidatorClient",
-                    "description": "",
-                    "url": "https://link-to-binary-or-github.com"
-                }
-            ],
-            "slashingConditions": ["Condition A", "Condition B"]
-        },
-        {
-            "name": "EIGEN Set",
-            "id": "2", // Note: we use this param to match the opSet id in the Allocation Manager
-            "description": "The EIGEN operatorSet for AVS",
-            "software": [
-                {
-                    "name": "NetworkMonitor",
-                    "description": "",
-                    "url": "https://link-to-binary-or-github.com"
-                },
-                {
-                    "name": "ValidatorClient",
-                    "description": "",
-                    "url": "https://link-to-binary-or-github.com"
-                }
-            ],
-            "slashingConditions": ["Condition A", "Condition B"]
-        }
-    ]
-}
-```
-
-*Effects*:
-* Emits an `AVSMetadataURIUpdated` event for use in offchain services
 
 *Requirements*:
 * Caller MUST be authorized, either as the AVS itself or an admin/appointee (see [`PermissionController.md`](../permissions/PermissionController.md))

--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -245,6 +245,7 @@ Optionally, the `avs` can provide a list of `strategies`, specifying which strat
 
 *Requirements*:
 * Caller MUST be authorized, either as the AVS itself or an admin/appointee (see [`PermissionController.md`](../permissions/PermissionController.md))
+* AVS MUST have registered metadata
 * For each `CreateSetParams` element:
     * Each `params.operatorSetId` MUST NOT already exist in `_operatorSets[avs]`
     

--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -68,7 +68,20 @@ function updateAVSMetadataURI(
 
 _Note: this method can be called directly by an AVS, or by a caller authorized by the AVS. See [`PermissionController.md`](../permissions/PermissionController.md) for details._
 
-Below is the format AVSs should use when updating their metadata URI. This is not validated onchain.
+Below is the format AVSs should use when updating their metadata URI initially. This is not validated onchain.
+
+```json
+{
+    "name": "AVS",
+    "website": "https.avs.xyz/",
+    "description": "Some description about",
+    "logo": "http://github.com/logo.png",
+    "twitter": "https://twitter.com/avs",
+}
+```
+
+
+Later on, once AVSs have created operator sets, content in their metadata URI can be updated subsequently.
 
 ```json
 {

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -338,7 +338,7 @@ contract AllocationManager is
     /// @inheritdoc IAllocationManager
     function createOperatorSets(address avs, CreateSetParams[] calldata params) external checkCanCall(avs) {
         // Check that the AVS exists and has registered metadata
-        require(_avsRegisteredMetadata[avs], InvalidAVSWithNoMetadataRegistered());
+        require(_avsRegisteredMetadata[avs], NonexistentAVSMetadata());
 
         for (uint256 i = 0; i < params.length; i++) {
             OperatorSet memory operatorSet = OperatorSet(avs, params[i].operatorSetId);

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -338,7 +338,7 @@ contract AllocationManager is
     /// @inheritdoc IAllocationManager
     function createOperatorSets(address avs, CreateSetParams[] calldata params) external checkCanCall(avs) {
         // Check that the AVS exists and has registered metadata
-        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
+        require(_avsRegisteredMetadata[avs], InvalidAVSWithNoMetadataRegistered());
 
         for (uint256 i = 0; i < params.length; i++) {
             OperatorSet memory operatorSet = OperatorSet(avs, params[i].operatorSetId);

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -288,8 +288,6 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) {
         // Check that the caller is either authorized on behalf of the operator or AVS
         require(_checkCanCall(params.operator) || _checkCanCall(params.avs), InvalidCaller());
-        // Check that the AVS exists and has registered metadata
-        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
 
         for (uint256 i = 0; i < params.operatorSetIds.length; i++) {
             // Check the operator set exists and the operator is registered to it

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -260,6 +260,8 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) checkCanCall(operator) {
         // Check that the operator exists
         require(delegation.isOperator(operator), InvalidOperator());
+        // Check that the AVS exists and has registered metadata
+        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
 
         for (uint256 i = 0; i < params.operatorSetIds.length; i++) {
             // Check the operator set exists and the operator is not currently registered to it
@@ -286,6 +288,8 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) {
         // Check that the caller is either authorized on behalf of the operator or AVS
         require(_checkCanCall(params.operator) || _checkCanCall(params.avs), InvalidCaller());
+        // Check that the AVS exists and has registered metadata
+        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
 
         for (uint256 i = 0; i < params.operatorSetIds.length; i++) {
             // Check the operator set exists and the operator is registered to it
@@ -328,6 +332,10 @@ contract AllocationManager is
 
     /// @inheritdoc IAllocationManager
     function updateAVSMetadataURI(address avs, string calldata metadataURI) external checkCanCall(avs) {
+        if (!_avsRegisteredMetadata[avs]) {
+            _avsRegisteredMetadata[avs] = true;
+        }
+
         emit AVSMetadataURIUpdated(avs, metadataURI);
     }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -260,8 +260,6 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) checkCanCall(operator) {
         // Check that the operator exists
         require(delegation.isOperator(operator), InvalidOperator());
-        // Check that the AVS exists and has registered metadata
-        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
 
         for (uint256 i = 0; i < params.operatorSetIds.length; i++) {
             // Check the operator set exists and the operator is not currently registered to it
@@ -339,6 +337,9 @@ contract AllocationManager is
 
     /// @inheritdoc IAllocationManager
     function createOperatorSets(address avs, CreateSetParams[] calldata params) external checkCanCall(avs) {
+        // Check that the AVS exists and has registered metadata
+        require(_avsRegisteredMetadata[params.avs], InvalidAVSWithNoMetadataRegistered());
+
         for (uint256 i = 0; i < params.length; i++) {
             OperatorSet memory operatorSet = OperatorSet(avs, params[i].operatorSetId);
 

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -43,10 +43,6 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// Note: if set to 0, defaults to the AVS's address
     mapping(address avs => IAVSRegistrar) internal _avsRegistrar;
 
-    /// @dev Lists the AVSs who has registered metadata and claimed itself as an AVS
-    /// @notice bool is not used and if always true if the avs has registered metadata
-    mapping(address avs => bool) internal _avsRegisteredMetadata;
-
     /// @dev Lists the operator set ids an AVS has created
     mapping(address avs => EnumerableSet.UintSet) internal _operatorSets;
 
@@ -92,6 +88,10 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @dev For a strategy, keeps an ordered queue of operator sets that have pending deallocations
     /// These must be completed in order to free up magnitude for future allocation
     mapping(address operator => mapping(IStrategy strategy => DoubleEndedQueue.Bytes32Deque)) internal deallocationQueue;
+
+    /// @dev Lists the AVSs who has registered metadata and claimed itself as an AVS
+    /// @notice bool is not used and is always true if the avs has registered metadata
+    mapping(address avs => bool) internal _avsRegisteredMetadata;
 
     // Construction
 

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -43,6 +43,10 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// Note: if set to 0, defaults to the AVS's address
     mapping(address avs => IAVSRegistrar) internal _avsRegistrar;
 
+    /// @dev Lists the AVSs who has registered metadata and claimed itself as an AVS
+    /// @notice bool is not used and if always true if the avs has registered metadata
+    mapping(address avs => bool) internal _avsRegisteredMetadata;
+
     /// @dev Lists the operator set ids an AVS has created
     mapping(address avs => EnumerableSet.UintSet) internal _operatorSets;
 
@@ -102,5 +106,5 @@ abstract contract AllocationManagerStorage is IAllocationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[37] private __gap;
+    uint256[36] private __gap;
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -25,7 +25,7 @@ interface IAllocationManagerErrors {
     /// @dev Thrown when an invalid operator is provided.
     error InvalidOperator();
     /// @dev Thrown when an invalid avs whose metadata is not registered is provided.
-    error InvalidAVSWithNoMetadataRegistered();
+    error NonexistentAVSMetadata();
     /// @dev Thrown when an operator's allocation delay has yet to be set.
     error UninitializedAllocationDelay();
     /// @dev Thrown when attempting to slash an operator when they are not slashable.

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -24,6 +24,8 @@ interface IAllocationManagerErrors {
 
     /// @dev Thrown when an invalid operator is provided.
     error InvalidOperator();
+    /// @dev Thrown when an invalid avs whose metadata is not registered is provided.
+    error InvalidAVSWithNoMetadataRegistered();
     /// @dev Thrown when an operator's allocation delay has yet to be set.
     error UninitializedAllocationDelay();
     /// @dev Thrown when attempting to slash an operator when they are not slashable.

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -147,6 +147,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     function _newRandomAVS() internal returns (AVS avs, OperatorSet[] memory operatorSets) {
         string memory avsName = string.concat("avs", numAVSs.toString());
         avs = _genRandAVS(avsName);
+        avs.updateAVSMetadataURI("https://example.com");
         operatorSets = avs.createOperatorSets(_randomStrategies());
         ++numAVSs;
     }

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -52,6 +52,9 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         staker.delegateTo(operator);
         check_Delegation_State(staker, operator, strategies, shares);
 
+        // update AVS metadata URI
+        avs.updateAVSMetadataURI("https://example.com");
+
         // Create operator set and register operator
         operatorSet = avs.createOperatorSet(strategies);
         operator.registerForOperatorSet(operatorSet);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -52,9 +52,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         staker.delegateTo(operator);
         check_Delegation_State(staker, operator, strategies, shares);
 
-        // update AVS metadata URI
-        avs.updateAVSMetadataURI("https://example.com");
-
         // Create operator set and register operator
         operatorSet = avs.createOperatorSet(strategies);
         operator.registerForOperatorSet(operatorSet);

--- a/src/test/integration/users/AVS.t.sol
+++ b/src/test/integration/users/AVS.t.sol
@@ -67,6 +67,18 @@ contract AVS is Logger, IAllocationManagerTypes, IAVSRegistrar {
     /// AllocationManager
     /// -----------------------------------------------------------------------
 
+    function updateAVSMetadataURI(
+        string memory uri
+    ) public createSnapshot {
+        print.method("updateAVSMetadataURI");
+        
+        console.log("Setting AVS metadata URI to: %s", uri);
+        _tryPrankAppointee_AllocationManager(IAllocationManager.updateAVSMetadataURI.selector);
+        allocationManager.updateAVSMetadataURI(address(this), uri);
+        
+        print.gasUsed();
+    }
+
     function createOperatorSets(
         IStrategy[][] memory strategies
     ) public createSnapshot returns (OperatorSet[] memory operatorSets) {

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -71,7 +71,10 @@ contract AllocationManagerUnitTests is EigenLayerUnitTestSetup, IAllocationManag
         defaultStrategies = strategyMock.toArray();
         defaultOperatorSet = OperatorSet(defaultAVS, 0);
 
+        cheats.prank(defaultAVS);
         allocationManager.updateAVSMetadataURI(defaultAVS, "https://example.com");
+
+
         _createOperatorSet(defaultOperatorSet, defaultStrategies);
         _registerOperator(defaultOperator);
         _setAllocationDelay(defaultOperator, DEFAULT_OPERATOR_ALLOCATION_DELAY);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3834,6 +3834,13 @@ contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitT
         allocationManager.createOperatorSets(defaultAVS, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray());
     }
 
+    function testRevert_createOperatorSets_InvalidAVSWithNoMetadataRegistered(Randomness r) public rand(r) {
+        address avs = r.Address();
+        cheats.expectRevert(InvalidAVSWithNoMetadataRegistered.selector);
+        cheats.prank(avs);
+        allocationManager.createOperatorSets(avs, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray());
+    }
+
     function testFuzz_createOperatorSets_Correctness(
         Randomness r
     ) public rand(r) {

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3841,6 +3841,9 @@ contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitT
         uint256 numOpSets = r.Uint256(1, FUZZ_MAX_OP_SETS);
         uint256 numStrategies = r.Uint256(1, FUZZ_MAX_STRATS);
 
+        cheats.prank(avs);
+        allocationManager.updateAVSMetadataURI(avs, "https://example.com");
+
         CreateSetParams[] memory createSetParams = new CreateSetParams[](numOpSets);
 
         for (uint256 i; i < numOpSets; ++i) {

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -71,6 +71,7 @@ contract AllocationManagerUnitTests is EigenLayerUnitTestSetup, IAllocationManag
         defaultStrategies = strategyMock.toArray();
         defaultOperatorSet = OperatorSet(defaultAVS, 0);
 
+        allocationManager.updateAVSMetadataURI(defaultAVS, "https://example.com");
         _createOperatorSet(defaultOperatorSet, defaultStrategies);
         _registerOperator(defaultOperator);
         _setAllocationDelay(defaultOperator, DEFAULT_OPERATOR_ALLOCATION_DELAY);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3834,9 +3834,9 @@ contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitT
         allocationManager.createOperatorSets(defaultAVS, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray());
     }
 
-    function testRevert_createOperatorSets_InvalidAVSWithNoMetadataRegistered(Randomness r) public rand(r) {
+    function testRevert_createOperatorSets_NonexistentAVSMetadata(Randomness r) public rand(r) {
         address avs = r.Address();
-        cheats.expectRevert(InvalidAVSWithNoMetadataRegistered.selector);
+        cheats.expectRevert(NonexistentAVSMetadata.selector);
         cheats.prank(avs);
         allocationManager.createOperatorSets(avs, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray());
     }


### PR DESCRIPTION
require avs register metadata in allocation manager before they can create operatorset