### PR TITLE
perf: correctly set profile optimizer

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -91,21 +91,21 @@
 #         "./src/contracts/**/*"
 #     ]
 
-[profile.forktest.fuzz]    
+[profile.forktest]    
     optimizer = false
-    runs = 16
+    fuzz.runs = 16
 
-[profile.coverage.fuzz]
+[profile.coverage]
     optimizer = false
-    runs = 1
+    fuzz.runs = 1
 
-[profile.medium.fuzz]
+[profile.medium]
     optimizer = false
-    runs = 256
+    fuzz.runs = 256
 
-[profile.intense.fuzz]
+[profile.intense]
     optimizer = false
-    runs = 5000
+    fuzz.runs = 5000
 
 [rpc_endpoints]
     mainnet = "${RPC_MAINNET}"

--- a/foundry.toml
+++ b/foundry.toml
@@ -92,19 +92,15 @@
 #     ]
 
 [profile.forktest]    
-    optimizer = false
     fuzz.runs = 16
 
 [profile.coverage]
-    optimizer = false
     fuzz.runs = 1
 
 [profile.medium]
-    optimizer = false
     fuzz.runs = 256
 
 [profile.intense]
-    optimizer = false
     fuzz.runs = 5000
 
 [rpc_endpoints]


### PR DESCRIPTION
**Motivation:**

there's no setting of `<profile>.fuzz.optimizer`, only `<profile>.optimizer`

see
- https://book.getfoundry.sh/reference/config/solidity-compiler#optimizer
- https://book.getfoundry.sh/reference/config/testing#fuzz

**Modifications:**

move 'fuzz' out of profile to be prefix of 'runs' vars

**Result:**

make '<profile>.optimizer' setting work
