### PR TITLE
perf: speed up test coverage job in CI

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -183,7 +183,7 @@ jobs:
       # Run Forge coverage with LCOV report format, excluding test and script files
       - name: Forge Coverage
         run: |
-          FOUNDRY_DENY_WARNINGS=false FOUNDRY_PROFILE=ci forge coverage --report lcov --report summary --no-match-coverage "script|test"
+          FOUNDRY_DENY_WARNINGS=false FOUNDRY_PROFILE=ci forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)
           genhtml -q -o report ./lcov.info
 
       # Upload coverage report as artifact before potential failure

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -204,11 +204,6 @@ jobs:
           FOUNDRY_CACHE_PATH=cache \
           forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)
           genhtml -q -o report ./lcov.info
-        env:
-          FOUNDRY_FUZZ_RUNS: 1  # Reduce fuzz runs for coverage
-          FOUNDRY_MATCH_TEST: ""  # Don't filter tests
-          FOUNDRY_INVARIANT_RUNS: 1  # Reduce invariant test runs
-          FOUNDRY_FUZZ_MAX_TEST_REJECTS: 65536
 
       # Upload coverage report as artifact before potential failure
       - name: Upload Coverage Report

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -160,6 +160,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      
+      # Cache Foundry dependencies
+      - name: Cache Foundry dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo
+            ~/.foundry
+            out/
+            cache/
+          key: ${{ runner.os }}-foundry-${{ hashFiles('**/foundry.toml', '**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-
 
       # Install the Foundry toolchain.
       - name: "Install Foundry"
@@ -170,7 +183,7 @@ jobs:
       # Install LCOV for coverage report generation.
       - name: Install LCOV
         run: |
-          sudo apt-get install lcov
+          sudo apt-get install -y lcov
         id: lcov
 
       # Build the project and display contract sizes.
@@ -183,8 +196,19 @@ jobs:
       # Run Forge coverage with LCOV report format, excluding test and script files
       - name: Forge Coverage
         run: |
-          FOUNDRY_DENY_WARNINGS=false FOUNDRY_PROFILE=ci forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)
+          FOUNDRY_DENY_WARNINGS=false \
+          FOUNDRY_PROFILE=ci \
+          FOUNDRY_OPTIMIZER=true \
+          FOUNDRY_OPTIMIZER_RUNS=1000000 \
+          FOUNDRY_CACHE=true \
+          FOUNDRY_CACHE_PATH=cache \
+          forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)
           genhtml -q -o report ./lcov.info
+        env:
+          FOUNDRY_FUZZ_RUNS: 1  # Reduce fuzz runs for coverage
+          FOUNDRY_MATCH_TEST: ""  # Don't filter tests
+          FOUNDRY_INVARIANT_RUNS: 1  # Reduce invariant test runs
+          FOUNDRY_FUZZ_MAX_TEST_REJECTS: 65536
 
       # Upload coverage report as artifact before potential failure
       - name: Upload Coverage Report
@@ -192,6 +216,7 @@ jobs:
         with:
           name: code-coverage-report
           path: report/*
+          if-no-files-found: error
 
       # Check coverage threshold after uploading report
       - name: Check Coverage Threshold

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -24,7 +24,7 @@ on:
       - '**/*.sol'
 
 env:
-  FOUNDRY_PROFILE: ci
+  FOUNDRY_PROFILE: medium
   RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
   RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
   CHAIN_ID: ${{ secrets.CHAIN_ID }}
@@ -74,7 +74,7 @@ jobs:
             Fork) forge test --match-contract Integration ;;
           esac
         env:
-          FOUNDRY_PROFILE: ${{ matrix.suite == 'Fork' && 'forktest' || 'ci' }}
+          FOUNDRY_PROFILE: ${{ matrix.suite == 'Fork' && 'forktest' || 'medium' }}
 
   # -----------------------------------------------------------------------
   # Forge Test (Intense)
@@ -197,9 +197,7 @@ jobs:
       - name: Forge Coverage
         run: |
           FOUNDRY_DENY_WARNINGS=false \
-          FOUNDRY_PROFILE=ci \
-          FOUNDRY_OPTIMIZER=true \
-          FOUNDRY_OPTIMIZER_RUNS=1000000 \
+          FOUNDRY_PROFILE=medium \
           FOUNDRY_CACHE=true \
           FOUNDRY_CACHE_PATH=cache \
           forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Forge Coverage
         run: |
           FOUNDRY_DENY_WARNINGS=false \
-          FOUNDRY_PROFILE=medium \
+          FOUNDRY_PROFILE=coverage \
           FOUNDRY_CACHE=true \
           FOUNDRY_CACHE_PATH=cache \
           forge coverage --report lcov --report summary --no-match-coverage "script|test" -j $(nproc)

--- a/foundry.toml
+++ b/foundry.toml
@@ -91,17 +91,21 @@
 #         "./src/contracts/**/*"
 #     ]
 
-[profile.ci]
-    fuzz.optimizer = false
-    fuzz.runs = 1
-    invariant_runs = 1
+[profile.forktest.fuzz]    
+    optimizer = false
+    runs = 16
+
+[profile.coverage.fuzz]
+    optimizer = false
+    runs = 1
+
+[profile.medium.fuzz]
+    optimizer = false
+    runs = 256
 
 [profile.intense.fuzz]
     optimizer = false
     runs = 5000
-
-[profile.forktest.fuzz]
-    runs = 16
 
 [rpc_endpoints]
     mainnet = "${RPC_MAINNET}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -94,9 +94,7 @@
 [profile.ci]
     fuzz.optimizer = false
     fuzz.runs = 1
-    match_test = ''
     invariant_runs = 1
-    max_test_rejects = 65536
 
 [profile.intense.fuzz]
     optimizer = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -91,9 +91,12 @@
 #         "./src/contracts/**/*"
 #     ]
 
-[profile.ci.fuzz]
-    optimizer = false
-    runs = 256
+[profile.ci]
+    fuzz.optimizer = false
+    fuzz.runs = 1
+    match_test = ''
+    invariant_runs = 1
+    max_test_rejects = 65536
 
 [profile.intense.fuzz]
     optimizer = false


### PR DESCRIPTION
**Motivation:**  

After multiple improvements to other parts of our CI, the coverage job has become the longest-running task, limiting the total CI runtime.  

This PR significantly reduces the coverage runtime from **16-18 minutes** (already down from **26 minutes** thanks to a previous improvement using an x64 16-core runner) to just **2 minutes**—an **8-9x speedup**.  

**Modifications:**  

- Parallelized coverage report generation.  
- Cached Foundry and Cargo artifacts.  
- Optimized Forge arguments.

**Result:**  

The coverage runtime is reduced from **16-18 minutes** (previously **26 minutes**) to **2 minutes**, achieving an **8-9x improvement**.