### PR TITLE
perf: add cache for forge build

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -47,6 +47,17 @@ jobs:
         with:
           submodules: recursive
 
+      # Restore Forge cache
+      - name: Cache Forge Build
+        uses: actions/cache@v3
+        with:
+          path: |
+            cache/
+            out/
+          key: ${{ runner.os }}-forge-${{ hashFiles('**/foundry.toml', '**/remappings.txt', 'src/**/*.sol', 'lib/**/*.sol') }}
+          restore-keys: |
+            ${{ runner.os }}-forge-
+
       # Install the Foundry toolchain.
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -93,6 +104,17 @@ jobs:
         with:
           submodules: recursive
 
+      # Restore Forge cache
+      - name: Cache Forge Build
+        uses: actions/cache@v3
+        with:
+          path: |
+            cache/
+            out/
+          key: ${{ runner.os }}-forge-${{ hashFiles('**/foundry.toml', '**/remappings.txt', 'src/**/*.sol', 'lib/**/*.sol') }}
+          restore-keys: |
+            ${{ runner.os }}-forge-
+
       # Install the Foundry toolchain.
       - name: "Install Foundry"
         uses: foundry-rs/foundry-toolchain@v1
@@ -125,6 +147,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      # Restore Forge cache
+      - name: Cache Forge Build
+        uses: actions/cache@v3
+        with:
+          path: |
+            cache/
+            out/
+          key: ${{ runner.os }}-forge-${{ hashFiles('**/foundry.toml', '**/remappings.txt', 'src/**/*.sol', 'lib/**/*.sol') }}
+          restore-keys: |
+            ${{ runner.os }}-forge-
 
       # Install the Foundry toolchain.
       - name: "Install Foundry"
@@ -160,8 +193,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      
-      # Cache Foundry dependencies
+
+      # Restore Foundry and Forge cache
       - name: Cache Foundry dependencies
         uses: actions/cache@v3
         with:
@@ -170,10 +203,10 @@ jobs:
             ~/.foundry
             out/
             cache/
-          key: ${{ runner.os }}-foundry-${{ hashFiles('**/foundry.toml', '**/Cargo.lock') }}
+          key: ${{ runner.os }}-forge-${{ hashFiles('**/foundry.toml', '**/remappings.txt', 'src/**/*.sol', 'lib/**/*.sol', '**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-foundry-
-
+        
       # Install the Foundry toolchain.
       - name: "Install Foundry"
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -195,7 +195,7 @@ jobs:
           submodules: recursive
 
       # Restore Foundry and Forge cache
-      - name: Cache Foundry dependencies
+      - name: Cache Foundry Dependencies
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
**Motivation:**

after multiple round of optimization, the bottleneck in CI is forge build now, which takes 1.2-1.5min

this PR added caching for forge build, so that every CI run can restore latest cache, and only compile solidity files that hv been changed, which significantly lowers compile time from 1.2-1.5min t0 <1s

**Modifications:**

this PR added caching for forge build, so that every CI run can restore latest cache, and only compile solidity files that hv been changed

**Result:**

significantly lowers compile time from 1.2-1.5min to <1s

before adding cache:
![image](https://github.com/user-attachments/assets/09b84912-6a22-449d-b065-8fb67ea6b835)


after adding cache:
![image](https://github.com/user-attachments/assets/fb7c20a8-a370-4297-a1bb-82fef99aa4e9)
