### PR TITLE
chore: comment out paths in foundry.yml workflow

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -3,25 +3,25 @@ name: Foundry
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
   push:
     branches:
       - "dev"
-    paths:
-      - '.github/**'
-      - 'bin/**'
-      - 'src/**'
-      - 'lib/**'
-      - 'certora/**'
-      - 'foundry.toml'
-      - '**/*.sol'
+    # paths:
+    #   - '.github/**'
+    #   - 'bin/**'
+    #   - 'src/**'
+    #   - 'lib/**'
+    #   - 'certora/**'
+    #   - 'foundry.toml'
+    #   - '**/*.sol'
 
 env:
   FOUNDRY_PROFILE: medium


### PR DESCRIPTION
**Motivation:**

The upstream repository has commented out path filtering in the foundry.yml workflow. To avoid PRs from getting blocked, we're making the same change in our branch.

**Modifications:**

* Commented out the `paths` section in the foundry.yml workflow.

**Result:**

PRs targeting `test/slashing-integration-testing` won't get blocked.