### PR TITLE
feat: add `getSharesFromQueuedWithdrawal`

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -777,7 +777,7 @@ contract DelegationManager is
     }
 
     /// @dev Get the shares from a queued withdrawal.
-    function _getSharesFromQueuedWithdrawal(
+    function _getSharesByWithdrawalRoot(
         bytes32 withdrawalRoot
     ) internal view returns (Withdrawal memory withdrawal, uint256[] memory shares) {
         withdrawal = queuedWithdrawals[withdrawalRoot];
@@ -953,11 +953,11 @@ contract DelegationManager is
     function getSharesFromQueuedWithdrawal(
         bytes32 withdrawalRoot
     ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares) {
-        (withdrawal, shares) = _getSharesFromQueuedWithdrawal(withdrawalRoot);
+        (withdrawal, shares) = _getSharesByWithdrawalRoot(withdrawalRoot);
     }
 
     /// @inheritdoc IDelegationManager
-    function getSharesFromQueuedWithdrawals(
+    function getQueuedWithdrawals(
         address staker
     ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares) {
         bytes32[] memory withdrawalRoots = getQueuedWithdrawalRoots(staker);
@@ -967,7 +967,7 @@ contract DelegationManager is
         shares = new uint256[][](totalQueued);
 
         for (uint256 i; i < totalQueued; ++i) {
-            (withdrawals[i], shares[i]) = _getSharesFromQueuedWithdrawal(withdrawalRoots[i]);
+            (withdrawals[i], shares[i]) = _getSharesByWithdrawalRoot(withdrawalRoots[i]);
         }
     }
 

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -784,7 +784,7 @@ contract DelegationManager is
         shares = new uint256[](withdrawal.strategies.length);
 
         uint32 slashableUntil = withdrawal.startBlock + MIN_WITHDRAWAL_DELAY_BLOCKS;
-        
+
         // If the slashableUntil block is in the past, read the slashing factors at that block.
         // Otherwise, read the current slashing factors. Note that if the slashableUntil block is the current block
         // or in the future, then the slashing factors are still subject to change before the withdrawal is completable,

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -952,8 +952,8 @@ contract DelegationManager is
     /// @inheritdoc IDelegationManager
     function getSharesFromQueuedWithdrawal(
         bytes32 withdrawalRoot
-    ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares) {
-        (withdrawal, shares) = _getSharesByWithdrawalRoot(withdrawalRoot);
+    ) external view returns (uint256[] memory shares) {
+        (, shares) = _getSharesByWithdrawalRoot(withdrawalRoot);
     }
 
     /// @inheritdoc IDelegationManager

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -967,7 +967,7 @@ contract DelegationManager is
         shares = new uint256[][](totalQueued);
 
         for (uint256 i; i < totalQueued; ++i) {
-            (withdrawals[i], shares[i]) = _getQueuedWithdrawal(staker, withdrawalRoots[i]);
+            (withdrawals[i], shares[i]) = _getSharesFromQueuedWithdrawal(withdrawalRoots[i]);
         }
     }
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -477,8 +477,13 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         bytes32 withdrawalRoot
     ) external view returns (Withdrawal memory);
 
-    /// @notice Returns a list of pending queued withdrawals for a `staker`, and the `shares` to be withdrawn.
-    function getQueuedWithdrawals(
+    /// @notice Returns the shares from a queued withdrawal.
+    function getSharesFromQueuedWithdrawal(
+        bytes32 withdrawalRoot
+    ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares);
+
+    /// @notice Returns a list of shares from a list of queued withdrawals.
+    function getSharesFromQueuedWithdrawals(
         address staker
     ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares);
 

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -477,12 +477,24 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
         bytes32 withdrawalRoot
     ) external view returns (Withdrawal memory);
 
-    /// @notice Returns the shares from a queued withdrawal.
+    /**
+     * @notice Returns the withdrawal details and corresponding shares for a specific queued withdrawal.
+     * @param withdrawalRoot The hash identifying the queued withdrawal.
+     * @return withdrawal The Withdrawal struct containing details about the queued withdrawal.
+     * @return shares Array of shares corresponding to each strategy in the withdrawal.
+     * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
+     */
     function getSharesFromQueuedWithdrawal(
         bytes32 withdrawalRoot
     ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares);
 
-    /// @notice Returns a list of shares from a list of queued withdrawals.
+    /**
+     * @notice Returns all queued withdrawals and their corresponding shares for a staker.
+     * @param staker The address of the staker to query withdrawals for.
+     * @return withdrawals Array of Withdrawal structs containing details about each queued withdrawal.
+     * @return shares 2D array of shares, where each inner array corresponds to the strategies in the withdrawal.
+     * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
+     */
     function getSharesFromQueuedWithdrawals(
         address staker
     ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares);

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -478,6 +478,17 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     ) external view returns (Withdrawal memory);
 
     /**
+     * @notice Returns all queued withdrawals and their corresponding shares for a staker.
+     * @param staker The address of the staker to query withdrawals for.
+     * @return withdrawals Array of Withdrawal structs containing details about each queued withdrawal.
+     * @return shares 2D array of shares, where each inner array corresponds to the strategies in the withdrawal.
+     * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
+     */
+    function getQueuedWithdrawals(
+        address staker
+    ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares);
+
+    /**
      * @notice Returns the withdrawal details and corresponding shares for a specific queued withdrawal.
      * @param withdrawalRoot The hash identifying the queued withdrawal.
      * @return withdrawal The Withdrawal struct containing details about the queued withdrawal.
@@ -487,17 +498,6 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     function getSharesFromQueuedWithdrawal(
         bytes32 withdrawalRoot
     ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares);
-
-    /**
-     * @notice Returns all queued withdrawals and their corresponding shares for a staker.
-     * @param staker The address of the staker to query withdrawals for.
-     * @return withdrawals Array of Withdrawal structs containing details about each queued withdrawal.
-     * @return shares 2D array of shares, where each inner array corresponds to the strategies in the withdrawal.
-     * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
-     */
-    function getSharesFromQueuedWithdrawals(
-        address staker
-    ) external view returns (Withdrawal[] memory withdrawals, uint256[][] memory shares);
 
     /// @notice Returns a list of queued withdrawal roots for the `staker`.
     /// NOTE that this only returns withdrawals queued AFTER the slashing release.

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -491,13 +491,12 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
     /**
      * @notice Returns the withdrawal details and corresponding shares for a specific queued withdrawal.
      * @param withdrawalRoot The hash identifying the queued withdrawal.
-     * @return withdrawal The Withdrawal struct containing details about the queued withdrawal.
      * @return shares Array of shares corresponding to each strategy in the withdrawal.
      * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
      */
     function getSharesFromQueuedWithdrawal(
         bytes32 withdrawalRoot
-    ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares);
+    ) external view returns (uint256[] memory shares);
 
     /// @notice Returns a list of queued withdrawal roots for the `staker`.
     /// NOTE that this only returns withdrawals queued AFTER the slashing release.

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -8939,4 +8939,12 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
             assertEq(shares[i], depositShares[i], "incorrect shares amount for strategy");
         }
     }
+
+    function test_getSharesFromQueuedWithdrawal_EmptyWithdrawal() public {
+        (
+            Withdrawal memory withdrawal, 
+            uint256[] memory shares
+        ) = delegationManager.getSharesFromQueuedWithdrawal(bytes32(0));
+        assertEq(shares.length, 0, "sanity check");
+    }
 }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1114,7 +1114,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
                 delegationManager.pendingWithdrawals(withdrawalRootToCheck),
                 "withdrawalRoot not pending"
             );
-            (Withdrawal[] memory withdrawalsInStorage, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
+            (Withdrawal[] memory withdrawalsInStorage, ) = delegationManager.getQueuedWithdrawals(staker);
             for (uint256 j = 0; j < withdrawalsInStorage.length; ++j) {
                 assertTrue(
                     withdrawalRootToCheck != delegationManager.calculateWithdrawalRoot(withdrawalsInStorage[j]),
@@ -1234,7 +1234,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
                 "withdrawalRoot not pending"
             );
 
-            (Withdrawal[] memory withdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
+            (Withdrawal[] memory withdrawals, ) = delegationManager.getQueuedWithdrawals(staker);
             for (uint256 j = 0; j < withdrawals.length; ++j) {
                 if (withdrawalRootToCheck == delegationManager.calculateWithdrawalRoot(withdrawals[j])) {
                     assertEq(
@@ -1291,7 +1291,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             "withdrawalRoot not pending"
         );
 
-        (Withdrawal[] memory withdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
+        (Withdrawal[] memory withdrawals, ) = delegationManager.getQueuedWithdrawals(staker);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             assertEq(
                 withdrawals[i].staker,
@@ -6544,7 +6544,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         cheats.roll(startBlock + 1);
         delegationManager.queueWithdrawals(queuedParams[1].toArray());
         
-        (Withdrawal[] memory firstWithdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory firstWithdrawals, ) = delegationManager.getQueuedWithdrawals(defaultStaker);
 
         cheats.roll(startBlock + 2);
         delegationManager.queueWithdrawals(queuedParams[2].toArray());
@@ -8568,7 +8568,7 @@ contract DelegationManagerUnitTests_ConvertToDepositShares is DelegationManagerU
     }
 }
 
-contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is DelegationManagerUnitTests {
+contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUnitTests {
     using ArrayLib for *;
     using SlashingLib for *;
 
@@ -8576,7 +8576,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
         return keccak256(abi.encode(withdrawal));
     }
 
-    function test_getSharesFromQueuedWithdrawals_Correctness(Randomness r) public rand(r) {
+    function test_getQueuedWithdrawals_Correctness(Randomness r) public rand(r) {
         uint256 numStrategies = r.Uint256(2, 8);
         uint256[] memory depositShares = r.Uint256Array({
             len: numStrategies, 
@@ -8612,7 +8612,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
         
         // Get queued withdrawals.
-        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
         // Checks
         for (uint256 i; i < strategies.length; ++i) {
             uint256 newStakerShares = depositShares[i] / 2;
@@ -8623,7 +8623,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
         assertEq(_withdrawalRoot(withdrawal), withdrawalRoot, "_withdrawalRoot(withdrawal) != withdrawalRoot");
     }
 
-    function test_getSharesFromQueuedWithdrawals_TotalQueuedGreaterThanTotalStrategies(
+    function test_getQueuedWithdrawals_TotalQueuedGreaterThanTotalStrategies(
         Randomness r
     ) public rand(r) {
         uint256 totalDepositShares = r.Uint256(2, 100 ether);
@@ -8667,7 +8667,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
         delegationManager.queueWithdrawals(queuedWithdrawalParams1);
 
         // Get queued withdrawals.
-        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
 
         // Sanity
         assertEq(withdrawals.length, 2, "withdrawal.length != 2");
@@ -8684,12 +8684,12 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
     }
 
     /**
-     * @notice Assert that the shares returned in the view function `getSharesFromQueuedWithdrawals` are unaffected from a
+     * @notice Assert that the shares returned in the view function `getQueuedWithdrawals` are unaffected from a
      * slash that occurs after the withdrawal is completed. Also assert that completing the withdrawal matches the
      * expected withdrawn shares from the view function.
      * Slashing on the completableBlock of the withdrawal should have no affect on the withdrawn shares.
      */
-    function test_getSharesFromQueuedWithdrawals_SlashAfterWithdrawalCompletion(Randomness r) public rand(r) {
+    function test_getQueuedWithdrawals_SlashAfterWithdrawalCompletion(Randomness r) public rand(r) {
         uint256 depositAmount = r.Uint256(1, MAX_STRATEGY_SHARES);
 
         // Deposit Staker
@@ -8747,9 +8747,9 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
             );
         }
 
-        // Assert that the getSharesFromQueuedWithdrawals returns shares that are halved as a result of being slashed 50%
+        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50%
         {
-            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
             assertEq(withdrawals.length, 1, "withdrawals.length != 1");
             assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");
             assertEq(shares[0][0], depositAmount / 2, "shares[0][0] != depositAmount / 2");
@@ -8778,12 +8778,12 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is Delegation
             );
         }
 
-        // Assert that the getSharesFromQueuedWithdrawals returns shares that are halved as a result of being slashed 50% and hasn't been
+        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50% and hasn't been
         // affected by the second slash
         uint256 expectedSharesIncrease = depositAmount / 2;
         uint256 queuedWithdrawableShares;
         {
-            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
             queuedWithdrawableShares = shares[0][0];
             assertEq(withdrawals.length, 1, "withdrawals.length != 1");
             assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -1114,7 +1114,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
                 delegationManager.pendingWithdrawals(withdrawalRootToCheck),
                 "withdrawalRoot not pending"
             );
-            (Withdrawal[] memory withdrawalsInStorage, ) = delegationManager.getQueuedWithdrawals(staker);
+            (Withdrawal[] memory withdrawalsInStorage, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
             for (uint256 j = 0; j < withdrawalsInStorage.length; ++j) {
                 assertTrue(
                     withdrawalRootToCheck != delegationManager.calculateWithdrawalRoot(withdrawalsInStorage[j]),
@@ -1234,7 +1234,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
                 "withdrawalRoot not pending"
             );
 
-            (Withdrawal[] memory withdrawals, ) = delegationManager.getQueuedWithdrawals(staker);
+            (Withdrawal[] memory withdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
             for (uint256 j = 0; j < withdrawals.length; ++j) {
                 if (withdrawalRootToCheck == delegationManager.calculateWithdrawalRoot(withdrawals[j])) {
                     assertEq(
@@ -1291,7 +1291,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
             "withdrawalRoot not pending"
         );
 
-        (Withdrawal[] memory withdrawals, ) = delegationManager.getQueuedWithdrawals(staker);
+        (Withdrawal[] memory withdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(staker);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             assertEq(
                 withdrawals[i].staker,
@@ -6544,7 +6544,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         cheats.roll(startBlock + 1);
         delegationManager.queueWithdrawals(queuedParams[1].toArray());
         
-        (Withdrawal[] memory firstWithdrawals, ) = delegationManager.getQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory firstWithdrawals, ) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
 
         cheats.roll(startBlock + 2);
         delegationManager.queueWithdrawals(queuedParams[2].toArray());
@@ -8568,7 +8568,7 @@ contract DelegationManagerUnitTests_ConvertToDepositShares is DelegationManagerU
     }
 }
 
-contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUnitTests {
+contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawals is DelegationManagerUnitTests {
     using ArrayLib for *;
     using SlashingLib for *;
 
@@ -8576,7 +8576,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         return keccak256(abi.encode(withdrawal));
     }
 
-    function test_getQueuedWithdrawals_Correctness(Randomness r) public rand(r) {
+    function test_getSharesFromQueuedWithdrawals_Correctness(Randomness r) public rand(r) {
         uint256 numStrategies = r.Uint256(2, 8);
         uint256[] memory depositShares = r.Uint256Array({
             len: numStrategies, 
@@ -8612,7 +8612,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
         
         // Get queued withdrawals.
-        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
         // Checks
         for (uint256 i; i < strategies.length; ++i) {
             uint256 newStakerShares = depositShares[i] / 2;
@@ -8623,7 +8623,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         assertEq(_withdrawalRoot(withdrawal), withdrawalRoot, "_withdrawalRoot(withdrawal) != withdrawalRoot");
     }
 
-    function test_getQueuedWithdrawals_TotalQueuedGreaterThanTotalStrategies(
+    function test_getSharesFromQueuedWithdrawals_TotalQueuedGreaterThanTotalStrategies(
         Randomness r
     ) public rand(r) {
         uint256 totalDepositShares = r.Uint256(2, 100 ether);
@@ -8667,7 +8667,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         delegationManager.queueWithdrawals(queuedWithdrawalParams1);
 
         // Get queued withdrawals.
-        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+        (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
 
         // Sanity
         assertEq(withdrawals.length, 2, "withdrawal.length != 2");
@@ -8684,12 +8684,12 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
     }
 
     /**
-     * @notice Assert that the shares returned in the view function `getQueuedWithdrawals` are unaffected from a
+     * @notice Assert that the shares returned in the view function `getSharesFromQueuedWithdrawals` are unaffected from a
      * slash that occurs after the withdrawal is completed. Also assert that completing the withdrawal matches the
      * expected withdrawn shares from the view function.
      * Slashing on the completableBlock of the withdrawal should have no affect on the withdrawn shares.
      */
-    function test_getQueuedWithdrawals_SlashAfterWithdrawalCompletion(Randomness r) public rand(r) {
+    function test_getSharesFromQueuedWithdrawals_SlashAfterWithdrawalCompletion(Randomness r) public rand(r) {
         uint256 depositAmount = r.Uint256(1, MAX_STRATEGY_SHARES);
 
         // Deposit Staker
@@ -8747,9 +8747,9 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             );
         }
 
-        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50%
+        // Assert that the getSharesFromQueuedWithdrawals returns shares that are halved as a result of being slashed 50%
         {
-            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
             assertEq(withdrawals.length, 1, "withdrawals.length != 1");
             assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");
             assertEq(shares[0][0], depositAmount / 2, "shares[0][0] != depositAmount / 2");
@@ -8778,12 +8778,12 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             );
         }
 
-        // Assert that the getQueuedWithdrawals returns shares that are halved as a result of being slashed 50% and hasn't been
+        // Assert that the getSharesFromQueuedWithdrawals returns shares that are halved as a result of being slashed 50% and hasn't been
         // affected by the second slash
         uint256 expectedSharesIncrease = depositAmount / 2;
         uint256 queuedWithdrawableShares;
         {
-            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getQueuedWithdrawals(defaultStaker);
+            (Withdrawal[] memory withdrawals, uint256[][] memory shares) = delegationManager.getSharesFromQueuedWithdrawals(defaultStaker);
             queuedWithdrawableShares = shares[0][0];
             assertEq(withdrawals.length, 1, "withdrawals.length != 1");
             assertEq(withdrawals[0].strategies.length, 1, "withdrawals[0].strategies.length != 1");

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -8843,10 +8843,9 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
 
         // Get shares from queued withdrawal
-        (Withdrawal memory returnedWithdrawal, uint256[] memory shares) = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
 
         // Verify withdrawal details match
-        assertEq(keccak256(abi.encode(returnedWithdrawal)), withdrawalRoot, "returned withdrawal root mismatch");
         assertEq(shares.length, 1, "incorrect shares array length");
         assertEq(shares[0], depositAmount, "incorrect shares amount");
     }
@@ -8880,23 +8879,16 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.slashOperatorShares(defaultOperator, strategyMock, WAD, 0.5 ether);
 
         // Get shares from queued withdrawal
-        (Withdrawal memory returnedWithdrawal, uint256[] memory shares) = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
 
         // Verify withdrawal details match and shares are slashed
-        assertEq(keccak256(abi.encode(returnedWithdrawal)), withdrawalRoot, "returned withdrawal root mismatch");
         assertEq(shares.length, 1, "incorrect shares array length");
         assertEq(shares[0], depositAmount / 2, "shares not properly slashed");
     }
 
     function test_getSharesFromQueuedWithdrawal_NonexistentWithdrawal() public {
         bytes32 nonexistentRoot = bytes32(uint256(1));
-        
-        (Withdrawal memory withdrawal, uint256[] memory shares) = delegationManager.getSharesFromQueuedWithdrawal(nonexistentRoot);
-        
-        // For a nonexistent withdrawal, we expect empty arrays and default values
-        assertEq(withdrawal.staker, address(0), "withdrawal staker should be zero address");
-        assertEq(withdrawal.strategies.length, 0, "withdrawal strategies should be empty");
-        assertEq(withdrawal.scaledShares.length, 0, "withdrawal scaledShares should be empty");
+        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(nonexistentRoot);
         assertEq(shares.length, 0, "shares array should be empty");
     }
 
@@ -8930,10 +8922,9 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
 
         // Get shares from queued withdrawal
-        (Withdrawal memory returnedWithdrawal, uint256[] memory shares) = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
 
         // Verify withdrawal details and shares for each strategy
-        assertEq(keccak256(abi.encode(returnedWithdrawal)), withdrawalRoot, "returned withdrawal root mismatch");
         assertEq(shares.length, numStrategies, "incorrect shares array length");
         for (uint256 i = 0; i < numStrategies; i++) {
             assertEq(shares[i], depositShares[i], "incorrect shares amount for strategy");
@@ -8941,10 +8932,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
     }
 
     function testFuzz_getSharesFromQueuedWithdrawal_EmptyWithdrawal(bytes32 withdrawalRoot) public {
-        (
-            Withdrawal memory withdrawal, 
-            uint256[] memory shares
-        ) = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
         assertEq(shares.length, 0, "sanity check");
     }
 }

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -8940,11 +8940,11 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         }
     }
 
-    function test_getSharesFromQueuedWithdrawal_EmptyWithdrawal() public {
+    function testFuzz_getSharesFromQueuedWithdrawal_EmptyWithdrawal(bytes32 withdrawalRoot) public {
         (
             Withdrawal memory withdrawal, 
             uint256[] memory shares
-        ) = delegationManager.getSharesFromQueuedWithdrawal(bytes32(0));
+        ) = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
         assertEq(shares.length, 0, "sanity check");
     }
 }


### PR DESCRIPTION
**Motivation:**

Users want a cost effective way to query withdrawable shares.

**Modifications:**

- added `getSharesFromQueuedWithdrawal(bytes32 withdrawalRoot)`
- renamed `getQueuedWithdrawals` to `getSharesFromQueuedWithdrawals`.

**Result:**

Users can query withdrawable shares with `withdrawalRoot` alone.
