### PR TITLE
feat: parallelize all test suites to expedite CI run time

### DIFF
--- a/.github/workflows/parallel_tests.yml
+++ b/.github/workflows/parallel_tests.yml
@@ -1,0 +1,40 @@
+name: Run Parallel Tests
+
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  test-suite:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        suite: [unit, integration, fork]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Forge build
+        run: |
+          forge --version
+          forge build
+
+      - name: Run ${{ matrix.suite }} tests
+        run: |
+          case "${{ matrix.suite }}" in
+            unit) forge test --no-match-contract Integration ;;
+            integration) forge test --match-contract Integration ;;
+            fork) forge test --match-contract Integration ;;
+          esac
+        env:
+          FOUNDRY_PROFILE: ${{ matrix.suite == 'fork' && 'forktest' || '' }}
+          RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
+          RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
+          CHAIN_ID: ${{ secrets.CHAIN_ID }}


### PR DESCRIPTION
**Motivation:**

parallelize unit, integration and fork tests to make CI time significantly faster

note currently tho the github action is called "testinparallel", unit, integration and fork tests are not parallelized

their time:
- unit test: 2-3 min
- integration test: 9-10 min
- fork test: 12-13 min


they run in sequence so the total time is sum(all tests) which is roughly 25-26 min. See https://github.com/Layr-Labs/eigenlayer-contracts/actions/runs/13208807194/job/36878141793?pr=1025 for example

by parallelizing the three test suites, we shrink the CI test to ~11-12 min in total https://github.com/Layr-Labs/eigenlayer-contracts/actions/runs/13209105775?pr=1074

- unit test: 2-3 min
- integration test: 9-10 min (total CI time is bounded by this test now)
- fork test: 6-7 min (not exactly sure why this got 2x improvement down from 12-13 min, my theory is that when running in sequence previously, integration tests run before fork test, and integration tests may hv resources not shut down completely, leading to significantly slow execution of fork test)

**Modifications:**

parallelize unit, integration and fork tests to make CI time significantly faster

**Result:**

*After your change, what will change.*
