### PR TITLE
docs: update DelegationManager doc `SignatureUtils.sol` -> `SignatureUtilsMixin.sol`

### DIFF
--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -11,7 +11,7 @@ Libraries and Mixins:
 | File | Notes |
 | -------- | -------- |
 | [`PermissionControllerMixin.sol`](../../src/contracts/mixins/PermissionControllerMixin.sol) | account delegation |
-| [`SignatureUtils.sol`](../../src/contracts/mixins/SignatureUtils.sol) | signature validation |
+| [`SignatureUtilsMixin.sol`](../../src/contracts/mixins/SignatureUtilsMixin.sol) | signature validation |
 | [`Pausable.sol`](../../src/contracts/permissions/Pausable.sol) | |
 | [`SlashingLib.sol`](../../src/contracts/libraries/SlashingLib.sol) | slashing math |
 | [`Snapshots.sol`](../../src/contracts/libraries/Snapshots.sol) | historical state |


### PR DESCRIPTION

### Description

File `SignatureUtils.sol` was renamed in PR #1015 to `SignatureUtilsMixin.sol`, `docs/core/DelegationManager.md` should reflect this. 