### PR TITLE
refactor: limit continuous fuzzing to dev branch

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -67,6 +67,8 @@ jobs:
   continuous-fuzzing:
     name: Test (Intense)
     runs-on: ubuntu-latest
+    # Only run on push events to dev branch, not on PR events
+    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
**Motivation:**

per chat w/ @0xClandestine , given continuous fuzzing tests takes too long (currently ~2.5h ish), we wanna make it only run when a commit is merged to dev branch, instead of every PR change

it should make the CI passes as a whole a lot faster, and save us huge money spent on github actions

**Modifications:**

make continuous fuzzing only run when a commit is merged to dev branch, instead of every PR change

**Result:**

*After your change, what will change.*
