### PR TITLE
test: slash invariants

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -565,6 +565,17 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             assertEq(slashableStake[i], 0, err);
         }
     }
+
+    function assert_DSF_Reset(
+        User staker,
+        IStrategy[] memory strategies,
+        string memory err
+    ) internal {
+        uint[] memory depositScalingFactors = _getDepositScalingFactors(staker, strategies);
+        for (uint i = 0; i < strategies.length; i++) {
+            assertEq(depositScalingFactors[i], WAD, err);
+        }
+    }
     
     /*******************************************************************************
                                 SNAPSHOT ASSERTIONS
@@ -2758,6 +2769,18 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
 
         return shares;
+    }
+
+    function _getDepositScalingFactors(User staker, IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory depositScalingFactors = new uint[](strategies.length);
+        for (uint i=0; i < strategies.length; i++) {
+            depositScalingFactors[i] = _getDepositScalingFactor(staker, strategies[i]);
+        }
+        return depositScalingFactors;
+    }
+
+    function _getDepositScalingFactor(User staker, IStrategy strategy) internal view returns (uint) {
+        return delegationManager.depositScalingFactor(address(staker), strategy);
     }
 
     function _getExpectedDSFUndelegate(User staker) internal view returns (uint expectedDepositScalingFactor) {

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -2760,6 +2760,22 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return shares;
     }
 
+    function _getExpectedDSFUndelegate(User staker) internal view returns (uint expectedDepositScalingFactor) {
+        return WAD.divWad(_getBeaconChainSlashingFactor(staker));
+    }
+
+    function _getExpectedWithdrawableSharesUndelegate(User staker, IStrategy[] memory strategies, uint[] memory shares) internal view returns (uint[] memory){
+        uint[] memory expectedWithdrawableShares = new uint[](strategies.length);
+        for (uint i = 0; i < strategies.length; i++) {
+            if (strategies[i] == BEACONCHAIN_ETH_STRAT) {
+                expectedWithdrawableShares[i] = shares[i].mulWad(_getExpectedDSFUndelegate(staker)).mulWad(_getBeaconChainSlashingFactor(staker));
+            } else {
+                expectedWithdrawableShares[i] = shares[i];
+             }
+        }
+        return expectedWithdrawableShares;
+    }
+
     function _getPrevWithdrawableShares(User staker, IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
         return _getWithdrawableShares(staker, strategies);
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -18,6 +18,7 @@ import "src/test/integration/users/User_M1.t.sol";
 abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     using StdStyle for *;
     using SlashingLib for *;
+    using Math for uint256;
     using Strings for *;
     using print for *;
 
@@ -65,6 +66,35 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newRandomStaker: failed to award token balances");
 
         numStakers++;
+        return (staker, strategies, tokenBalances);
+    }
+
+    function _newBasicStaker() internal returns (User, IStrategy[] memory, uint[] memory) {
+        string memory stakerName;
+
+        User staker;
+        IStrategy[] memory strategies;
+        uint[] memory tokenBalances;
+
+        if (!isUpgraded) {
+            stakerName = string.concat("M2Staker", cheats.toString(numStakers));
+
+            (staker, strategies, tokenBalances) = _randUser(stakerName);
+
+            stakersToMigrate.push(staker);
+        } else {
+            stakerName = string.concat("staker", cheats.toString(numStakers));
+
+            (staker, strategies, tokenBalances) = _randUser(stakerName);
+        }
+
+        assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newRandomStaker: failed to award token balances");
+
+        numStakers++;
+        assembly { // TODO HACK
+            mstore(strategies, 1)
+            mstore(tokenBalances, 1)
+        }
         return (staker, strategies, tokenBalances);
     }
 
@@ -836,6 +866,29 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_SlashableStake(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curSlashableStake = _getMinSlashableStake(operator, operatorSet, params.strategies);
+        uint[] memory prevSlashableStake = _getPrevMinSlashableStake(operator, operatorSet, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevSlashableStake[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curSlashableStake[i], prevSlashableStake[i] - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_StakeBecameAllocated(
         User operator,
         OperatorSet memory operatorSet,
@@ -875,6 +928,29 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         for (uint i = 0; i < curAllocatedStake.length; i++) {
             assertEq(curAllocatedStake[i], prevAllocatedStake[i], err);
+        }
+    }
+
+    function assert_Snap_Slashed_AllocatedStake(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curAllocatedStake = _getAllocatedStake(operator, operatorSet, params.strategies);
+        uint[] memory prevAllocatedStake = _getPrevAllocatedStake(operator, operatorSet, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < curAllocatedStake.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevAllocatedStake[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curAllocatedStake[i], prevAllocatedStake[i] - expectedSlashed, err);
         }
     }
 
@@ -919,6 +995,20 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_EncumberedMagnitude(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevMagnitudes[i].encumbered.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curMagnitudes[i].encumbered, prevMagnitudes[i].encumbered - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_Added_AllocatableMagnitude(
         User operator,
         IStrategy[] memory strategies,
@@ -949,14 +1039,14 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     function assert_Snap_Removed_AllocatableMagnitude(
         User operator,
         IStrategy[] memory strategies,
-        uint64[] memory magnitudeAllocated,
+        uint64[] memory magnitudeRemoved,
         string memory err
     ) internal {
         Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, strategies);
         Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
-            assertEq(curMagnitudes[i].allocatable, prevMagnitudes[i].allocatable - magnitudeAllocated[i], err);
+            assertEq(curMagnitudes[i].allocatable, prevMagnitudes[i].allocatable - magnitudeRemoved[i], err);
         }
     }
 
@@ -1010,6 +1100,21 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_Allocation(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Allocation[] memory curAllocations = _getAllocations(operator, operatorSet, params.strategies);
+        Allocation[] memory prevAllocations = _getPrevAllocations(operator, operatorSet, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevAllocations[i].currentMagnitude.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curAllocations[i].currentMagnitude, prevAllocations[i].currentMagnitude - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_Unchanged_MaxMagnitude(
         User operator,
         IStrategy[] memory strategies,
@@ -1020,6 +1125,20 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         for (uint i = 0; i < strategies.length; i++) {
             assertEq(curMagnitudes[i].max, prevMagnitudes[i].max, err);
+        }
+    }
+
+    function assert_Snap_Slashed_MaxMagnitude(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevMagnitudes[i].max.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curMagnitudes[i].max, prevMagnitudes[i].max - expectedSlashed, err);
         }
     }
 
@@ -1235,6 +1354,47 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
                 expectedShares = prevShares[i] + uint(shareDeltas[i]);
             }
             assertEq(expectedShares, curShares[i], err);
+        }
+    }
+
+    function assert_Snap_Slashed_OperatorShares(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curShares = _getOperatorShares(operator, params.strategies);
+        uint[] memory prevShares = _getPrevOperatorShares(operator, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevShares[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curShares[i], prevShares[i] - expectedSlashed, err);
+        }
+    }
+
+    function assert_Snap_Increased_BurnableShares(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curBurnable = _getBurnableShares(params.strategies);
+        uint[] memory prevBurnable = _getPrevBurnableShares(params.strategies);
+
+        uint[] memory curShares = _getOperatorShares(operator, params.strategies);
+        uint[] memory prevShares = _getPrevOperatorShares(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint slashedAtLeast = prevShares[i] - curShares[i];
+
+            // Not factoring in slashable shares in queue here, because that gets more complex (TODO)
+            assertTrue(curBurnable[i] >= (prevBurnable[i] + slashedAtLeast), err);
         }
     }
 
@@ -1788,9 +1948,31 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         Magnitudes[] memory magnitudes = _getMagnitudes(operator, strategies);
 
         for (uint i = 0; i < params.strategies.length; i++) {
-            IStrategy strategy = params.strategies[i];
             uint64 halfAvailable = uint64(magnitudes[i].allocatable) / 2;
             params.newMagnitudes[i] = allocations[i].currentMagnitude + halfAvailable;
+        }
+    }
+
+    /// @dev Generate params to allocate a random portion of available magnitude to each strategy
+    /// in the operator set. All strategies will have a nonzero allocation, and the minimum allocation
+    /// will be 10% of available magnitude
+    function _genAllocation_Rand(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal returns (AllocateParams memory params) {
+        params.operatorSet = operatorSet;
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet);
+        params.newMagnitudes = new uint64[](params.strategies.length);
+
+        Allocation[] memory allocations = _getAllocations(operator, operatorSet, params.strategies);
+        Magnitudes[] memory magnitudes = _getMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            // minimum of 10%, maximum of 100%. increments of 10%.
+            uint r = _randUint({min: 1, max: 10});
+            uint64 allocation = uint64(magnitudes[i].allocatable) / uint64(r);
+
+            params.newMagnitudes[i] = allocations[i].currentMagnitude + allocation;
         }
     }
 
@@ -1839,10 +2021,44 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         User operator,
         OperatorSet memory operatorSet,
         IStrategy[] memory strategies
-    ) internal view returns (AllocateParams memory params) {
+    ) internal pure returns (AllocateParams memory params) {
         params.operatorSet = operatorSet;
         params.strategies = strategies;
         params.newMagnitudes = new uint64[](params.strategies.length);
+    }
+
+    /// Generate random slashing between 1 and 99%
+    function _genSlashing_Rand(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal returns (SlashingParams memory params) {
+        params.operator = address(operator);
+        params.operatorSetId = operatorSet.id;
+        params.description = "genSlashing_Half";
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet).sort();
+        params.wadsToSlash = new uint[](params.strategies.length);
+
+        /// 1% * rand(1, 99)
+        uint slashWad = 1e16 * _randUint({min: 1, max: 99});
+
+        for (uint i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = slashWad;
+        }
+    }
+
+    function _genSlashing_Half(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal view returns (SlashingParams memory params) {
+        params.operator = address(operator);
+        params.operatorSetId = operatorSet.id;
+        params.description = "genSlashing_Half";
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet).sort();
+        params.wadsToSlash = new uint[](params.strategies.length);
+
+        for (uint i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e17;
+        }
     }
 
     function _randWadToSlash() internal returns (uint) {
@@ -2370,6 +2586,38 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         OperatorSet memory operatorSet
     ) internal view returns (bool) {
         return allocationManager.isMemberOfOperatorSet(address(operator), operatorSet);
+    }
+
+    function _getPrevBurnableShares(IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
+        return _getBurnableShares(strategies);
+    }
+
+    function _getBurnableShares(IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory burnableShares = new uint[](strategies.length);
+
+        for (uint i = 0; i < strategies.length; i++) {
+            if (strategies[i] == beaconChainETHStrategy) {
+                burnableShares[i] = eigenPodManager.burnableETHShares();
+            } else {
+                burnableShares[i] = strategyManager.getBurnableShares(strategies[i]);
+            }
+        }
+
+        return burnableShares;
+    }
+
+    function _getPrevSlashableSharesInQueue(User operator, IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
+        return _getSlashableSharesInQueue(operator, strategies);
+    }
+
+    function _getSlashableSharesInQueue(User operator, IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory slashableShares = new uint[](strategies.length);
+
+        for (uint i = 0; i < strategies.length; i++) {
+            slashableShares[i] = delegationManager.getSlashableSharesInQueue(address(operator), strategies[i]);
+        }
+
+        return slashableShares;
     }
 
     /// @dev Uses timewarp modifier to get operator shares at the last snapshot

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -358,7 +358,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected deposit shares");
-        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "staker should have received expected withdrawable shares");
+        uint[] memory expectedWithdrawableShares = _getExpectedWithdrawableSharesUndelegate(staker, strategies, shares);
+        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, expectedWithdrawableShares, "staker should have received expected withdrawable shares");
         assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
     }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -243,6 +243,8 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_Undelegate_State: calculated withdrawal should match returned root");
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_Undelegate_State: stakers withdrawal should now be pending");
+        assert_DSF_Reset(staker, strategies,
+            "check_Undelegate_State: staker dsfs should be reset to wad");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,
             "check_Undelegate_State: staker should have increased nonce by withdrawals.length");
         assert_Snap_Removed_OperatorShares(operator, strategies, stakerDelegatedShares,

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -357,7 +357,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
-        assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected shares");
+        assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected deposit shares");
+        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "staker should have received expected withdrawable shares");
         assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
     }
@@ -486,18 +487,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_EncumberedMagnitude(operator, allStrats, "should not have updated encumbered magnitude");
         assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "should not have updated allocatable magnitude");
     }
-
-    // /// @dev Checks invariants for registration for a variety of allocation states
-    // /// 
-    // function check_Registration_State(
-    //     User operator,
-    //     OperatorSet memory operatorSet,
-    //     IStrategy[] memory unallocated,
-    //     AllocateParams memory pending,
-    //     AllocateParams memory active
-    // ) internal {
-    //     check_Base_Registration_State(operator, operatorSet);
-    // }
 
     /// @dev Check invariants for registerForOperatorSets given a set of strategies
     /// for which NO allocation exists (currentMag/pendingDiff are 0)
@@ -873,6 +862,37 @@ contract IntegrationCheckUtils is IntegrationBase {
         
         assert_MaxEqualsAllocatablePlusEncumbered(operator, "max magnitude should equal encumbered plus allocatable");
         check_ActiveModification_State(operator, deallocateParams); 
+    }
+
+    /*******************************************************************************
+                                ALM - SLASHING
+    *******************************************************************************/
+
+    function check_Base_Slashing_State(
+        User operator,
+        AllocateParams memory allocateParams,
+        SlashingParams memory slashParams
+    ) internal {
+        OperatorSet memory operatorSet = allocateParams.operatorSet;
+
+        check_MaxMag_Invariants(operator);
+        check_IsSlashable_State(operator, operatorSet, allocateParams.strategies);
+
+        // Slashing SHOULD change max magnitude and current allocation
+        assert_Snap_Slashed_MaxMagnitude(operator, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_AllocatedStake(operator, operatorSet, slashParams, "slash should lower allocated stake");
+        assert_Snap_Slashed_SlashableStake(operator, operatorSet, slashParams, "slash should lower slashable stake");
+        assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
+        assert_Snap_Slashed_Allocation(operator, operatorSet, slashParams, "slash should reduce current magnitude");
+        assert_Snap_Increased_BurnableShares(operator, slashParams, "slash should increase burnable shares");
+
+        // Slashing SHOULD NOT change allocatable magnitude, registration, and slashability status
+        assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");
+        assert_Snap_Unchanged_Registration(operator, operatorSet, "slash should not change registration status");
+        assert_Snap_Unchanged_Slashability(operator, operatorSet, "slash should not change slashability status");
+        assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
+        assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
     }
 
     // TODO: improvement needed 

--- a/src/test/integration/tests/ALM_RegisterAndModify.t.sol
+++ b/src/test/integration/tests/ALM_RegisterAndModify.t.sol
@@ -52,11 +52,9 @@ contract Integration_InitRegistered is Integration_ALMBase {
         check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
     }
 
-    function testFuzz_allocate_deallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_allocate_deallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Allocate to the operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -77,11 +75,9 @@ contract Integration_InitRegistered is Integration_ALMBase {
         check_FullyDeallocated_State(operator, allocateParams, deallocateParams);
     }
 
-    function testFuzz_allocate_deallocate_waitDeallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_allocate_deallocate_waitDeallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Allocate to the operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -111,7 +107,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
         _rollForward_DeallocationDelay();
 
         // 3. Allocate to operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
 
@@ -132,7 +128,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
 
         // 2. Before deregistration is complete, allocate to operator set
         // The operator should be slashable after the allocation delay
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -156,7 +152,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
 
         // 2. Before deregistration is complete, allocate to operator set
         // The operator should be slashable after the allocation delay
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -184,9 +180,7 @@ contract Integration_InitAllocated is Integration_ALMBase {
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
     }
 
-    function testFuzz_register_deallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_register_deallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Register for the operator set
         operator.registerForOperatorSet(operatorSet);
         check_Registration_State_PendingAllocation(operator, allocateParams);
@@ -208,9 +202,7 @@ contract Integration_InitAllocated is Integration_ALMBase {
         check_FullyDeallocated_State(operator, allocateParams, deallocateParams);
     }
 
-    function testFuzz_waitAllocation_register_deallocate(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_waitAllocation_register_deallocate(uint24 _r) public rand(_r) {
         _rollForward_AllocationDelay(operator);
 
         // 1. Register for the operator set. The allocation immediately becomes slashable

--- a/src/test/integration/users/AVS.t.sol
+++ b/src/test/integration/users/AVS.t.sol
@@ -116,6 +116,37 @@ contract AVS is Logger, IAllocationManagerTypes, IAVSRegistrar {
     }
 
     function slashOperator(
+        SlashingParams memory params
+    ) public createSnapshot {
+
+
+        for (uint256 i; i < params.strategies.length; ++i) {
+            string memory strategyName = params.strategies[i] == beaconChainETHStrategy ? 
+                "Native ETH" : 
+                IERC20Metadata(address(params.strategies[i].underlyingToken())).name();
+
+            print.method(
+                "slashOperator",
+                string.concat(
+                    "{operator: ",
+                    User(payable(params.operator)).NAME_COLORED(),
+                    ", operatorSetId: ",
+                    cheats.toString(params.operatorSetId),
+                    ", strategy: ",
+                    strategyName,
+                    ", wadToSlash: ",
+                    params.wadsToSlash[i].asWad(),
+                    "}"
+                )
+            );
+        }
+
+        _tryPrankAppointee_AllocationManager(IAllocationManager.slashOperator.selector);
+        allocationManager.slashOperator(address(this), params);
+        print.gasUsed();
+    }
+
+    function slashOperator(
         User operator, 
         uint32 operatorSetId, 
         IStrategy[] memory strategies, 


### PR DESCRIPTION
**Motivation:**

Improve slashing invariants in integration tests

**Modifications:**

Adds `check_Base_Slashing_State`, and implements several checks used within

**Result:**

Slashing invariants check all manner of state changes in the ALM and delegation.
