### PR TITLE
test: adding slashable shares in queue

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -901,6 +901,50 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    //@dev requires slashparams strategies to be same as withdrawal strategies
+    // meant to be used in check_base_slashing_state
+    function assert_Snap_Decreased_SlashableSharesInQueue(
+        User operator,
+        SlashingParams memory slashParams,
+        Withdrawal[] memory withdrawals,
+        string memory err
+    ) internal {
+        IStrategy[] memory strategies = slashParams.strategies;
+        uint[] memory curSlashableSharesInQueue = _getSlashableSharesInQueue(operator, strategies);
+        uint[] memory prevSlashableSharesInQueue = _getPrevSlashableSharesInQueue(operator, strategies);
+
+
+        uint[] memory totalScaledShares = new uint[](strategies.length);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            for (uint j = 0; j < withdrawals[i].strategies.length; j++) {
+                totalScaledShares[j] = totalScaledShares[j] + withdrawals[i].scaledShares[j];
+            }
+        }
+
+        for (uint i = 0; i < strategies.length; i++) {
+            assertEq(curSlashableSharesInQueue[i], prevSlashableSharesInQueue[i] - totalScaledShares[i].mulWad(slashParams.wadsToSlash[i]), err);
+        }
+    }
+
+    function assert_Snap_Increased_SlashableSharesInQueue(
+        User operator,
+        Withdrawal[] memory withdrawals,
+        string memory err
+    ) internal {
+        uint[] memory curSlashableSharesInQueue;
+        uint[] memory prevSlashableSharesInQueue;
+        uint64[] memory maxMagnitudes;
+        for (uint i = 0; i < withdrawals.length; i++) {
+            curSlashableSharesInQueue = _getSlashableSharesInQueue(operator, withdrawals[i].strategies);
+            prevSlashableSharesInQueue = _getPrevSlashableSharesInQueue(operator, withdrawals[i].strategies);
+            maxMagnitudes = _getMaxMagnitudes(operator, withdrawals[i].strategies);
+
+            for (uint j = 0; j < withdrawals[i].strategies.length; j++) {
+                assertEq(curSlashableSharesInQueue[j], prevSlashableSharesInQueue[j] + withdrawals[i].scaledShares[j].mulWad(maxMagnitudes[j]), err);
+            }
+        }
+    }
+
     function assert_Snap_StakeBecameAllocated(
         User operator,
         OperatorSet memory operatorSet,

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -279,6 +279,8 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_QueuedWithdrawal_State: failed to remove staker shares");
         assert_Snap_Removed_Staker_WithdrawableShares(staker, strategies, withdrawableShares,
             "check_QueuedWithdrawal_State: failed to remove staker withdrawable shares");
+        assert_Snap_Increased_SlashableSharesInQueue(operator, withdrawals,
+            "check_QueuedWithdrawal_State: failed to increase slashable shares in queue");
         check_Decreased_SlashableStake(operator, withdrawableShares, strategies);
         // Check that the dsf is either reset to wad or unchanged
         for (uint i = 0; i < strategies.length; i++) {
@@ -988,6 +990,35 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
         assert_Snap_Slashed_Allocation(operator, operatorSet, slashParams, "slash should reduce current magnitude");
         assert_Snap_Increased_BurnableShares(operator, slashParams, "slash should increase burnable shares");
+
+        // Slashing SHOULD NOT change allocatable magnitude, registration, and slashability status
+        assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");
+        assert_Snap_Unchanged_Registration(operator, operatorSet, "slash should not change registration status");
+        assert_Snap_Unchanged_Slashability(operator, operatorSet, "slash should not change slashability status");
+        // assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
+        // assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
+    }
+
+    function check_Base_Slashing_State(
+        User operator,
+        AllocateParams memory allocateParams,
+        SlashingParams memory slashParams,
+        Withdrawal[] memory withdrawals
+    ) internal {
+        OperatorSet memory operatorSet = allocateParams.operatorSet;
+
+        check_MaxMag_Invariants(operator);
+        check_IsSlashable_State(operator, operatorSet, allocateParams.strategies);
+
+        // Slashing SHOULD change max magnitude and current allocation
+        assert_Snap_Slashed_MaxMagnitude(operator, operatorSet, slashParams, "slash should lower max magnitude");
+        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower encumbered magnitude");
+        assert_Snap_Slashed_AllocatedStake(operator, operatorSet, slashParams, "slash should lower allocated stake");
+        assert_Snap_Slashed_SlashableStake(operator, operatorSet, slashParams, "slash should lower slashable stake");
+        assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
+        assert_Snap_Slashed_Allocation(operator, operatorSet, slashParams, "slash should reduce current magnitude");
+        assert_Snap_Increased_BurnableShares(operator, slashParams, "slash should increase burnable shares");
+        assert_Snap_Decreased_SlashableSharesInQueue(operator, slashParams, withdrawals, "slash should decrease slashable shares in queue");
 
         // Slashing SHOULD NOT change allocatable magnitude, registration, and slashability status
         assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1005,27 +1005,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         SlashingParams memory slashParams,
         Withdrawal[] memory withdrawals
     ) internal {
-        OperatorSet memory operatorSet = allocateParams.operatorSet;
-
-        check_MaxMag_Invariants(operator);
-        check_IsSlashable_State(operator, operatorSet, allocateParams.strategies);
-
-        // Slashing SHOULD change max magnitude and current allocation
-        assert_Snap_Slashed_MaxMagnitude(operator, operatorSet, slashParams, "slash should lower max magnitude");
-        assert_Snap_Slashed_EncumberedMagnitude(operator, slashParams, "slash should lower encumbered magnitude");
-        assert_Snap_Slashed_AllocatedStake(operator, operatorSet, slashParams, "slash should lower allocated stake");
-        assert_Snap_Slashed_SlashableStake(operator, operatorSet, slashParams, "slash should lower slashable stake");
-        assert_Snap_Slashed_OperatorShares(operator, slashParams, "slash should remove operator shares");
-        assert_Snap_Slashed_Allocation(operator, operatorSet, slashParams, "slash should reduce current magnitude");
-        assert_Snap_Increased_BurnableShares(operator, slashParams, "slash should increase burnable shares");
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
         assert_Snap_Decreased_SlashableSharesInQueue(operator, slashParams, withdrawals, "slash should decrease slashable shares in queue");
-
-        // Slashing SHOULD NOT change allocatable magnitude, registration, and slashability status
-        assert_Snap_Unchanged_AllocatableMagnitude(operator, allStrats, "slashing should not change allocatable magnitude");
-        assert_Snap_Unchanged_Registration(operator, operatorSet, "slash should not change registration status");
-        assert_Snap_Unchanged_Slashability(operator, operatorSet, "slash should not change slashability status");
-        // assert_Snap_Unchanged_AllocatedSets(operator, "should not have updated allocated sets");
-        // assert_Snap_Unchanged_AllocatedStrats(operator, operatorSet, "should not have updated allocated strategies");
     }
 
     /// Slashing invariants when the operator has been fully slashed for every strategy in the operator set

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -211,9 +211,10 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
 
         maxUniqueAssetsHeld = allStrats.length;
 
-        // Create time machine and beacon chain. Set block time to beacon chain genesis time
+        // Create time machine and beacon chain. Set block time to beacon chain genesis time and starting block number
         BEACON_GENESIS_TIME = GENESIS_TIME_LOCAL;
         cheats.warp(BEACON_GENESIS_TIME);
+        cheats.roll(10000);
         timeMachine = new TimeMachine();
         beaconChain = new BeaconChainMock(eigenPodManager, BEACON_GENESIS_TIME);
     }


### PR DESCRIPTION
**Motivation:**

Slashable shares in queue aren't currently checked by any invariants.

**Modifications:**

- added assertion that slashable shares in queue decrease on slash if a withdrawal is queued
- added assertion that slashable shares in queue increase on queued withdrawal
- changed IntegrationDeployer to initialize starting block as nonzero to address edge cases

**Result:**

Invariant coverage for slashable shares in queue state
