### PR TITLE
fix: running ci only on relevant changes

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -3,25 +3,25 @@ name: Foundry
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
   push:
     branches:
       - "dev"
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
 
 env:
   FOUNDRY_PROFILE: medium

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -3,25 +3,9 @@ name: Foundry
 on:
   workflow_dispatch:
   pull_request:
-    # paths:
-    #   - '.github/**'
-    #   - 'bin/**'
-    #   - 'src/**'
-    #   - 'lib/**'
-    #   - 'certora/**'
-    #   - 'foundry.toml'
-    #   - '**/*.sol'
   push:
     branches:
       - "dev"
-    # paths:
-    #   - '.github/**'
-    #   - 'bin/**'
-    #   - 'src/**'
-    #   - 'lib/**'
-    #   - 'certora/**'
-    #   - 'foundry.toml'
-    #   - '**/*.sol'
 
 env:
   FOUNDRY_PROFILE: medium
@@ -36,6 +20,15 @@ jobs:
 
   test-suite:
     name: Test
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.modified, '.github/') ||
+      contains(github.event.head_commit.modified, 'bin/') ||
+      contains(github.event.head_commit.modified, 'src/') ||
+      contains(github.event.head_commit.modified, 'lib/') ||
+      contains(github.event.head_commit.modified, 'certora/') ||
+      contains(github.event.head_commit.modified, 'foundry.toml') ||
+      endsWith(github.event.head_commit.modified, '.sol')
     runs-on: protocol-x64-16core
     strategy:
       matrix:
@@ -95,7 +88,17 @@ jobs:
     name: Test (Intense)
     runs-on: protocol-x64-16core
     # Only run on push events to dev branch, not on PR events
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    if: |
+      github.event_name == 'push' && 
+      github.ref == 'refs/heads/dev' && (
+        contains(github.event.head_commit.modified, '.github/') ||
+        contains(github.event.head_commit.modified, 'bin/') ||
+        contains(github.event.head_commit.modified, 'src/') ||
+        contains(github.event.head_commit.modified, 'lib/') ||
+        contains(github.event.head_commit.modified, 'certora/') ||
+        contains(github.event.head_commit.modified, 'foundry.toml') ||
+        endsWith(github.event.head_commit.modified, '.sol')
+      )
     strategy:
       fail-fast: true
     steps:
@@ -141,6 +144,15 @@ jobs:
 
   storage-diff:
     name: Test (Storage)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.modified, '.github/') ||
+      contains(github.event.head_commit.modified, 'bin/') ||
+      contains(github.event.head_commit.modified, 'src/') ||
+      contains(github.event.head_commit.modified, 'lib/') ||
+      contains(github.event.head_commit.modified, 'certora/') ||
+      contains(github.event.head_commit.modified, 'foundry.toml') ||
+      endsWith(github.event.head_commit.modified, '.sol')
     runs-on: protocol-x64-16core
     steps:
       # Check out repository with all submodules for complete codebase access.
@@ -180,12 +192,23 @@ jobs:
     runs-on: protocol-x64-16core
     # Only run coverage checks on dev, testnet-holesky, and mainnet branches, or PRs targeting these branches
     if: |
-      github.ref == 'refs/heads/dev' ||
-      github.ref == 'refs/heads/testnet-holesky' ||
-      github.ref == 'refs/heads/mainnet' ||
-      github.base_ref == 'dev' ||
-      github.base_ref == 'testnet-holesky' ||
-      github.base_ref == 'mainnet'
+      (
+        github.ref == 'refs/heads/dev' ||
+        github.ref == 'refs/heads/testnet-holesky' ||
+        github.ref == 'refs/heads/mainnet' ||
+        github.base_ref == 'dev' ||
+        github.base_ref == 'testnet-holesky' ||
+        github.base_ref == 'mainnet'
+      ) && (
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.head_commit.modified, '.github/') ||
+        contains(github.event.head_commit.modified, 'bin/') ||
+        contains(github.event.head_commit.modified, 'src/') ||
+        contains(github.event.head_commit.modified, 'lib/') ||
+        contains(github.event.head_commit.modified, 'certora/') ||
+        contains(github.event.head_commit.modified, 'foundry.toml') ||
+        endsWith(github.event.head_commit.modified, '.sol')
+      )
     strategy:
       fail-fast: true
     steps:
@@ -276,6 +299,15 @@ jobs:
 
   compare-contract-sizes:
     name: Size Diff
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.head_commit.modified, '.github/') ||
+      contains(github.event.head_commit.modified, 'bin/') ||
+      contains(github.event.head_commit.modified, 'src/') ||
+      contains(github.event.head_commit.modified, 'lib/') ||
+      contains(github.event.head_commit.modified, 'certora/') ||
+      contains(github.event.head_commit.modified, 'foundry.toml') ||
+      endsWith(github.event.head_commit.modified, '.sol')
     runs-on: protocol-x64-16core
     steps:
       # Check out repository with all submodules for complete codebase access.

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -54,6 +54,8 @@ contract AllocationManager is
         _disableInitializers();
     }
 
+    // MODIFY THIS TO MAKE CI RUN TESTS (HOPEFULLY)
+
     /// @inheritdoc IAllocationManager
     function initialize(address initialOwner, uint256 initialPausedStatus) external initializer {
         _setPausedStatus(initialPausedStatus);


### PR DESCRIPTION
**Motivation:**

GitHub Actions workflow for foundry tests fails to run when it should due to path filters at the workflow level preventing execution.

**Modifications:**

- Moved path filters from workflow level to individual job level conditions
- Used `github.event.head_commit.modified` to check file changes
- Added path checks to all foundry workflow jobs


**Result:**

CI now properly skips foundry tests for non-relevant prs, and doesn't prevent merge when attempting to skip.