### PR TITLE
Alex/avs slashing tests

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -565,6 +565,17 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             assertEq(slashableStake[i], 0, err);
         }
     }
+
+    function assert_DSF_Reset(
+        User staker,
+        IStrategy[] memory strategies,
+        string memory err
+    ) internal {
+        uint[] memory depositScalingFactors = _getDepositScalingFactors(staker, strategies);
+        for (uint i = 0; i < strategies.length; i++) {
+            assertEq(depositScalingFactors[i], WAD, err);
+        }
+    }
     
     /*******************************************************************************
                                 SNAPSHOT ASSERTIONS
@@ -2758,6 +2769,18 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
 
         return shares;
+    }
+
+    function _getDepositScalingFactors(User staker, IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory depositScalingFactors = new uint[](strategies.length);
+        for (uint i=0; i < strategies.length; i++) {
+            depositScalingFactors[i] = _getDepositScalingFactor(staker, strategies[i]);
+        }
+        return depositScalingFactors;
+    }
+
+    function _getDepositScalingFactor(User staker, IStrategy strategy) internal view returns (uint) {
+        return delegationManager.depositScalingFactor(address(staker), strategy);
     }
 
     function _getExpectedDSFUndelegate(User staker) internal view returns (uint expectedDepositScalingFactor) {

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -2760,6 +2760,22 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return shares;
     }
 
+    function _getExpectedDSFUndelegate(User staker) internal view returns (uint expectedDepositScalingFactor) {
+        return WAD.divWad(_getBeaconChainSlashingFactor(staker));
+    }
+
+    function _getExpectedWithdrawableSharesUndelegate(User staker, IStrategy[] memory strategies, uint[] memory shares) internal view returns (uint[] memory){
+        uint[] memory expectedWithdrawableShares = new uint[](strategies.length);
+        for (uint i = 0; i < strategies.length; i++) {
+            if (strategies[i] == BEACONCHAIN_ETH_STRAT) {
+                expectedWithdrawableShares[i] = shares[i].mulWad(_getExpectedDSFUndelegate(staker)).mulWad(_getBeaconChainSlashingFactor(staker));
+            } else {
+                expectedWithdrawableShares[i] = shares[i];
+             }
+        }
+        return expectedWithdrawableShares;
+    }
+
     function _getPrevWithdrawableShares(User staker, IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
         return _getWithdrawableShares(staker, strategies);
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -18,6 +18,7 @@ import "src/test/integration/users/User_M1.t.sol";
 abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     using StdStyle for *;
     using SlashingLib for *;
+    using Math for uint256;
     using Strings for *;
     using print for *;
 
@@ -65,6 +66,35 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newRandomStaker: failed to award token balances");
 
         numStakers++;
+        return (staker, strategies, tokenBalances);
+    }
+
+    function _newBasicStaker() internal returns (User, IStrategy[] memory, uint[] memory) {
+        string memory stakerName;
+
+        User staker;
+        IStrategy[] memory strategies;
+        uint[] memory tokenBalances;
+
+        if (!isUpgraded) {
+            stakerName = string.concat("M2Staker", cheats.toString(numStakers));
+
+            (staker, strategies, tokenBalances) = _randUser(stakerName);
+
+            stakersToMigrate.push(staker);
+        } else {
+            stakerName = string.concat("staker", cheats.toString(numStakers));
+
+            (staker, strategies, tokenBalances) = _randUser(stakerName);
+        }
+
+        assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "_newRandomStaker: failed to award token balances");
+
+        numStakers++;
+        assembly { // TODO HACK
+            mstore(strategies, 1)
+            mstore(tokenBalances, 1)
+        }
         return (staker, strategies, tokenBalances);
     }
 
@@ -836,6 +866,29 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_SlashableStake(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curSlashableStake = _getMinSlashableStake(operator, operatorSet, params.strategies);
+        uint[] memory prevSlashableStake = _getPrevMinSlashableStake(operator, operatorSet, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevSlashableStake[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curSlashableStake[i], prevSlashableStake[i] - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_StakeBecameAllocated(
         User operator,
         OperatorSet memory operatorSet,
@@ -875,6 +928,29 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         for (uint i = 0; i < curAllocatedStake.length; i++) {
             assertEq(curAllocatedStake[i], prevAllocatedStake[i], err);
+        }
+    }
+
+    function assert_Snap_Slashed_AllocatedStake(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curAllocatedStake = _getAllocatedStake(operator, operatorSet, params.strategies);
+        uint[] memory prevAllocatedStake = _getPrevAllocatedStake(operator, operatorSet, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < curAllocatedStake.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevAllocatedStake[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curAllocatedStake[i], prevAllocatedStake[i] - expectedSlashed, err);
         }
     }
 
@@ -919,6 +995,20 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_EncumberedMagnitude(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevMagnitudes[i].encumbered.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curMagnitudes[i].encumbered, prevMagnitudes[i].encumbered - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_Added_AllocatableMagnitude(
         User operator,
         IStrategy[] memory strategies,
@@ -949,14 +1039,14 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     function assert_Snap_Removed_AllocatableMagnitude(
         User operator,
         IStrategy[] memory strategies,
-        uint64[] memory magnitudeAllocated,
+        uint64[] memory magnitudeRemoved,
         string memory err
     ) internal {
         Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, strategies);
         Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
-            assertEq(curMagnitudes[i].allocatable, prevMagnitudes[i].allocatable - magnitudeAllocated[i], err);
+            assertEq(curMagnitudes[i].allocatable, prevMagnitudes[i].allocatable - magnitudeRemoved[i], err);
         }
     }
 
@@ -1010,6 +1100,21 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function assert_Snap_Slashed_Allocation(
+        User operator,
+        OperatorSet memory operatorSet,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Allocation[] memory curAllocations = _getAllocations(operator, operatorSet, params.strategies);
+        Allocation[] memory prevAllocations = _getPrevAllocations(operator, operatorSet, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevAllocations[i].currentMagnitude.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curAllocations[i].currentMagnitude, prevAllocations[i].currentMagnitude - expectedSlashed, err);
+        }
+    }
+
     function assert_Snap_Unchanged_MaxMagnitude(
         User operator,
         IStrategy[] memory strategies,
@@ -1020,6 +1125,20 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         for (uint i = 0; i < strategies.length; i++) {
             assertEq(curMagnitudes[i].max, prevMagnitudes[i].max, err);
+        }
+    }
+
+    function assert_Snap_Slashed_MaxMagnitude(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = prevMagnitudes[i].max.mulWadRoundUp(params.wadsToSlash[i]);
+            assertEq(curMagnitudes[i].max, prevMagnitudes[i].max - expectedSlashed, err);
         }
     }
 
@@ -1235,6 +1354,47 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
                 expectedShares = prevShares[i] + uint(shareDeltas[i]);
             }
             assertEq(expectedShares, curShares[i], err);
+        }
+    }
+
+    function assert_Snap_Slashed_OperatorShares(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curShares = _getOperatorShares(operator, params.strategies);
+        uint[] memory prevShares = _getPrevOperatorShares(operator, params.strategies);
+
+        Magnitudes[] memory curMagnitudes = _getMagnitudes(operator, params.strategies);
+        Magnitudes[] memory prevMagnitudes = _getPrevMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint expectedSlashed = SlashingLib.calcSlashedAmount({
+                operatorShares: prevShares[i],
+                prevMaxMagnitude: prevMagnitudes[i].max,
+                newMaxMagnitude: curMagnitudes[i].max
+            });
+
+            assertEq(curShares[i], prevShares[i] - expectedSlashed, err);
+        }
+    }
+
+    function assert_Snap_Increased_BurnableShares(
+        User operator,
+        SlashingParams memory params,
+        string memory err
+    ) internal {
+        uint[] memory curBurnable = _getBurnableShares(params.strategies);
+        uint[] memory prevBurnable = _getPrevBurnableShares(params.strategies);
+
+        uint[] memory curShares = _getOperatorShares(operator, params.strategies);
+        uint[] memory prevShares = _getPrevOperatorShares(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            uint slashedAtLeast = prevShares[i] - curShares[i];
+
+            // Not factoring in slashable shares in queue here, because that gets more complex (TODO)
+            assertTrue(curBurnable[i] >= (prevBurnable[i] + slashedAtLeast), err);
         }
     }
 
@@ -1788,9 +1948,31 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         Magnitudes[] memory magnitudes = _getMagnitudes(operator, strategies);
 
         for (uint i = 0; i < params.strategies.length; i++) {
-            IStrategy strategy = params.strategies[i];
             uint64 halfAvailable = uint64(magnitudes[i].allocatable) / 2;
             params.newMagnitudes[i] = allocations[i].currentMagnitude + halfAvailable;
+        }
+    }
+
+    /// @dev Generate params to allocate a random portion of available magnitude to each strategy
+    /// in the operator set. All strategies will have a nonzero allocation, and the minimum allocation
+    /// will be 10% of available magnitude
+    function _genAllocation_Rand(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal returns (AllocateParams memory params) {
+        params.operatorSet = operatorSet;
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet);
+        params.newMagnitudes = new uint64[](params.strategies.length);
+
+        Allocation[] memory allocations = _getAllocations(operator, operatorSet, params.strategies);
+        Magnitudes[] memory magnitudes = _getMagnitudes(operator, params.strategies);
+
+        for (uint i = 0; i < params.strategies.length; i++) {
+            // minimum of 10%, maximum of 100%. increments of 10%.
+            uint r = _randUint({min: 1, max: 10});
+            uint64 allocation = uint64(magnitudes[i].allocatable) / uint64(r);
+
+            params.newMagnitudes[i] = allocations[i].currentMagnitude + allocation;
         }
     }
 
@@ -1839,10 +2021,44 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         User operator,
         OperatorSet memory operatorSet,
         IStrategy[] memory strategies
-    ) internal view returns (AllocateParams memory params) {
+    ) internal pure returns (AllocateParams memory params) {
         params.operatorSet = operatorSet;
         params.strategies = strategies;
         params.newMagnitudes = new uint64[](params.strategies.length);
+    }
+
+    /// Generate random slashing between 1 and 99%
+    function _genSlashing_Rand(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal returns (SlashingParams memory params) {
+        params.operator = address(operator);
+        params.operatorSetId = operatorSet.id;
+        params.description = "genSlashing_Half";
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet).sort();
+        params.wadsToSlash = new uint[](params.strategies.length);
+
+        /// 1% * rand(1, 99)
+        uint slashWad = 1e16 * _randUint({min: 1, max: 99});
+
+        for (uint i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = slashWad;
+        }
+    }
+
+    function _genSlashing_Half(
+        User operator,
+        OperatorSet memory operatorSet
+    ) internal view returns (SlashingParams memory params) {
+        params.operator = address(operator);
+        params.operatorSetId = operatorSet.id;
+        params.description = "genSlashing_Half";
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet).sort();
+        params.wadsToSlash = new uint[](params.strategies.length);
+
+        for (uint i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = 1e17;
+        }
     }
 
     function _randWadToSlash() internal returns (uint) {
@@ -2370,6 +2586,38 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         OperatorSet memory operatorSet
     ) internal view returns (bool) {
         return allocationManager.isMemberOfOperatorSet(address(operator), operatorSet);
+    }
+
+    function _getPrevBurnableShares(IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
+        return _getBurnableShares(strategies);
+    }
+
+    function _getBurnableShares(IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory burnableShares = new uint[](strategies.length);
+
+        for (uint i = 0; i < strategies.length; i++) {
+            if (strategies[i] == beaconChainETHStrategy) {
+                burnableShares[i] = eigenPodManager.burnableETHShares();
+            } else {
+                burnableShares[i] = strategyManager.getBurnableShares(strategies[i]);
+            }
+        }
+
+        return burnableShares;
+    }
+
+    function _getPrevSlashableSharesInQueue(User operator, IStrategy[] memory strategies) internal timewarp() returns (uint[] memory) {
+        return _getSlashableSharesInQueue(operator, strategies);
+    }
+
+    function _getSlashableSharesInQueue(User operator, IStrategy[] memory strategies) internal view returns (uint[] memory) {
+        uint[] memory slashableShares = new uint[](strategies.length);
+
+        for (uint i = 0; i < strategies.length; i++) {
+            slashableShares[i] = delegationManager.getSlashableSharesInQueue(address(operator), strategies[i]);
+        }
+
+        return slashableShares;
     }
 
     /// @dev Uses timewarp modifier to get operator shares at the last snapshot

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -358,7 +358,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected deposit shares");
-        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "staker should have received expected withdrawable shares");
+        uint[] memory expectedWithdrawableShares = _getExpectedWithdrawableSharesUndelegate(staker, strategies, shares);
+        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, expectedWithdrawableShares, "staker should have received expected withdrawable shares");
         assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
     }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -243,6 +243,8 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_Undelegate_State: calculated withdrawal should match returned root");
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_Undelegate_State: stakers withdrawal should now be pending");
+        assert_DSF_Reset(staker, strategies,
+            "check_Undelegate_State: staker dsfs should be reset to wad");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,
             "check_Undelegate_State: staker should have increased nonce by withdrawals.length");
         assert_Snap_Removed_OperatorShares(operator, strategies, stakerDelegatedShares,

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -199,7 +199,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         User staker, 
         User operator, 
         IStrategy[] memory strategies, 
-        uint[] memory shares, 
+        uint[] memory depositShares,
+        uint[] memory withdrawableShares, 
         Withdrawal[] memory withdrawals, 
         bytes32[] memory withdrawalRoots
     ) internal {
@@ -215,11 +216,11 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_QueuedWithdrawal_State: calculated withdrawals should match returned roots");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,
             "check_QueuedWithdrawal_State: staker should have increased nonce by withdrawals.length");
-        assert_Snap_Removed_OperatorShares(operator, strategies, shares,
+        assert_Snap_Removed_OperatorShares(operator, strategies, withdrawableShares,
             "check_QueuedWithdrawal_State: failed to remove operator shares");
-        assert_Snap_Removed_Staker_DepositShares(staker, strategies, shares,
+        assert_Snap_Removed_Staker_DepositShares(staker, strategies, depositShares,
             "check_QueuedWithdrawal_State: failed to remove staker shares");
-        assert_Snap_Removed_Staker_WithdrawableShares(staker, strategies, shares,
+        assert_Snap_Removed_Staker_WithdrawableShares(staker, strategies, withdrawableShares,
             "check_QueuedWithdrawal_State: failed to remove staker withdrawable shares");
     }
 
@@ -237,6 +238,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         // ... check that the staker is undelegated, all strategies from which the staker is deposited are unqueued,
         //     that the returned root matches the hashes for each strategy and share amounts, and that the staker
         //     and operator have reduced shares
+        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
         assertFalse(delegationManager.isDelegated(address(staker)),
             "check_Undelegate_State: staker should not be delegated");
         assert_ValidWithdrawalHashes(withdrawals, withdrawalRoots,
@@ -257,7 +259,8 @@ contract IntegrationCheckUtils is IntegrationBase {
 
     function check_Redelegate_State(
         User staker, 
-        User operator,
+        User prevOperator,
+        User newOperator,
         IDelegationManagerTypes.Withdrawal[] memory withdrawals,
         bytes32[] memory withdrawalRoots,
         IStrategy[] memory strategies,
@@ -271,13 +274,16 @@ contract IntegrationCheckUtils is IntegrationBase {
         //     and operator have reduced shares
         assertTrue(delegationManager.isDelegated(address(staker)),
             "check_Redelegate_State: staker should not be delegated");
+        assertEq(address(newOperator), delegationManager.delegatedTo(address(staker)), "staker should be delegated to operator");
+        assert_HasExpectedShares(staker, strategies, new uint[](strategies.length), "staker should not have deposit shares after redelegation");
+        assert_Snap_Unchanged_OperatorShares(newOperator, "new operator should not have received any shares");
         assert_ValidWithdrawalHashes(withdrawals, withdrawalRoots,
             "check_Redelegate_State: calculated withdrawl should match returned root");
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_Redelegate_State: stakers withdrawal should now be pending");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,
             "check_Redelegate_State: staker should have increased nonce by withdrawals.length");
-        assert_Snap_Removed_OperatorShares(operator, strategies, stakerDelegatedShares,
+        assert_Snap_Removed_OperatorShares(prevOperator, strategies, stakerDelegatedShares,
             "check_Redelegate_State: failed to remove operator shares");
         assert_Snap_Removed_Staker_DepositShares(staker, strategies, stakerDepositShares,
             "check_Redelegate_State: failed to remove staker shares");
@@ -338,7 +344,7 @@ contract IntegrationCheckUtils is IntegrationBase {
             if (operator != staker) {
                 assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
             }
-            assert_Snap_Added_OperatorShares(operator, withdrawal.strategies, withdrawal.scaledShares, "operator should have received shares");
+            assert_Snap_Added_OperatorShares(operator, strategies, shares, "operator should have received shares");
         }
     }
 
@@ -882,8 +888,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         check_IsSlashable_State(operator, operatorSet, allocateParams.strategies);
 
         // Slashing SHOULD change max magnitude and current allocation
-        assert_Snap_Slashed_MaxMagnitude(operator, slashParams, "slash should lower max magnitude");
-        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_MaxMagnitude(operator, operatorSet, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower encumbered magnitude");
         assert_Snap_Slashed_AllocatedStake(operator, operatorSet, slashParams, "slash should lower allocated stake");
         assert_Snap_Slashed_SlashableStake(operator, operatorSet, slashParams, "slash should lower slashable stake");
         assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
@@ -894,97 +900,19 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");
         assert_Snap_Unchanged_Registration(operator, operatorSet, "slash should not change registration status");
         assert_Snap_Unchanged_Slashability(operator, operatorSet, "slash should not change slashability status");
-        assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
-        assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
+        // assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
+        // assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
     }
 
-    // TODO: improvement needed 
-
-    function check_Withdrawal_AsTokens_State_AfterSlash(
-        User staker,
+    /// Slashing invariants when the operator has been fully slashed for every strategy in the operator set
+    function check_FullySlashed_State(
         User operator,
-        Withdrawal memory withdrawal,
         AllocateParams memory allocateParams,
-        SlashingParams memory slashingParams,
-        uint[] memory expectedTokens
+        SlashingParams memory slashParams
     ) internal {
-        IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
 
-        for (uint i; i < withdrawal.strategies.length; i++) {
-            IStrategy strat = withdrawal.strategies[i];
-
-            bool isBeaconChainETHStrategy = strat == beaconChainETHStrategy;
-
-            tokens[i] = isBeaconChainETHStrategy ? NATIVE_ETH : withdrawal.strategies[i].underlyingToken();
-            
-            if (slashingParams.strategies.contains(strat)) {
-                uint wadToSlash = slashingParams.wadsToSlash[slashingParams.strategies.indexOf(strat)];
-
-                expectedTokens[i] -= expectedTokens[i]
-                    .mulWadRoundUp(allocateParams.newMagnitudes[i].mulWadRoundUp(wadToSlash));
-
-                uint256 max = allocationManager.getMaxMagnitude(address(operator), strat);
-
-                withdrawal.scaledShares[i] -= withdrawal.scaledShares[i].calcSlashedAmount(WAD, max);
-
-                // Round down to the nearest gwei for beaconchain ETH strategy.
-                if (isBeaconChainETHStrategy) {
-                    expectedTokens[i] -= expectedTokens[i] % 1 gwei;
-                }
-            }
-        }
-
-        // Common checks
-        assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
-        
-        // TODO FIXME
-        // assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
-        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have changed");
-        assert_Snap_Removed_StrategyShares(withdrawal.strategies, withdrawal.scaledShares, "strategies should have total shares decremented");
-
-        // Checks specific to an operator that the Staker has delegated to
-        if (operator != User(payable(0))) {
-            if (operator != staker) {
-                assert_Snap_Unchanged_TokenBalances(operator, "operator token balances should not have changed");
-            }
-            assert_Snap_Unchanged_OperatorShares(operator, "operator shares should not have changed");
-        }
-    }
-
-    function check_Withdrawal_AsShares_State_AfterSlash(
-        User staker,
-        User operator,
-        Withdrawal memory withdrawal,
-        AllocateParams memory allocateParams, // TODO - was this needed?
-        SlashingParams memory slashingParams
-    ) internal {
-        IERC20[] memory tokens = new IERC20[](withdrawal.strategies.length);
-
-        for (uint i; i < withdrawal.strategies.length; i++) {
-            IStrategy strat = withdrawal.strategies[i];
-
-            bool isBeaconChainETHStrategy = strat == beaconChainETHStrategy;
-
-            tokens[i] = isBeaconChainETHStrategy ? NATIVE_ETH : withdrawal.strategies[i].underlyingToken();
-            
-            if (slashingParams.strategies.contains(strat)) {
-                uint256 max = allocationManager.getMaxMagnitude(address(operator), strat);
-
-                withdrawal.scaledShares[i] -= withdrawal.scaledShares[i].calcSlashedAmount(WAD, max);
-            }
-        }
-        
-        // Common checks applicable to both user and non-user operator types
-        assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
-        assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
-        assert_Snap_Added_Staker_DepositShares(staker, withdrawal.strategies,  withdrawal.scaledShares, "staker should have received expected shares");
-        assert_Snap_Unchanged_StrategyShares(withdrawal.strategies, "strategies should have total shares unchanged");
-
-        // Additional checks or handling for the non-user operator scenario
-        if (operator != User(User(payable(0)))) {
-            if (operator != staker) {
-                assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
-            }
-        }
+        assert_Snap_Removed_AllocatedSet(operator, allocateParams.operatorSet, "should not have updated allocated sets");
+        assert_Snap_Removed_AllocatedStrats(operator, allocateParams.operatorSet, slashParams.strategies, "should not have updated allocated strategies");
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -357,7 +357,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
-        assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected shares");
+        assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should have received expected deposit shares");
+        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "staker should have received expected withdrawable shares");
         assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
     }
@@ -486,18 +487,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_EncumberedMagnitude(operator, allStrats, "should not have updated encumbered magnitude");
         assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "should not have updated allocatable magnitude");
     }
-
-    // /// @dev Checks invariants for registration for a variety of allocation states
-    // /// 
-    // function check_Registration_State(
-    //     User operator,
-    //     OperatorSet memory operatorSet,
-    //     IStrategy[] memory unallocated,
-    //     AllocateParams memory pending,
-    //     AllocateParams memory active
-    // ) internal {
-    //     check_Base_Registration_State(operator, operatorSet);
-    // }
 
     /// @dev Check invariants for registerForOperatorSets given a set of strategies
     /// for which NO allocation exists (currentMag/pendingDiff are 0)
@@ -873,6 +862,37 @@ contract IntegrationCheckUtils is IntegrationBase {
         
         assert_MaxEqualsAllocatablePlusEncumbered(operator, "max magnitude should equal encumbered plus allocatable");
         check_ActiveModification_State(operator, deallocateParams); 
+    }
+
+    /*******************************************************************************
+                                ALM - SLASHING
+    *******************************************************************************/
+
+    function check_Base_Slashing_State(
+        User operator,
+        AllocateParams memory allocateParams,
+        SlashingParams memory slashParams
+    ) internal {
+        OperatorSet memory operatorSet = allocateParams.operatorSet;
+
+        check_MaxMag_Invariants(operator);
+        check_IsSlashable_State(operator, operatorSet, allocateParams.strategies);
+
+        // Slashing SHOULD change max magnitude and current allocation
+        assert_Snap_Slashed_MaxMagnitude(operator, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_AllocatedStake(operator, operatorSet, slashParams, "slash should lower allocated stake");
+        assert_Snap_Slashed_SlashableStake(operator, operatorSet, slashParams, "slash should lower slashable stake");
+        assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
+        assert_Snap_Slashed_Allocation(operator, operatorSet, slashParams, "slash should reduce current magnitude");
+        assert_Snap_Increased_BurnableShares(operator, slashParams, "slash should increase burnable shares");
+
+        // Slashing SHOULD NOT change allocatable magnitude, registration, and slashability status
+        assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");
+        assert_Snap_Unchanged_Registration(operator, operatorSet, "slash should not change registration status");
+        assert_Snap_Unchanged_Slashability(operator, operatorSet, "slash should not change slashability status");
+        assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
+        assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
     }
 
     // TODO: improvement needed 

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -35,6 +35,7 @@ IStrategy constant beaconChainETHStrategy = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeE
 
 abstract contract IntegrationDeployer is ExistingDeploymentParser {
     using StdStyle for *;
+    using ArrayLib for *;
 
     // Fork ids for specific fork tests
     bool isUpgraded;
@@ -193,6 +194,13 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         _upgradeProxies();
         _initializeProxies();
 
+        // Place native ETH first in `allStrats`
+        // This ensures when we select a nonzero number of strategies from this array, we always
+        // have beacon chain ETH
+        ethStrats.push(BEACONCHAIN_ETH_STRAT);
+        allStrats.push(BEACONCHAIN_ETH_STRAT);
+        allTokens.push(NATIVE_ETH);
+
         // Deploy and configure strategies and tokens
         for (uint i = 1; i < NUM_LST_STRATS + 1; ++i) {
             string memory name = string.concat("LST-Strat", cheats.toString(i), " token");
@@ -201,9 +209,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
             _newStrategyAndToken(name, symbol, 10e50, address(this), i % 2 == 0);
         }
 
-        ethStrats.push(BEACONCHAIN_ETH_STRAT);
-        allStrats.push(BEACONCHAIN_ETH_STRAT);
-        allTokens.push(NATIVE_ETH);
         maxUniqueAssetsHeld = allStrats.length;
 
         // Create time machine and beacon chain. Set block time to beacon chain genesis time
@@ -225,6 +230,13 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         _parseDeployedContracts(deploymentInfoPath);
         string memory existingDeploymentParams = "script/configs/mainnet.json";
         _parseParamsForIntegrationUpgrade(existingDeploymentParams);
+
+        // Place native ETH first in `allStrats`
+        // This ensures when we select a nonzero number of strategies from this array, we always
+        // have beacon chain ETH
+        ethStrats.push(BEACONCHAIN_ETH_STRAT);
+        allStrats.push(BEACONCHAIN_ETH_STRAT);
+        allTokens.push(NATIVE_ETH);
 
         // Add deployed strategies to lstStrats and allStrats
         for (uint i; i < deployedStrategyArray.length; i++) {
@@ -281,11 +293,6 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         });
 
         cheats.stopPrank();
-
-        ethStrats.push(BEACONCHAIN_ETH_STRAT);
-        allStrats.push(BEACONCHAIN_ETH_STRAT);
-        allTokens.push(NATIVE_ETH);
-        maxUniqueAssetsHeld = allStrats.length;
     }
 
     function _deployProxies() public {
@@ -547,49 +554,56 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
     function _randUser(
         string memory name
     ) internal noTracing returns (User, IStrategy[] memory, uint[] memory) {
-        // For the new user, select what type of assets they'll have and whether
-        // they'll use `xWithSignature` methods.
-        //
-        // The values selected here are in the ranges configured via `_configRand`
-        uint assetType = _randAssetType();
-        uint userType = _randUserType();
-
         // Deploy new User contract
+        uint userType = _randUserType();
         User user = _genRandUser(name, userType);
 
-        // For the specific asset selection we made, get a random assortment of
-        // strategies and deal the user some corresponding underlying token balances
-        (IStrategy[] memory strategies, uint[] memory tokenBalances) = _dealRandAssets(user, assetType);
+        // For the specific asset selection we made, get a random assortment of strategies 
+        // and deal the user some corresponding underlying token balances
+        uint assetType = _randAssetType();
+        IStrategy[] memory strategies = _selectRandAssets(assetType);
+        uint[] memory tokenBalances = _dealRandAmounts(user, strategies);
 
         print.user(name, assetType, userType, strategies, tokenBalances);
         return (user, strategies, tokenBalances);
+    }
+
+    function _randUser(
+        string memory name,
+        IStrategy[] memory strategies
+    ) internal noTracing returns (User, uint[] memory) {
+        // Deploy new User contract
+        uint userType = _randUserType();
+        User user = _genRandUser(name, userType);
+
+        // Deal the user some corresponding underlying token balances
+        uint[] memory tokenBalances = _dealRandAmounts(user, strategies);
+
+        print.user(name, HOLDS_ALL, userType, strategies, tokenBalances);
+        return (user, tokenBalances);
     }
 
     /// @dev Create a new user without native ETH. See _randUser above for standard usage
     function _randUser_NoETH(
         string memory name
     ) internal noTracing returns (User, IStrategy[] memory, uint[] memory) {
-        // For the new user, select what type of assets they'll have and whether
-        // they'll use `xWithSignature` methods.
-        //
-        // The values selected here are in the ranges configured via `_configRand`
+        // Deploy new User contract
         uint userType = _randUserType();
+        User user = _genRandUser(name, userType);
 
         // Pick the user's asset distribution, removing "native ETH" as an option
         // I'm sorry if this eventually leads to a bug that's really hard to track down
         uint assetType = _randAssetType();
         if (assetType == HOLDS_ETH) {
             assetType = NO_ASSETS;
-        } else if (assetType == HOLDS_ALL) {
+        } else if (assetType == HOLDS_ALL || assetType == HOLDS_MAX) {
             assetType = HOLDS_LST;
         }
 
-        // Deploy new User contract
-        User user = _genRandUser(name, userType);
-
-        // For the specific asset selection we made, get a random assortment of
-        // strategies and deal the user some corresponding underlying token balances
-        (IStrategy[] memory strategies, uint[] memory tokenBalances) = _dealRandAssets(user, assetType);
+        // For the specific asset selection we made, get a random assortment of strategies 
+        // and deal the user some corresponding underlying token balances
+        IStrategy[] memory strategies = _selectRandAssets(assetType);
+        uint[] memory tokenBalances = _dealRandAmounts(user, strategies);
 
         print.user(name, assetType, userType, strategies, tokenBalances);
         return (user, strategies, tokenBalances);
@@ -599,13 +613,8 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
     function _randUser_NoAssets(
         string memory name
     ) internal noTracing returns (User) {
-        // For the new user, select what type of assets they'll have and whether
-        // they'll use `xWithSignature` methods.
-        //
-        // The values selected here are in the ranges configured via `_configRand`
-        uint userType = _randUserType();
-
         // Deploy new User contract
+        uint userType = _randUserType();
         User user = _genRandUser(name, userType);
 
         print.user(name, NO_ASSETS, userType, new IStrategy[](0), new uint[](0));
@@ -651,83 +660,64 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         }
     }
 
-    /// @dev For a given `assetType`, select a random assortment of strategies and assets
-    /// NO_ASSETS - return will be empty
-    /// HOLDS_LST - `strategies` will be a random subset of initialized strategies
-    ///             `tokenBalances` will be the user's balances in each token
-    /// HOLDS_ETH - `strategies` will only contain BEACONCHAIN_ETH_STRAT, and
-    ///             `tokenBalances` will contain the user's eth balance
-    /// HOLDS_ALL - `strategies` will contain ALL initialized strategies AND BEACONCHAIN_ETH_STRAT, and
-    ///             `tokenBalances` will contain random token/eth balances accordingly
-    function _dealRandAssets(User user, uint assetType) internal noTracing returns (IStrategy[] memory, uint[] memory) {
-        IStrategy[] memory strategies;
-        uint[] memory tokenBalances;
+    /// Given an assetType, select strategies the user will be dealt assets in
+    function _selectRandAssets(uint assetType) internal noTracing returns (IStrategy[] memory) {
         if (assetType == NO_ASSETS) {
-            strategies = new IStrategy[](0);
-            tokenBalances = new uint[](0);
-        } else if (assetType == HOLDS_LST) {
-            assetType = HOLDS_LST;
-            // Select a random number of assets
-            uint max = lstStrats.length;
-            if (max > maxUniqueAssetsHeld) {
-                max = maxUniqueAssetsHeld;
-            }
-            uint numAssets = _randUint({min: 1, max: max});
-
-            strategies = new IStrategy[](numAssets);
-            tokenBalances = new uint[](numAssets);
-
-            // For each asset, award the user a random balance of the underlying token
-            for (uint i = 0; i < numAssets; i++) {
-                IStrategy strat = lstStrats[i];
-                IERC20 underlyingToken = strat.underlyingToken();
-                uint balance = _randUint({min: MIN_BALANCE, max: MAX_BALANCE});
-
-                StdCheats.deal(address(underlyingToken), address(user), balance);
-                tokenBalances[i] = balance;
-                strategies[i] = strat;
-            }
-        } else if (assetType == HOLDS_ETH) {
-            strategies = new IStrategy[](1);
-            tokenBalances = new uint[](1);
-
-            // Award the user with a random amount of ETH
-            // This guarantees a multiple of 32 ETH (at least 1, up to/incl 5)
-            uint amount = 32 ether * _randUint({min: 1, max: 5});
-            cheats.deal(address(user), amount);
-
-            strategies[0] = BEACONCHAIN_ETH_STRAT;
-            tokenBalances[0] = amount;
-        } else if (assetType == HOLDS_ALL || assetType == HOLDS_MAX) {
-            uint randHeld = _randUint({min: 1, max: maxUniqueAssetsHeld-1});
-            uint numLSTs = assetType == HOLDS_MAX ? lstStrats.length : randHeld;
-            strategies = new IStrategy[](numLSTs + 1);
-            tokenBalances = new uint[](numLSTs + 1);
-
-            // For each LST, award the user a random balance of the underlying token
-            for (uint i = 0; i < numLSTs; i++) {
-                IStrategy strat = lstStrats[i];
-                IERC20 underlyingToken = strat.underlyingToken();
-                uint balance = _randUint({min: MIN_BALANCE, max: MAX_BALANCE});
-
-                StdCheats.deal(address(underlyingToken), address(user), balance);
-                tokenBalances[i] = balance;
-                strategies[i] = strat;
-            }
-
-            // Award the user with a random amount of ETH
-            // This guarantees a multiple of 32 ETH (at least 1, up to/incl 5)
-            uint amount = 32 ether * _randUint({min: 1, max: 5});
-            cheats.deal(address(user), amount);
-
-            // Add BEACONCHAIN_ETH_STRAT and eth balance
-            strategies[numLSTs] = BEACONCHAIN_ETH_STRAT;
-            tokenBalances[numLSTs] = amount;
-        } else {
-            revert("_dealRandAssets: assetType unimplemented");
+            return new IStrategy[](0);
+        } 
+        
+        /// Select only ETH
+        if (assetType == HOLDS_ETH) {
+            return beaconChainETHStrategy.toArray();
         }
 
-        return (strategies, tokenBalances);
+        /// Select multiple LSTs, and maybe add ETH:
+
+        // Select number of assets:
+        // HOLDS_LST can hold at most all LSTs. HOLDS_ALL and HOLDS_MAX also hold ETH.
+        // Clamp number of assets to maxUniqueAssetsHeld (guaranteed to be at least 1)
+        uint assetPoolSize = assetType == HOLDS_LST ? lstStrats.length : allStrats.length;
+        uint maxAssets = assetPoolSize > maxUniqueAssetsHeld ? maxUniqueAssetsHeld : assetPoolSize;
+
+        uint numAssets = assetType == HOLDS_MAX ? maxAssets : _randUint(1, maxAssets);
+
+        IStrategy[] memory strategies = new IStrategy[](numAssets);
+        for (uint i = 0; i < strategies.length; i++) {
+            if (assetType == HOLDS_LST) {
+                strategies[i] = lstStrats[i];
+            } else {
+                // allStrats[0] is the beaconChainETHStrategy
+                strategies[i] = allStrats[i];
+            }
+        }
+
+        return strategies;
+    }
+
+    /// Given an input list of strategies, deal random underlying token amounts to a user
+    function _dealRandAmounts(User user, IStrategy[] memory strategies) internal noTracing returns (uint[] memory) {
+        uint[] memory tokenBalances = new uint[](strategies.length);
+
+        for (uint i = 0; i < tokenBalances.length; i++) {
+            IStrategy strategy = strategies[i];
+            uint balance;
+
+            if (strategy == BEACONCHAIN_ETH_STRAT) {
+                // Award the user with a random amount of ETH
+                // This guarantees a multiple of 32 ETH (at least 1, up to/incl 5)
+                balance = 32 ether * _randUint({min: 1, max: 5});
+                cheats.deal(address(user), balance);
+            } else {
+                IERC20 underlyingToken = strategy.underlyingToken();
+                balance = _randUint({min: MIN_BALANCE, max: MAX_BALANCE});
+
+                StdCheats.deal(address(underlyingToken), address(user), balance);
+            }
+
+            tokenBalances[i] = balance;
+        }
+
+        return tokenBalances;
     }
 
     /// @dev Uses `random` to return a random uint, with a range given by `min` and `max` (inclusive)

--- a/src/test/integration/tests/ALM_RegisterAndModify.t.sol
+++ b/src/test/integration/tests/ALM_RegisterAndModify.t.sol
@@ -52,11 +52,9 @@ contract Integration_InitRegistered is Integration_ALMBase {
         check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
     }
 
-    function testFuzz_allocate_deallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_allocate_deallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Allocate to the operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -77,11 +75,9 @@ contract Integration_InitRegistered is Integration_ALMBase {
         check_FullyDeallocated_State(operator, allocateParams, deallocateParams);
     }
 
-    function testFuzz_allocate_deallocate_waitDeallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_allocate_deallocate_waitDeallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Allocate to the operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -111,7 +107,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
         _rollForward_DeallocationDelay();
 
         // 3. Allocate to operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
 
@@ -132,7 +128,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
 
         // 2. Before deregistration is complete, allocate to operator set
         // The operator should be slashable after the allocation delay
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -156,7 +152,7 @@ contract Integration_InitRegistered is Integration_ALMBase {
 
         // 2. Before deregistration is complete, allocate to operator set
         // The operator should be slashable after the allocation delay
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        allocateParams = _genAllocation_Rand(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
@@ -184,9 +180,7 @@ contract Integration_InitAllocated is Integration_ALMBase {
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
     }
 
-    function testFuzz_register_deallocate_deregister(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_register_deallocate_deregister(uint24 _r) public rand(_r) {
         // 1. Register for the operator set
         operator.registerForOperatorSet(operatorSet);
         check_Registration_State_PendingAllocation(operator, allocateParams);
@@ -208,9 +202,7 @@ contract Integration_InitAllocated is Integration_ALMBase {
         check_FullyDeallocated_State(operator, allocateParams, deallocateParams);
     }
 
-    function testFuzz_waitAllocation_register_deallocate(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_waitAllocation_register_deallocate(uint24 _r) public rand(_r) {
         _rollForward_AllocationDelay(operator);
 
         // 1. Register for the operator set. The allocation immediately becomes slashable

--- a/src/test/integration/tests/Delegate_Deposit_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Delegate_Deposit_Queue_Complete.t.sol
@@ -24,9 +24,10 @@ contract Integration_Delegate_Deposit_Queue_Complete is IntegrationCheckUtils {
         assert_Snap_Added_OperatorShares(operator, strategies, shares, "operator should have received shares");
 
         // 3. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete Queued Withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -55,9 +56,10 @@ contract Integration_Delegate_Deposit_Queue_Complete is IntegrationCheckUtils {
         assert_Snap_Added_OperatorShares(operator, strategies, shares, "operator should have received shares");
 
         // 3. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete Queued Withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Queue_Complete.t.sol
@@ -43,9 +43,10 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         check_Delegation_State(staker, operator, strategies, shares);
 
         // 3. Queue Withdrawals
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -96,9 +97,10 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
         check_Delegation_State(staker, operator, strategies, shares);
 
         // 3. Queue Withdrawals
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -160,7 +162,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
 
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(withdrawStrats, withdrawShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, withdrawStrats, withdrawShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, withdrawStrats, withdrawShares, withdrawShares, withdrawals, withdrawalRoots);
 
         // 4. Complete withdrawals
         // Fast forward to when we can complete the withdrawal
@@ -216,7 +218,7 @@ contract Integration_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
 
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(withdrawStrats, withdrawShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, withdrawStrats, withdrawShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, withdrawStrats, withdrawShares, withdrawShares, withdrawals, withdrawalRoots);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -64,9 +64,10 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -129,9 +130,10 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -230,7 +232,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             shares = _calculateExpectedShares(strategies, tokenBalances);
             Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, shares);
             bytes32[] memory newWithdrawalRoots = _getWithdrawalHashes(newWithdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, newWithdrawals, newWithdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, newWithdrawals, newWithdrawalRoots);
 
             // 8. Complete withdrawal
             // Fast forward to when we can complete the withdrawal
@@ -323,7 +325,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             totalShares = _calculateExpectedShares(strategies, tokenBalances);
             Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, totalShares);
             bytes32[] memory newWithdrawalRoots = _getWithdrawalHashes(newWithdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, totalShares, newWithdrawals, newWithdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, totalShares, totalShares, newWithdrawals, newWithdrawalRoots);
 
             // 8. Complete withdrawal
             // Fast forward to when we can complete the withdrawal
@@ -388,10 +390,13 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         check_Delegation_State(staker, operator2, strategies, shares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
-        // 7. Queue Withdrawal
-        withdrawals = staker.queueWithdrawals(strategies, shares);
-        withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawals, withdrawalRoots);
+        {
+            // 7. Queue Withdrawal
+            uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+            withdrawals = staker.queueWithdrawals(strategies, shares);
+            withdrawalRoots = _getWithdrawalHashes(withdrawals);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
+        }
 
         // 8. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -459,7 +464,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
         withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, withdrawals, withdrawalRoots);
 
         // 8. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/Deposit_Register_QueueWithdrawal_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Register_QueueWithdrawal_Complete.t.sol
@@ -19,9 +19,10 @@ contract Integration_Deposit_Register_QueueWithdrawal_Complete is IntegrationChe
         assertTrue(delegationManager.isOperator(address(staker)), "Staker should be registered as an operator");
 
         // 3. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, staker, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, staker, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete Queued Withdrawal as Shares
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -44,9 +45,10 @@ contract Integration_Deposit_Register_QueueWithdrawal_Complete is IntegrationChe
         assertTrue(delegationManager.isOperator(address(staker)), "Staker should be registered as an operator");
 
         // 3. Queue Withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, shares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, staker, strategies, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, staker, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 4. Complete Queued Withdrawal as Tokens
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Slashed_Eigenpod.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod.t.sol
@@ -236,7 +236,7 @@ contract Integration_SlashedEigenpod is IntegrationCheckUtils {
         // Undelegate from an operator
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = staker.redelegate(operator2);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Redelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, delegatedShares);
+        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, initDepositShares, delegatedShares);
 
         // Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/SlashingWithdrawals.t.sol
+++ b/src/test/integration/tests/SlashingWithdrawals.t.sol
@@ -10,9 +10,11 @@ contract Integration_ALMSlashBase is IntegrationCheckUtils {
 
     User operator;
     AllocateParams allocateParams;
+    SlashingParams slashParams;
 
     User staker;
     IStrategy[] strategies;
+    IERC20[] tokens; // underlying token for each strategy
     uint[] initTokenBalances;
     uint[] initDepositShares;
 
@@ -26,13 +28,10 @@ contract Integration_ALMSlashBase is IntegrationCheckUtils {
     /// NOTE: Steps 4 and 5 are done in random order, as these should not have an outcome on the test
     function _init() internal virtual override {
         _configAssetTypes(HOLDS_LST);
-        // (staker, strategies, initTokenBalances) = _newRandomStaker();
-        // operator = _newRandomOperator_NoAssets();
-        // (avs,) = _newRandomAVS();
-
-        (staker, strategies, initTokenBalances) = _newBasicStaker();
+        (staker, strategies, initTokenBalances) = _newRandomStaker();
         operator = _newRandomOperator_NoAssets();
         (avs,) = _newRandomAVS();
+        tokens = _getUnderlyingTokens(strategies);
 
         // 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, initTokenBalances);
@@ -70,24 +69,86 @@ contract Integration_ALMSlashBase is IntegrationCheckUtils {
     }
 }
 
-contract Integration_InitSlash is Integration_ALMSlashBase {
+contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
 
-    SlashingParams slashParams;
+    User stakerB;
+    uint[] initTokenBalancesB;
+    uint[] initTokenSharesB;
 
-    function testFuzz_slashSingle(uint24 _r) public rand(_r) {
-        slashParams = _genSlashing_Rand(operator, operatorSet);
-        avs.slashOperator(slashParams);
-        check_Base_Slashing_State(operator, allocateParams, slashParams);
-    } 
+    User operatorB;
+    OperatorSet operatorSetB;
+    AllocateParams allocateParamsB;
+    SlashingParams slashParamsB;
 
-    function testFuzz_slashMulti_WithdrawTokens(uint24 _r) public rand(_r) {
-        for (uint i = 0; i < 25; i++) {
-            slashParams = _genSlashing_Rand(operator, operatorSet);
-            avs.slashOperator(slashParams);
-            check_Base_Slashing_State(operator, allocateParams, slashParams);
+    /// Init: Registered operator gets slashed one or more times for a random magnitude
+    /// - Second operator (for redelegation) may or may not be slashed
+    ///
+    /// Tests: Operator is slashed one or more times, then staker withdraws in different ways
+    function _init() internal override {
+        super._init();
+
+        /// Create second operator set with the same strategies as the first
+        /// Create a second operator. Register and allocate to operatorSetB
+        /// Also create a second staker with the same assets as the first,
+        /// delegated to operatorB. This is to give operatorB initial assets that can
+        /// be checked via invariants.
+        {
+            // Create operatorB
+            operatorB = _newRandomOperator_NoAssets();
+            
+            // Create stakerB, deposit, and delegate to operatorB
+            (stakerB, initTokenBalancesB) = _newStaker(strategies);
+            
+            stakerB.depositIntoEigenlayer(strategies, initTokenBalancesB);
+            initTokenSharesB = _calculateExpectedShares(strategies, initTokenBalancesB);
+            check_Deposit_State(stakerB, strategies, initTokenSharesB);
+
+            stakerB.delegateTo(operatorB);
+            check_Delegation_State(stakerB, operatorB, strategies, initTokenSharesB);
+
+            // Create operatorSetB
+            operatorSetB = avs.createOperatorSet(strategies);
+
+            // Register and allocate fully to operatorSetB
+            operatorB.registerForOperatorSet(operatorSetB);
+            check_Registration_State_NoAllocation(operatorB, operatorSetB, allStrats);
+
+            allocateParamsB = _genAllocation_AllAvailable(operatorB, operatorSetB);
+            operatorB.modifyAllocations(allocateParamsB);
+            check_IncrAlloc_State_Slashable(operatorB, allocateParamsB);
+
+            _rollBlocksForCompleteAllocation(operatorB, operatorSetB, strategies);
         }
 
-        // undelegate
+        /// Slash first operator one or more times
+        /// Each slash is for 1 to 99%
+        {
+            uint numSlashes = _randUint(1, 10);
+            for (uint i = 0; i < numSlashes; i++) {
+                slashParams = _genSlashing_Rand(operator, operatorSet);
+                avs.slashOperator(slashParams);
+                check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+                // TODO - staker variant?
+                // assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+                // assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashParams, "staker deposit shares should be slashed");
+            }
+        }
+
+        /// Optionally do a single slash for the second operator
+        /// This is to test redelegation where the new operator has already been slashed
+        {
+            bool slashSecondOperator = _randBool();
+            if (slashSecondOperator) {
+                slashParamsB = _genSlashing_Half(operatorB, operatorSetB);
+                avs.slashOperator(slashParamsB);
+                check_Base_Slashing_State(operatorB, allocateParamsB, slashParamsB);
+            }
+        }
+    }
+
+    function testFuzz_undelegate_completeAsTokens(uint24 _r) public rand(_r) {
+        /// Undelegate from operatorA
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
@@ -95,24 +156,51 @@ contract Integration_InitSlash is Integration_ALMSlashBase {
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
-        // try withdrawing as tokens:
-        IERC20[] memory tokens = _getUnderlyingTokens(strategies);
+        /// Complete withdrawal as tokens
         uint[] memory expectedTokens = _calculateExpectedTokens(strategies, shares);
-
         staker.completeWithdrawalsAsTokens(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
 
-    function testFuzz_slashMulti_WithdrawShares(uint24 _r) public rand(_r) {
-        for (uint i = 0; i < 25; i++) {
-            slashParams = _genSlashing_Rand(operator, operatorSet);
-            avs.slashOperator(slashParams);
-            check_Base_Slashing_State(operator, allocateParams, slashParams);
-        }
+    function testFuzz_redelegate_completeAsTokens(uint24 _r) public rand(_r) {
+        /// Redelegate to operatorB
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.redelegate(operatorB);
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, initDepositShares, shares);
 
-        // undelegate
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        /// Complete withdrawal as tokens
+        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, shares);
+        staker.completeWithdrawalsAsTokens(withdrawals);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_queueFull_completeAsTokens(uint24 _r) public rand(_r) {
+        // Queue a withdrawal for all shares
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        // Complete withdrawal as tokens
+        for (uint i = 0; i < withdrawals.length; i++) {
+            uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_undelegate_completeAsShares(uint24 _r) public rand(_r) {
+        // Undelegate from operatorA
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
@@ -120,165 +208,108 @@ contract Integration_InitSlash is Integration_ALMSlashBase {
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
-        // try withdrawing as shares
+        // Complete withdrawal as shares
         staker.completeWithdrawalsAsShares(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
             check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], strategies, shares);
         }
     }
+    
+    function testFuzz_redelegate_completeAsShares(uint24 _r) public rand(_r) {
+        // Redelegate to operatorB
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.redelegate(operatorB);
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, initDepositShares, shares);
+
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        // Complete withdrawal as shares
+        staker.completeWithdrawalsAsShares(withdrawals);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operatorB, withdrawals[i], strategies, shares);
+        }
+    }
+
+    function testFuzz_queueFull_completeAsShares(uint24 _r) public rand(_r) {
+        // Queue a withdrawal for all shares
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        // Complete withdrawal as shares
+        staker.completeWithdrawalsAsShares(withdrawals);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            check_Withdrawal_AsShares_State(staker, operator, withdrawals[i], strategies, withdrawableShares);
+        }
+    }
 }
 
-contract Integration_SlashingWithdrawals is Integration_ALMSlashBase {
-
-    function testFuzz_slash_undelegate_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
-        // 4. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
-
-        // 5. Undelegate from an operator
-        Withdrawal[] memory withdrawals = staker.undelegate();
+contract Integration_QueueWithdrawalThenSlash is Integration_ALMSlashBase {
+    
+    function testFuzz_queue_slash_completeAsTokens(uint24 _r) public rand(_r) {
+        // 4. Queue withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        // 5. Slash operator
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+        // TODO - staker variants?
 
         // 6. Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens =
-                _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
+            uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
             staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State_AfterSlash(staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, expectedShares, tokens, expectedTokens);
         }
 
         // Check Final State
+        // check_FullyWithdrawn_State(staker, ..., ); TODO
         assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
-        assert_HasUnderlyingTokenBalances_AfterSlash(
-            staker,
-            allocateParams,
-            slashingParams,
-            initTokenBalances,
-            "staker should once again have original token initTokenBalances minus slashed"
-        );
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    function testFuzz_slash_undelegate_completeAsShares(
-        uint24 _random
-    ) public rand(_random) {
-        // 4. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
-
-        // 5. Undelegate from an operator
-        Withdrawal[] memory withdrawals = staker.undelegate();
+    function testFuzz_queue_slash_completeAsShares(uint24 _r) public rand(_r) {
+        // 4. Queue withdrawal
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        // 5. Slash operator
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+        // TODO - staker variants?
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
         for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_State_AfterSlash(staker, operator, withdrawals[i], allocateParams, slashingParams);
+            check_Withdrawal_AsShares_State(staker, operator, withdrawals[i], strategies, expectedShares);
         }
 
         // Check final state:
         assert_HasNoUnderlyingTokenBalance(staker, strategies, "staker not have any underlying tokens");
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
+}
 
-    function testFuzz_queue_slash_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
-        // 4. Queue withdrawal
-        Withdrawal[] memory withdrawals =
-            staker.queueWithdrawals(strategies, _calculateExpectedShares(strategies, initTokenBalances));
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+contract Integration_DeallocateThenSlash is Integration_ALMSlashBase {
 
-        // 5. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
-
-        // 6. Complete withdrawal
-        _rollBlocksForCompleteWithdrawals(withdrawals);
-        for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens =
-                _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State_AfterSlash(
-                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
-            );
-        }
-
-        // Check Final State
-        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
-        assert_HasUnderlyingTokenBalances_AfterSlash(
-            staker,
-            allocateParams,
-            slashingParams,
-            initTokenBalances,
-            "staker should once again have original token initTokenBalances minus slashed"
-        );
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
-    }
-
-    function testFuzz_queue_slash_completeAsShares(
-        uint24 _random
-    ) public rand(_random) {
-        // 4. Queue withdrawal
-        Withdrawal[] memory withdrawals =
-            staker.queueWithdrawals(strategies, _calculateExpectedShares(strategies, initTokenBalances));
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-
-        // 5. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
-
-        // 4. Complete withdrawal
-        // Fast forward to when we can complete the withdrawal
-        _rollBlocksForCompleteWithdrawals(withdrawals);
-
-        for (uint256 i = 0; i < withdrawals.length; ++i) {
-            staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_State_AfterSlash(staker, operator, withdrawals[i], allocateParams, slashingParams);
-        }
-
-        // Check final state:
-        assert_HasNoUnderlyingTokenBalance(staker, strategies, "staker not have any underlying tokens");
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
-    }
-
-    function testFuzz_deallocate_slash_queue_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_deallocate_slash_queue_completeAsTokens(uint24 _r) public rand(_r) {
         // 4. Deallocate all.
         AllocateParams memory deallocateParams = _genDeallocation_Full(operator, operatorSet);
         operator.modifyAllocations(deallocateParams);
@@ -287,20 +318,16 @@ contract Integration_SlashingWithdrawals is Integration_ALMSlashBase {
         _rollForward_DeallocationDelay();
 
         // 5. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, deallocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, deallocateParams, slashParams);
+        // TODO - staker variants?
         
         // 6. Queue withdrawals
-        Withdrawal[] memory withdrawals =
-            staker.queueWithdrawals(strategies, _calculateExpectedShares(strategies, initTokenBalances));
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -308,9 +335,7 @@ contract Integration_SlashingWithdrawals is Integration_ALMSlashBase {
             uint256[] memory expectedTokens =
                 _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
             staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State_AfterSlash(
-                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
-            );
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, initDepositShares, tokens, expectedTokens);
         }
         
         // Check Final State
@@ -323,22 +348,15 @@ contract Integration_SlashingWithdrawals is Integration_ALMSlashBase {
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    function testFuzz_deregister_slash(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_deregister_slash(uint24 _r) public rand(_r) {
         // 4. Deregister.
         operator.deregisterFromOperatorSet(operatorSet);
         check_Deregistration_State_PendingAllocation(operator, operatorSet);
 
         // 5. Slash operator
-        SlashingParams memory slashingParams;
-        {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
-        }
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+        // TODO - staker variants?
     }
 }

--- a/src/test/integration/users/AVS.t.sol
+++ b/src/test/integration/users/AVS.t.sol
@@ -116,6 +116,37 @@ contract AVS is Logger, IAllocationManagerTypes, IAVSRegistrar {
     }
 
     function slashOperator(
+        SlashingParams memory params
+    ) public createSnapshot {
+
+
+        for (uint256 i; i < params.strategies.length; ++i) {
+            string memory strategyName = params.strategies[i] == beaconChainETHStrategy ? 
+                "Native ETH" : 
+                IERC20Metadata(address(params.strategies[i].underlyingToken())).name();
+
+            print.method(
+                "slashOperator",
+                string.concat(
+                    "{operator: ",
+                    User(payable(params.operator)).NAME_COLORED(),
+                    ", operatorSetId: ",
+                    cheats.toString(params.operatorSetId),
+                    ", strategy: ",
+                    strategyName,
+                    ", wadToSlash: ",
+                    params.wadsToSlash[i].asWad(),
+                    "}"
+                )
+            );
+        }
+
+        _tryPrankAppointee_AllocationManager(IAllocationManager.slashOperator.selector);
+        allocationManager.slashOperator(address(this), params);
+        print.gasUsed();
+    }
+
+    function slashOperator(
         User operator, 
         uint32 operatorSetId, 
         IStrategy[] memory strategies, 


### PR DESCRIPTION
**Motivation:**

Improve slashing invariants, fix existing DM/ALM invariants, and refactor user generation logic

**Modifications:**

* Improve `IntegrationDeployer._randUser` generation logic so that additional helpers can be implemented to generate users with specific assets
* Update some withdrawal invariants to distinguish between deposit and withdrawable shares. More work to be done here.
* Implement several new tests in `SlashingWithdrawals`

**Followup**:

* Additional cleanup for queue/complete withdrawal invariants and calling conventions
* Additional tests needed in `SlashingWithdrawals`
* Additional staker-level invariants needed when slashing an operator
