### PR TITLE
perf: install lcov via prebuilt binary, instead of via apt

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -181,10 +181,11 @@ jobs:
           version: stable
 
       # Install LCOV for coverage report generation.
-      - name: Install LCOV
+      - name: Install LCOV (Prebuilt)
         run: |
-          sudo apt-get install -y lcov
-        id: lcov
+          curl -L https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz | tar xz
+          sudo cp lcov-1.16/bin/* /usr/local/bin/
+          sudo cp -r lcov-1.16/man/* /usr/share/man/
 
       # Build the project and display contract sizes.
       - name: "Forge Build"


### PR DESCRIPTION
**Motivation:**

after a few rounds of optimization, the whole CI suite is now bounded by `coverage` job which is then bounded by the `install lcov` step that takes 3.5min to install lcov via apt

this PR changes to install lcov via prebuilt binary, instead of via apt, which shortens the installation from 3.5min to 1s

**Modifications:**

this PR changes to install lcov via prebuilt binary, instead of via apt

**Result:**

shortens the installation from 3.5min to 1s