### PR TITLE
fix: set registrar check

### DIFF
--- a/script/tasks/register_operator_to_operatorSet.s.sol
+++ b/script/tasks/register_operator_to_operatorSet.s.sol
@@ -13,6 +13,7 @@ import "forge-std/Test.sol";
 contract AVSRegistrar is IAVSRegistrar {
     function registerOperator(address operator, uint32[] calldata operatorSetIds, bytes calldata data) external {}
     function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external {}
+    function avs() external view returns (address) {}
     fallback () external {}
 }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -318,6 +318,9 @@ contract AllocationManager is
 
     /// @inheritdoc IAllocationManager
     function setAVSRegistrar(address avs, IAVSRegistrar registrar) external checkCanCall(avs) {
+        // Check that the registrar is correctly configured to prevent an AVSRegistrar contract
+        // from being used with the wrong AVS
+        require(registrar.avs() == avs, InvalidAVSRegistrar());
         _avsRegistrar[avs] = registrar;
         emit AVSRegistrarSet(avs, getAVSRegistrar(avs));
     }

--- a/src/contracts/interfaces/IAVSRegistrar.sol
+++ b/src/contracts/interfaces/IAVSRegistrar.sol
@@ -19,4 +19,11 @@ interface IAVSRegistrar {
      * @param operatorSetIds the list of operator set ids being deregistered from
      */
     function deregisterOperator(address operator, uint32[] calldata operatorSetIds) external;
+
+    /**
+     * @notice Returns the account identifier address of the AVS. This should be the
+     * the same address as the AVS's UAM account identifier address.
+     * @return address of the AVS
+     */
+    function avs() external view returns (address);
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -13,6 +13,9 @@ interface IAllocationManagerErrors {
     error InvalidWadToSlash();
     /// @dev Thrown when two array parameters have mismatching lengths.
     error InputArrayLengthMismatch();
+    /// @dev Thrown when the AVSRegistrar is not correctly configured to prevent an AVSRegistrar contract
+    /// from being used with the wrong AVS
+    error InvalidAVSRegistrar();
 
     /// Caller
 

--- a/src/test/integration/users/AVS.t.sol
+++ b/src/test/integration/users/AVS.t.sol
@@ -63,6 +63,10 @@ contract AVS is Logger, IAllocationManagerTypes, IAVSRegistrar {
         return _NAME;
     }
 
+    function avs() external view override returns (address) {
+        return address(this);
+    }
+
     /// -----------------------------------------------------------------------
     /// AllocationManager
     /// -----------------------------------------------------------------------


### PR DESCRIPTION
**Motivation:**

https://github.com/Layr-Labs/eigenlayer-contracts/pull/1085
An alternate solution to this problem with less intrusive changes to AVS integrations.

**Modifications:**

Adding a `avs()` view function to `IAVSRegistrar.sol` and an additional require check in `setAVSRegistrar`

**Result:**

Uniqueness of AVS registrars set per AVS.
