### PR TITLE
perf: use x86 16core machine for CI

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -20,7 +20,7 @@ jobs:
 
   test-suite:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: protocol-x64-16core
     strategy:
       matrix:
         suite: [Unit, Integration, Fork]

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -66,7 +66,7 @@ jobs:
 
   continuous-fuzzing:
     name: Test (Intense)
-    runs-on: ubuntu-latest
+    runs-on: protocol-x64-16core
     # Only run on push events to dev branch, not on PR events
     if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     strategy:
@@ -103,7 +103,7 @@ jobs:
 
   storage-diff:
     name: Test (Storage)
-    runs-on: ubuntu-latest
+    runs-on: protocol-x64-16core
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
 
   run-coverage:
     name: Coverage
-    runs-on: ubuntu-latest
+    runs-on: protocol-x64-16core
     # Only run coverage checks on dev, testnet-holesky, and mainnet branches, or PRs targeting these branches
     if: |
       github.ref == 'refs/heads/dev' ||
@@ -208,7 +208,7 @@ jobs:
 
   compare-contract-sizes:
     name: Size Diff
-    runs-on: ubuntu-latest
+    runs-on: protocol-x64-16core
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Motivation:**

use more powerful machine to run CI and speed it up

we've tested in following combo:

- arch: x86 vs arm64
- cpu: 8 vs 16 vs 32 cores 

turns out our CI has best perf on x86 16core. 

**Modifications:**

use X86 16core runner i configured to run all CI jobs

**Result:**

improvements results:

- integration: 10min -> 4min, 2.5X
- forktest: 16min -> 4min, 4X
- intense fuzz tests: 2.5h -> 56min, 2.5X
- test storage: 13 min -> 2min, 6.5X
- coverage: 22min -> 8min, 3X
