### PR TITLE
test: more slashing state validation

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -566,7 +566,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     function assert_BCSF_Zero(
         User staker,
         string memory err
-    ) internal {
+    ) internal view {
         uint64 curBCSF = _getBeaconChainSlashingFactor(staker);
         assertEq(curBCSF, 0, err);
     }
@@ -2927,7 +2927,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
-    function _getExpectedWithdrawableSharesUndelegate(User staker, IStrategy[] memory strategies, uint[] memory shares) internal returns (uint[] memory){
+    function _getExpectedWithdrawableSharesUndelegate(User staker, IStrategy[] memory strategies, uint[] memory shares) internal view returns (uint[] memory){
         uint[] memory expectedWithdrawableShares = new uint[](strategies.length);
         for (uint i = 0; i < strategies.length; i++) {
             if (strategies[i] == BEACONCHAIN_ETH_STRAT) {
@@ -2963,7 +2963,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return expectedWithdrawableShares;
     }
 
-    function _getExpectedWithdrawableSharesFullWithdrawal(User staker, User operator, IStrategy strategy, uint depositShares) internal returns (uint) {
+    function _getExpectedWithdrawableSharesFullWithdrawal(User staker, User operator, IStrategy strategy, uint depositShares) internal view returns (uint) {
         return depositShares.mulWad(_getExpectedDSFFullWithdrawal(staker, operator, strategy)).mulWad(_getSlashingFactor(staker, strategy));
     }
 

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1521,7 +1521,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         // For each strategy, check (prev - removed == cur)
         for (uint i = 0; i < strategies.length; i++) {
-            assertEq(prevShares[i] + addedShares[i], curShares[i], err);
+            assertApproxEqAbs(prevShares[i] + addedShares[i], curShares[i], 1, err);
         }
     }
 

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -220,7 +220,13 @@ contract IntegrationCheckUtils is IntegrationBase {
         //     and that the staker now has the expected amount of delegated shares in each strategy
         assert_HasUnderlyingTokenBalances(staker, strategies, tokenBalances, "staker should have transferred some underlying tokens");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should expected shares in each strategy after depositing");
-        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
+        
+        if (delegationManager.isDelegated(address(staker))) {
+            User operator = User(payable(delegationManager.delegatedTo(address(staker))));
+            assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, operator, strategies, shares, "staker should have received expected withdrawable shares");
+        } else {
+            assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
+        }
     }
 
     function check_Delegation_State(

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -399,7 +399,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Common checks
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         
-        // assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
+        assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have changed");
         assert_Snap_Unchanged_DSF(staker, strategies, "dsf should not be changed");
         assert_Snap_Removed_StrategyShares(strategies, shares, "strategies should have total shares decremented");

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -202,7 +202,13 @@ contract IntegrationCheckUtils is IntegrationBase {
         //     and that the staker now has the expected amount of delegated shares in each strategy
         assert_HasNoUnderlyingTokenBalance(staker, strategies, "staker should have transferred all underlying tokens");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should expect shares in each strategy after depositing");
-        assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
+
+        if (delegationManager.isDelegated(address(staker))) {
+            User operator = User(payable(delegationManager.delegatedTo(address(staker))));
+            assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, operator, strategies, shares, "staker should have received expected withdrawable shares");
+        } else {
+            assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
+        }
     }
 
     function check_Deposit_State_PartialDeposit(User staker, IStrategy[] memory strategies, uint[] memory shares, uint[] memory tokenBalances) internal {
@@ -424,7 +430,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, withdrawableShares, "staker should have received expected shares");
-        assert_Snap_Expected_Staker_WithdrawableShares_Withdrawal(staker, operator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
+        assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, operator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
 
         // Additional checks or handling for the non-user operator scenario
@@ -480,7 +486,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Added_Staker_DepositShares(staker, strategies, withdrawableShares, "staker should have received expected shares");
         assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
-        assert_Snap_Expected_Staker_WithdrawableShares_Withdrawal(staker, newOperator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
+        assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, newOperator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
     }
 
     /*******************************************************************************

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -399,7 +399,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Common checks
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         
-        assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
+        // assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have changed");
         assert_Snap_Unchanged_DSF(staker, strategies, "dsf should not be changed");
         assert_Snap_Removed_StrategyShares(strategies, shares, "strategies should have total shares decremented");

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -181,6 +181,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         assert_AllWithdrawalsPending(withdrawalRoots, "withdrawals should be pending after queueing");
@@ -190,7 +191,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, withdrawableShares, tokens, expectedTokens);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
     

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -176,7 +176,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
-        check_PartiallySlashed_State(operator, allocateParams, slashParams);
 
         // Redeposit remaining tokens
         uint[] memory additionalShares = _calculateExpectedShares(strategies, numTokensRemaining);
@@ -216,7 +215,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
-        check_PartiallySlashed_State(operator, allocateParams, slashParams);
         
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -256,8 +254,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
-        check_PartiallySlashed_State(operator, allocateParams, slashParams);
-        
+
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);
@@ -284,8 +281,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
-        check_PartiallySlashed_State(operator, allocateParams, slashParams);
-        
+
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -43,9 +43,8 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
             numTokensRemaining[i] = initTokenBalances[i] - tokensToDeposit[i];
         }
 
-        initDepositShares = _calculateExpectedShares(strategies, tokensToDeposit);
-
         // 1. Deposit Into Strategies
+        initDepositShares = _calculateExpectedShares(strategies, tokensToDeposit);
         staker.depositIntoEigenlayer(strategies, tokensToDeposit);
         check_Deposit_State_PartialDeposit(staker, strategies, initDepositShares, numTokensRemaining);
 
@@ -151,11 +150,15 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         staker.depositIntoEigenlayer(strategies, numTokensRemaining);
         check_Deposit_State(staker, strategies, depositShares);
 
+        for (uint i = 0; i < depositShares.length; i++) {
+            initDepositShares[i] += depositShares[i];
+        }
+
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositShares);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, initDepositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator, strategies, initDepositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -241,16 +241,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
             newMagnitudes: new uint64[](allocateParams.strategies.length)
         }));
         
-        // Check that the operator has deallocated
-        for (uint i = 0; i < allocateParams.strategies.length; i++) {
-            (uint64 currentMagnitude, ) = allocationManager.getAllocation(
-                address(operator), 
-                operatorSet.id, 
-                allocateParams.strategies[i]
-            );
-            assertEq(currentMagnitude, 0, "operator should have zero allocation after deallocating");
-        }
-        
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -80,7 +80,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // 6. Complete withdrawal. Staker should receive 0 shares/tokens after a full slash
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; ++i) {
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(
                 staker, operator, withdrawals[i], strategies, new uint[](strategies.length), tokens, new uint[](strategies.length)
             );
@@ -110,7 +110,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; ++i) {
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, expectedShares, tokens, expectedTokens);
         }
 
@@ -147,7 +147,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
         for (uint i = 0; i < withdrawals.length; ++i) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
-            staker.completeWithdrawalAsShares(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsShares(withdrawals[i]);
             check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares);
         }
     }
@@ -178,7 +178,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -200,7 +200,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -227,7 +227,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -253,7 +253,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -286,7 +286,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
+            tokens = zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(zeroSharesStaker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -168,10 +168,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    /**
-     * T-83: Staker with nonzero shares, Operator allocated, Staker Delegated
-     * Partially slash operator on opSet, Redeposit, Queue Full Withdrawal, Complete as Tokens
-     */
     function testFuzz_deposit_delegate_allocate_partialSlash_redeposit_queue_complete(uint24 r) public rand(r) {
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
@@ -202,10 +198,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
     
-    /**
-     * T-84: Staker with nonzero shares, Operator allocated, Staker Delegated
-     * Undelegate, Partially slash operator on opSet, Complete as Tokens
-     */
     function testFuzz_deposit_delegate_undelegate_partialSlash_complete(uint24 r) public rand(r) {
         // Undelegate from operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -231,10 +223,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    /**
-     * T-85: Staker with nonzero shares, Operator allocated, Staker Delegated
-     * Deallocate from opSet, Partially slash operator on opSet, Queue Full Withdrawal, Complete as Tokens
-     */
     function testFuzz_deposit_delegate_deallocate_partialSlash_queue_complete(uint24 r) public rand(r) {
         // Deallocate from operator set
         operator.modifyAllocations(AllocateParams({
@@ -263,10 +251,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    /**
-     * T-86: Staker with nonzero shares, Operator allocated, Staker Delegated
-     * Deregister from opSet, Partially slash operator on opSet, Queue Full Withdrawal, Complete as Tokens
-     */
     function testFuzz_deposit_delegate_deregister_partialSlash_queue_complete(uint24 r) public rand(r) {
         // Deregister operator from operator set
         operator.deregisterFromOperatorSet(operatorSet);
@@ -291,10 +275,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    /**
-     * T-95: Staker Delegated - 0 Shares, Operator allocated
-     * Partially slash operator on opSet, Deposit, Undelegate, Complete as Tokens
-     */
     function testFuzz_delegate_zeroShares_partialSlash_deposit_undelegate_complete(uint24 r) public rand(r) {
         // Create a new staker with 0 shares
         (User zeroSharesStaker, uint[] memory tokensToDeposit) = _newStaker(strategies);
@@ -326,10 +306,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
-    /**
-     * T-96: Staker with nonzero shares, Staker Delegated
-     * Allocate to opSet, Partially slash operator on opSet, Deallocate from opSet
-     */
     function testFuzz_deposit_delegate_allocate_partialSlash_deallocate(uint24 r) public rand(r) {
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -75,7 +75,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         // 6. Complete withdrawal. Staker should receive 0 shares/tokens after a full slash
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -97,7 +97,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         // 5. Fully slash operator
         SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
@@ -139,7 +139,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         // 6. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -188,7 +188,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
@@ -277,7 +277,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _getStakerWithdrawableShares(zeroSharesStaker, strategies);
         Withdrawal[] memory withdrawals = zeroSharesStaker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(zeroSharesStaker, operator, withdrawals, roots, strategies, depositShares, shares);
+        check_Undelegate_State(zeroSharesStaker, operator, withdrawals, roots, strategies, shares);
 
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -196,9 +196,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
             staker.completeWithdrawalAsTokens(withdrawals[i]);
-            // Check that each withdrawal is properly completed
-            assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawals[i]), 
-                "withdrawal should not be pending after completion");
+            // How to handle slashed withdrawal via undelegating?
         }
     }
 
@@ -217,13 +215,16 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
 
@@ -238,13 +239,16 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
+        uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
         
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
-            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
 
@@ -272,7 +276,9 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
-            zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
 

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -178,7 +178,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -225,7 +225,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -251,7 +251,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
@@ -284,7 +284,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
-            IERC20[] memory tokens = zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
+            zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(zeroSharesStaker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -176,6 +176,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // Redeposit remaining tokens
         uint[] memory additionalShares = _calculateExpectedShares(strategies, numTokensRemaining);
@@ -215,6 +216,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
         
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -244,6 +246,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
@@ -271,6 +274,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // Queue withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
@@ -301,6 +305,7 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
         
         // Deposit tokens
         uint[] memory depositShares = _calculateExpectedShares(strategies, tokensToDeposit);
@@ -319,7 +324,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         
         // Final state checks
         assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
-        assertFalse(delegationManager.isDelegated(address(zeroSharesStaker)), "staker should not be delegated after undelegating");
     }
 
     /**
@@ -330,14 +334,11 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
         avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
         
         // Deallocate from operator set
-        operator.deallocateAll(operatorSet);
-        
-        // Verify operator is no longer allocated to the operator set
-        
-        // Verify staker is still delegated
-        assertTrue(delegationManager.isDelegated(address(staker)), "staker should still be delegated");
-        assertEq(delegationManager.delegatedTo(address(staker)), address(operator), "staker should still be delegated to operator");
+        AllocateParams memory deallocateParams = _genDeallocation_Full(operator, operatorSet);
+        operator.modifyAllocations(deallocateParams);
+        check_DecrAlloc_State_Slashable(operator, deallocateParams);
     }
 }

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -93,10 +93,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         staker.depositIntoEigenlayer(strategies, numTokensRemaining);
         check_Deposit_State(staker, strategies, shares);
-
-        // Final state checks
-        assert_HasExpectedShares(staker, strategies, shares, "staker should have expected shares after redeposit");
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");      
     }
 
     function testFuzz_undelegate_fullSlash_complete_redeposit(
@@ -112,10 +108,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         check_FullySlashed_State(operator, allocateParams, slashParams);
 
         // 6. Complete withdrawal. Staker should receive 0 shares/tokens after a full slash
-        _rollBlocksForCompleteWithdrawals(withdrawals);
         uint[] memory expectedShares = new uint[](strategies.length);
         uint[] memory expectedTokens = new uint[](strategies.length);
 
+        _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             staker.completeWithdrawalAsTokens(withdrawals[i]);
             check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], strategies, expectedShares, tokens, expectedTokens);
@@ -125,10 +121,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         staker.depositIntoEigenlayer(strategies, numTokensRemaining);
         check_Deposit_State(staker, strategies, shares);
-
-        // Final state checks
-        assert_HasExpectedShares(staker, strategies, shares, "staker should have expected shares after redeposit");
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");      
     }
 
     function testFuzz_depositFull_fullSlash_undelegate_completeAsShares(
@@ -162,10 +154,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
             staker.completeWithdrawalAsShares(withdrawals[i]);
             check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares);
         }
-
-        // Check final state:
-        assert_HasNoUnderlyingTokenBalance(staker, slashingParams.strategies, "staker not have any underlying tokens");
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     function testFuzz_deposit_delegate_allocate_partialSlash_redeposit_queue_complete(uint24 r) public rand(r) {
@@ -184,7 +172,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         uint[] memory shares = _calculateExpectedShares(strategies, numTokensRemaining);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawableShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        assert_AllWithdrawalsPending(withdrawalRoots, "withdrawals should be pending after queueing");
 
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -199,8 +186,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Undelegate from operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        assert_AllWithdrawalsPending(withdrawalRoots, "withdrawals should be pending after undelegating");
-        assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated after undelegating");
         
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
@@ -215,9 +200,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
             assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawals[i]), 
                 "withdrawal should not be pending after completion");
         }
-        
-        // Final state checks
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     function testFuzz_deposit_delegate_deallocate_partialSlash_queue_complete(uint24 r) public rand(r) {
@@ -243,9 +225,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             staker.completeWithdrawalAsTokens(withdrawals[i]);
         }
-        
-        // Final state checks
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     function testFuzz_deposit_delegate_deregister_partialSlash_queue_complete(uint24 r) public rand(r) {
@@ -267,9 +246,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             staker.completeWithdrawalAsTokens(withdrawals[i]);
         }
-        
-        // Final state checks
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     function testFuzz_delegate_zeroShares_partialSlash_deposit_undelegate_complete(uint24 r) public rand(r) {
@@ -298,9 +274,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         for (uint i = 0; i < withdrawals.length; i++) {
             zeroSharesStaker.completeWithdrawalAsTokens(withdrawals[i]);
         }
-        
-        // Final state checks
-        assert_NoWithdrawalsPending(withdrawalRoots, "all withdrawals should be removed from pending");
     }
 
     function testFuzz_deposit_delegate_allocate_partialSlash_deallocate(uint24 r) public rand(r) {

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -198,8 +198,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
+            uint[] memory expectedShares = _calculateExpectedShares(withdrawals[i]);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, expectedShares);
             staker.completeWithdrawalAsTokens(withdrawals[i]);
-            // How to handle slashed withdrawal via undelegating?
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, expectedShares, tokens, expectedTokens);
         }
     }
 

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -72,7 +72,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         check_FullySlashed_State(operator, allocateParams, slashParams);
 
         // 5. Undelegate from an operator
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
 
         // 6. Complete withdrawal. Staker should receive 0 shares/tokens after a full slash
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -91,7 +94,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
     function testFuzz_undelegate_fullSlash_complete_redeposit(uint24 _random) public rand(_random) {
         // 4. Undelegate from an operator
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
 
         // 5. Fully slash operator
         SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
@@ -124,8 +130,16 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         avs.slashOperator(slashParams);
         check_FullySlashed_State(operator, allocateParams, slashParams);
 
+        // add deposit shares to initDepositShares
+        for (uint i = 0; i < depositShares.length; i++) {
+            initDepositShares[i] += depositShares[i];
+        }
+
         // 5. Undelegate from an operator
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
 
         // 6. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -138,7 +152,6 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         }
     }
 
-    // TODO
     function testFuzz_deposit_delegate_allocate_partialSlash_redeposit_queue_complete(uint24 r) public rand(r) {
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
@@ -172,7 +185,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
 
     function testFuzz_deposit_delegate_undelegate_partialSlash_complete(uint24 r) public rand(r) {
         // Undelegate from operator
+        uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
 
         // Partially slash operator
         SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
@@ -258,7 +274,10 @@ contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is Integrat
         check_Deposit_State(zeroSharesStaker, strategies, depositShares);
 
         // Undelegate
+        uint[] memory shares = _getStakerWithdrawableShares(zeroSharesStaker, strategies);
         Withdrawal[] memory withdrawals = zeroSharesStaker.undelegate();
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(zeroSharesStaker, operator, withdrawals, roots, strategies, depositShares, shares);
 
         // Complete withdrawal
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -30,20 +30,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
         
-        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = shares;
+        uint[] memory delegatableShares = depositShares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        check_Deposit_State(staker, strategies, shares);
+        check_Deposit_State(staker, strategies, depositShares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, shares);
+        check_Delegation_State(staker, operator1, strategies, depositShares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -60,14 +60,14 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         // 5. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, shares);
+        check_Delegation_State(staker, operator2, strategies, depositShares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-        withdrawals = staker.queueWithdrawals(strategies, shares);
+        withdrawals = staker.queueWithdrawals(strategies, depositShares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -96,20 +96,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = shares;
+        uint[] memory delegatableShares = depositShares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        check_Deposit_State(staker, strategies, shares);
+        check_Deposit_State(staker, strategies, depositShares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, shares);
+        check_Delegation_State(staker, operator1, strategies, depositShares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -126,14 +126,14 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         // 5. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, shares);
+        check_Delegation_State(staker, operator2, strategies, depositShares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-        withdrawals = staker.queueWithdrawals(strategies, shares);
+        withdrawals = staker.queueWithdrawals(strategies, depositShares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -142,19 +142,19 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // Complete all but last withdrawal as tokens
         for (uint i = 0; i < withdrawals.length - 1; i++) {
             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-            uint[] memory expectedTokens = _calculateExpectedTokens(strategies, shares);
-            check_Withdrawal_AsTokens_State(staker, staker, withdrawals[i], strategies, shares, tokens, expectedTokens);
+            uint[] memory expectedTokens = _calculateExpectedTokens(strategies, depositShares);
+            check_Withdrawal_AsTokens_State(staker, staker, withdrawals[i], strategies, depositShares, tokens, expectedTokens);
         }
 
         // Complete last withdrawal as shares
         IERC20[] memory finalWithdrawaltokens = staker.completeWithdrawalAsTokens(withdrawals[withdrawals.length - 1]);
-        uint[] memory finalExpectedTokens = _calculateExpectedTokens(strategies, shares);
+        uint[] memory finalExpectedTokens = _calculateExpectedTokens(strategies, depositShares);
         check_Withdrawal_AsTokens_State(
             staker,
             operator2,
             withdrawals[withdrawals.length - 1],
             strategies,
-            shares,
+            depositShares,
             finalWithdrawaltokens,
             finalExpectedTokens
         );
@@ -177,7 +177,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
@@ -186,7 +186,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             // Divide shares by 2 in new array to do deposits after redelegate
             uint[] memory numTokensToDeposit = new uint[](tokenBalances.length);
             uint[] memory numTokensRemaining = new uint[](tokenBalances.length);
-            for (uint i = 0; i < shares.length; i++) {
+            for (uint i = 0; i < depositShares.length; i++) {
                 numTokensToDeposit[i] = tokenBalances[i] / 2;
                 numTokensRemaining[i] = tokenBalances[i] - numTokensToDeposit[i];
             }
@@ -223,16 +223,16 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             // 6. Deposit into Strategies
             uint[] memory sharesAdded = _calculateExpectedShares(strategies, numTokensRemaining);
             staker.depositIntoEigenlayer(strategies, numTokensRemaining);
-            tokenBalances = _calculateExpectedTokens(strategies, shares);
+            tokenBalances = _calculateExpectedTokens(strategies, depositShares);
             check_Deposit_State(staker, strategies, sharesAdded);
         }
 
         {
             // 7. Queue Withdrawal
-            shares = _calculateExpectedShares(strategies, tokenBalances);
-            Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, shares);
+            depositShares = _calculateExpectedShares(strategies, tokenBalances);
+            Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, depositShares);
             bytes32[] memory newWithdrawalRoots = _getWithdrawalHashes(newWithdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, newWithdrawals, newWithdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, depositShares, newWithdrawals, newWithdrawalRoots);
 
             // 8. Complete withdrawal
             // Fast forward to when we can complete the withdrawal
@@ -242,7 +242,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             for (uint i = 0; i < newWithdrawals.length; i++) {
                 uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledShares);
                 IERC20[] memory tokens = staker.completeWithdrawalAsTokens(newWithdrawals[i]);
-                check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, shares, tokens, expectedTokens);
+                check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, depositShares, tokens, expectedTokens);
             }
         }
     }
@@ -350,21 +350,21 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = shares;
+        uint[] memory delegatableShares = depositShares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, shares);
-        check_Deposit_State(staker, strategies, shares);
+        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, depositShares);
+        check_Deposit_State(staker, strategies, depositShares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, shares);
+        check_Delegation_State(staker, operator1, strategies, depositShares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -382,20 +382,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         //5. Deposit into Strategies
         staker.depositIntoEigenlayer(strategies, withdrawnTokenBalances);
-        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
-        check_Deposit_State(staker, strategies, shares);
+        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        check_Deposit_State(staker, strategies, depositShares);
         
         // 6. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, shares);
+        check_Delegation_State(staker, operator2, strategies, depositShares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         {
             // 7. Queue Withdrawal
             uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-            withdrawals = staker.queueWithdrawals(strategies, shares);
+            withdrawals = staker.queueWithdrawals(strategies, depositShares);
             withdrawalRoots = _getWithdrawalHashes(withdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
         }
 
         // 8. Complete withdrawal as shares
@@ -406,7 +406,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], strategies, shares, tokens, expectedTokens);
+            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], strategies, depositShares, tokens, expectedTokens);
         }
     }
 
@@ -420,21 +420,21 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = shares;
+        uint[] memory delegatableShares = depositShares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, shares);
-        check_Deposit_State(staker, strategies, shares);
+        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, depositShares);
+        check_Deposit_State(staker, strategies, depositShares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, shares);
+        check_Delegation_State(staker, operator1, strategies, depositShares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -451,20 +451,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         }
 
         // 5. Deposit into Strategies
-        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
         staker.depositIntoEigenlayer(strategies, withdrawnTokenBalances);
-        check_Deposit_State(staker, strategies, shares);
+        check_Deposit_State(staker, strategies, depositShares);
         
         // 6. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, shares);
+        check_Delegation_State(staker, operator2, strategies, depositShares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 7. Queue Withdrawal
-        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
-        withdrawals = staker.queueWithdrawals(strategies, shares);
+        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        withdrawals = staker.queueWithdrawals(strategies, depositShares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, depositShares, withdrawals, withdrawalRoots);
 
         // 8. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -473,7 +473,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // Complete withdrawals as shares
         for (uint i = 0; i < withdrawals.length; i++) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_State(staker, operator2, withdrawals[i], strategies, shares);
+            check_Withdrawal_AsShares_State(staker, operator2, withdrawals[i], strategies, depositShares);
         }
     }
 }

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -30,20 +30,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
         
-        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = depositShares;
+        uint[] memory delegatableShares = shares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        check_Deposit_State(staker, strategies, depositShares);
+        check_Deposit_State(staker, strategies, shares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, depositShares);
+        check_Delegation_State(staker, operator1, strategies, shares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -60,14 +60,14 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         // 5. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, depositShares);
+        check_Delegation_State(staker, operator2, strategies, shares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-        withdrawals = staker.queueWithdrawals(strategies, depositShares);
+        withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -96,20 +96,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = depositShares;
+        uint[] memory delegatableShares = shares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        check_Deposit_State(staker, strategies, depositShares);
+        check_Deposit_State(staker, strategies, shares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, depositShares);
+        check_Delegation_State(staker, operator1, strategies, shares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -126,14 +126,14 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         // 5. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, depositShares);
+        check_Delegation_State(staker, operator2, strategies, shares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 6. Queue Withdrawal
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-        withdrawals = staker.queueWithdrawals(strategies, depositShares);
+        withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // 7. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -142,19 +142,19 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // Complete all but last withdrawal as tokens
         for (uint i = 0; i < withdrawals.length - 1; i++) {
             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-            uint[] memory expectedTokens = _calculateExpectedTokens(strategies, depositShares);
-            check_Withdrawal_AsTokens_State(staker, staker, withdrawals[i], strategies, depositShares, tokens, expectedTokens);
+            uint[] memory expectedTokens = _calculateExpectedTokens(strategies, shares);
+            check_Withdrawal_AsTokens_State(staker, staker, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
 
         // Complete last withdrawal as shares
         IERC20[] memory finalWithdrawaltokens = staker.completeWithdrawalAsTokens(withdrawals[withdrawals.length - 1]);
-        uint[] memory finalExpectedTokens = _calculateExpectedTokens(strategies, depositShares);
+        uint[] memory finalExpectedTokens = _calculateExpectedTokens(strategies, shares);
         check_Withdrawal_AsTokens_State(
             staker,
             operator2,
             withdrawals[withdrawals.length - 1],
             strategies,
-            depositShares,
+            shares,
             finalWithdrawaltokens,
             finalExpectedTokens
         );
@@ -177,7 +177,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
@@ -186,7 +186,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             // Divide shares by 2 in new array to do deposits after redelegate
             uint[] memory numTokensToDeposit = new uint[](tokenBalances.length);
             uint[] memory numTokensRemaining = new uint[](tokenBalances.length);
-            for (uint i = 0; i < depositShares.length; i++) {
+            for (uint i = 0; i < shares.length; i++) {
                 numTokensToDeposit[i] = tokenBalances[i] / 2;
                 numTokensRemaining[i] = tokenBalances[i] - numTokensToDeposit[i];
             }
@@ -223,16 +223,16 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             // 6. Deposit into Strategies
             uint[] memory sharesAdded = _calculateExpectedShares(strategies, numTokensRemaining);
             staker.depositIntoEigenlayer(strategies, numTokensRemaining);
-            tokenBalances = _calculateExpectedTokens(strategies, depositShares);
+            tokenBalances = _calculateExpectedTokens(strategies, shares);
             check_Deposit_State(staker, strategies, sharesAdded);
         }
 
         {
             // 7. Queue Withdrawal
-            depositShares = _calculateExpectedShares(strategies, tokenBalances);
-            Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, depositShares);
+            shares = _calculateExpectedShares(strategies, tokenBalances);
+            Withdrawal[] memory newWithdrawals = staker.queueWithdrawals(strategies, shares);
             bytes32[] memory newWithdrawalRoots = _getWithdrawalHashes(newWithdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, depositShares, newWithdrawals, newWithdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, newWithdrawals, newWithdrawalRoots);
 
             // 8. Complete withdrawal
             // Fast forward to when we can complete the withdrawal
@@ -242,7 +242,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             for (uint i = 0; i < newWithdrawals.length; i++) {
                 uint[] memory expectedTokens = _calculateExpectedTokens(newWithdrawals[i].strategies, newWithdrawals[i].scaledShares);
                 IERC20[] memory tokens = staker.completeWithdrawalAsTokens(newWithdrawals[i]);
-                check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, depositShares, tokens, expectedTokens);
+                check_Withdrawal_AsTokens_State(staker, operator2, newWithdrawals[i], strategies, shares, tokens, expectedTokens);
             }
         }
     }
@@ -350,21 +350,21 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = depositShares;
+        uint[] memory delegatableShares = shares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, depositShares);
-        check_Deposit_State(staker, strategies, depositShares);
+        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, shares);
+        check_Deposit_State(staker, strategies, shares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, depositShares);
+        check_Delegation_State(staker, operator1, strategies, shares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -382,20 +382,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
 
         //5. Deposit into Strategies
         staker.depositIntoEigenlayer(strategies, withdrawnTokenBalances);
-        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
-        check_Deposit_State(staker, strategies, depositShares);
+        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        check_Deposit_State(staker, strategies, shares);
         
         // 6. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, depositShares);
+        check_Delegation_State(staker, operator2, strategies, shares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         {
             // 7. Queue Withdrawal
             uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
-            withdrawals = staker.queueWithdrawals(strategies, depositShares);
+            withdrawals = staker.queueWithdrawals(strategies, shares);
             withdrawalRoots = _getWithdrawalHashes(withdrawals);
-            check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+            check_QueuedWithdrawal_State(staker, operator2, strategies, shares, withdrawableShares, withdrawals, withdrawalRoots);
         }
 
         // 8. Complete withdrawal as shares
@@ -406,7 +406,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         for (uint i = 0; i < withdrawals.length; i++) {
             uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawals[i].scaledShares);
             IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
-            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], strategies, depositShares, tokens, expectedTokens);
+            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], strategies, shares, tokens, expectedTokens);
         }
     }
 
@@ -420,21 +420,21 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         (User operator1, ,) = _newRandomOperator();
         (User operator2, ,) = _newRandomOperator();
 
-        uint[] memory depositShares = _calculateExpectedShares(strategies, tokenBalances);
+        uint[] memory shares = _calculateExpectedShares(strategies, tokenBalances);
         //delegatable shares equals deposit shares here because no bc slashing
-        uint[] memory delegatableShares = depositShares;
+        uint[] memory delegatableShares = shares;
 
         assert_HasNoDelegatableShares(staker, "staker should not have delegatable shares before depositing");
         assertFalse(delegationManager.isDelegated(address(staker)), "staker should not be delegated");
 
         /// 1. Deposit Into Strategies
         staker.depositIntoEigenlayer(strategies, tokenBalances);
-        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, depositShares);
-        check_Deposit_State(staker, strategies, depositShares);
+        uint[] memory withdrawnTokenBalances = _calculateExpectedTokens(strategies, shares);
+        check_Deposit_State(staker, strategies, shares);
 
         // 2. Delegate to an operator
         staker.delegateTo(operator1);
-        check_Delegation_State(staker, operator1, strategies, depositShares);
+        check_Delegation_State(staker, operator1, strategies, shares);
 
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
@@ -451,20 +451,20 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         }
 
         // 5. Deposit into Strategies
-        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
         staker.depositIntoEigenlayer(strategies, withdrawnTokenBalances);
-        check_Deposit_State(staker, strategies, depositShares);
+        check_Deposit_State(staker, strategies, shares);
         
         // 6. Delegate to a new operator
         staker.delegateTo(operator2);
-        check_Delegation_State(staker, operator2, strategies, depositShares);
+        check_Delegation_State(staker, operator2, strategies, shares);
         assertNotEq(address(operator1), delegationManager.delegatedTo(address(staker)), "staker should not be delegated to operator1");
 
         // 7. Queue Withdrawal
-        depositShares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
-        withdrawals = staker.queueWithdrawals(strategies, depositShares);
+        shares = _calculateExpectedShares(strategies, withdrawnTokenBalances);
+        withdrawals = staker.queueWithdrawals(strategies, shares);
         withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State(staker, operator2, strategies, depositShares, depositShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, operator2, strategies, shares, shares, withdrawals, withdrawalRoots);
 
         // 8. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -473,7 +473,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // Complete withdrawals as shares
         for (uint i = 0; i < withdrawals.length; i++) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_State(staker, operator2, withdrawals[i], strategies, depositShares);
+            check_Withdrawal_AsShares_State(staker, operator2, withdrawals[i], strategies, shares);
         }
     }
 }

--- a/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
+++ b/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
@@ -51,14 +51,4 @@ contract Integration_Upgrade_Deposit_Delegate_Allocate is UpgradeTest {
         (state.avs,) = _newRandomAVS();
         _setupAllocation(state);
     }
-
-    // TODO
- 
-    function testFuzz_deposit_delegate_upgrade_allocate_partialSlash_redeposit_queue_complete(uint24 r) public rand(r) {}
-    
-    function testFuzz_deposit_delegate_undelegate_partialSlash_complete(uint24 r) public rand(r) {}
-
-    function testFuzz_deposit_delegate_deallocate_partialSlash_queue_complete(uint24 r) public rand(r) {}
-
-    function testFuzz_deposit_delegate_deregister_partialSlash_queue_complete(uint24 r) public rand(r) {}
 }

--- a/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
+++ b/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
@@ -4,37 +4,61 @@ pragma solidity ^0.8.27;
 import "src/test/integration/UpgradeTest.t.sol";
 
 contract Integration_Upgrade_Deposit_Delegate_Allocate is UpgradeTest {
+    struct TestState {
+        User staker;
+        User operator;
+        AVS avs;
+        IStrategy[] strategies;
+        uint256[] tokenBalances;
+        OperatorSet operatorSet;
+        AllocateParams allocateParams;
+    }
 
-    function testFuzz_deposit_delegate_upgrade_allocate(uint24 _random) public rand(_random) {
-        (User staker, IStrategy[] memory strategies, uint256[] memory tokenBalances) = _newRandomStaker();
-        (User operator,,) = _newRandomOperator();
+    function _init_(uint24 randomness) internal returns (TestState memory state) {
+        (state.staker, state.strategies, state.tokenBalances) = _newRandomStaker();
+        (state.operator,,) = _newRandomOperator();
 
         // Pre-upgrade:
         // 1. Create staker and operator with assets, then deposit into EigenLayer
         // 2. Delegate to operator
-        staker.depositIntoEigenlayer(strategies, tokenBalances);
-        staker.delegateTo(operator);
+        state.staker.depositIntoEigenlayer(state.strategies, state.tokenBalances);
+        state.staker.delegateTo(state.operator);
+    }
 
-        // Upgrade to slashing release
-        _upgradeEigenLayerContracts();
-        (AVS avs,) = _newRandomAVS();
-
+    function _setupAllocation(TestState memory state) internal {
         // 3. Set allocation delay for operator
-        operator.setAllocationDelay(1);
+        state.operator.setAllocationDelay(1);
         rollForward({blocks: ALLOCATION_CONFIGURATION_DELAY + 1});
 
         // 4. Create an operator set and register an operator.
-        OperatorSet memory operatorSet = avs.createOperatorSet(strategies);
-        operator.registerForOperatorSet(operatorSet);
-        check_Registration_State_NoAllocation(operator, operatorSet, allStrats);
+        state.operatorSet = state.avs.createOperatorSet(state.strategies);
+        state.operator.registerForOperatorSet(state.operatorSet);
+        check_Registration_State_NoAllocation(state.operator, state.operatorSet, allStrats);
 
         // 5. Allocate to operator set.
-        AllocateParams memory allocateParams = AllocateParams({
-            operatorSet: operatorSet,
-            strategies: strategies,
-            newMagnitudes: _randMagnitudes({sum: 1 ether, len: strategies.length})
+        state.allocateParams = AllocateParams({
+            operatorSet: state.operatorSet,
+            strategies: state.strategies,
+            newMagnitudes: _randMagnitudes({sum: 1 ether, len: state.strategies.length})
         });
-        operator.modifyAllocations(allocateParams);
-        check_IncrAlloc_State_Slashable(operator, allocateParams);
+        state.operator.modifyAllocations(state.allocateParams);
+        check_IncrAlloc_State_Slashable(state.operator, state.allocateParams);
     }
+
+    function testFuzz_deposit_delegate_upgrade_allocate(uint24 r) public rand(r) {
+        TestState memory state = _init_(r);
+        _upgradeEigenLayerContracts();
+        (state.avs,) = _newRandomAVS();
+        _setupAllocation(state);
+    }
+
+    // TODO
+ 
+    function testFuzz_deposit_delegate_upgrade_allocate_partialSlash_redeposit_queue_complete(uint24 r) public rand(r) {}
+    
+    function testFuzz_deposit_delegate_undelegate_partialSlash_complete(uint24 r) public rand(r) {}
+
+    function testFuzz_deposit_delegate_deallocate_partialSlash_queue_complete(uint24 r) public rand(r) {}
+
+    function testFuzz_deposit_delegate_deregister_partialSlash_queue_complete(uint24 r) public rand(r) {}
 }


### PR DESCRIPTION
**Motivation:**

We want to increase coverage for integration state validation.

**Modifications:**

- Added new test cases:
     - `testFuzz_deposit_delegate_allocate_partialSlash_redeposit_queue_complete`
     - `testFuzz_deposit_delegate_undelegate_partialSlash_complete` 
     - `testFuzz_deposit_delegate_deallocate_partialSlash_queue_complete`
     - `testFuzz_deposit_delegate_deregister_partialSlash_queue_complete`
     - `testFuzz_delegate_zeroShares_partialSlash_deposit_undelegate_complete`
     - `testFuzz_deposit_delegate_allocate_partialSlash_deallocate`

**Result:**

Move coverage.