### PR TITLE
test: integration multi staker

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -69,6 +69,23 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return (staker, strategies, tokenBalances);
     }
 
+    /// @dev creates `numNewStakers` new stakers with random strategies and token balances
+    function _newRandomStakers(uint numNewStakers) internal returns (User[] memory, IStrategy[][] memory, uint[][] memory) {
+        User[] memory stakers = new User[](numNewStakers);
+        IStrategy[][] memory strategies = new IStrategy[][](numNewStakers);
+        uint[][] memory tokenBalances = new uint[][](numNewStakers);
+
+        for (uint i = 0; i < numNewStakers; i++) {
+            (stakers[i], strategies[i], tokenBalances[i]) = _newRandomStaker();
+        }
+
+        numStakers += numNewStakers;
+    
+        return (stakers, strategies, tokenBalances);
+    }
+
+    /// @dev Exactly like _newRandomStaker above but sets strategies and tokenBalances arrays to length 1
+    /// to use a single strategy and balance
     function _newBasicStaker() internal returns (User, IStrategy[] memory, uint[] memory) {
         string memory stakerName;
 
@@ -2302,6 +2319,21 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             } else {
                 expectedShares[i] = strat.underlyingToShares(tokenBalance);
             }
+        }
+
+        return expectedShares;
+    }
+
+    /// @dev For some strategies/underlying token balances, calculate the expected shares received
+    /// Exact same as _calculateExpectedShares but for multiple stakers
+    function _calculateExpectedShares(
+        IStrategy[][] memory strategies,
+        uint[][] memory tokenBalances
+    ) internal returns (uint[][] memory) {
+        uint[][] memory expectedShares = new uint[][](strategies.length);
+
+        for (uint i = 0; i < strategies.length; i++) {
+            expectedShares[i] = _calculateExpectedShares(strategies[i], tokenBalances[i]);
         }
 
         return expectedShares;

--- a/src/test/integration/tests/multiStaker/Deposit_Delegate_Queue_Complete.t.sol
+++ b/src/test/integration/tests/multiStaker/Deposit_Delegate_Queue_Complete.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/IntegrationChecks.t.sol";
+import "src/test/integration/users/User.t.sol";
+
+import "src/test/integration/utils/MultiStakersLib.sol";
+
+contract Integration_MultiStaker_Deposit_Delegate_Queue_Complete is IntegrationCheckUtils {
+    using MultiStakersLib for User[];
+
+    /*******************************************************************************
+                                FULL WITHDRAWALS
+    *******************************************************************************/
+
+    // TODO: fix test
+    /// Generates multiple random stakers and an operator. The stakers:
+    /// 1. deposits all assets into strategies
+    /// 2. delegates to an operator
+    /// 3. queues a withdrawal for ALL shares
+    /// 4. completes the queued withdrawal as tokens
+    function testFuzz_deposit_delegate_queue_completeAsTokens(uint24 _random) public rand(_random) {   
+        /// 0. Create multiple random stakers with:
+        // - some nonzero underlying token balances
+        // - corresponding to a random subset of valid strategies (StrategyManager and/or EigenPodManager)
+        //
+        // ... check that the staker has no delegatable shares and isn't currently delegated
+
+        ( 
+            User[] memory stakers,
+            IStrategy[][] memory strategiesPerStaker,
+            uint[][] memory tokenBalancesPerStaker
+        ) = _newRandomStakers({numNewStakers: _randUint(1, 10)});
+        (User operator, ,) = _newRandomOperator();
+
+        uint[][] memory sharesPerStaker = _calculateExpectedShares(strategiesPerStaker, tokenBalancesPerStaker);
+
+        // 1. Deposit Into Strategies
+        stakers.depositIntoEigenlayer(strategiesPerStaker, tokenBalancesPerStaker);
+        // check_Deposit_State(staker, strategies, shares);
+
+        // 2. Delegate to an operator
+        stakers.delegateTo(operator);
+        // check_Delegation_State(staker, operator, strategies, shares);
+
+        // 3. Queue Withdrawals
+        Withdrawal[][] memory withdrawals = stakers.queueWithdrawals(strategiesPerStaker, sharesPerStaker);
+
+        // 4. Complete withdrawal
+        _rollBlocksForCompleteWithdrawals(withdrawals[0]);
+        stakers.completeWithdrawalsAsTokens(withdrawals);
+    }
+}

--- a/src/test/integration/utils/MultiStakersLib.sol
+++ b/src/test/integration/utils/MultiStakersLib.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/users/User.t.sol";
+
+
+/// @notice Contract that provides utility functions to reuse staker actions in User.t.sol
+// for multiple stakers at once. 
+library MultiStakersLib {
+
+    function depositIntoEigenlayer(
+        User[] memory stakers,
+        IStrategy[][] memory strategies,
+        uint[][] memory tokenBalances
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].depositIntoEigenlayer(strategies[i], tokenBalances[i]);
+        }
+    }
+
+    function delegateTo(
+        User[] memory stakers,
+        User operator
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].delegateTo(operator);
+        }
+    }
+
+    function undelegate(
+        User[] memory stakers
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].undelegate();
+        }
+    }
+
+    function redelegate(
+        User[] memory stakers,
+        User newOperator
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].redelegate(newOperator);
+        }
+    }
+
+    function queueWithdrawals(
+        User[] memory stakers,
+        IStrategy[][] memory strategies,
+        uint[][] memory shares
+    ) internal returns (IDelegationManagerTypes.Withdrawal[][] memory withdrawals) {
+        withdrawals = new IDelegationManagerTypes.Withdrawal[][](stakers.length);
+        for (uint i = 0; i < stakers.length; i++) {
+            withdrawals[i] = stakers[i].queueWithdrawals(strategies[i], shares[i]);
+        }
+    }
+
+    function completeWithdrawalsAsTokens(
+        User[] memory stakers,
+        IDelegationManagerTypes.Withdrawal[][] memory withdrawals
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].completeWithdrawalsAsTokens(withdrawals[i]);
+        }
+    }
+
+    function completeWithdrawalsAsShares(
+        User[] memory stakers,
+        IDelegationManagerTypes.Withdrawal[][] memory withdrawals
+    ) internal {
+        for (uint i = 0; i < stakers.length; i++) {
+            stakers[i].completeWithdrawalsAsShares(withdrawals[i]);
+        }
+    }
+}


### PR DESCRIPTION
**Motivation:**

Currently integration tests mainly simulate generating a single staker delegated to an operator.

**Modifications:**

Added deploy functions and modified User.t.sol

**Result:**

Draft for writing a test with User[].
TODO: 
- Updated assertions used in clean way
- Updated beaconChainMock to account for validators and multiple stakers
