### PR TITLE
refactor: `getSharesForQueuedWithdrawal`

### DIFF
--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -972,10 +972,10 @@ contract DelegationManager is
     }
 
     /// @inheritdoc IDelegationManager
-    function getSharesFromQueuedWithdrawal(
+    function getQueuedWithdrawalFromRoot(
         bytes32 withdrawalRoot
-    ) external view returns (uint256[] memory shares) {
-        (, shares) = _getSharesByWithdrawalRoot(withdrawalRoot);
+    ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares) {
+        (withdrawal, shares) = _getSharesByWithdrawalRoot(withdrawalRoot);
     }
 
     /// @inheritdoc IDelegationManager

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -491,12 +491,13 @@ interface IDelegationManager is ISignatureUtilsMixin, IDelegationManagerErrors, 
     /**
      * @notice Returns the withdrawal details and corresponding shares for a specific queued withdrawal.
      * @param withdrawalRoot The hash identifying the queued withdrawal.
+     * @return withdrawal The withdrawal details.
      * @return shares Array of shares corresponding to each strategy in the withdrawal.
      * @dev The shares are what a user would receive from completing a queued withdrawal, assuming all slashings are applied.
      */
-    function getSharesFromQueuedWithdrawal(
+    function getQueuedWithdrawalFromRoot(
         bytes32 withdrawalRoot
-    ) external view returns (uint256[] memory shares);
+    ) external view returns (Withdrawal memory withdrawal, uint256[] memory shares);
 
     /// @notice Returns a list of queued withdrawal roots for the `staker`.
     /// NOTE that this only returns withdrawals queued AFTER the slashing release.

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -8670,16 +8670,16 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
 
         // Get shares from withdrawal - should return 50 shares (100 * 0.5) using original magnitude
         // rather than incorrectly returning 100 shares (100 * 1.0) using new magnitude
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(withdrawalRoot);
         assertEq(shares[0], 50e18, "shares should be 50e18 (100e18 * 0.5) using original magnitude");
     }
 }
 
-contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationManagerUnitTests {
+contract DelegationManagerUnitTests_getQueuedWithdrawalFromRoot is DelegationManagerUnitTests {
     using ArrayLib for *;
     using SlashingLib for *;
 
-    function test_getSharesFromQueuedWithdrawal_Correctness(Randomness r) public rand(r) {
+    function test_getQueuedWithdrawalFromRoot_Correctness(Randomness r) public rand(r) {
         // Set up initial deposit
         uint256 depositAmount = r.Uint256(1 ether, 100 ether);
         _depositIntoStrategies(defaultStaker, strategyMock.toArray(), depositAmount.toArrayU256());
@@ -8703,14 +8703,14 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
 
         // Get shares from queued withdrawal
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(withdrawalRoot);
 
         // Verify withdrawal details match
         assertEq(shares.length, 1, "incorrect shares array length");
         assertEq(shares[0], depositAmount, "incorrect shares amount");
     }
 
-    function test_getSharesFromQueuedWithdrawal_AfterSlashing(Randomness r) public rand(r) {
+    function test_getQueuedWithdrawalFromRoot_AfterSlashing(Randomness r) public rand(r) {
         // Set up initial deposit
         uint256 depositAmount = r.Uint256(1 ether, 100 ether);
         _depositIntoStrategies(defaultStaker, strategyMock.toArray(), depositAmount.toArrayU256());
@@ -8739,20 +8739,20 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.slashOperatorShares(defaultOperator, strategyMock, WAD, 0.5 ether);
 
         // Get shares from queued withdrawal
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(withdrawalRoot);
 
         // Verify withdrawal details match and shares are slashed
         assertEq(shares.length, 1, "incorrect shares array length");
         assertEq(shares[0], depositAmount / 2, "shares not properly slashed");
     }
 
-    function test_getSharesFromQueuedWithdrawal_NonexistentWithdrawal() public {
+    function test_getQueuedWithdrawalFromRoot_NonexistentWithdrawal() public {
         bytes32 nonexistentRoot = bytes32(uint256(1));
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(nonexistentRoot);
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(nonexistentRoot);
         assertEq(shares.length, 0, "shares array should be empty");
     }
 
-    function test_getSharesFromQueuedWithdrawal_MultipleStrategies(Randomness r) public rand(r) {
+    function test_getQueuedWithdrawalFromRoot_MultipleStrategies(Randomness r) public rand(r) {
         // Set up multiple strategies with deposits
         uint256 numStrategies = r.Uint256(2, 5);
         uint256[] memory depositShares = r.Uint256Array({
@@ -8782,7 +8782,7 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         delegationManager.queueWithdrawals(queuedWithdrawalParams);
 
         // Get shares from queued withdrawal
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(withdrawalRoot);
 
         // Verify withdrawal details and shares for each strategy
         assertEq(shares.length, numStrategies, "incorrect shares array length");
@@ -8791,8 +8791,8 @@ contract DelegationManagerUnitTests_getSharesFromQueuedWithdrawal is DelegationM
         }
     }
 
-    function testFuzz_getSharesFromQueuedWithdrawal_EmptyWithdrawal(bytes32 withdrawalRoot) public {
-        uint256[] memory shares = delegationManager.getSharesFromQueuedWithdrawal(withdrawalRoot);
+    function testFuzz_getQueuedWithdrawalFromRoot_EmptyWithdrawal(bytes32 withdrawalRoot) public {
+        (, uint256[] memory shares) = delegationManager.getQueuedWithdrawalFromRoot(withdrawalRoot);
         assertEq(shares.length, 0, "sanity check");
     }
 }


### PR DESCRIPTION
**Motivation:**

Current fn only returns scaled shares, which leads integrators to making two calls. This is expensive in terms of gas.

**Modifications:**

- `getSharesFromQueuedWithdrawal` has been renamed to `getQueuedWithdrawalFromRoot` and now also returns `Withdrawal` struct.

**Result:**

Integrators can fetch both in a single call.
