### PR TITLE
fix: beaconchain slashable shares in queue

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -770,13 +770,11 @@ contract DelegationManager is
 
     /// @dev Add to the cumulative withdrawn scaled shares from an operator for a given strategy
     function _addQueuedSlashableShares(address operator, IStrategy strategy, uint256 scaledShares) internal {
-        if (strategy != beaconChainETHStrategy) {
-            uint256 currCumulativeScaledShares = _cumulativeScaledSharesHistory[operator][strategy].latest();
-            _cumulativeScaledSharesHistory[operator][strategy].push({
-                key: uint32(block.number),
-                value: currCumulativeScaledShares + scaledShares
-            });
-        }
+        uint256 currCumulativeScaledShares = _cumulativeScaledSharesHistory[operator][strategy].latest();
+        _cumulativeScaledSharesHistory[operator][strategy].push({
+            key: uint32(block.number),
+            value: currCumulativeScaledShares + scaledShares
+        });
     }
 
     /// @dev Get the shares from a queued withdrawal.


### PR DESCRIPTION
**Motivation:**  

Fixes an issue where `beaconChainETHStrategy` queued withdrawals were excluded from slashable shares tracking, leading to undercounted burnable shares. This ensures correct accounting for future ETH burning post-Ethereum Pectra upgrade.  (EGSL-03)

**Modifications:**  

- Removed exclusion of `beaconChainETHStrategy` in `_addQueuedSlashableShares()`.  
- Updated tests to ensure correct tracking and slashing behavior.  

**Result:**  

- Proper tracking of `beaconChainETHStrategy` shares in slashing calculations.  
- Accurate burnable share accounting, preparing for future ETH burning.