### PR TITLE
docs: fix all misspellings

### DIFF
--- a/certora/specs/core/Slasher.spec
+++ b/certora/specs/core/Slasher.spec
@@ -142,7 +142,7 @@ invariant listHeadHasSmallestValueOfLatestUpdateBlock(address operator, uint256 
 TODO: rule doesn't pass. We've got separate rules for checking the LinkedList lib properties.
 key properties seem to be that
 1) `StructuredLinkedList._createLink` creates only two-way links
-2) `StructuredLinkedList.remove` removes both links from a node, and stiches together its existing links (which it breaks)
+2) `StructuredLinkedList.remove` removes both links from a node, and stitches together its existing links (which it breaks)
 3) `StructuredLinkedList._insert` similarly inserts a new node 'between' nodes, ensuring that the new node is well-linked
 invariant consistentListStructure(address operator, uint256 node1)
 	(

--- a/certora/specs/libraries/StructuredLinkedList.spec
+++ b/certora/specs/libraries/StructuredLinkedList.spec
@@ -134,7 +134,7 @@ invariant headInList(uint256 node)
 
 /*
 1) `StructuredLinkedList._createLink` creates only two-way links
-2) `StructuredLinkedList.remove` removes both links from a node, and stiches together its existing links (which it breaks)
+2) `StructuredLinkedList.remove` removes both links from a node, and stitches together its existing links (which it breaks)
 3) `StructuredLinkedList._insert` similarly inserts a new node 'between' nodes, ensuring that the new node is well-linked
 */
 /*

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ See full documentation in [`/core/RewardsCoordinator.md`](./core/RewardsCoordina
 | -------- | -------- | -------- |
 | [`AVSDirectory.sol`](../src/contracts/core/AVSDirectory.sol) | Singleton | Transparent proxy |
 
-##### Note: This contract is left unchanged for backwards compatability. Operator<>AVS Registrations are to be replaced entirely with the `AllocationManager` and this contract will be deprecated in a future release.
+##### Note: This contract is left unchanged for backwards compatibility. Operator<>AVS Registrations are to be replaced entirely with the `AllocationManager` and this contract will be deprecated in a future release.
 
 Previously, the `AVSDirectory` handled interactions between AVSs and the EigenLayer core contracts. Once registered as an operator in EigenLayer core (via the `DelegationManager`), operators could register with one or more AVSs (via the AVS's contracts) to begin providing services to them offchain. As a part of registering with an AVS, the AVS would record this registration in the core contracts by calling into the `AVSDirectory`. As of the slashing release, this process is now managed by the [`AllocationManager`](#allocationmanager).
 

--- a/docs/core/AVSDirectory.md
+++ b/docs/core/AVSDirectory.md
@@ -18,7 +18,7 @@ Functionality is provided for AVSs to migrate from an pre-operatorSet registrati
 function becomeOperatorSetAVS() external;
 ```
 
-AVSs call this to become an operator set AVS. Once an AVS becomes an operator set AVS, they can no longer register operators via the legacy M2 registration path. This is a seperate function to help avoid accidental migrations to the operator set AVS model.
+AVSs call this to become an operator set AVS. Once an AVS becomes an operator set AVS, they can no longer register operators via the legacy M2 registration path. This is a separate function to help avoid accidental migrations to the operator set AVS model.
 
 ## `createOperatorSets`
 ```solidity
@@ -122,7 +122,7 @@ function forceDeregisterFromOperatorSets(
 
 Operators can use this function to deregister from an operator set without requiring the AVS to sign off on the deregistration. This function is intended to be used in cases where the AVS contracts are in a state that prevents operators from deregistering (either malicious or unintentional).
 
-Operators can also deallocate their slashable stake allocation seperately to avoid slashing risk, so this function is mainly for external integrations to interpret the correct state of the protocol.
+Operators can also deallocate their slashable stake allocation separately to avoid slashing risk, so this function is mainly for external integrations to interpret the correct state of the protocol.
 
 ## `updateAVSMetadataURI`
 ```solidity
@@ -142,4 +142,4 @@ This function allows an AVS to update the metadata URI associated with the AVS. 
 
 ## View Functions
 
-See the [AVS Directory Inteface](../../../src/contracts/interfaces/IAVSDirectory.sol) for view functions. 
+See the [AVS Directory Interface](../../../src/contracts/interfaces/IAVSDirectory.sol) for view functions. 

--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -463,7 +463,7 @@ _Note: this method can be called directly by an operator, or by a caller authori
 
 This function is called by an operator to EITHER increase OR decrease the slashable magnitude allocated from a strategy to an operator set. As input, the operator provides an operator set as the target, and a list of strategies and corresponding `newMagnitudes` to allocate. The `newMagnitude` value is compared against the operator's current `Allocation` for that operator set/strategy:
 * If `newMagnitude` is _greater than_ `Allocation.currentMagnitude`, this is an allocation
-* If `newMagnitude` is _less than_ `Allocation.currentMagnitude`, this is a dellocation
+* If `newMagnitude` is _less than_ `Allocation.currentMagnitude`, this is a deallocation
 * If `newMagnitude` is _equal to_ `Allocation.currentMagnitude`, this is invalid (revert)
 
 Allocation modifications play by different rules depending on a few factors. Recall that at all times, the `encumberedMagnitude` for a strategy may not exceed that strategy's `maxMagnitude`. Additionally, note that _before processing a modification for a strategy,_ the `deallocationQueue` for that strategy is first cleared. This ensures any completable deallocations are processed first, freeing up magnitude for allocation. This process is further explained in [`clearDeallocationQueue`](#cleardeallocationqueue). 
@@ -550,7 +550,7 @@ This queue contains a per-strategy ordered list of operator sets that, due to pr
 This method stops iterating when: the queue is empty, a deallocation is reached that cannot be completed yet, or when it has cleared `numToClear` entries from the queue.
 
 *Effects*:
-* For each `strategy` and _completeable_ deallocation in `deallocationQueue[operator][strategy]`:
+* For each `strategy` and _completable_ deallocation in `deallocationQueue[operator][strategy]`:
     * Pops the corresponding operator set from the `deallocationQueue`
     * Reduces `allocation.currentMagnitude` by the deallocated amount
     * Sets `allocation.pendingDiff` and `allocation.effectBlock` to 0
@@ -602,7 +602,7 @@ AVSs use slashing as a punitive disincentive for misbehavior. For details and ex
 
 In order to slash an eligible operator, the AVS specifies which operator set the operator belongs to, the `strategies` the operator should be slashed for, and for each strategy, the _proportion of the operator's allocated magnitude_ that should be slashed (given by `wadsToSlash`). An optional `description` string allows the AVS to add context to the slash.
 
-Once triggered in the `AllocationManager`, slashing is instant and irreversable. For each slashed strategy, the operator's `maxMagnitude` and `encumberedMagnitude` are decreased, and the allocation made to the given operator set has its `currentMagnitude` reduced. See [TODO - Accounting Doc]() for details on how slashed amounts are calculated.
+Once triggered in the `AllocationManager`, slashing is instant and irreversible. For each slashed strategy, the operator's `maxMagnitude` and `encumberedMagnitude` are decreased, and the allocation made to the given operator set has its `currentMagnitude` reduced. See [TODO - Accounting Doc]() for details on how slashed amounts are calculated.
 
 There are two edge cases to note for this method:
 1. In the process of slashing an `operator` for a given `strategy`, if the `Allocation` being slashed has a `currentMagnitude` of 0, the call will NOT revert. Instead, the `strategy` is skipped and slashing continues with the next `strategy` listed. This is to prevent an edge case where slashing occurs on or around a deallocation's `effectBlock` -- if the call reverted, the entire slash would fail. Skipping allows any valid slashes to be processed without requiring resubmission.

--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -47,7 +47,7 @@ The `DelegationManager's` responsibilities can be broken down into the following
 The `DelegationManager` tracks operator-related state in the following mappings:
 
 ```solidity
-/// @notice Returns the `operator` a `staker` is delgated to, or address(0) if not delegated.
+/// @notice Returns the `operator` a `staker` is delegated to, or address(0) if not delegated.
 /// Note: operators are delegated to themselves
 mapping(address staker => address operator) public delegatedTo;
 
@@ -192,7 +192,7 @@ The `DelegationManager` tracks withdrawal-related state in the following mapping
  *
  * @param staker The address that queued the withdrawal
  * @param delegatedTo The address that the staker was delegated to at the time the withdrawal was queued. Used to determine if additional slashing occurred before
- * this withdrawal became completeable.
+ * this withdrawal became completable.
  * @param withdrawer The address that will call the contract to complete the withdrawal. Note that this will always equal `staker`; alternate withdrawers are not
  * supported at this time.
  * @param nonce The staker's `cumulativeWithdrawalsQueued` at time of queuing. Used to ensure withdrawals have unique hashes.
@@ -464,7 +464,7 @@ struct QueuedWithdrawalParams {
  * to slashing. If any slashing has occurred, the shares received may be less than the queued deposit shares.
  *
  * @dev To view all the staker's strategies/deposit shares that can be queued for withdrawal, see `getDepositedShares`
- * @dev To view the current coversion between a staker's deposit shares and withdrawable shares, see `getWithdrawableShares`
+ * @dev To view the current conversion between a staker's deposit shares and withdrawable shares, see `getWithdrawableShares`
  */
 function queueWithdrawals(
     QueuedWithdrawalParams[] calldata queuedWithdrawalParams
@@ -518,7 +518,7 @@ Note that the `QueuedWithdrawalParams.__deprecated_withdrawer` field is ignored.
  *
  * @param staker The address that queued the withdrawal
  * @param delegatedTo The address that the staker was delegated to at the time the withdrawal was queued. Used to determine if additional slashing occurred before
- * this withdrawal became completeable.
+ * this withdrawal became completable.
  * @param withdrawer The address that will call the contract to complete the withdrawal. Note that this will always equal `staker`; alternate withdrawers are not
  * supported at this time.
  * @param nonce The staker's `cumulativeWithdrawalsQueued` at time of queuing. Used to ensure withdrawals have unique hashes.
@@ -661,7 +661,7 @@ This method is called by the `AllocationManager` when processing an AVS's slash 
 
 Additionally, any _slashable shares_ in the withdrawal queue are marked for burning according to the same slashing proportion (shares in the withdrawal queue remain slashable for `MIN_WITHDRAWAL_DELAY_BLOCKS`). For the slashed strategy, the corresponding share manager (`EigenPodManager/StrateyManager`) is called, increasing the burnable shares for that strategy.
 
-**Note**: native ETH does not currently posess a burning mechanism, as this requires Pectra to be able to force exit validators. Currently, slashing for the `beaconChainETHStrategy` is realized by modifying the amount stakers are able to withdraw.
+**Note**: native ETH does not currently possess a burning mechanism, as this requires Pectra to be able to force exit validators. Currently, slashing for the `beaconChainETHStrategy` is realized by modifying the amount stakers are able to withdraw.
 
 *Effects*:
 * The `operator's` `operatorShares` are reduced for the given `strategy`, according to the proportion given by `prevMaxMagnitude` and `newMaxMagnitude`

--- a/docs/core/RewardsCoordinator.md
+++ b/docs/core/RewardsCoordinator.md
@@ -43,7 +43,7 @@ This document is organized according to the following themes (click each to be t
     * Stakers and Operators can designate a "claimer" who can claim rewards via on their behalf via `processClaim`. If a claimer is not set in `claimerFor`, the earner will have to call `processClaim` themselves.
     * Note that the claimer isn't necessarily the reward recipient, but they do have the authority to specify the recipient when calling `processClaim` on the earner's behalf.
 * `mapping(address => mapping(IERC20 => uint256)) public cumulativeClaimed`: earner => token => total amount claimed to date
-    * Mapping for earners(Stakers/Operators) to track their total claimed earnings per reward token. This mapping is used to calculate the difference between the cumulativeEarnings stored in the merkle tree and the previous total claimed amount. This difference is then transfered to the specified destination address.
+    * Mapping for earners(Stakers/Operators) to track their total claimed earnings per reward token. This mapping is used to calculate the difference between the cumulativeEarnings stored in the merkle tree and the previous total claimed amount. This difference is then transferred to the specified destination address.
 * `uint16 public defaultOperatorSplitBips`: *Used off-chain* by the rewards updater to calculate an Operator's split for a specific reward.
     * This is expected to be a flat 10% rate for the initial rewards release. Expressed in basis points, this is `1000`.
 * `mapping(address => mapping(address => OperatorSplit)) internal _operatorAVSSplitBips`: operator => AVS => `OperatorSplit`
@@ -58,7 +58,7 @@ This document is organized according to the following themes (click each to be t
 * **AVS** (Autonomous Verifiable Service) refers to the contract entity that is submitting rewards to the `RewardsCoordinator`.
   * This is assumed to be a customized `ServiceManager` contract of some kind that is interfacing with the EigenLayer protocol. See the `ServiceManagerBase` docs here: [`eigenlayer-middleware/docs/ServiceManagerBase.md`](https://github.com/Layr-Labs/eigenlayer-middleware/blob/dev/docs/ServiceManagerBase.md).
 * An **Operator Set** refers to a collection of registered operators and strategies. See [ELIP-002](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md#operator-sets) for more details.
-* An **Operator Set Key** descibes the tuple of an AVS address and an ID that uniquely identifies an Operator Set. See the [AllocationManager](./AllocationManager.md#operator-sets) for details.
+* An **Operator Set Key** describes the tuple of an AVS address and an ID that uniquely identifies an Operator Set. See the [AllocationManager](./AllocationManager.md#operator-sets) for details.
 * A **rewards submission** includes, unless specified otherwise, both the v1 `RewardsSubmission` and the v2 `OperatorDirectedRewardsSubmission` types.
 * The internal function `_checkClaim(RewardsMerkleClaim calldata claim, DistributionRoot memory root)` checks the merkle inclusion of a claim against a `DistributionRoot`
     * It reverts if any of the following are true:

--- a/docs/core/accounting/SharesAccountingEdgeCases.md
+++ b/docs/core/accounting/SharesAccountingEdgeCases.md
@@ -32,7 +32,7 @@ Note that in the first case, it _is_ possible for the staker to undelegate, queu
 
 Additionally, if $l_n = 0$ for a given staker in the beacon chain ETH strategy, then **any further deposits of ETH or restaking of validators will not yield shares in EigenLayer.** This should only occur in extraordinary circumstances, as a beacon chain slashing factor of 0 means that a staker both has ~0 assets in their `EigenPod`, and ALL of their validators have been ~100% slashed on the beacon chain - something that happens only when coordinated groups of validators are slashed. If this case occurs, an `EigenPod` is essentially bricked - the pod owner should NOT send ETH to the pod, and should NOT point additional validators at the pod.
 
-These are all expected edge cases and their occurances and side effects are within acceptable tolerances.
+These are all expected edge cases and their occurrences and side effects are within acceptable tolerances.
 
 ## Upper Bound on Deposit Scaling Factor $k_n$
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eigenlayer-contracts",
   "version": "1.0.0",
-  "description": "<a name=\"introduction\"/></a> # EigenLayer EigenLayer (formerly 'EigenLayr') is a set of smart contracts deployed on Ethereum that enable restaking of assets to secure new services. At present, this repository contains *both* the contracts for EigenLayer *and* a set of general \"middleware\" contracts, designed to be reuseable across different applications built on top of EigenLayer.",
+  "description": "<a name=\"introduction\"/></a> # EigenLayer EigenLayer (formerly 'EigenLayr') is a set of smart contracts deployed on Ethereum that enable restaking of assets to secure new services. At present, this repository contains *both* the contracts for EigenLayer *and* a set of general \"middleware\" contracts, designed to be reusable across different applications built on top of EigenLayer.",
   "main": "index.js",
   "directories": {
     "doc": "docs",

--- a/script/deploy/devnet/deploy_from_scratch.s.sol
+++ b/script/deploy/devnet/deploy_from_scratch.s.sol
@@ -330,7 +330,7 @@ contract DeployFromScratch is Script, Test {
         // Create a proxy beacon for base strategy implementation
         strategyBeacon = new UpgradeableBeacon(address(baseStrategyImplementation));
 
-        // Strategy Factory, upgrade and initalized
+        // Strategy Factory, upgrade and initialized
         eigenLayerProxyAdmin.upgradeAndCall(
             ITransparentUpgradeableProxy(payable(address(strategyFactory))),
             address(strategyFactoryImplementation),

--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -572,7 +572,7 @@ contract ExistingDeploymentParser is Script, Logger {
     }
 
     function logInitialDeploymentParams() public {
-        console.log("==== Parsed Initilize Params for Initial Deployment,==");
+        console.log("==== Parsed Initialize Params for Initial Deployment,==");
 
         console.log("executorMultisig", executorMultisig);
         console.log("operationsMultisig", operationsMultisig);

--- a/src/contracts/core/AVSDirectory.sol
+++ b/src/contracts/core/AVSDirectory.sol
@@ -24,7 +24,7 @@ contract AVSDirectory is
      */
 
     /**
-     * @dev Initializes the immutable addresses of the strategy mananger, delegationManager,
+     * @dev Initializes the immutable addresses of the strategy manager, delegationManager,
      * and eigenpodManager contracts
      */
     constructor(

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -61,7 +61,7 @@ contract DelegationManager is
      */
 
     /**
-     * @dev Initializes the immutable addresses of the strategy mananger, eigenpod manager, and allocation manager.
+     * @dev Initializes the immutable addresses of the strategy manager, eigenpod manager, and allocation manager.
      */
     constructor(
         IStrategyManager _strategyManager,

--- a/src/contracts/core/DelegationManagerStorage.sol
+++ b/src/contracts/core/DelegationManagerStorage.sol
@@ -73,7 +73,7 @@ abstract contract DelegationManagerStorage is IDelegationManager {
     /// is `OperatorDetails.delegationApprover`.
     mapping(address operator => OperatorDetails) internal _operatorDetails;
 
-    /// @notice Returns the `operator` a `staker` is delgated to, or address(0) if not delegated.
+    /// @notice Returns the `operator` a `staker` is delegated to, or address(0) if not delegated.
     /// Note: operators are delegated to themselves
     mapping(address staker => address operator) public delegatedTo;
 

--- a/src/contracts/core/RewardsCoordinatorStorage.sol
+++ b/src/contracts/core/RewardsCoordinatorStorage.sol
@@ -80,7 +80,7 @@ abstract contract RewardsCoordinatorStorage is IRewardsCoordinator {
     bytes32 internal __deprecated_DOMAIN_SEPARATOR;
 
     /**
-     * @notice List of roots submited by the rewardsUpdater
+     * @notice List of roots submitted by the rewardsUpdater
      * @dev Array is internal with an external getter so we can return a `DistributionRoot[] memory` object
      */
     DistributionRoot[] internal _distributionRoots;

--- a/src/contracts/interfaces/IAVSDirectory.sol
+++ b/src/contracts/interfaces/IAVSDirectory.sol
@@ -41,7 +41,7 @@ interface IAVSDirectoryTypes {
 
 interface IAVSDirectoryEvents is IAVSDirectoryTypes {
     /**
-     *  @notice Emitted when an operator's registration status with an AVS id udpated
+     *  @notice Emitted when an operator's registration status with an AVS id updated
      *  @notice Only used by legacy M2 AVSs that have not integrated with operatorSets.
      */
     event OperatorAVSRegistrationStatusUpdated(

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -94,7 +94,7 @@ interface IDelegationManagerTypes {
      *
      * @param staker The address that queued the withdrawal
      * @param delegatedTo The address that the staker was delegated to at the time the withdrawal was queued. Used to determine if additional slashing occurred before
-     * this withdrawal became completeable.
+     * this withdrawal became completable.
      * @param withdrawer The address that will call the contract to complete the withdrawal. Note that this will always equal `staker`; alternate withdrawers are not
      * supported at this time.
      * @param nonce The staker's `cumulativeWithdrawalsQueued` at time of queuing. Used to ensure withdrawals have unique hashes.
@@ -276,7 +276,7 @@ interface IDelegationManager is ISignatureUtils, IDelegationManagerErrors, IDele
      * to slashing. If any slashing has occurred, the shares received may be less than the queued deposit shares.
      *
      * @dev To view all the staker's strategies/deposit shares that can be queued for withdrawal, see `getDepositedShares`
-     * @dev To view the current coversion between a staker's deposit shares and withdrawable shares, see `getWithdrawableShares`
+     * @dev To view the current conversion between a staker's deposit shares and withdrawable shares, see `getWithdrawableShares`
      */
     function queueWithdrawals(
         QueuedWithdrawalParams[] calldata params

--- a/src/contracts/interfaces/IPermissionController.sol
+++ b/src/contracts/interfaces/IPermissionController.sol
@@ -124,7 +124,7 @@ interface IPermissionController is IPermissionControllerErrors, IPermissionContr
     ) external view returns (address[] memory);
 
     /**
-     * @notice Checks if the given caller has permissions to call the fucntion
+     * @notice Checks if the given caller has permissions to call the function
      * @param account to check
      * @param caller to check permission for
      * @param target to check permission for

--- a/src/contracts/interfaces/IRewardsCoordinator.sol
+++ b/src/contracts/interfaces/IRewardsCoordinator.sol
@@ -72,7 +72,7 @@ interface IRewardsCoordinatorErrors {
     error InvalidTokenLeafIndex();
     /// @dev Thrown when an invalid earner leaf index is provided.
     error InvalidEarnerLeafIndex();
-    /// @dev Thrown when cummulative earnings are not greater than cummulative claimed.
+    /// @dev Thrown when cumulative earnings are not greater than cumulative claimed.
     error EarningsNotGreaterThanClaimed();
 
     /// Reward Root Checks
@@ -296,7 +296,7 @@ interface IRewardsCoordinatorEvents is IRewardsCoordinatorTypes {
         OperatorDirectedRewardsSubmission operatorDirectedRewardsSubmission
     );
 
-    /// @notice rewardsUpdater is responsible for submiting DistributionRoots, only owner can set rewardsUpdater
+    /// @notice rewardsUpdater is responsible for submitting DistributionRoots, only owner can set rewardsUpdater
     event RewardsUpdaterSet(address indexed oldRewardsUpdater, address indexed newRewardsUpdater);
 
     event RewardsForAllSubmitterSet(
@@ -625,7 +625,7 @@ interface IRewardsCoordinator is IRewardsCoordinatorErrors, IRewardsCoordinatorE
     /// @notice Mapping: claimer => token => total amount claimed
     function cumulativeClaimed(address claimer, IERC20 token) external view returns (uint256);
 
-    /// @notice the defautl split for all operators across all avss
+    /// @notice the default split for all operators across all avss
     function defaultOperatorSplitBips() external view returns (uint16);
 
     /// @notice the split for a specific `operator` for a specific `avs`

--- a/src/contracts/libraries/BytesLib.sol
+++ b/src/contracts/libraries/BytesLib.sol
@@ -396,14 +396,14 @@ library BytesLib {
                 } {
                     // if any of these checks fails then arrays are not equal
                     if iszero(eq(mload(mc), mload(cc))) {
-                        // unsuccess:
+                        // unsuccessful:
                         success := 0
                         cb := 0
                     }
                 }
             }
             default {
-                // unsuccess:
+                // unsuccessful:
                 success := 0
             }
         }
@@ -434,7 +434,7 @@ library BytesLib {
                         fslot := mul(div(fslot, 0x100), 0x100)
 
                         if iszero(eq(fslot, mload(add(_postBytes, 0x20)))) {
-                            // unsuccess:
+                            // unsuccessful:
                             success := 0
                         }
                     }
@@ -460,7 +460,7 @@ library BytesLib {
                             mc := add(mc, 0x20)
                         } {
                             if iszero(eq(sload(sc), mload(mc))) {
-                                // unsuccess:
+                                // unsuccessful:
                                 success := 0
                                 cb := 0
                             }
@@ -469,7 +469,7 @@ library BytesLib {
                 }
             }
             default {
-                // unsuccess:
+                // unsuccessful:
                 success := 0
             }
         }

--- a/src/contracts/strategies/EigenStrategy.sol
+++ b/src/contracts/strategies/EigenStrategy.sol
@@ -19,7 +19,7 @@ import "../interfaces/IEigen.sol";
  * To mitigate against the common "inflation attack" vector, we have chosen to use the 'virtual shares' mitigation route,
  * similar to [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626.sol).
  * We acknowledge that this mitigation has the known downside of the virtual shares causing some losses to users, which are pronounced
- * particularly in the case of the share exchange rate changing signficantly, either positively or negatively.
+ * particularly in the case of the share exchange rate changing significantly, either positively or negatively.
  * For a fairly thorough discussion of this issue and our chosen mitigation strategy, we recommend reading through
  * [this thread](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3706) on the OpenZeppelin repo.
  * We specifically use a share offset of `SHARES_OFFSET` and a balance offset of `BALANCE_OFFSET`.
@@ -66,7 +66,7 @@ contract EigenStrategy is StrategyBase {
     /**
      * @notice This function hook is called in EigenStrategy.withdraw() before withdrawn shares are calculated and is
      * overridden here to allow for withdrawing shares either into EIGEN or bEIGEN tokens. If wrapping bEIGEN into EIGEN is needed,
-     * it is performed in _afterWithdrawal(). This hook just checks the token paramater is either EIGEN or bEIGEN.
+     * it is performed in _afterWithdrawal(). This hook just checks the token parameter is either EIGEN or bEIGEN.
      * @param token token to be withdrawn, can be either EIGEN or bEIGEN. If EIGEN, then bEIGEN is wrapped into EIGEN
      */
     function _beforeWithdrawal(

--- a/src/contracts/strategies/StrategyBase.sol
+++ b/src/contracts/strategies/StrategyBase.sol
@@ -23,7 +23,7 @@ import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
  * To mitigate against the common "inflation attack" vector, we have chosen to use the 'virtual shares' mitigation route,
  * similar to [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC4626.sol).
  * We acknowledge that this mitigation has the known downside of the virtual shares causing some losses to users, which are pronounced
- * particularly in the case of the share exchange rate changing signficantly, either positively or negatively.
+ * particularly in the case of the share exchange rate changing significantly, either positively or negatively.
  * For a fairly thorough discussion of this issue and our chosen mitigation strategy, we recommend reading through
  * [this thread](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3706) on the OpenZeppelin repo.
  * We specifically use a share offset of `SHARES_OFFSET` and a balance offset of `BALANCE_OFFSET`.

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -280,7 +280,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         // Create a proxy beacon for base strategy implementation
         strategyBeacon = new UpgradeableBeacon(address(baseStrategyImplementation));
 
-        // Strategy Factory, upgrade and initalized
+        // Strategy Factory, upgrade and initialized
         eigenLayerProxyAdmin.upgradeAndCall(
             ITransparentUpgradeableProxy(payable(address(strategyFactory))),
             address(strategyFactoryImplementation),
@@ -475,7 +475,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         eigenLayerProxyAdmin.upgrade(
             ITransparentUpgradeableProxy(payable(address(eigenPodManager))), address(eigenPodManagerImplementation)
         );
-        // AVSDirectory, upgrade and initalized
+        // AVSDirectory, upgrade and initialized
         eigenLayerProxyAdmin.upgradeAndCall(
             ITransparentUpgradeableProxy(payable(address(avsDirectory))),
             address(avsDirectoryImplementation),
@@ -574,7 +574,7 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
      * Depending on the forkType, either deploy contracts locally or parse existing contracts
      * from network.
      *
-     * Note: for non-LOCAL forktypes, upgrade of contracts will be peformed after user initialization.
+     * Note: for non-LOCAL forktypes, upgrade of contracts will be performed after user initialization.
      */
     function _deployOrFetchContracts() internal {
         if (forkType == LOCAL) {

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -89,7 +89,7 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
     /// Allocation Manager Methods
     /// -----------------------------------------------------------------------
 
-    /// @dev Allocates randomly accross the operator set's strategies with a sum of `magnitudeSum`.
+    /// @dev Allocates randomly across the operator set's strategies with a sum of `magnitudeSum`.
     /// NOTE: Calling more than once will lead to deallocations...
     function modifyAllocations(
         OperatorSet memory operatorSet, 
@@ -426,7 +426,7 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
             int256 delta = tokenDeltas[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // If any balance update has occured, a checkpoint will pick it up
+                // If any balance update has occurred, a checkpoint will pick it up
                 _startCheckpoint();
                 if (pod.activeValidatorCount() != 0) {
                     _completeCheckpoint();

--- a/src/test/integration/users/User_M2.t.sol
+++ b/src/test/integration/users/User_M2.t.sol
@@ -134,7 +134,7 @@ contract User_M2 is User {
             int256 delta = tokenDeltas[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                // If any balance update has occured, a checkpoint will pick it up
+                // If any balance update has occurred, a checkpoint will pick it up
                 _startCheckpoint();
                 if (pod.activeValidatorCount() != 0) {
                     _completeCheckpoint();

--- a/src/test/tree/AllocationManagerUnit.tree
+++ b/src/test/tree/AllocationManagerUnit.tree
@@ -61,7 +61,7 @@
 │           ├── given that the pendingDiff is less than 0 (this is a deallocation)
 │           │   └── it should update the effect block in memory to be the operator deallocation delay
 │           ├── given that the pendingDiff is greater than 0 (this is an allocation)
-│           │   ├── it should update the effect timestmap in memory to be the operator allocation delay
+│           │   ├── it should update the effect timestamp in memory to be the operator allocation delay
 │           │   └── it should increase the encumberedMagnitude in memory by the pendingDiff
 │           ├── it should push to the modification queue
 │           ├── it should update the magnitude info, encumbered magnitude, emit an event for encumbered magnitude
@@ -79,7 +79,7 @@
         ├── it should slash the current magnitude by wads to slash
         ├── given that there is a pending deallocation
         │   ├── it should slash the pending diff
-        │   └── it should emit an event for AllocationUpdated with the orginial deallocation's effect timestamp
+        │   └── it should emit an event for AllocationUpdated with the original deallocation's effect timestamp
         ├── it should update the magnitude info, encumbered magnitude, emit an event for encumbered magnitude
         ├── it should decrease the operator's max magnitude
         ├── it should decrease the operators shares in the delegation manager

--- a/src/test/tree/PermissionControllerUnit.tree
+++ b/src/test/tree/PermissionControllerUnit.tree
@@ -5,7 +5,7 @@
     │   │   └── given that the caller is not the account
     │   │       └── it should revert
     │   ├── given that the current admin is set
-    │   │   └── given taht the msg.sender is not the current admin
+    │   │   └── given that the msg.sender is not the current admin
     │   │       └── it should revert
     │   ├── given that the new admin is the zero address
     │   │   └── it should revert

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -547,7 +547,7 @@ contract AllocationManagerUnitTests_Initialization_Setters is AllocationManagerU
         assertEq(alm.DEALLOCATION_DELAY(), DEALLOCATION_DELAY);
         assertEq(alm.ALLOCATION_CONFIGURATION_DELAY(), ALLOCATION_CONFIGURATION_DELAY);
 
-        // Assert initialiation state
+        // Assert initialization state
         assertEq(alm.owner(), expectedInitialOwner);
         assertEq(alm.paused(), initialPausedStatus);
     }
@@ -3592,7 +3592,7 @@ contract AllocationManagerUnitTests_removeStrategiesFromOperatorSet is Allocatio
         cheats.prank(defaultAVS);
         allocationManager.removeStrategiesFromOperatorSet(defaultAVS, defaultOperatorSet.id, strategies);
 
-        // The orginal strategy should still be in the operator set.
+        // The original strategy should still be in the operator set.
         assertEq(
             allocationManager.getStrategiesInOperatorSet(defaultOperatorSet).length, 1, "should not be strat of set"
         );

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -88,7 +88,7 @@ contract DelegationManagerUnitTests is EigenLayerUnitTestSetup, IDelegationManag
         // Redeploy StrategyManagerMock with DM
         strategyManagerMock = StrategyManagerMock(payable(address(new StrategyManagerMock(delegationManager))));
 
-        // Deploy DelegationManager implmentation and upgrade proxy
+        // Deploy DelegationManager implementation and upgrade proxy
         delegationManagerImplementation = new DelegationManagerHarness(
             IStrategyManager(address(strategyManagerMock)),
             IEigenPodManager(address(eigenPodManagerMock)),
@@ -1363,7 +1363,7 @@ contract DelegationManagerUnitTests_Initialization_Setters is DelegationManagerU
         assertEq(delegationManager.paused(), 0, "constructor / initializer incorrect, paused status set wrong");
     }
 
-    /// @notice Verifies that the DelegationManager cannot be iniitalized multiple times
+    /// @notice Verifies that the DelegationManager cannot be initialized multiple times
     function test_initialize_revert_reinitialization() public {
         cheats.expectRevert("Initializable: contract is already initialized");
         delegationManager.initialize(address(this), 0);
@@ -2191,7 +2191,7 @@ contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
             ),
             "salt somehow spent too early?"
         );
-        // Set staker shares in BeaconChainStrategy and StrategyMananger
+        // Set staker shares in BeaconChainStrategy and StrategyManager
         strategyManagerMock.addDeposit(staker, strategyMock, shares);
         eigenPodManagerMock.setPodOwnerShares(staker, beaconShares);
         (
@@ -2286,7 +2286,7 @@ contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
         _setOperatorMagnitude(defaultOperator, beaconChainETHStrategy, maxMagnitudeBeacon);
         _setOperatorMagnitude(defaultOperator, strategyMock, maxMagnitudeStrategy);
 
-        // 2. Set staker shares in BeaconChainStrategy and StrategyMananger
+        // 2. Set staker shares in BeaconChainStrategy and StrategyManager
         strategyManagerMock.addDeposit(defaultStaker, strategyMock, shares);
         eigenPodManagerMock.setPodOwnerShares(defaultStaker, beaconShares);
         (
@@ -2803,7 +2803,7 @@ contract DelegationManagerUnitTests_delegateTo is DelegationManagerUnitTests {
             expiry
         );
 
-        // Set staker shares in BeaconChainStrategy and StrategyMananger
+        // Set staker shares in BeaconChainStrategy and StrategyManager
         uint256[] memory depositScalingFactors = new uint256[](2);
         depositScalingFactors[0] = uint256(WAD);
         depositScalingFactors[1] = uint256(WAD);
@@ -6693,7 +6693,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(defaultOperator, strategyMock, WAD, 0);
 
-        // Complete withdrawal as tokens and assert that we call back into teh SM with 100 tokens
+        // Complete withdrawal as tokens and assert that we call back into the SM with 100 tokens
         IERC20[] memory tokens = strategyMock.underlyingToken().toArray();
         cheats.expectCall(
             address(strategyManagerMock),

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -362,7 +362,7 @@ contract EigenPodManagerUnitTests_WithdrawSharesAsTokensTests is EigenPodManager
         assertEq(eigenPodManager.podOwnerDepositShares(defaultStaker), int256(0), "Shares not reduced to 0");
     }
 
-    function test_withdrawSharesAsTokens_m2NegativeShares_partialDefecitReduction() public {
+    function test_withdrawSharesAsTokens_m2NegativeShares_partialDeficitReduction() public {
         // Shares to initialize & withdraw
         int256 sharesBeginning = -100e18;
         uint256 sharesToWithdraw = 50e18;


### PR DESCRIPTION
**Motivation:**  

Tired of seeing PRs for minor misspellings—let's fix them all at once.  

**Modifications:**  

- Used [typos-cli](https://github.com/crate-ci/typos) to automatically correct all misspellings across the repository.  

**Result:**  

A typo-free codebase... at least for now. 😅 