### PR TITLE
perf: run Foundry CI tests only for relevant code changes

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -3,9 +3,21 @@ name: Foundry
 on:
   workflow_dispatch:
   pull_request:
+    paths:
+      - '.github/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'certora/**'
+      - 'foundry.toml'
   push:
     branches:
       - "dev"
+    paths:
+      - '.github/**'
+      - 'src/**'
+      - 'lib/**'
+      - 'certora/**'
+      - 'foundry.toml'
 
 env:
   FOUNDRY_PROFILE: ci

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/**'
+      - 'bin/**'
       - 'src/**'
       - 'lib/**'
       - 'certora/**'
@@ -14,6 +15,7 @@ on:
       - "dev"
     paths:
       - '.github/**'
+      - 'bin/**'
       - 'src/**'
       - 'lib/**'
       - 'certora/**'

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -10,6 +10,7 @@ on:
       - 'lib/**'
       - 'certora/**'
       - 'foundry.toml'
+      - '**/*.sol'
   push:
     branches:
       - "dev"
@@ -20,6 +21,7 @@ on:
       - 'lib/**'
       - 'certora/**'
       - 'foundry.toml'
+      - '**/*.sol'
 
 env:
   FOUNDRY_PROFILE: ci


### PR DESCRIPTION
**Motivation:**  

Foundry tests only need to run when specific codebase paths are modified, rather than for all changes.  

For example, tests are not required when only documentation or deployment scripts are updated.  

**Modifications:**  

- Added a list of code paths that trigger Foundry tests when modified.  

**Result:**  

- Speeds up CI for non-core contract changes.  
- Reduces CI costs.