### PR TITLE
fix: avs registrar interface

### DIFF
--- a/script/tasks/register_operator_to_operatorSet.s.sol
+++ b/script/tasks/register_operator_to_operatorSet.s.sol
@@ -11,8 +11,8 @@ import "forge-std/Test.sol";
 
 // Define dummy AVSRegistrar contract to prevent revert
 contract AVSRegistrar is IAVSRegistrar {
-    function registerOperator(address operator, uint32[] calldata operatorSetIds, bytes calldata data) external {}
-    function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external {}
+    function registerOperator(address operator, address avs, uint32[] calldata operatorSetIds, bytes calldata data) external {}
+    function deregisterOperator(address operator, address avs, uint32[] calldata operatorSetIds) external {}
     fallback () external {}
 }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -273,7 +273,7 @@ contract AllocationManager is
         }
 
         // Call the AVS to complete registration. If the AVS reverts, registration will fail.
-        getAVSRegistrar(params.avs).registerOperator(operator, params.operatorSetIds, params.data);
+        getAVSRegistrar(params.avs).registerOperator(operator, params.avs, params.operatorSetIds, params.data);
     }
 
     /// @inheritdoc IAllocationManager
@@ -304,7 +304,8 @@ contract AllocationManager is
 
         // Call the AVS to complete deregistration. Even if the AVS reverts, the operator is
         // considered deregistered
-        try getAVSRegistrar(params.avs).deregisterOperator(params.operator, params.operatorSetIds) {} catch {}
+        try getAVSRegistrar(params.avs).deregisterOperator(params.operator, params.avs, params.operatorSetIds) {}
+            catch {}
     }
 
     /// @inheritdoc IAllocationManager

--- a/src/contracts/interfaces/IAVSRegistrar.sol
+++ b/src/contracts/interfaces/IAVSRegistrar.sol
@@ -7,16 +7,23 @@ interface IAVSRegistrar {
      * for one or more operator sets. This method should revert if registration
      * is unsuccessful.
      * @param operator the registering operator
+     * @param avs the address of the AVS this operator set belongs to
      * @param operatorSetIds the list of operator set ids being registered for
      * @param data arbitrary data the operator can provide as part of registration
      */
-    function registerOperator(address operator, uint32[] calldata operatorSetIds, bytes calldata data) external;
+    function registerOperator(
+        address operator,
+        address avs,
+        uint32[] calldata operatorSetIds,
+        bytes calldata data
+    ) external;
 
     /**
      * @notice Called by the AllocationManager when an operator is deregistered from
      * one or more operator sets. If this method reverts, it is ignored.
      * @param operator the deregistering operator
+     * @param avs the address of the AVS this operator set belongs to
      * @param operatorSetIds the list of operator set ids being deregistered from
      */
-    function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external;
+    function deregisterOperator(address operator, address avs, uint32[] calldata operatorSetIds) external;
 }

--- a/src/test/integration/users/AVS.t.sol
+++ b/src/test/integration/users/AVS.t.sol
@@ -200,11 +200,16 @@ contract AVS is Logger, IAllocationManagerTypes, IAVSRegistrar {
 
     function registerOperator(
         address operator,
+        address avs,
         uint32[] calldata operatorSetIds,
         bytes calldata data
     ) external override {}
 
-    function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external override {}
+    function deregisterOperator(
+        address operator,
+        address avs,
+        uint32[] calldata operatorSetIds
+    ) external override {}
 
     /// -----------------------------------------------------------------------
     /// Internal Helpers

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3609,7 +3609,7 @@ contract AllocationManagerUnitTests_registerForOperatorSets is AllocationManager
         }
 
         cheats.expectCall(
-            defaultAVS, abi.encodeWithSelector(IAVSRegistrar.registerOperator.selector, operator, operatorSetIds, "")
+            defaultAVS, abi.encodeWithSelector(IAVSRegistrar.registerOperator.selector, operator, defaultAVS, operatorSetIds, "")
         );
 
         cheats.prank(operator);
@@ -3710,7 +3710,7 @@ contract AllocationManagerUnitTests_deregisterFromOperatorSets is AllocationMana
         }
 
         cheats.expectCall(
-            defaultAVS, abi.encodeWithSelector(IAVSRegistrar.deregisterOperator.selector, operator, operatorSetIds)
+            defaultAVS, abi.encodeWithSelector(IAVSRegistrar.deregisterOperator.selector, operator, defaultAVS, operatorSetIds)
         );
 
         bool callFromAVS = r.Boolean();


### PR DESCRIPTION
**Motivation:**

Currently there is no way for an AVS implementing these callback functions of the `IAVSRegistrar.sol` to verify that the operatorSetIds belong to their operatorSets. This is because AVSRegistrar configuration does not have uniqueness and implementing uniqueness in the AllocationManager is not feasible due to frontrunning DOS vectors for existing AVSs.

**Modifications:**

`IAVSRegistrar.sol` interface

**Result:**

- Allowing AVSs to verify the correct operatorSet is being passed into their register/deregister callback functions and whether or not to proceed with the Operator action.
- Downstream breaking interface changes for AVSs
