### PR TITLE
fix: disable foundry ci suite path check

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -3,25 +3,25 @@ name: Foundry
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
   push:
     branches:
       - "dev"
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
 
 env:
   FOUNDRY_PROFILE: medium


### PR DESCRIPTION
**Motivation:**

There's currently a bug present when only running ci tests when relevant code has changed.

**Modifications:**

- Commented out filtering logic.

**Result:**

PRs can be merged.