### PR TITLE
chore: update to open source zeus repo

### DIFF
--- a/.zeus
+++ b/.zeus
@@ -1,4 +1,4 @@
 {
-    	"zeusHost": "https://github.com/Layr-Labs/eigenlayer-contracts-metadata",
+	"zeusHost": "https://github.com/Layr-Labs/eigenlayer-contracts-zeus-metadata",
 	"migrationDirectory": "script/releases"
 }


### PR DESCRIPTION
- We're sunsetting the previous repository for our new repo.
- We're squashing commit history here in-case anything unintentional was added to that repo during the development of Zeus, as a pre-caution for Open Source.