### PR TITLE
fix: enforce no compile warnings

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -180,7 +180,7 @@ jobs:
       # Run Forge coverage with LCOV report format, excluding test and script files
       - name: Forge Coverage
         run: |
-          FOUNDRY_PROFILE=ci forge coverage --report lcov --no-match-coverage "src/test/*","script/*","*Storage" 
+          FOUNDRY_DENY_WARNINGS=false FOUNDRY_PROFILE=ci forge coverage --report lcov --no-match-coverage "src/test/*","script/*","*Storage" 
           genhtml -q -o report ./lcov.info
 
       # Upload coverage report as artifact before potential failure

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,7 @@
     # Specifies the exact version of Solidity to use, overriding auto-detection.
     solc_version = '0.8.27'
     # If enabled, treats Solidity compiler warnings as errors, preventing artifact generation if warnings are present.
-    deny_warnings = false 
+    deny_warnings = true 
     # If set to true, changes compilation pipeline to go through the new IR optimizer.
     via_ir = false
     # Whether or not to enable the Solidity optimizer.

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -394,7 +394,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         User staker,
         User operator,
         IDelegationManagerTypes.Withdrawal memory withdrawal,
-        IAllocationManagerTypes.AllocateParams memory allocateParams, // TODO - was this needed?
+        IAllocationManagerTypes.AllocateParams memory, // TODO - was this needed?
         IAllocationManagerTypes.SlashingParams memory slashingParams
     ) internal {
         IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate.t.sol
@@ -166,7 +166,6 @@ contract Integration_Deposit_Delegate_Allocate is IntegrationCheckUtils {
 
         // 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        uint256[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
         // TODO - post-deposit and post-delegate checks?
 
         // 2. Delegate to an operator

--- a/src/test/unit/libraries/SnapshotsUnit.t.sol
+++ b/src/test/unit/libraries/SnapshotsUnit.t.sol
@@ -30,15 +30,15 @@ contract SnapshotsUnitTests is Test {
         assertEq(history.length(), 1);
     }
 
-    function test_UpperLookup_InitiallyWad(uint32 r) public {
+    function test_UpperLookup_InitiallyWad(uint32 r) public view {
         assertEq(history.upperLookup(r), 1e18);
     }
 
-    function test_Latest_InitiallyWad() public {
+    function test_Latest_InitiallyWad() public view {
         assertEq(history.latest(), 1e18);
     }
 
-    function test_Length_InitiallyZero() public {
+    function test_Length_InitiallyZero() public view {
         assertEq(history.length(), 0);
     }
 }

--- a/src/test/unit/mixins/SignatureUtilsUnit.t.sol
+++ b/src/test/unit/mixins/SignatureUtilsUnit.t.sol
@@ -42,7 +42,7 @@ contract SignatureUtilsUnit is Test, SignatureUtils {
         );
     }
 
-    function test_domainSeparator_NonZero() public {
+    function test_domainSeparator_NonZero() public view {
         assertTrue(_INITIAL_DOMAIN_SEPARATOR != 0, "The initial domain separator should be non-zero");
         assertTrue(domainSeparator() != 0, "The domain separator should be non-zero");
         assertTrue(domainSeparator() == expectedDomainSeparator, "The domain separator should be as expected");
@@ -70,7 +70,7 @@ contract SignatureUtilsUnit is Test, SignatureUtils {
         _checkIsValidSignatureNow(signer, digest, abi.encode(r, s, v), block.timestamp - 1);
     }
 
-    function testFail_checkIsValidSignatureNow_InvalidSignature() public {
+    function testFail_checkIsValidSignatureNow_InvalidSignature() public view {
         _checkIsValidSignatureNow(signer, digest, "", block.timestamp);
     }
 }


### PR DESCRIPTION
**Motivation:**  

Ensuring stricter code quality by preventing compilation warnings from being ignored. This helps catch potential issues early and enforces cleaner code.  

**Modifications:**  

Set `deny_warnings` to *true* in `foundry.toml`.  

**Result:**  

Any compilation warnings will now cause a hard failure, enforcing stricter code hygiene and reducing the risk of overlooking potential issues.