### PR TITLE
docs: add warning in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,13 @@
+<!-- 
+    🚨 ATTENTION! 🚨 
+    
+    This PR template is REQUIRED. PRs not following this format will be closed without review.
+    
+    Requirements:
+    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
+    - Provide clear and specific details in each section
+-->
+
 **Motivation:**
 
 *Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
     This PR template is REQUIRED. PRs not following this format will be closed without review.
     
     Requirements:
+    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
     - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
     - Provide clear and specific details in each section
 -->


### PR DESCRIPTION
**Motivation:**

We keep getting PRs that do not follow the template, that are not labeled.

**Modifications:**

- Add a warning in `pull_request_template.md` noting to use the template, and to label the PR.

**Result:**

Contributors will be prompted to properly use the template, and to label the PR.
