### PR TITLE
fix: dont call strategy if we have no burnable shares

### DIFF
--- a/docs/core/StrategyManager.md
+++ b/docs/core/StrategyManager.md
@@ -298,6 +298,8 @@ function burnShares(
 
 Anyone can call this method to burn slashed shares previously added by the `DelegationManager` via `increaseBurnableShares`. This method resets the strategy's burnable shares to 0, and directs the corresponding `strategy` to convert the shares to tokens and transfer them to `DEFAULT_BURN_ADDRESS`, rendering them unrecoverable.
 
+The `strategy` is not called if the strategy had no burnable shares.
+
 *Effects*:
 * Resets the strategy's burnable shares to 0
 * Calls `withdraw` on the `strategy`, withdrawing shares and sending a corresponding amount of tokens to the `DEFAULT_BURN_ADDRESS`

--- a/src/contracts/core/StrategyManager.sol
+++ b/src/contracts/core/StrategyManager.sol
@@ -158,8 +158,12 @@ contract StrategyManager is
         (, uint256 sharesToBurn) = EnumerableMap.tryGet(burnableShares, address(strategy));
         EnumerableMap.remove(burnableShares, address(strategy));
         emit BurnableSharesDecreased(strategy, sharesToBurn);
-        // burning shares is functionally the same as withdrawing but with different destination address
-        strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn);
+
+        // Burning acts like withdrawing, except that the destination is to the burn address.
+        // If we have no shares to burn, we don't need to call the strategy.
+        if (sharesToBurn != 0) {
+            strategy.withdraw(DEFAULT_BURN_ADDRESS, strategy.underlyingToken(), sharesToBurn);
+        }
     }
 
     /// @inheritdoc IStrategyManager


### PR DESCRIPTION
**Motivation:**

Fixes an issue arbitrary external contracts could be called via `StrategyManager.burnShares`. (Certora L-04)

**Modifications:**

`StrategyManager.burnShares` does not do an external call if the burnable share amount is zero

**Result:**

Should no longer be possible to call untrusted code directly through `burnShares`