### PR TITLE
fix: funny syntax

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -227,7 +227,7 @@ contract AllocationManager is
                 // 6. Emit an event for the updated allocation
                 emit AllocationUpdated(
                     operator,
-                    OperatorSetLib.decode(operatorSet.key()),
+                    operatorSet,
                     strategy,
                     _addInt128(allocation.currentMagnitude, allocation.pendingDiff),
                     allocation.effectBlock

--- a/src/contracts/libraries/OperatorSetLib.sol
+++ b/src/contracts/libraries/OperatorSetLib.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+using OperatorSetLib for OperatorSet global;
+
 /**
  * @notice An operator set identified by the AVS address and an identifier
  * @param avs The address of the AVS this operator set belongs to


### PR DESCRIPTION
**Modifications:**

- `OperatorSetLib.decode(operatorSet.key())` -> `operatorSet`
