### PR TITLE
feat: add typos-cli ci check

### DIFF
--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -28,3 +28,131 @@ extend-ignore-re = []
 [default.extend-words]
 strat = "strat"
 froms = "froms"
+
+[type.go]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.go.extend-identifiers]
+flate = "flate"
+
+[type.go.extend-words]
+
+[type.cpp]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.cpp.extend-identifiers]
+countr_one = "countr_one"
+
+[type.cpp.extend-words]
+
+[type.cert]
+extend-glob = []
+check-file = false
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.cert.extend-identifiers]
+
+[type.cert.extend-words]
+
+[type.sh]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.sh.extend-identifiers]
+ot = "ot"
+stap = "stap"
+
+[type.sh.extend-words]
+
+[type.man]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.man.extend-identifiers]
+Nd = "Nd"
+
+[type.man.extend-words]
+
+[type.lock]
+extend-glob = []
+check-file = false
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.lock.extend-identifiers]
+
+[type.lock.extend-words]
+
+[type.css]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.css.extend-identifiers]
+nd = "nd"
+
+[type.css.extend-words]
+
+[type.jl]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.jl.extend-identifiers]
+
+[type.jl.extend-words]
+egals = "egals"
+egal = "egal"
+modul = "modul"
+usig = "usig"
+
+[type.py]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.py.extend-identifiers]
+NDArray = "NDArray"
+arange = "arange"
+EOFError = "EOFError"
+
+[type.py.extend-words]
+
+[type.vimscript]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.vimscript.extend-identifiers]
+windo = "windo"
+
+[type.vimscript.extend-words]
+
+[type.rust]
+extend-glob = []
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[type.rust.extend-identifiers]
+flate2 = "flate2"
+
+[type.rust.extend-words]
+ser = "ser"

--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -1,5 +1,8 @@
 [files]
-extend-exclude = []
+extend-exclude = [
+    "**/lib/**",
+    "**/docs/images/**"
+]
 ignore-hidden = true
 ignore-files = true
 ignore-dot = true

--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -1,7 +1,9 @@
 [files]
 extend-exclude = [
     "**/lib/**",
-    "**/docs/images/**"
+    "**/docs/images/**",
+    # Not present locally, but is in remote (github).
+    "**/doc/**"
 ]
 ignore-hidden = true
 ignore-files = true

--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -1,0 +1,27 @@
+[files]
+extend-exclude = []
+ignore-hidden = true
+ignore-files = true
+ignore-dot = true
+ignore-vcs = true
+ignore-global = true
+ignore-parent = true
+
+[default]
+binary = false
+check-filename = true
+check-file = true
+unicode = true
+ignore-hex = true
+identifier-leading-digits = false
+locale = "en"
+extend-ignore-identifiers-re = []
+extend-ignore-words-re = []
+extend-ignore-re = []
+
+[default.extend-identifiers]
+
+# Weird syntax, but this how you ignore corrections for certain words.
+[default.extend-words]
+strat = "strat"
+froms = "froms"

--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -42,28 +42,6 @@ flate = "flate"
 
 [type.go.extend-words]
 
-[type.cpp]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.cpp.extend-identifiers]
-countr_one = "countr_one"
-
-[type.cpp.extend-words]
-
-[type.cert]
-extend-glob = []
-check-file = false
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.cert.extend-identifiers]
-
-[type.cert.extend-words]
-
 [type.sh]
 extend-glob = []
 extend-ignore-identifiers-re = []
@@ -75,53 +53,6 @@ ot = "ot"
 stap = "stap"
 
 [type.sh.extend-words]
-
-[type.man]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.man.extend-identifiers]
-Nd = "Nd"
-
-[type.man.extend-words]
-
-[type.lock]
-extend-glob = []
-check-file = false
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.lock.extend-identifiers]
-
-[type.lock.extend-words]
-
-[type.css]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.css.extend-identifiers]
-nd = "nd"
-
-[type.css.extend-words]
-
-[type.jl]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.jl.extend-identifiers]
-
-[type.jl.extend-words]
-egals = "egals"
-egal = "egal"
-modul = "modul"
-usig = "usig"
 
 [type.py]
 extend-glob = []
@@ -135,26 +66,3 @@ arange = "arange"
 EOFError = "EOFError"
 
 [type.py.extend-words]
-
-[type.vimscript]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.vimscript.extend-identifiers]
-windo = "windo"
-
-[type.vimscript.extend-words]
-
-[type.rust]
-extend-glob = []
-extend-ignore-identifiers-re = []
-extend-ignore-words-re = []
-extend-ignore-re = []
-
-[type.rust.extend-identifiers]
-flate2 = "flate2"
-
-[type.rust.extend-words]
-ser = "ser"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
           sudo mv typos /usr/local/bin/
 
       - name: Run typos check
-        run:  typos --exclude "**/lib/**" --exclude "**/docs/images/**" --config .github/configs/typos-cli.toml --diff
+        run:  typos --config .github/configs/typos-cli.toml
 
   commitlint:
     name: Commit Linting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,9 @@ permissions:
   contents: read
   pull-requests: read
 
+env:
+  CLICOLOR: 1
+
 jobs:
   typos:
     name: Typo Linting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
           sudo mv typos /usr/local/bin/
 
       - name: Run typos check
-        run:  typos --exclude "**/lib/**" --exclude "**/docs/images/**" --diff
+        run:  typos --exclude "**/lib/**" --exclude "**/docs/images/**" --config .github/configs/typos-cli.toml --diff
 
   commitlint:
     name: Commit Linting

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,23 @@ permissions:
   pull-requests: read
 
 jobs:
+  typos:
+    name: Typo Linting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Typos CLI (Latest)
+        run: |
+          TYTOS_VERSION=$(curl -s https://api.github.com/repos/crate-ci/typos/releases/latest | jq -r .tag_name)
+          curl -Ls https://github.com/crate-ci/typos/releases/download/${TYTOS_VERSION}/typos-${TYTOS_VERSION}-x86_64-unknown-linux-musl.tar.gz | tar xz
+          sudo mv typos /usr/local/bin/
+
+      - name: Run typos check
+        run:  typos --exclude "**/lib/**" --exclude "**/docs/images/**" --diff
+
   commitlint:
     name: Commit Linting
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,19 +15,11 @@ jobs:
   typos:
     name: Typo Linting
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Typos CLI (Latest)
-        run: |
-          TYTOS_VERSION=$(curl -s https://api.github.com/repos/crate-ci/typos/releases/latest | jq -r .tag_name)
-          curl -Ls https://github.com/crate-ci/typos/releases/download/${TYTOS_VERSION}/typos-${TYTOS_VERSION}-x86_64-unknown-linux-musl.tar.gz | tar xz
-          sudo mv typos /usr/local/bin/
-
-      - name: Run typos check
-        run:  typos --config .github/configs/typos-cli.toml
+      - uses: actions/checkout@v4
+      - uses: crate-ci/typos@v1.29.7
+        with:
+          config: .github/configs/typos-cli.toml
 
   commitlint:
     name: Commit Linting

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ gha-docker:
 
 storage-report:
 	bash "bin/storage-report.sh" "docs/storage-report/"
+
+fix-typos:
+	typos --config .github/configs/typos-cli.toml --write-changes

--- a/certora/specs/core/Slasher.spec
+++ b/certora/specs/core/Slasher.spec
@@ -42,8 +42,8 @@ methods {
 	function get_previous_node_exists(address, uint256) external returns (bool) envfree;
 	function get_previous_node(address, uint256) external returns (uint256) envfree;
 	function get_list_head(address) external returns (uint256) envfree;
-	function get_lastest_update_block_at_node(address, uint256) external returns (uint256) envfree;
-	function get_lastest_update_block_at_head(address) external returns (uint256) envfree;
+	function get_latest_update_block_at_node(address, uint256) external returns (uint256) envfree;
+	function get_latest_update_block_at_head(address) external returns (uint256) envfree;
 	function get_linked_list_entry(address operator, uint256 node, bool direction) external returns (uint256) envfree;
 
 	// nodeDoesExist(address operator, uint256 node) returns (bool) envfree
@@ -134,7 +134,7 @@ is always at the 'HEAD' position in the linked list
 invariant listHeadHasSmallestValueOfLatestUpdateBlock(address operator, uint256 node)
 	(
 	get_list_exists(operator) && get_next_node_exists(operator, get_list_head(operator)) => 
-		get_lastest_update_block_at_head(operator) <= get_lastest_update_block_at_node(operator, get_next_node(operator, get_list_head(operator)))
+		get_latest_update_block_at_head(operator) <= get_latest_update_block_at_node(operator, get_next_node(operator, get_list_head(operator)))
 	)
 */
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -317,7 +317,7 @@ contract AllocationManager is
 
     /// @inheritdoc IAllocationManager
     function setAVSRegistrar(address avs, IAVSRegistrar registrar) external checkCanCall(avs) {
-        // Chekc that the registrar is correctly configured to prevent an AVSRegistrar contract
+        // Check that the registrar is correctly configured to prevent an AVSRegistrar contract
         // from being used with the wrong AVS
         require(registrar.supportsAVS(avs), InvalidAVSRegistrar());
         _avsRegistrar[avs] = registrar;

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -317,7 +317,7 @@ contract AllocationManager is
 
     /// @inheritdoc IAllocationManager
     function setAVSRegistrar(address avs, IAVSRegistrar registrar) external checkCanCall(avs) {
-        // Check that the registrar is correctly configured to prevent an AVSRegistrar contract
+        // Chekc that the registrar is correctly configured to prevent an AVSRegistrar contract
         // from being used with the wrong AVS
         require(registrar.supportsAVS(avs), InvalidAVSRegistrar());
         _avsRegistrar[avs] = registrar;

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -244,7 +244,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         assertFalse(delegationManager.isDelegated(address(staker)),
             "check_Undelegate_State: staker should not be delegated");
         assert_ValidWithdrawalHashes(withdrawals, withdrawalRoots,
-            "check_Undelegate_State: calculated withdrawl should match returned root");
+            "check_Undelegate_State: calculated withdrawals should match returned roots");
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_Undelegate_State: stakers withdrawal should now be pending");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,

--- a/src/test/unit/EigenPodManagerUnit.t.sol
+++ b/src/test/unit/EigenPodManagerUnit.t.sol
@@ -257,7 +257,7 @@ contract EigenPodManagerUnitTests_ShareUpdateTests is EigenPodManagerUnitTests {
     }
 
     function testFuzz_removeShares(uint224 sharesToAdd, uint224 sharesToRemove) public {
-        // Constain inputs
+        // Constrain inputs
         cheats.assume(sharesToRemove <= sharesToAdd);
         uint256 sharesAdded = sharesToAdd * GWEI_TO_WEI;
         uint256 sharesRemoved = sharesToRemove * GWEI_TO_WEI;


### PR DESCRIPTION
**Motivation:**  

We frequently receive PRs for minor typo fixes. Recently, we addressed most of the typos in the repository (see #1119). However, this only corrects typos up to this point and does not prevent new typos from being introduced in the future.  

**Modifications:**  

- Added a CI workflow to check for typos using [typos-cli](https://github.com/crate-ci/typos).  

**Result:**  

Typos will now be automatically detected and linted.