### PR TITLE
test: bc/avs slash tests

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1322,21 +1322,15 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         require(allocateParams.strategies[0] == BEACONCHAIN_ETH_STRAT, "only beacon strategy supported");
         require(slashingParams.strategies[0] == BEACONCHAIN_ETH_STRAT, "only beacon strategy supported");
 
-        uint[] memory curShares = _getWithdrawableShares(staker, allocateParams.strategies);
-        uint[] memory prevShares = _getPrevWithdrawableShares(staker, allocateParams.strategies);
+        uint curShares = _getWithdrawableShares(staker, allocateParams.strategies)[0];
+        uint prevShares = _getPrevWithdrawableShares(staker, allocateParams.strategies)[0];
 
-        for (uint i = 0; i < allocateParams.strategies.length; i++) {
-            IStrategy strat = allocateParams.strategies[i];
+        uint256 slashedShares = 0;
 
-            uint256 slashedShares = 0;
+        uint wadToSlash = slashingParams.wadsToSlash[0];
+        slashedShares = prevShares.mulWadRoundUp(allocateParams.newMagnitudes[0].mulWadRoundUp(wadToSlash));
 
-            if (slashingParams.strategies.contains(strat)) {
-                uint wadToSlash = slashingParams.wadsToSlash[slashingParams.strategies.indexOf(strat)];
-                slashedShares = prevShares[i].mulWadRoundUp(allocateParams.newMagnitudes[i].mulWadRoundUp(wadToSlash));
-            }
-
-            assertEq(prevShares[i] - slashedShares, curShares[i], err);
-        }
+        assertEq(prevShares - slashedShares, curShares, err);
     }
 
     /// @dev Validates behavior of "restaking", ie. that the funds can be slashed twice

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -303,6 +303,8 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         string memory err
     ) internal view {
         EigenPod pod = staker.pod();
+        console.log("proofsRemaining: ", pod.currentCheckpoint().proofsRemaining);
+        console.log("activeValidatorCount: ", pod.activeValidatorCount());
         assertEq(pod.currentCheckpoint().proofsRemaining, pod.activeValidatorCount(), err);
     }
 

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -562,6 +562,37 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint curActiveValidatorCount = _getActiveValidatorCount(staker);
         assertEq(curActiveValidatorCount, expectedCount, err);
     }
+    function assert_withdrawableSharesDecreasedByAtLeast(
+        User staker,
+        IStrategy[] memory strategies,
+        uint256[] memory originalShares,
+        uint256[] memory expectedDecreases,
+        string memory err
+    ) internal view {
+        uint256[] memory currentShares = _getWithdrawableShares(staker, strategies);
+        for (uint i = 0; i < currentShares.length; i++) {
+            assertLt(currentShares[i], originalShares[i] - expectedDecreases[i], err);
+        }
+    }
+
+    function assert_withdrawableSharesDecreasedByAtLeast(
+        User staker,
+        IStrategy strategy,
+        uint256 originalShares,
+        uint256 expectedDecreases,
+        string memory err
+    ) internal view {
+        return assert_withdrawableSharesDecreasedByAtLeast(staker, strategy.toArray(), originalShares.toArrayU256(), expectedDecreases.toArrayU256(), err);
+    }
+
+    function assert_withdrawbleShares_bc_AVS_Slash_State(
+        User staker,
+        IStrategy strategy,
+        uint256 expectedDecreases,
+        string memory err
+    ) internal view {
+    }
+    
     
     /*******************************************************************************
                                 SNAPSHOT ASSERTIONS

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1400,7 +1400,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint prevShares = _getPrevWithdrawableShares(staker, allocateParams.strategies)[0];
 
         // 1. The withdrawable shares should decrease by a factor of the BCSF
-        assertApproxEqAbs(prevShares.mulWad(_getBeaconChainSlashingFactor(staker)), curShares, 1e4, err);
+        assertApproxEqAbs(prevShares.mulWad(_getBeaconChainSlashingFactor(staker)), curShares, 1e5, err);
 
         /**
          * 2. The delta in shares is given by:
@@ -1411,7 +1411,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint originalAVSSlashedShares = originalWithdrawableShares.mulWadRoundUp(allocateParams.newMagnitudes[0].mulWadRoundUp(wadToSlash));
         uint withdrawableSharesAfterValidatorProven = originalWithdrawableShares - originalAVSSlashedShares + extraValidatorShares;
         uint expectedDelta = withdrawableSharesAfterValidatorProven.mulWad(WAD - beaconChainSlashingFactor);
-        assertApproxEqAbs(prevShares - expectedDelta, curShares, 1e4, err);
+        assertApproxEqAbs(prevShares - expectedDelta, curShares, 1e5, err);
 
         /**
          * 3. The attributable avs slashed shares should decrease by a factor of the BCSF
@@ -1421,7 +1421,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint depositShares = _getStakerDepositShares(staker, allocateParams.strategies)[0];
         uint bcSlashedShares = depositShares.mulWad(WAD - beaconChainSlashingFactor);
         uint attributableAVSSlashedShares = depositShares - bcSlashedShares - curShares;
-        assertApproxEqAbs(originalAVSSlashedShares.mulWad(beaconChainSlashingFactor), attributableAVSSlashedShares, 1e4, err);
+        assertApproxEqAbs(originalAVSSlashedShares.mulWad(beaconChainSlashingFactor), attributableAVSSlashedShares, 1e5, err);
     }
 
 

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1643,9 +1643,9 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
-    /// @dev This is currently used
-    /// TODO: Figure out how to bound this better
-    function assert_Snap_Added_Staker_WithdrawableSharesAtLeast(
+    /// @dev This is currently used by dual slashing tests
+    /// TODO: potentially bound better
+    function assert_Snap_Added_Staker_WithdrawableShares_AtLeast(
         User staker,
         IStrategy[] memory strategies,
         uint[] memory addedShares,

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1336,8 +1336,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
                 slashedShares = prevShares[i].mulWadRoundUp(allocateParams.newMagnitudes[i].mulWadRoundUp(wadToSlash));
             }
 
-            // TODO: bound this better
-            assertApproxEqAbs(prevShares[i] - slashedShares, curShares[i], 1e3, err);
+            assertEq(prevShares[i] - slashedShares, curShares[i], err);
         }
     }
 
@@ -1357,7 +1356,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint depositShares = _getStakerDepositShares(staker, allocateParams.strategies)[0];
 
         // 1. The withdrawable shares should decrease by a factor of the BCSF
-        assertApproxEqAbs(prevShares.mulWad(_getBeaconChainSlashingFactor(staker)), curShares, 1e3, err);
+        assertEq(prevShares.mulWad(_getBeaconChainSlashingFactor(staker)), curShares, err);
 
         /**
          * 2. The delta in shares is given by:
@@ -1369,7 +1368,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint originalAVSSlashedShares = depositShares.mulWadRoundUp(allocateParams.newMagnitudes[0].mulWadRoundUp(wadToSlash));
         uint withdrawableSharesAfterAVSSlash = depositShares - originalAVSSlashedShares;
         uint expectedDelta = withdrawableSharesAfterAVSSlash.mulWad(WAD - beaconChainSlashingFactor);
-        assertApproxEqAbs(prevShares - expectedDelta, curShares, 1e3, err);
+        assertEq(prevShares - expectedDelta, curShares, err);
 
         /**
          * 3. The attributable avs slashed shares should decrease by a factor of the BCSF
@@ -1378,7 +1377,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
          */
         uint bcSlashedShares = depositShares.mulWad(WAD - beaconChainSlashingFactor);
         uint attributableAVSSlashedShares = depositShares - bcSlashedShares - curShares;
-        assertApproxEqAbs(originalAVSSlashedShares.mulWad(beaconChainSlashingFactor), attributableAVSSlashedShares, 1e3, err);
+        assertEq(originalAVSSlashedShares.mulWad(beaconChainSlashingFactor), attributableAVSSlashedShares, err);
     }
 
     /**

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1309,6 +1309,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     /*******************************************************************************
                     SNAPSHOT ASSERTIONS: BEACON CHAIN AND AVS SLASHING
     *******************************************************************************/
+    
     /// @dev Same as `assert_Snap_StakerWithdrawableShares_AfterSlash`
     /// @dev but when a BC slash occurs before an AVS slash
     /// @dev There is additional rounding error when a BC and AVS slash occur together

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1318,7 +1318,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         SlashingParams memory slashingParams,
         string memory err
     ) internal {
-        require(allocateParams.strategies.length == 1  && slashingParams.strategies.length == 1, "only beacon strategy supported");
+        require(allocateParams.strategies.length == 1 && slashingParams.strategies.length == 1, "only beacon strategy supported");
         require(allocateParams.strategies[0] == BEACONCHAIN_ETH_STRAT, "only beacon strategy supported");
         require(slashingParams.strategies[0] == BEACONCHAIN_ETH_STRAT, "only beacon strategy supported");
 

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1064,6 +1064,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
         assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
 
-        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), sharesAdded.toArrayU256(), "staker withdrawable shares should increase by diff of deposit and slash");
+        assert_Snap_Added_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), sharesAdded.toArrayU256(), "staker withdrawable shares should increase by diff of deposit and slash");
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1012,7 +1012,7 @@ contract IntegrationCheckUtils is IntegrationBase {
                                  BC/AVS SLASHING CHECKS
     *******************************************************************************/
 
-    function check_CompleteCheckPoint_AVSSLash_BCSLash_HandleRoundDown_State(
+    function check_CompleteCheckPoint_AfterAVSAndBCSlash(
         User staker,
         uint40[] memory slashedValidators,
         uint256 originalWithdrawableShares,
@@ -1029,6 +1029,9 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Between the AVS slash and the BC slash, the shares should have decreased by at least the BC slash amount
         assert_withdrawableSharesDecreasedByAtLeast(staker, BEACONCHAIN_ETH_STRAT, originalWithdrawableShares, uint256(slashedBalanceGwei * GWEI_TO_WEI), "should have decreased withdrawable shares by at least the BC slash amount");
 
-        // 
+        // Calculate the withdrawable shares
+        assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
     }
+
+    
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1047,7 +1047,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
         assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
 
-        // TODO: bound this better
         assert_Snap_StakerWithdrawableShares_AVSSlash_ValidatorProven_BCSlash(staker, originalWithdrawableShares, extraValidatorShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1012,10 +1012,10 @@ contract IntegrationCheckUtils is IntegrationBase {
                                  BC/AVS SLASHING CHECKS
     *******************************************************************************/
 
-    function check_CompleteCheckPoint_AfterAVSAndBCSlash(
+    function check_CompleteCheckPoint_AfterAVS_BCSlash(
         User staker,
         uint40[] memory slashedValidators,
-        uint256 originalWithdrawableShares,
+        uint256 depositShares,
         uint64 slashedBalanceGwei,
         AllocateParams memory allocateParams,
         SlashingParams memory slashingParams
@@ -1026,18 +1026,20 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
         assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
 
-        // Between the AVS slash and the BC slash, the shares should have decreased by at least the BC slash amount
-        assert_withdrawableSharesDecreasedByAtLeast(staker, BEACONCHAIN_ETH_STRAT, originalWithdrawableShares, uint256(slashedBalanceGwei * GWEI_TO_WEI), "should have decreased withdrawable shares by at least the BC slash amount");
+        // From the original shares to the BC slash, the shares should have decreased by at least the BC slash amount
+        assert_withdrawableSharesDecreasedByAtLeast(staker, BEACONCHAIN_ETH_STRAT, depositShares, uint256(slashedBalanceGwei * GWEI_TO_WEI), "should have decreased withdrawable shares by at least the BC slash amount");
 
         // Calculate the withdrawable shares
-        assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
+        assert_Snap_StakerWithdrawableShares_AfterAVSSlash_BCSlash(staker, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
     }
 
-    function check_CompleteCheckpoint_AfterAVSAndBCSlash_ExtraValidatorProven(
+    function check_CompleteCheckpoint_AfterAVSSlash_ValidatorProven_BCSlash(
         User staker,
         uint40[] memory slashedValidators,
         uint256 originalWithdrawableShares,
-        uint64 slashedAmountGwei
+        uint256 extraValidatorShares,
+        AllocateParams memory allocateParams,
+        SlashingParams memory slashingParams
     ) internal {
         // Checkpoint State
         check_CompleteCheckpoint_State(staker);
@@ -1046,7 +1048,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
 
         // TODO: bound this better
-        // assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash_ExtraValidatorProven(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
-        // assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, 1e11, "should have decreased withdrawable shares by at least slashed amount");
+        assert_Snap_StakerWithdrawableShares_AVSSlash_ValidatorProven_BCSlash(staker, originalWithdrawableShares, extraValidatorShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1031,19 +1031,22 @@ contract IntegrationCheckUtils is IntegrationBase {
 
         // Calculate the withdrawable shares
         assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
-    }    
+    }
 
-    function check_CompleteCheckpoint_WithAVSAndBCSlashing_HandleRoundDown_State(
+    function check_CompleteCheckpoint_AfterAVSAndBCSlash_ExtraValidatorProven(
         User staker,
         uint40[] memory slashedValidators,
+        uint256 originalWithdrawableShares,
         uint64 slashedAmountGwei
     ) internal {
+        // Checkpoint State
         check_CompleteCheckpoint_State(staker);
-
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have decreased");
-        // TODO: bound this better
-        assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, 1e11, "should have decreased withdrawable shares by at least slashed amount");
         assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
         assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+
+        // TODO: bound this better
+        // assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash_ExtraValidatorProven(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
+        // assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, 1e11, "should have decreased withdrawable shares by at least slashed amount");
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1049,4 +1049,21 @@ contract IntegrationCheckUtils is IntegrationBase {
 
         assert_Snap_StakerWithdrawableShares_AVSSlash_ValidatorProven_BCSlash(staker, originalWithdrawableShares, extraValidatorShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
     }
+
+    /// @dev Assumes the eth deposit was greater than the amount slashed
+    function check_CompleteCheckpoint_AfterAVSSlash_ETHDeposit_BCSlash(
+        User staker,
+        uint40[] memory slashedValidators,
+        uint64 slashedBalanceGwei,
+        uint256 beaconSharesAddedGwei
+    ) internal {
+        uint sharesAdded = uint(beaconSharesAddedGwei - slashedBalanceGwei) * GWEI_TO_WEI;
+        // Checkpoint State
+        check_CompleteCheckpoint_State(staker); 
+        assert_Snap_Added_Staker_DepositShares(staker, BEACONCHAIN_ETH_STRAT, sharesAdded, "staker deposit shares should have increased");
+        assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
+        assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+
+        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), sharesAdded.toArrayU256(), "staker withdrawable shares should increase by diff of deposit and slash");
+    }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -8,8 +8,7 @@ import "src/test/integration/users/User_M2.t.sol";
 
 /// @notice Contract that provides utility functions to reuse common test blocks & checks
 contract IntegrationCheckUtils is IntegrationBase {
-    using ArrayLib for IStrategy[];
-    using ArrayLib for IStrategy;
+    using ArrayLib for *;
     using SlashingLib for *;
     using StdStyle for *;
 
@@ -1007,5 +1006,27 @@ contract IntegrationCheckUtils is IntegrationBase {
 
         assert_Snap_Removed_AllocatedSet(operator, allocateParams.operatorSet, "should not have updated allocated sets");
         assert_Snap_Removed_AllocatedStrats(operator, allocateParams.operatorSet, slashParams.strategies, "should not have updated allocated strategies");
+    }
+
+    /*******************************************************************************
+                                 BC/AVS SLASHING CHECKS
+    *******************************************************************************/
+
+    function check_CompleteCheckPoint_AVSSLash_BCSLash_HandleRoundDown_State(
+        User staker,
+        uint40[] memory slashedValidators,
+        uint256 originalWithdrawableShares,
+        uint64 slashedBalanceGwei
+    ) internal {
+        // Checkpoint State
+        check_CompleteCheckpoint_State(staker);
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have decreased");
+        assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
+        assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+
+        // Between the AVS slash and the BC slash, the shares should have decreased by at least the BC slash amount
+        assert_withdrawableSharesDecreasedByAtLeast(staker, BEACONCHAIN_ETH_STRAT, originalWithdrawableShares, uint256(slashedBalanceGwei * GWEI_TO_WEI), "should have decreased withdrawable shares by at least the BC slash amount");
+
+        assert_withdrawbleShare
     }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1031,7 +1031,19 @@ contract IntegrationCheckUtils is IntegrationBase {
 
         // Calculate the withdrawable shares
         assert_Snap_StakerWithdrawableShares_AfterAVSAndBCSlash(staker, originalWithdrawableShares, allocateParams, slashingParams, "should have decreased withdrawable shares correctly");
-    }
+    }    
 
-    
+    function check_CompleteCheckpoint_WithAVSAndBCSlashing_HandleRoundDown_State(
+        User staker,
+        uint40[] memory slashedValidators,
+        uint64 slashedAmountGwei
+    ) internal {
+        check_CompleteCheckpoint_State(staker);
+
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have decreased");
+        // TODO: bound this better
+        assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, 1e11, "should have decreased withdrawable shares by at least slashed amount");
+        assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
+        assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+    }
 }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1012,7 +1012,7 @@ contract IntegrationCheckUtils is IntegrationBase {
                                  BC/AVS SLASHING CHECKS
     *******************************************************************************/
 
-    function check_CompleteCheckPoint_AfterAVS_BCSlash(
+    function check_CompleteCheckpoint_AfterAVSSlash_BCSlash(
         User staker,
         uint40[] memory slashedValidators,
         uint256 depositShares,

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1016,7 +1016,9 @@ contract IntegrationCheckUtils is IntegrationBase {
         User staker,
         uint40[] memory slashedValidators,
         uint256 originalWithdrawableShares,
-        uint64 slashedBalanceGwei
+        uint64 slashedBalanceGwei,
+        AllocateParams memory allocateParams,
+        SlashingParams memory slashingParams
     ) internal {
         // Checkpoint State
         check_CompleteCheckpoint_State(staker);
@@ -1027,6 +1029,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Between the AVS slash and the BC slash, the shares should have decreased by at least the BC slash amount
         assert_withdrawableSharesDecreasedByAtLeast(staker, BEACONCHAIN_ETH_STRAT, originalWithdrawableShares, uint256(slashedBalanceGwei * GWEI_TO_WEI), "should have decreased withdrawable shares by at least the BC slash amount");
 
-        assert_withdrawbleShare
+        // 
     }
 }

--- a/src/test/integration/tests/BC_AVS_Slashing.t.sol
+++ b/src/test/integration/tests/BC_AVS_Slashing.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/IntegrationChecks.t.sol";
+
+contract Integration_BeaconChain_AVS_Ordering is IntegrationCheckUtils {
+    using ArrayLib for *;
+
+    AVS avs;
+    OperatorSet operatorSet;
+
+    User operator;
+    AllocateParams allocateParams;
+
+    User staker;
+    uint64 beaconBalanceGwei;
+    uint40[] validators;
+    IStrategy[] strategies;
+    uint[] initTokenBalances;
+    uint[] initDepositShares;
+
+    function _init() internal override {
+        _configAssetTypes(HOLDS_ETH);
+
+        // Create staker, operator, and avs
+        (staker, strategies, initTokenBalances) = _newRandomStaker();
+        (operator,,) = _newRandomOperator();
+        (avs,) = _newRandomAVS();
+
+        // 1. Deposit into strategies
+        (validators, beaconBalanceGwei) = staker.startValidators();
+        beaconChain.advanceEpoch_NoRewards();
+        staker.verifyWithdrawalCredentials(validators);
+        initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);
+        check_Deposit_State(staker, strategies, initDepositShares);
+
+        // 2. Delegate staker to operator
+        staker.delegateTo(operator);
+        check_Delegation_State(staker, operator, strategies, initDepositShares);
+
+        // 3. Create an operator set containing the strategies held by the staker
+        operatorSet = avs.createOperatorSet(strategies);
+
+        // 4. Register operator to AVS
+        operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
+        
+        // 5. Allocate to the operator set
+        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        operator.modifyAllocations(allocateParams);
+        check_IncrAlloc_State_Slashable(operator, allocateParams);    
+
+        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
+    }
+
+    function testFuzz_avsSlash_bcSlash_checkpoint(uint24 _random) public rand(_random){ 
+        // 6. Slash Operator by AVS
+        SlashingParams memory slashingParams;
+        {
+            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+                _randStrategiesAndWadsToSlash(operatorSet);
+            console.log("Strategies to slash: %s", strategiesToSlash.length);
+            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker deposit shares should be slashed");
+        }
+        uint[] memory sharesGotten = _getWithdrawableShares(staker, strategies);
+        console.log("Shares after avs slash: ", sharesGotten[0]);
+
+        // 7. Slash Staker on BC
+        uint64 slashedBalanceGwei = beaconChain.slashValidators(validators);
+        beaconChain.advanceEpoch_NoRewards();
+        
+        console.log("slashedBalanceGwei: ", slashedBalanceGwei);
+
+        // 8. Checkpoint
+        staker.startCheckpoint();
+        check_StartCheckpoint_WithPodBalance_State(staker, beaconBalanceGwei - slashedBalanceGwei);
+        staker.completeCheckpoint();
+        uint64[] memory maxMagnitudes = _getMaxMagnitudes(operator, strategies);
+        console.log("maxMagnitudes: ", maxMagnitudes[0]);
+        uint64 bcsf = _getBeaconChainSlashingFactor(staker);
+        console.log("bcsf: ", bcsf);
+        sharesGotten = _getWithdrawableShares(staker, strategies);
+        console.log("Shares after bc slash: ", sharesGotten[0]);
+        check_CompleteCheckPoint_AVSSLash_BCSLash_HandleRoundDown_State(staker, validators, initDepositShares[0], slashedBalanceGwei);
+
+
+        // sharesGotten = _getWithdrawableShares(staker, strategies);
+        // console.log("Shares after bc slash: ", sharesGotten[0]);
+        // console.log("Test test test");
+
+        // Assert state
+        // assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+        // assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedBalanceGwei * GWEI_TO_WEI, "should have decreased withdrawable shares by slashed amount");
+    }
+
+}

--- a/src/test/integration/tests/BC_AVS_Slashing.t.sol
+++ b/src/test/integration/tests/BC_AVS_Slashing.t.sol
@@ -101,4 +101,36 @@ contract Integration_BeaconChain_AVS_Ordering is IntegrationCheckUtils {
         }
     }
 
+    function testFuzz_avsSlash_verifyValidator_bcSlash_checkpoint(uint24 _random) public rand(_random) {
+        // 6. Slash operator by AVS
+        SlashingParams memory slashingParams;
+        {
+            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+                _randStrategiesAndWadsToSlash(operatorSet);
+            console.log("Strategies to slash: %s", strategiesToSlash.length);
+            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+            assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+            assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+            assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        }
+
+        // 7. Verify Validator
+        cheats.deal(address(staker), 32 ether);
+        (uint40[] memory newValidators, uint64 addedBeaconBalanceGwei) = staker.startValidators();
+        beaconChain.advanceEpoch_NoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, addedBeaconBalanceGwei);
+        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), uint256(addedBeaconBalanceGwei * GWEI_TO_WEI).toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
+
+        // 8. Slash first validators on BC
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        beaconChain.advanceEpoch_NoRewards();
+
+        // 9. Checkpoint
+        staker.startCheckpoint();
+        check_StartCheckpoint_WithPodBalance_State(staker, beaconBalanceGwei - slashedAmountGwei);
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_WithAVSAndBCSlashing_HandleRoundDown_State(staker, validators, slashedAmountGwei);
+    }
+
 }

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -113,6 +113,8 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         check_CompleteCheckPoint_AfterAVS_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
     }
 
+    /// @notice Because the validator is proven prior to the BC slash, the system applies the new balance 
+    ///         to the BC and AVS slash combined
     function testFuzz_avsSlash_verifyValidator_bcSlash_checkpoint(uint24 _random) public rand(_random) {
         // 7. Verify Validator
         cheats.deal(address(staker), 32 ether);
@@ -156,6 +158,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         check_CompleteCheckpoint_AfterAVSSlash_ValidatorProven_BCSlash(staker, validators, initDepositShares[0], beaconSharesAdded, allocateParams, slashingParams);
     }
 
+    /// @notice The validator proven should not be affected by the BC or AVS slashes
     function testFuzz_avsSlash_bcSlash_checkpoint_verifyValidator(uint24 _rand) public rand(_rand) {
         // 7. Slash Staker on BC
         uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
@@ -177,6 +180,8 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
     }
 
+    /// @notice The balance increase results in the pods not processing the beacon slash as a slash, given
+    ///         that the checkpoint had a positive delta
     function testFuzz_avsSlash_balanceIncrease_checkpoint_verifyValidator(uint24 _rand) public rand(_rand) {
         // 7. Slash Staker on BC
         uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
@@ -197,4 +202,6 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         staker.completeCheckpoint();
         check_CompleteCheckpoint_AfterAVSSlash_ETHDeposit_BCSlash(staker, validators, slashedAmountGwei, beaconSharesAddedGwei);
     }
+
+
 }

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -106,7 +106,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         staker.startCheckpoint();
         check_StartCheckpoint_WithPodBalance_State(staker, beaconBalanceGwei - slashedAmountGwei);
         staker.completeCheckpoint();
-        check_CompleteCheckPoint_AfterAVS_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
+        check_CompleteCheckpoint_AfterAVSSlash_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
     }
 
     /// @notice Because the validator is proven prior to the BC slash, the system applies the new balance 
@@ -164,7 +164,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         staker.startCheckpoint();
         check_StartCheckpoint_WithPodBalance_State(staker, beaconBalanceGwei - slashedAmountGwei);
         staker.completeCheckpoint();
-        check_CompleteCheckPoint_AfterAVS_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
+        check_CompleteCheckpoint_AfterAVSSlash_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
 
         // 9. Verify Validator
         cheats.deal(address(staker), 32 ether);
@@ -207,7 +207,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         staker.startCheckpoint();
         check_StartCheckpoint_WithPodBalance_State(staker, beaconBalanceGwei - slashedAmountGwei);
         staker.completeCheckpoint();
-        check_CompleteCheckPoint_AfterAVS_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
+        check_CompleteCheckpoint_AfterAVSSlash_BCSlash(staker, validators, initDepositShares[0], slashedAmountGwei, allocateParams, slashingParams);
 
         // 9. Send 32 ETH to pod, some random amount of ETH, greater than the amount slashed
         uint ethToDeposit = 32 ether;

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -88,12 +88,13 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     function _init() internal virtual override {
         super._init();
 
-        // 8. Slash operator by AVS
+        // 6. Slash operator by AVS
         slashingParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(slashingParams);
+        check_Base_Slashing_State(operator, allocateParams, slashingParams);
         assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-        assert_Snap_StakerWithdrawableShares_AfterBCSlash_AVSSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
     }
 
     /// @dev Validates behavior of "restaking", ie. that the funds can be slashed twice

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -71,10 +71,8 @@ contract Integration_DualSlashing_Base_BeaconChainFirst is Integration_DualSlash
         // 8. Slash operator by AVS
         SlashingParams memory slashingParams;
         {
-            (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-                _randStrategiesAndWadsToSlash(operatorSet);
-            console.log("Strategies to slash: %s", strategiesToSlash.length);
-            slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+            slashingParams = _genSlashing_Rand(operator, operatorSet);
+            avs.slashOperator(slashingParams);
             assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
             assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
             assert_Snap_StakerWithdrawableShares_AfterBCSlash_AVSSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
@@ -90,14 +88,12 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     function _init() internal virtual override {
         super._init();
 
-        // 6. Slash Operator by AVS
-        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-            _randStrategiesAndWadsToSlash(operatorSet);
-        console.log("Strategies to slash: %s", strategiesToSlash.length);
-        slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+        // 8. Slash operator by AVS
+        slashingParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashingParams);
         assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterBCSlash_AVSSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
     }
 
     /// @dev Validates behavior of "restaking", ie. that the funds can be slashed twice

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -59,7 +59,7 @@ contract Integration_DualSlashing_Base_BeaconChainFirst is Integration_DualSlash
 
     function testFuzz_bcSlash_checkpoint_avsSlash(uint24 _random) public rand(_random) {
         // 6. Slash staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
 
         // 7. Checkpoint
@@ -99,7 +99,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     /// @dev Validates behavior of "restaking", ie. that the funds can be slashed twice
     function testFuzz_avsSlash_bcSlash_checkpoint(uint24 _random) public rand(_random){ 
         // 7. Slash Staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
         
         // 8. Checkpoint
@@ -122,7 +122,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
 
         // 8. Slash first validators on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
 
         // 9. Checkpoint
@@ -135,7 +135,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     /// @dev Same as above, but validator is proven after BC slash (this ordering doesn't matter to EL)
     function testFuzz_avsSlash_bcSlash_verifyValidator_checkpoint(uint24 _random) public rand(_random) {
         // 7. Slash Staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
 
         // 8. Verify Validator
@@ -157,7 +157,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     /// @notice The validator proven should not be affected by the BC or AVS slashes
     function testFuzz_avsSlash_bcSlash_checkpoint_verifyValidator(uint24 _rand) public rand(_rand) {
         // 7. Slash Staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
         
         // 8. Checkpoint
@@ -180,7 +180,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     ///         that the checkpoint had a positive delta
     function testFuzz_avsSlash_bcSlash_balanceIncrease_checkpoint(uint24 _rand) public rand(_rand) {
         // 7. Slash Staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
 
         // 8. Send 32 ETH to pod, some random amount of ETH, greater than the amount slashed
@@ -200,7 +200,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
     /// @notice The balance increase occurs after the slashings are processed, so it should be unaffected by the slashings
     function testFuzz_avsSlash_bcSlash_checkpoint_balanceIncrease(uint24 _rand) public rand(_rand) {
         // 7. Slash Staker on BC
-        uint64 slashedAmountGwei = beaconChain.slashValidators(validators);
+        uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
         beaconChain.advanceEpoch_NoRewards();
         
         // 8. Checkpoint

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -119,7 +119,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         beaconChain.advanceEpoch_NoRewards();
         staker.verifyWithdrawalCredentials(newValidators);
         check_VerifyWC_State(staker, newValidators, addedBeaconBalanceGwei);
-        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
+        assert_Snap_Added_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
 
         // 8. Slash first validators on BC
         uint64 slashedAmountGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Minor);
@@ -145,7 +145,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         beaconChain.advanceEpoch_NoRewards();
         staker.verifyWithdrawalCredentials(newValidators);
         check_VerifyWC_State(staker, newValidators, addedBeaconBalanceGwei);
-        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
+        assert_Snap_Added_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
 
         // 9. Checkpoint
         staker.startCheckpoint();
@@ -173,7 +173,7 @@ contract Integration_DualSlashing_Base_AVSFirst is Integration_DualSlashing_Base
         beaconChain.advanceEpoch_NoRewards();
         staker.verifyWithdrawalCredentials(newValidators);
         check_VerifyWC_State(staker, newValidators, addedBeaconBalanceGwei);
-        assert_Snap_Added_Staker_WithdrawableSharesAtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
+        assert_Snap_Added_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconSharesAdded.toArrayU256(), "staker withdrawable shares should increase by the added beacon balance");
     }
 
     /// @notice The balance increase results in the pods not processing the beacon slash as a slash, given


### PR DESCRIPTION
**Motivation:**

Tests that handle slashes by both the BC and AVS onto Native ETH. 

**Modifications:**

Added assertions for BC/AVS slashings, no full slashed included

- [x] testFuzz_avsSlash_bcSlash_checkpoint
- [x] testFuzz_bcSlash_checkpoint_avsSlash
- [x] testFuzz_avsSlash_verifyValidator_bcSlash_checkpoint
- [x] testFuzz_avsSlash_bcSlash_verifyValidator_checkpoint
- [x] testFuzz_avsSlash_bcSlash_checkpoint_verifyValidator
- [x] testFuzz_avsSlash_bcSlash_balanceIncrease_checkpoint
- [x] testFuzz_avsSlash_bcSlash_checkpoint_balanceIncrease


**Result:**

Test coverage for BC/AVS edge cases. 

Need to properly bound a lot of the AVS/BC slashing cases, but this is a start