### PR TITLE
test: timing integration tests

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -2826,6 +2826,15 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return withdrawableShares; 
     }
 
+    function _calcWithdrawable(User staker, IStrategy[] memory strategies, uint[] memory depositSharesToWithdraw) internal view returns (uint[] memory) {
+        uint[] memory withdrawableShares = new uint[](strategies.length);
+        uint[] memory depositScalingFactors = _getDepositScalingFactors(staker, strategies);
+        for (uint i = 0; i < strategies.length; i++) {
+            withdrawableShares[i] = depositSharesToWithdraw[i].mulWad(depositScalingFactors[i]).mulWad(_getSlashingFactor(staker, strategies[i]));
+        }
+        return withdrawableShares;
+    }
+
     /// @dev Uses timewarp modifier to get staker beacon chain scaling factor at the last snapshot
     function _getPrevBeaconChainSlashingFactor(User staker) internal timewarp() returns (uint64) {
         return _getBeaconChainSlashingFactor(staker);

--- a/src/test/integration/tests/Timing.t.sol
+++ b/src/test/integration/tests/Timing.t.sol
@@ -12,6 +12,10 @@ import {Integration_ALMSlashBase, IStrategy, IERC20} from "src/test/integration/
  * - The staker is delegated to the operator
  */
 contract Integration_Timing is Integration_ALMSlashBase {
+    
+    ///////////////////////////////
+    /// WITHDRAWAL TIMING TESTS ///
+    ///////////////////////////////
 
     /**
      * @notice Test that a slash works correctly just before a partial withdrawal is completed
@@ -19,16 +23,23 @@ contract Integration_Timing is Integration_ALMSlashBase {
     function testFuzz_queuePartialWithdrawal_slashBeforeWithdrawal_completeAsTokens(
         uint24 _random
     ) public rand(_random) {
+        uint256[] memory depositSharesToWithdraw = new uint256[](initDepositShares.length);
         // 0. Calculate partial withdrawal amounts
-        for (uint256 i = 0; i < initTokenBalances.length; ++i) {
+        for (uint256 i = 0; i < initDepositShares.length; ++i) {
             // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
             // but 10 as the maximum divisor is more arbitrary
-            initTokenBalances[i] /= _randUint(2, 10);
+            depositSharesToWithdraw[i] = initDepositShares[i] / _randUint(2, 10);
         }
 
         // 1. Queue withdrawal
-        uint256[] memory sharesToWithdraw = _calculateExpectedShares(strategies, initTokenBalances);
-        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, sharesToWithdraw);
+        uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositSharesToWithdraw);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        
+        // Note: Because this is a partial withdrawal, we pass in the initial token balances as the withdrawable shares
+        // rather than `initDepositShares`
+        // Moreover, the shares to withdraw are the expected shares calculated from the token balances
+        check_QueuedWithdrawal_State(staker, operator, strategies, depositSharesToWithdraw, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 2. Move time forward to _just before_ withdrawal block
         // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
@@ -37,30 +48,19 @@ contract Integration_Timing is Integration_ALMSlashBase {
         vm.roll(block.number - 1);
 
         // 3. Slash operator
-        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-            _randStrategiesAndWadsToSlash(operatorSet);
-        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-
-        // Assert that the operator allocations and staker withdrawable shares are slashed, but the staker deposit shares are not
-        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
-        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+        SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
         // 4. Move time forward to withdrawal block
         vm.roll(block.number + 1);
 
         // 5. Complete withdrawals
+        withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
+        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
+        staker.completeWithdrawalsAsTokens(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens = _calculateExpectedTokens(
-                withdrawals[i].strategies,
-                withdrawals[i].scaledShares
-            );
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
-
-            // Assert that the withdrawal is completed as expected
-            check_Withdrawal_AsTokens_State_AfterSlash(
-                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
-            );
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
         // 6. Check final state
@@ -69,17 +69,7 @@ contract Integration_Timing is Integration_ALMSlashBase {
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
         assertEq(strats.length, strategies.length, "all strategies should have some shares remaining");
 
-        // Assert that the staker has withdrawn the expected tokens
-        assert_HasUnderlyingTokenBalances_AfterSlash(
-            staker,
-            allocateParams,
-            slashingParams,
-            initTokenBalances,
-            "staker should have withdrawn tokens minus slashed"
-        );
-
         // Assert that all withdrawals are removed from pending
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
@@ -89,8 +79,12 @@ contract Integration_Timing is Integration_ALMSlashBase {
     function testFuzz_queueTotalWithdrawal_slashBeforeWithdrawal_completeAsTokens(
         uint24 _random
     ) public rand(_random) {
-        // 1. Undelegate (i.e. queue a total withdrawal from every strategy)
-        Withdrawal[] memory withdrawals = staker.undelegate();
+        // 1. Queue withdrawal
+        uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 2. Move time forward to _just before_ withdrawal block
         // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
@@ -99,190 +93,118 @@ contract Integration_Timing is Integration_ALMSlashBase {
         vm.roll(block.number - 1);
 
         // 3. Slash operator
-        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-            _randStrategiesAndWadsToSlash(operatorSet);
-        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-
-        // Assert that the operator allocations and staker withdrawable shares are slashed, but the staker deposit shares are not
-        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
-        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+        SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
         // 4. Move time forward to withdrawal block
         vm.roll(block.number + 1);
 
         // 5. Complete withdrawals
+        withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
+        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
+        staker.completeWithdrawalsAsTokens(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens = _calculateExpectedTokens(
-                withdrawals[i].strategies,
-                withdrawals[i].scaledShares
-            );
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
-
-            // Assert that the withdrawal is completed as expected
-            check_Withdrawal_AsTokens_State_AfterSlash(
-                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
-            );
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
         // 6. Check final state
 
-        // Assert that no strategies have any shares remaining
-        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
-
-        // Assert that the staker has withdrawn the expected tokens
-        assert_HasUnderlyingTokenBalances_AfterSlash(
-            staker,
-            allocateParams,
-            slashingParams,
-            initTokenBalances,
-            "staker should have withdrawn tokens minus slashed"
-        );
+        // Assert that all strategies have some shares remaining
+        (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
+        assertEq(strats.length, 0, "all strategies should have no shares remaining");
 
         // Assert that all withdrawals are removed from pending
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     /**
      * @notice Test that a staker can still complete a partial withdrawal even after a slash has been performed
      */
+     // TODO: revisit with updated syntax
     function testFuzz_queuePartialWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
         uint24 _random
     ) public rand(_random) {
+        uint256[] memory depositSharesToWithdraw = new uint256[](initDepositShares.length);
         // 0. Calculate partial withdrawal amounts
-        for (uint256 i = 0; i < initTokenBalances.length; ++i) {
+        for (uint256 i = 0; i < initDepositShares.length; ++i) {
             // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
             // but 10 as the maximum divisor is more arbitrary
-            initTokenBalances[i] /= _randUint(2, 10);
+            depositSharesToWithdraw[i] = initDepositShares[i] / _randUint(2, 10);
         }
 
         // 1. Queue withdrawal
-        uint256[] memory sharesToWithdraw = _calculateExpectedShares(strategies, initTokenBalances);
-        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, sharesToWithdraw);
+        uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositSharesToWithdraw);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        
+        // Note: Because this is a partial withdrawal, we pass in the initial token balances as the withdrawable shares
+        // rather than `initDepositShares`
+        // Moreover, the shares to withdraw are the expected shares calculated from the token balances
+        check_QueuedWithdrawal_State(staker, operator, strategies, depositSharesToWithdraw, withdrawableShares, withdrawals, withdrawalRoots);
 
-        // 2. Move time forward to _exactly_ the withdrawal block
-        // Expected behavior: Withdrawals are still pending, but can be completed, and slashes can no longer be 
-        // performed _on the partial withdrawals_. The remaining shares may still be affected.
+        // 2. Move time forward to _just before_ withdrawal block
+        // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
         // 3. Slash operator
-        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-            _randStrategiesAndWadsToSlash(operatorSet);
-        // Note: This will _partially_ impact the staker's withdrawable shares as they have not withdrawn all shares
-        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+        SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // Assert:
-        // * Operator allocations are slashed
-        // * Staker withdrawable shares are _partially_ affected due to the partial withdrawal
-        // * Staker deposit shares are unaffected
-        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
-        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
-
-        // 4. Complete withdrawal
+        // 5. Complete withdrawals
+        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
+        staker.completeWithdrawalsAsTokens(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens = _calculateExpectedTokens(
-                withdrawals[i].strategies,
-                withdrawals[i].scaledShares
-            );
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
-
-            IERC20[] memory tokens = new IERC20[](withdrawals[i].strategies.length);
-            for (uint256 j = 0; j < withdrawals[i].strategies.length; ++j) {
-                tokens[j] = withdrawals[i].strategies[j].underlyingToken();
-            }
-
-            // Assert that the withdrawal is completed as expected, with NO IMPACT from the slash 
-            // as these withdrawals are past the delay
-            check_Withdrawal_AsTokens_State(
-                staker, operator, withdrawals[i], strategies, sharesToWithdraw, tokens, expectedTokens
-            );
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 5. Check final state
+        // 6. Check final state
 
         // Assert that all strategies have some shares remaining
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
         assertEq(strats.length, strategies.length, "all strategies should have some shares remaining");
 
-        // Assert that the staker has withdrawn the expected tokens
-        assert_HasUnderlyingTokenBalances(
-            staker,
-            strategies,
-            initTokenBalances,
-            "staker should have withdrawn tokens"
-        );
-
         // Assert that all withdrawals are removed from pending
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
-    
-    
+
     /**
      * @notice Test that a staker is unaffected by a slash after the withdrawal delay has passed
      */
     function testFuzz_queueTotalWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
         uint24 _random
     ) public rand(_random) {
-        // 1. Undelegate (i.e. queue a total withdrawal from every strategy)
-        uint256[] memory sharesToWithdraw = _getWithdrawableShares(staker, strategies);
-        Withdrawal[] memory withdrawals = staker.undelegate();
+        // 1. Queue withdrawal
+        uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
 
-        // 2. Move time forward to _exactly_ the withdrawal block
-        // Expected behavior: Withdrawals are still pending, but can be completed, and slashes can no longer affect 
-        // this staker
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        // 2. Move time forward to _just before_ withdrawal block
+        // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
         // 3. Slash operator
-        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
-            _randStrategiesAndWadsToSlash(operatorSet);
-        // Note: This should have no effect on the STAKER as the withdrawal is already past the withdrawal block
-        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
-        
-        // Assert:
-        // * Operator allocations are slashed
-        // * Staker withdrawable shares are unaffected by the slash
-        // * Staker deposit shares are unaffected
-        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
-        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should NOT be slashed"); // TODO: verify if this should be passing
-        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+        SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // 4. Complete withdrawal
+        // 5. Complete withdrawals
+        uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
+        staker.completeWithdrawalsAsTokens(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
-            uint256[] memory expectedTokens = _calculateExpectedTokens(
-                withdrawals[i].strategies,
-                withdrawals[i].scaledShares
-            );
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
-
-            IERC20[] memory tokens = new IERC20[](withdrawals[i].strategies.length);
-            for (uint256 j = 0; j < withdrawals[i].strategies.length; ++j) {
-                tokens[j] = withdrawals[i].strategies[j].underlyingToken();
-            }
-
-            // Assert that the withdrawal is completed as expected, with NO IMPACT from the slash
-            check_Withdrawal_AsTokens_State(
-                staker, operator, withdrawals[i], strategies, sharesToWithdraw, tokens, expectedTokens
-            );
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 5. Check final state
+        // 6. Check final state
 
         // Assert that all strategies have some shares remaining
-        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
-
-        // Assert that the staker has withdrawn the expected tokens
-        assert_HasUnderlyingTokenBalances(
-            staker,
-            strategies,
-            initTokenBalances,
-            "staker should have withdrawn tokens"
-        );
+        (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
+        assertEq(strats.length, 0, "all strategies should have no shares remaining");
 
         // Assert that all withdrawals are removed from pending
-        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 }

--- a/src/test/integration/tests/Timing.t.sol
+++ b/src/test/integration/tests/Timing.t.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Integration_ALMSlashBase, IStrategy, IERC20} from "src/test/integration/tests/SlashingWithdrawals.t.sol";
+
+/**
+ * @notice These tests check for specific timing edge case behavior correctness
+ * @dev These tests assume the following:
+ * - The staker has a positive balance in all given trategies
+ * - The staker has no pending withdrawals
+ * - The staker has no pending slash requests
+ * - The staker is delegated to the operator
+ */
+contract Integration_Timing is Integration_ALMSlashBase {
+
+    /**
+     * @notice Test that a slash works correctly just before a partial withdrawal is completed
+     */
+    function testFuzz_queuePartialWithdrawal_slashBeforeWithdrawal_completeAsTokens(
+        uint24 _random
+    ) public rand(_random) {
+        // 0. Calculate partial withdrawal amounts
+        for (uint256 i = 0; i < initTokenBalances.length; ++i) {
+            // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
+            // but 10 as the maximum divisor is more arbitrary
+            initTokenBalances[i] /= _randUint(2, 10);
+        }
+
+        // 1. Queue withdrawal
+        uint256[] memory sharesToWithdraw = _calculateExpectedShares(strategies, initTokenBalances);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, sharesToWithdraw);
+
+        // 2. Move time forward to _just before_ withdrawal block
+        // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        // Note: This is done to ensure that the withdrawal is still pending
+        vm.roll(block.number - 1);
+
+        // 3. Slash operator
+        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+            _randStrategiesAndWadsToSlash(operatorSet);
+        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+
+        // Assert that the operator allocations and staker withdrawable shares are slashed, but the staker deposit shares are not
+        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+
+        // 4. Move time forward to withdrawal block
+        vm.roll(block.number + 1);
+
+        // 5. Complete withdrawals
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint256[] memory expectedTokens = _calculateExpectedTokens(
+                withdrawals[i].strategies,
+                withdrawals[i].scaledShares
+            );
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+
+            // Assert that the withdrawal is completed as expected
+            check_Withdrawal_AsTokens_State_AfterSlash(
+                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
+            );
+        }
+
+        // 6. Check final state
+
+        // Assert that all strategies have some shares remaining
+        (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
+        assertEq(strats.length, strategies.length, "all strategies should have some shares remaining");
+
+        // Assert that the staker has withdrawn the expected tokens
+        assert_HasUnderlyingTokenBalances_AfterSlash(
+            staker,
+            allocateParams,
+            slashingParams,
+            initTokenBalances,
+            "staker should have withdrawn tokens minus slashed"
+        );
+
+        // Assert that all withdrawals are removed from pending
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
+    }
+
+    /**
+     * @notice Test that a slash works correctly just before a total withdrawal is completed
+     */
+    function testFuzz_queueTotalWithdrawal_slashBeforeWithdrawal_completeAsTokens(
+        uint24 _random
+    ) public rand(_random) {
+        // 1. Undelegate (i.e. queue a total withdrawal from every strategy)
+        Withdrawal[] memory withdrawals = staker.undelegate();
+
+        // 2. Move time forward to _just before_ withdrawal block
+        // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        // Note: This is done to ensure that the withdrawal is still pending
+        vm.roll(block.number - 1);
+
+        // 3. Slash operator
+        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+            _randStrategiesAndWadsToSlash(operatorSet);
+        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+
+        // Assert that the operator allocations and staker withdrawable shares are slashed, but the staker deposit shares are not
+        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+
+        // 4. Move time forward to withdrawal block
+        vm.roll(block.number + 1);
+
+        // 5. Complete withdrawals
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint256[] memory expectedTokens = _calculateExpectedTokens(
+                withdrawals[i].strategies,
+                withdrawals[i].scaledShares
+            );
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+
+            // Assert that the withdrawal is completed as expected
+            check_Withdrawal_AsTokens_State_AfterSlash(
+                staker, operator, withdrawals[i], allocateParams, slashingParams, expectedTokens
+            );
+        }
+
+        // 6. Check final state
+
+        // Assert that no strategies have any shares remaining
+        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
+
+        // Assert that the staker has withdrawn the expected tokens
+        assert_HasUnderlyingTokenBalances_AfterSlash(
+            staker,
+            allocateParams,
+            slashingParams,
+            initTokenBalances,
+            "staker should have withdrawn tokens minus slashed"
+        );
+
+        // Assert that all withdrawals are removed from pending
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
+    }
+
+    /**
+     * @notice Test that a staker can still complete a partial withdrawal even after a slash has been performed
+     */
+    function testFuzz_queuePartialWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
+        uint24 _random
+    ) public rand(_random) {
+        // 0. Calculate partial withdrawal amounts
+        for (uint256 i = 0; i < initTokenBalances.length; ++i) {
+            // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
+            // but 10 as the maximum divisor is more arbitrary
+            initTokenBalances[i] /= _randUint(2, 10);
+        }
+
+        // 1. Queue withdrawal
+        uint256[] memory sharesToWithdraw = _calculateExpectedShares(strategies, initTokenBalances);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, sharesToWithdraw);
+
+        // 2. Move time forward to _exactly_ the withdrawal block
+        // Expected behavior: Withdrawals are still pending, but can be completed, and slashes can no longer be 
+        // performed _on the partial withdrawals_. The remaining shares may still be affected.
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        // 3. Slash operator
+        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+            _randStrategiesAndWadsToSlash(operatorSet);
+        // Note: This will _partially_ impact the staker's withdrawable shares as they have not withdrawn all shares
+        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+
+        // Assert:
+        // * Operator allocations are slashed
+        // * Staker withdrawable shares are _partially_ affected due to the partial withdrawal
+        // * Staker deposit shares are unaffected
+        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should be slashed");
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+
+        // 4. Complete withdrawal
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint256[] memory expectedTokens = _calculateExpectedTokens(
+                withdrawals[i].strategies,
+                withdrawals[i].scaledShares
+            );
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+
+            IERC20[] memory tokens = new IERC20[](withdrawals[i].strategies.length);
+            for (uint256 j = 0; j < withdrawals[i].strategies.length; ++j) {
+                tokens[j] = withdrawals[i].strategies[j].underlyingToken();
+            }
+
+            // Assert that the withdrawal is completed as expected, with NO IMPACT from the slash 
+            // as these withdrawals are past the delay
+            check_Withdrawal_AsTokens_State(
+                staker, operator, withdrawals[i], strategies, sharesToWithdraw, tokens, expectedTokens
+            );
+        }
+
+        // 5. Check final state
+
+        // Assert that all strategies have some shares remaining
+        (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
+        assertEq(strats.length, strategies.length, "all strategies should have some shares remaining");
+
+        // Assert that the staker has withdrawn the expected tokens
+        assert_HasUnderlyingTokenBalances(
+            staker,
+            strategies,
+            initTokenBalances,
+            "staker should have withdrawn tokens"
+        );
+
+        // Assert that all withdrawals are removed from pending
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
+    }
+    
+    
+    /**
+     * @notice Test that a staker is unaffected by a slash after the withdrawal delay has passed
+     */
+    function testFuzz_queueTotalWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
+        uint24 _random
+    ) public rand(_random) {
+        // 1. Undelegate (i.e. queue a total withdrawal from every strategy)
+        uint256[] memory sharesToWithdraw = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.undelegate();
+
+        // 2. Move time forward to _exactly_ the withdrawal block
+        // Expected behavior: Withdrawals are still pending, but can be completed, and slashes can no longer affect 
+        // this staker
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        // 3. Slash operator
+        (IStrategy[] memory strategiesToSlash, uint256[] memory wadsToSlash) =
+            _randStrategiesAndWadsToSlash(operatorSet);
+        // Note: This should have no effect on the STAKER as the withdrawal is already past the withdrawal block
+        SlashingParams memory slashingParams = avs.slashOperator(operator, operatorSet.id, strategiesToSlash, wadsToSlash);
+        
+        // Assert:
+        // * Operator allocations are slashed
+        // * Staker withdrawable shares are unaffected by the slash
+        // * Staker deposit shares are unaffected
+        assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
+        assert_Snap_StakerWithdrawableShares_AfterSlash(staker, allocateParams, slashingParams, "staker withdrawable shares should NOT be slashed"); // TODO: verify if this should be passing
+        assert_Snap_Unchanged_Staker_DepositShares(staker, "staker deposit shares should be unchanged after slashing");
+
+        // 4. Complete withdrawal
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint256[] memory expectedTokens = _calculateExpectedTokens(
+                withdrawals[i].strategies,
+                withdrawals[i].scaledShares
+            );
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+
+            IERC20[] memory tokens = new IERC20[](withdrawals[i].strategies.length);
+            for (uint256 j = 0; j < withdrawals[i].strategies.length; ++j) {
+                tokens[j] = withdrawals[i].strategies[j].underlyingToken();
+            }
+
+            // Assert that the withdrawal is completed as expected, with NO IMPACT from the slash
+            check_Withdrawal_AsTokens_State(
+                staker, operator, withdrawals[i], strategies, sharesToWithdraw, tokens, expectedTokens
+            );
+        }
+
+        // 5. Check final state
+
+        // Assert that all strategies have some shares remaining
+        assert_HasNoDelegatableShares(staker, "staker should have withdrawn all shares");
+
+        // Assert that the staker has withdrawn the expected tokens
+        assert_HasUnderlyingTokenBalances(
+            staker,
+            strategies,
+            initTokenBalances,
+            "staker should have withdrawn tokens"
+        );
+
+        // Assert that all withdrawals are removed from pending
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
+    }
+}

--- a/src/test/integration/tests/Timing.t.sol
+++ b/src/test/integration/tests/Timing.t.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Integration_ALMSlashBase, IStrategy, IERC20, IAllocationManagerErrors, IntegrationCheckUtils, User, OperatorSet, AVS, HOLDS_LST} from "src/test/integration/tests/SlashingWithdrawals.t.sol";
+import "src/test/integration/tests/SlashingWithdrawals.t.sol";
 
 /**
- * @notice These tests check for specific timing edge case behavior correctness
+ * @notice These tests check for specific withdrawal correctness around timing
  * @dev These tests assume the following:
- * - The staker has a positive balance in all given trategies
+ * - The staker has a positive balance in all given strategies
  * - The staker has no pending withdrawals
- * - The staker has no pending slash requests
  * - The staker is delegated to the operator
  */
 contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
@@ -18,48 +17,65 @@ contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
     ///////////////////////////////
 
     /**
-     * @notice Test that a slash works correctly just before a partial withdrawal is completed
+     * @notice Test that a slash works correctly just before a _partial_ withdrawal is completed
      */
-    function testFuzz_queuePartialWithdrawal_slashBeforeWithdrawal_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
+    function testFuzz_queuePartialWithdrawal_slashBeforeWithdrawalDelay_completeAsTokens(
+        uint24 _r
+    ) public rand(_r) {
         uint256[] memory depositSharesToWithdraw = new uint256[](initDepositShares.length);
-        // 0. Calculate partial withdrawal amounts
+        /// 0. Calculate partial withdrawal amounts
         for (uint256 i = 0; i < initDepositShares.length; ++i) {
-            // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
-            // but 10 as the maximum divisor is more arbitrary
+            // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial but 10 as
+            // the maximum divisor is more arbitrary
             depositSharesToWithdraw[i] = initDepositShares[i] / _randUint(2, 10);
         }
 
-        // 1. Queue withdrawal
+        /// 1. Queue withdrawal
         uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositSharesToWithdraw);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        
+        // Validate correctly queued withdrawals
         check_QueuedWithdrawal_State(staker, operator, strategies, depositSharesToWithdraw, withdrawableShares, withdrawals, withdrawalRoots);
 
-        // 2. Move time forward to _just before_ withdrawal block
+        /// 2. Move time forward to _just before_ withdrawal block
         // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
         _rollBlocksForCompleteWithdrawals(withdrawals);
-        // Note: This is done to ensure that the withdrawal is still pending
         vm.roll(block.number - 1);
+        
+        // Verify that the withdrawals are _still_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) <= slashableUntil);
+        }
 
-        // 3. Slash operator
+        /// 3. Slash operator
         SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // 4. Move time forward to withdrawal block
+        /// 4. Move time forward to withdrawal block
         vm.roll(block.number + 1);
+        
+        // Verify that the withdrawals are _no longer_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) > slashableUntil);
+        }
 
-        // 5. Complete withdrawals
+        /// 5. Complete withdrawals
         withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
         uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
         staker.completeWithdrawalsAsTokens(withdrawals);
+        
+        // Verify that the withdrawals were completed correctly
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 6. Check final state
+        /// 6. Check final state
 
         // Assert that all strategies have some shares remaining
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
@@ -70,41 +86,57 @@ contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
     }
 
     /**
-     * @notice Test that a slash works correctly just before a total withdrawal is completed
+     * @notice Test that a slash works correctly just before a _total_ withdrawal is completed
      */
-    function testFuzz_queueTotalWithdrawal_slashBeforeWithdrawal_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
-        // 1. Queue withdrawal
+    function testFuzz_queueTotalWithdrawal_slashBeforeWithdrawalDelay_completeAsTokens(
+        uint24 _r
+    ) public rand(_r) {
+        /// 1. Queue withdrawal
         uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
 
+        // Validate correctly queued withdrawals
         check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
-        // 2. Move time forward to _just before_ withdrawal block
+        /// 2. Move time forward to _just before_ withdrawal block
         // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
         _rollBlocksForCompleteWithdrawals(withdrawals);
-        // Note: This is done to ensure that the withdrawal is still pending
         vm.roll(block.number - 1);
+        
+        // Verify that the withdrawals are _still_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) <= slashableUntil);
+        }
 
-        // 3. Slash operator
+        /// 3. Slash operator
         SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // 4. Move time forward to withdrawal block
+        /// 4. Move time forward to withdrawal block
         vm.roll(block.number + 1);
+        
+        // Verify that the withdrawals are _no longer_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) > slashableUntil);
+        }
 
-        // 5. Complete withdrawals
+        /// 5. Complete withdrawals
         withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
         uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
         staker.completeWithdrawalsAsTokens(withdrawals);
+        
+        // Verify that the withdrawals were completed correctly
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 6. Check final state
+        /// 6. Check final state
 
         // Assert that all strategies have some shares remaining
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
@@ -118,45 +150,53 @@ contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
      * @notice Test that a staker can still complete a partial withdrawal even after a slash has been performed
      */
     function testFuzz_queuePartialWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
+        uint24 _r
+    ) public rand(_r) {
         uint256[] memory depositSharesToWithdraw = new uint256[](initDepositShares.length);
-        // 0. Calculate partial withdrawal amounts
+        /// 0. Calculate partial withdrawal amounts
         for (uint256 i = 0; i < initDepositShares.length; ++i) {
             // Note: 2 is specifically chosen as the minimum divisor to ensure that the withdrawal is partial
             // but 10 as the maximum divisor is more arbitrary
             depositSharesToWithdraw[i] = initDepositShares[i] / _randUint(2, 10);
         }
 
-        // 1. Queue withdrawal
+        /// 1. Queue withdrawal
         uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, depositSharesToWithdraw);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositSharesToWithdraw);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
 
-        // Note: Because this is a partial withdrawal, we pass in the initial token balances as the withdrawable shares
-        // rather than `initDepositShares`
-        // Moreover, the shares to withdraw are the expected shares calculated from the token balances
+        // Validate correctly queued withdrawals
         check_QueuedWithdrawal_State(staker, operator, strategies, depositSharesToWithdraw, withdrawableShares, withdrawals, withdrawalRoots);
 
-        // 2. Move time forward to _just before_ withdrawal block
-        // Expected behavior: Withdrawals are still pending and cannot be completed, but slashes can still be performed
+        /// 2. Move time forward to _just after_ withdrawal block
+        // Expected behavior: Withdrawals are no longer slashable, so slashes no longer affect the staker
         _rollBlocksForCompleteWithdrawals(withdrawals);
+        
+        // Verify that the withdrawals are _no longer_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) > slashableUntil);
+        }
 
-        // 3. Slash operator
+        /// 3. Slash operator
         SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // 5. Complete withdrawals
+        /// 4. Complete withdrawals
         // Note: expectedTokens must be recalculated because the withdrawable shares
         // have changed due to the slash
         uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
         staker.completeWithdrawalsAsTokens(withdrawals);
+        
+        // Verify that the withdrawals were completed correctly
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 6. Check final state
+        /// 5. Check final state
 
         // Assert that all strategies have some shares remaining
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
@@ -170,33 +210,43 @@ contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
      * @notice Test that a staker is unaffected by a slash after the withdrawal delay has passed
      */
     function testFuzz_queueTotalWithdrawal_slashAfterWithdrawalDelay_completeAsTokens(
-        uint24 _random
-    ) public rand(_random) {
-        // 1. Queue withdrawal
+        uint24 _r
+    ) public rand(_r) {
+        /// 1. Queue withdrawal
         uint256[] memory withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
 
+        // Validate correctly queued withdrawals
         check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
-        // 2. Move time forward to withdrawal block
-        // Expected behavior: Withdrawals are no longer pending, and slashes
-        // no longer affect the staker
+        /// 2. Move time forward to withdrawal block
+        // Expected behavior: Withdrawals are no longer slashable, so slashes no longer affect the staker
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
-        // 3. Slash operator
+        // Verify that the withdrawals are _no longer_ slashable
+        for (uint256 i = 0; i < withdrawals.length; ++i) { 
+            uint32 slashableUntil = withdrawals[i].startBlock + delegationManager.minWithdrawalDelayBlocks();
+            assert(uint32(block.number) > slashableUntil);
+        }
+
+        /// 3. Slash operator
         SlashingParams memory slashingParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(operator, operatorSet.id, slashingParams.strategies, slashingParams.wadsToSlash);
+        
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashingParams);
 
-        // 5. Complete withdrawals
+        /// 4. Complete withdrawals
         uint[] memory expectedTokens = _calculateExpectedTokens(strategies, withdrawableShares);
         staker.completeWithdrawalsAsTokens(withdrawals);
+        
+        // Verify that the withdrawals were completed correctly
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
         }
 
-        // 6. Check final state
+        /// 5. Check final state
 
         // Assert that all strategies have some shares remaining
         (IStrategy[] memory strats,) = delegationManager.getDepositedShares(address(staker));
@@ -207,6 +257,12 @@ contract Integration_WithdrawalTiming is Integration_ALMSlashBase {
     }
 }
 
+
+/**
+ * @notice These tests check for specific deallocation correctness around timing
+ * @dev These tests assume the following:
+ * - The operator is registered and allocated to the operator set
+ */
 contract Integration_OperatorDeallocationTiming is Integration_ALMSlashBase {
 
     //////////////////////////////////////////
@@ -214,35 +270,40 @@ contract Integration_OperatorDeallocationTiming is Integration_ALMSlashBase {
     //////////////////////////////////////////
 
     function testFuzz_deallocateFully_slashBeforeDelay(uint24 _r) public rand(_r) {
-        // 1. Deallocate
-        AllocateParams memory deallocateParams = _genDeallocation_Full(operator, operatorSet);
-        operator.modifyAllocations(deallocateParams);
-        check_DecrAlloc_State_Slashable(operator, deallocateParams);
+        /// 1. Deallocate
+        operator.deregisterFromOperatorSet(operatorSet);
+        // Validate the deallocation
+        check_Deregistration_State_NoAllocation(operator, operatorSet);
 
-        // 2. Move time forward to _just before_ deallocation delay
+        /// 2. Move time forward to _just before_ deallocation delay
         // Expected behavior: Deallocation delay is not yet passed, so slashes can still be performed
         _rollForward_DeallocationDelay();
-        rollBackward(1); // make sure that deallocation delay is not yet passed
+        rollBackward(1);
+        // Verify that the operator is _still_ slashable
+        check_IsSlashable_State(operator, operatorSet, strategies);
 
-        // 3. Slash operator
+        /// 3. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(slashParams);
-        check_Base_Slashing_State(operator, deallocateParams, slashParams);
+        // Verify that the slash was performed correctly
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
     }
 
     function testFuzz_deallocateFully_slashAfterDelay(uint24 _r) public rand(_r) {
-        // 1. Deallocate
-        AllocateParams memory deallocateParams = _genDeallocation_Full(operator, operatorSet);
-        operator.modifyAllocations(deallocateParams);
-        check_DecrAlloc_State_Slashable(operator, deallocateParams);
+        /// 1. Deallocate
+        operator.deregisterFromOperatorSet(operatorSet);
+        // Validate the deallocation
+        check_Deregistration_State_NoAllocation(operator, operatorSet);
 
-        // 2. Move time forward to deallocation delay
+        /// 2. Move time forward to deallocation delay
         _rollForward_DeallocationDelay();
+        // Verify that the operator is _no longer_ slashable
+        check_NotSlashable_State(operator, operatorSet);
 
-        // 3. Slash operator
+        /// 3. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
+        vm.expectRevert(IAllocationManagerErrors.OperatorNotSlashable.selector);
         avs.slashOperator(slashParams);
-        check_Base_Slashing_State(operator, deallocateParams, slashParams);
     }
 }
 
@@ -251,44 +312,58 @@ contract Integration_OperatorDeregistrationTiming is Integration_ALMSlashBase {
     ////////////////////////////////////////////
     /// OPERATOR DEREGISTRATION TIMING TESTS ///
     ////////////////////////////////////////////
-    
+
     function testFuzz_deregister_slashBeforeDelay(uint24 _r) public rand(_r) {
+        /// 1. Deregister
         operator.deregisterFromOperatorSet(operatorSet);
+        // Validate the deregistration
         check_Deregistration_State_PendingAllocation(operator, operatorSet);
 
-        // 2. Move time forward to _just before_ deregistration delay
+        /// 2. Move time forward to _just before_ deregistration delay
+        // Expected behavior: Deregistration delay is not yet passed, so slashes can still be performed
         _rollForward_DeallocationDelay();
-        rollBackward(1); // make sure that deregistration delay is not yet passed
+        rollBackward(1);
+        // Verify that the operator is _still_ slashable
+        check_IsSlashable_State(operator, operatorSet, strategies);
 
-        // 3. Slash operator
+        /// 3. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(slashParams);
         check_Base_Slashing_State(operator, allocateParams, slashParams);
     }
 
     function testFuzz_deregister_slashAfterDelay(uint24 _r) public rand(_r) {
-        // 1. Deregister
+        /// 1. Deregister
         operator.deregisterFromOperatorSet(operatorSet);
+        // Validate the deregistration
         check_Deregistration_State_PendingAllocation(operator, operatorSet);
 
-        // 2. Move time forward to deregistration delay
+        /// 2. Move time forward to deregistration delay
         _rollForward_DeallocationDelay();
+        // Verify that the operator is _no longer_ slashable
+        check_NotSlashable_State(operator, operatorSet);
 
-        // 3. Slash operator
+        /// 3. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
         vm.expectRevert(IAllocationManagerErrors.OperatorNotSlashable.selector);
         avs.slashOperator(slashParams);
     }
 }
 
+/**
+ * @notice These tests check for specific allocation correctness around timing
+ * @dev These tests inherit from IntegrationCheckUtils instead of Integration_ALMSlashBase because they require a 
+ * different initialization -- specifically, the allocation must be performed within the tests. As such, there are no 
+ * assumptions and many state variables are declared below.
+ */
 contract Integration_OperatorAllocationTiming is IntegrationCheckUtils {
     AVS avs;
     User operator;
     OperatorSet operatorSet;
-    
+
     AllocateParams allocateParams;
     SlashingParams slashParams;
-    
+
     User staker;
     IStrategy[] strategies;
     IERC20[] tokens;
@@ -298,104 +373,129 @@ contract Integration_OperatorAllocationTiming is IntegrationCheckUtils {
     ////////////////////////////////////////
     /// OPERATOR ALLOCATION TIMING TESTS ///
     ////////////////////////////////////////
-    
+
     function _init() internal virtual override {
+        /// 0. Instantiate relevant objects
         _configAssetTypes(HOLDS_LST);
         (staker, strategies, initTokenBalances) = _newRandomStaker();
         operator = _newRandomOperator_NoAssets();
         (avs,) = _newRandomAVS();
         tokens = _getUnderlyingTokens(strategies);
 
-        // 1. Deposit Into Strategies
+        /// 1. Deposit into strategies
         staker.depositIntoEigenlayer(strategies, initTokenBalances);
         initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);
+        // Validate the deposits
         check_Deposit_State(staker, strategies, initDepositShares);
 
-        // 2. Delegate to an operator
+        /// 2. Delegate to an operator
         staker.delegateTo(operator);
+        // Validate the delegation
         check_Delegation_State(staker, operator, strategies, initDepositShares);
 
-        // 3. Create an operator set and register an operator.
+        /// 3. Create an operator set and register an operator.
         operatorSet = avs.createOperatorSet(strategies);
+        // Validate that the operator set was correctly created
+        assertTrue(allocationManager.isOperatorSet(operatorSet));        
     }
-    
+
     function testFuzz_register_allocate_slashBeforeDelay(uint24 _r) public rand(_r) {
-        // 0. Create and register operator
+        /// 1. Create and register operator
         operator.registerForOperatorSet(operatorSet);
+        // Validate registration
         check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
-        
-        // 1. Allocate
+
+        /// 2. Allocate
         allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
+        // Validate the allocation
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
-        // 2. Move time forward to _just before_ allocation delay
+        /// 3. Move time forward to _just before_ allocation delay
         _rollForward_AllocationDelay(operator);
         rollBackward(1); // make sure that allocation delay is not yet passed
 
-        // 3. Slash operator
-        avs.slashOperator(_genSlashing_Rand(operator, operatorSet));
-        // Note: slashParams remains uninitialized, as the slash _should not_ impact the 
-        // operator.
-        check_Base_Slashing_State(operator, allocateParams, slashParams);
+        /// 4. Slash operator
+        // Note: This slash does not revert as the operator, even though it is not allocated, is
+        // still registered. However, since there is no allocation, the slash has no material effect.
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        
+        // Verify that the slash has no impact on the operator
+        // Note: emptySlashParams remains uninitialized, as the slash _should not_ impact the operator.
+        SlashingParams memory emptySlashParams;
+        check_Base_Slashing_State(operator, allocateParams, emptySlashParams);
     }
-    
+
     function testFuzz_allocate_register_slashBeforeDelay(uint24 _r) public rand(_r) {
-        // 0. Allocate
+        /// 1. Allocate
         allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
+        // Validate the allocation
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
-        
-        // 1. Create and register operator
+
+        /// 2. Create and register operator
         operator.registerForOperatorSet(operatorSet);
+        // Validate the registration
         check_Registration_State_PendingAllocation(operator, allocateParams);
 
-        // 2. Move time forward to _just before_ allocation delay
+        /// 3. Move time forward to _just before_ allocation delay
         _rollForward_AllocationDelay(operator);
         rollBackward(1); // make sure that allocation delay is not yet passed
 
-        // 3. Slash operator
-        avs.slashOperator(_genSlashing_Rand(operator, operatorSet));
-        // Note: slashParams remains uninitialized, as the slash _should not_ impact the 
-        // operator.
-        check_Base_Slashing_State(operator, allocateParams, slashParams);
-    }
-    
-    function testFuzz_register_allocate_slashAfterDelay(uint24 _r) public rand(_r) {
-        // 0. Create and register operator
-        operator.registerForOperatorSet(operatorSet);
-        check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
+        /// 4. Slash operator
+        // Note: This slash does not revert as the operator, even though it is not allocated, is
+        // still registered. However, since there is no allocation, the slash has no material effect.
+        slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
         
-        // 1. Allocate
+        // Verify that the slash has no impact on the operator
+        // Note: emptySlashParams remains uninitialized, as the slash _should not_ impact the operator.
+        SlashingParams memory emptySlashParams;
+        check_Base_Slashing_State(operator, allocateParams, emptySlashParams);
+    }
+
+    function testFuzz_register_allocate_slashAfterDelay(uint24 _r) public rand(_r) {
+        /// 1. Create and register operator
+        operator.registerForOperatorSet(operatorSet);
+        // Validate the registration
+        check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
+
+        /// 2. Allocate
         allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
+        // Validate the allocation
         check_IncrAlloc_State_Slashable(operator, allocateParams);
 
-        // 2. Move time forward to _just before_ allocation delay
+        /// 3. Move time forward to after the allocation delay completes
         _rollForward_AllocationDelay(operator);
 
-        // 3. Slash operator
+        /// 4. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(slashParams);
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashParams);
     }
-    
+
     function testFuzz_allocate_register_slashAfterDelay(uint24 _r) public rand(_r) {
-        // 0. Allocate
+        /// 1. Allocate
         allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
         operator.modifyAllocations(allocateParams);
+        // Validate the allocation
         check_IncrAlloc_State_NotSlashable(operator, allocateParams);
-        
-        // 1. Create and register operator
+
+        /// 2. Create and register operator
         operator.registerForOperatorSet(operatorSet);
+        // Validate the registration
         check_Registration_State_PendingAllocation(operator, allocateParams);
 
-        // 2. Move time forward to _just before_ allocation delay
+        /// 3. Move time forward to after the allocation delay completes
         _rollForward_AllocationDelay(operator);
 
-        // 3. Slash operator
+        /// 4. Slash operator
         slashParams = _genSlashing_Rand(operator, operatorSet);
         avs.slashOperator(slashParams);
+        // Verify that the slash was performed correctly
         check_Base_Slashing_State(operator, allocateParams, slashParams);
     }
 }


### PR DESCRIPTION
**Motivation:**

These tests cover scenarios that specifically validate correct behavior on the cusp of a delay completing.

**Modifications:**

This PR adds test that perform a slash on the following critical timing scenarios:

* Before/after a partial/total withdrawal is no longer slashable
* Before/after an operator fully deallocates
* Before/after an operator completes deregistration from an operator set
* Before/after an operator completes an allocation

**Result:**

These timing tests ensure that the correct behavior happens on either side of critical delays