### PR TITLE
Fix broken link in AVS-Guide.md

### DIFF
--- a/docs/experimental/AVS-Guide.md
+++ b/docs/experimental/AVS-Guide.md
@@ -72,7 +72,7 @@ EigenLayer is a dynamic system where stakers and operators are constantly adjust
 Let us illustrate the usage of this facility with an example: A staker has delegated to an operator, who has opted-in to serving an AVS. Whenever the staker withdraws some or all of its stake from EigenLayer, this withdrawal affects all the AVSs uniformly that the staker's delegated operator is participating in. The series of steps for withdrawing stake is as follows:
  - The staker queues their withdrawal request with EigenLayer. The staker can place this request by calling  `StrategyManager.queueWithdrawal(..)`.
  - The operator, noticing an upcoming change in their delegated stake, notifies the AVS about this change. To do this, the operator triggers the AVS to call the `ServiceManager.recordStakeUpdate(..)` which in turn accesses `Slasher.recordStakeUpdate(..)`.  On successful execution of this call, the event `MiddlewareTimesAdded(..)` is emitted.
-- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/EigenLayer-withdrawal-flow.md) for more details
+- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/outdated/EigenLayer-withdrawal-flow.md) for more details
 
 The following figure illustrates the above flow: 
 ![Stake update](../images/staker_withdrawing.png)


### PR DESCRIPTION
This PR fixes a broken link in the AVS-Guide.md file by updating the reference to the correct location in the outdated documentation folder.

Old (Broken) Link:
https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/EigenLayer-withdrawal-flow.md

New (Fixed) Link:
https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/outdated/EigenLayer-withdrawal-flow.md