### PR TITLE
test: rounding tests low slashing factors

### DIFF
--- a/src/test/harnesses/EigenPodManagerWrapper.sol
+++ b/src/test/harnesses/EigenPodManagerWrapper.sol
@@ -20,4 +20,11 @@ contract EigenPodManagerWrapper is EigenPodManager {
     function setPodOwnerShares(address owner, int256 shares) external {
         podOwnerDepositShares[owner] = shares;
     }
+
+    function setBeaconChainSlashingFactor(address podOwner, uint64 slashingFactor) external {
+        _beaconChainSlashingFactor[podOwner] = BeaconChainSlashingFactor({
+            slashingFactor: slashingFactor,
+            isSet: true
+        });
+    }
 }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -930,24 +930,11 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         IStrategy[] memory strategies,
         string memory err
     ) internal {
-        uint[] memory curSlashableStake = _getMinSlashableStake(operator, operatorSet, strategies);
-        uint[] memory prevSlashableStake = _getPrevMinSlashableStake(operator, operatorSet, strategies);
+        uint[] memory curSlashableStake = _getMinSlashableStake(address(operator), operatorSet, strategies);
+        uint[] memory prevSlashableStake = _getPrevMinSlashableStake(address(operator), operatorSet, strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
             assertTrue(prevSlashableStake[i] > curSlashableStake[i], err);
-        }
-    }
-
-    function assert_Snap_StakeBecomeUnslashable(
-        address operator,
-        OperatorSet memory operatorSet,
-        IStrategy[] memory strategies,
-        string memory err
-    ) internal {
-        uint[] memory curSlashableStake = _getMinSlashableStake(operator, operatorSet, strategies);
-        uint[] memory prevSlashableStake = _getPrevMinSlashableStake(operator, operatorSet, strategies);
-
-        for (uint i = 0; i < strategies.length; i++) {
             assertTrue(prevSlashableStake[i] > curSlashableStake[i], err);
         }
     }
@@ -2105,7 +2092,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             (OperatorSet[] memory operatorSets, Allocation[] memory allocations) = _getStrategyAllocations(operator, BEACONCHAIN_ETH_STRAT);
             for (uint i = 0; i < operatorSets.length; i++) {
                 if (allocations[i].currentMagnitude > 0) {
-                    assert_Snap_StakeBecomeUnslashable(operator, operatorSets[i], BEACONCHAIN_ETH_STRAT.toArray(), "operator should have minSlashableStake decreased");
+                    assert_Snap_StakeBecomeUnslashable(User(payable(operator)), operatorSets[i], BEACONCHAIN_ETH_STRAT.toArray(), "operator should have minSlashableStake decreased");
                 }
             }
         }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1870,9 +1870,10 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         // Use timewarp to get previous staker shares
         uint[] memory prevShares = _getPrevStakerWithdrawableShares(staker, strategies);
 
-        // For each strategy, check diff between (prev-removed) and curr is at most 1 gwei
+        // Assert that the decrease in withdrawable shares is at least as much as the removed shares
+        // Checking for expected rounding down behavior
         for (uint i = 0; i < strategies.length; i++) {
-            assertApproxEqAbs(prevShares[i] - removedShares[i], curShares[i], 1e9, err);
+            assertGe(prevShares[i] - curShares[i], removedShares[i], err);
         }
     }
 

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -2567,6 +2567,22 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    function _genSlashing_Custom(
+        User operator,
+        OperatorSet memory operatorSet,
+        uint wadsToSlash
+    ) internal view returns (SlashingParams memory params) {
+        params.operator = address(operator);
+        params.operatorSetId = operatorSet.id;
+        params.description = "_genSlashing_Custom";
+        params.strategies = allocationManager.getStrategiesInOperatorSet(operatorSet).sort();
+        params.wadsToSlash = new uint[](params.strategies.length);
+
+        for (uint i = 0; i < params.wadsToSlash.length; i++) {
+            params.wadsToSlash[i] = wadsToSlash;
+        }
+    }
+
     function _randWadToSlash() internal returns (uint) {
         return _randUint({ min: 0.01 ether, max: 1 ether });
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1998,7 +1998,11 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             // If there was a slashing, but we complete a withdrawal for 0 shares, no need to normalize
             if (curSlashingFactor == WAD || curDepositShares[i] == 0) {
                 assert_Snap_Unchanged_DSF(staker, stratArray, err);
-                assert_DSF_WAD(staker, stratArray, err);
+                assert_DSF_WAD(staker, stratArray, err);    
+            } 
+            // If the staker has a slashingFactor of 0, any withdrawal as shares won't change the DSF
+            else if (staker.getSlashingFactor(strategies[i]) == 0) {
+                assert_Snap_Unchanged_DSF(staker, stratArray, err);
             }
             // If there was a slashing and we complete a withdrawal for non-zero shares, normalize the DSF
             else {
@@ -2018,7 +2022,8 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         uint[] memory delegatableShares,
         string memory err
     ) internal {
-        uint64[] memory maxMags = _getMaxMagnitudes(operator, strategies);
+        address operator = delegationManager.delegatedTo(address(staker));
+        uint64[] memory maxMags = _getMaxMagnitudes(User(payable(operator)), strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
             IStrategy[] memory stratArray = strategies[i].toArray();

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -247,7 +247,31 @@ contract IntegrationCheckUtils is IntegrationBase {
         } else {
             assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
         }
-        assert_Snap_DSF_State_Deposit(staker, strategies, "staker's DSF not updated correctly");    }
+        assert_Snap_DSF_State_Deposit(staker, strategies, "staker's DSF not updated correctly");
+    }
+
+    /// @notice Used for edge cases where rounding behaviors impact the assertions after a deposit, specifically when
+    /// there already exists depositShares for a staker for a strategy.
+    function check_Deposit_State_SubsequentDeposit_WithRounding(User staker, IStrategy[] memory strategies, uint[] memory shares) internal {
+        /// Deposit into strategies:
+        // For each of the assets held by the staker (either StrategyManager or EigenPodManager),
+        // the staker calls the relevant deposit function, depositing all held assets.
+        //
+        // ... check that all underlying tokens were transferred to the correct destination
+        //     and that the staker now has the expected amount of delegated shares in each strategy
+        assert_HasNoUnderlyingTokenBalance(staker, strategies, "staker should have transferred all underlying tokens");
+        assert_DepositShares_GTE_WithdrawableShares(staker, strategies, "deposit shares should be greater than or equal to withdrawable shares");
+        assert_Snap_Added_Staker_DepositShares(staker, strategies, shares, "staker should expect shares in each strategy after depositing");
+        assert_StrategiesInStakerStrategyList(staker, strategies, "staker strategy list should contain all strategies");
+
+        if (delegationManager.isDelegated(address(staker))) {
+            User operator = User(payable(delegationManager.delegatedTo(address(staker))));
+            assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, operator, strategies, shares, "staker should have received expected withdrawable shares");
+        } else {
+            assert_Snap_Added_Staker_WithdrawableShares(staker, strategies, shares, "deposit should increase withdrawable shares");
+        }
+        assert_Snap_WithinErrorBounds_DSF(staker, strategies, "staker's DSF not updated correctly");
+    }
 
     function check_Delegation_State(
         User staker, 

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -151,7 +151,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         uint64 slashedAmountGwei
     ) internal {
         check_CompleteCheckpoint_State(staker);
-
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have decreased");
         assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, "should have decreased withdrawable shares by at least slashed amount");
         assert_Snap_Unchanged_ActiveValidatorCount(staker, "should not have changed active validator count");
@@ -167,10 +166,11 @@ contract IntegrationCheckUtils is IntegrationBase {
         uint64 slashedAmountGwei
     ) internal {
         check_CompleteCheckpoint_State(staker);
-
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have decreased");
         assert_Snap_Removed_Staker_WithdrawableShares_AtLeast(staker, BEACONCHAIN_ETH_STRAT, slashedAmountGwei * GWEI_TO_WEI, "should have decreased withdrawable shares by at least slashed amount");
         assert_Snap_Unchanged_ActiveValidatorCount(staker, "should not have changed active validator count");
+        assert_Snap_BCSF_Decreased(staker, "BCSF should decrease");
+        assert_Snap_Unchanged_DSF(staker, BEACONCHAIN_ETH_STRAT.toArray(), "DSF should be unchanged");
     }
 
     function check_CompleteCheckpoint_WithCLSlashing_State(

--- a/src/test/integration/IntegrationDeployer.t.sol
+++ b/src/test/integration/IntegrationDeployer.t.sol
@@ -721,6 +721,20 @@ abstract contract IntegrationDeployer is ExistingDeploymentParser {
         return tokenBalances;
     }
 
+    /// Given an array of strategies and an array of amounts, deal the amounts to the user
+    function _dealAmounts(User user, IStrategy[] memory strategies, uint[] memory amounts) internal noTracing {
+        for (uint i = 0; i < amounts.length; i++) {
+            IStrategy strategy = strategies[i];
+
+            if (strategy == BEACONCHAIN_ETH_STRAT) {
+                cheats.deal(address(user), amounts[i]);
+            } else {
+                IERC20 underlyingToken = strategy.underlyingToken();
+                StdCheats.deal(address(underlyingToken), address(user), amounts[i]);
+            }
+        }
+    }
+
     /// @dev Uses `random` to return a random uint, with a range given by `min` and `max` (inclusive)
     /// @return `min` <= result <= `max`
     function _randUint(uint min, uint max) internal returns (uint) {

--- a/src/test/integration/tests/FullySlashed_EigenPod.t.sol
+++ b/src/test/integration/tests/FullySlashed_EigenPod.t.sol
@@ -168,7 +168,7 @@ contract Integration_FullySlashedEigenpod_NotCheckpointed is Integration_FullySl
             // BCSF is asserted to be zero here
             check_CompleteCheckpoint_FullySlashed_State(staker, validators, slashedGwei);
         } else {
-            check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, validators, slashedGwei);
+            check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, validators, slashedGwei - podBalanceGwei);
         }
     }
 }

--- a/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
+++ b/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/IntegrationChecks.t.sol";
+
+/// @notice Testing the rounding behavior when the DSF is high and there are multiple deposits
+contract Integration_HighDSF_Multiple_Deposits is IntegrationCheckUtils {
+    using ArrayLib for *;
+ 
+    AVS avs;
+    OperatorSet operatorSet;
+
+    User operator;
+    AllocateParams allocateParams;
+    SlashingParams slashParams;
+
+    User staker;
+    IStrategy[] strategies;
+    IERC20[] tokens; // underlying token for each strategy
+    uint[] initTokenBalances;
+    uint[] initDepositShares;
+
+    /**
+     * Shared setup:
+     * 1. create a new staker, operator, and avs
+     * 2. create an operator set and register an operator, allocate all magnitude to the operator set
+     * 3. slash operator to 1 magnitude remaining
+     * 4. delegate to operator
+     */
+    function _init() internal override {
+        // 1. create a new staker, operator, and avs
+        _configAssetTypes(HOLDS_LST);
+        (staker, strategies, initTokenBalances) = _newRandomStaker();
+        (operator,,) = _newRandomOperator();
+        (avs,) = _newRandomAVS();
+
+        // 2. Create an operator set and register an operator, allocate all magnitude to the operator set
+        operatorSet = avs.createOperatorSet(strategies);
+        operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
+        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
+        operator.modifyAllocations(allocateParams);
+        check_IncrAlloc_State_Slashable_NoDelegatedStake(operator, allocateParams);
+        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
+
+        // 3. slash operator to 1 magnitude remaining
+        SlashingParams memory slashParams = _genSlashing_Custom(operator, operatorSet, WAD - 1);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // 4. delegate to operator
+        staker.delegateTo(operator);
+
+        uint256 slashingFactor = staker.getSlashingFactor(strategies[0]);
+        assertEq(slashingFactor, 1, "slashing factor should be 1");
+    }
+
+    /// @notice Test setup with a staker with slashingFactor of 1 (maxMagnitude = 1)
+    /// with repeat deposits to increase the DSF. Limiting number of fuzzed runs to speed up tests since this
+    /// for loops several times.
+    /// forge-config: default.fuzz.runs = 10
+    function test_multiple_deposits_verifyWC(uint24 _r) public rand(_r) {
+        // deposit initial assets into strategies
+        staker.depositIntoEigenlayer(strategies, initTokenBalances);
+        initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);
+        check_Deposit_State(staker, strategies, initDepositShares);
+
+        // Repeat the deposit 50 times
+        for (uint i = 0; i < 50; i++) {
+            _dealAmounts(staker, strategies, initTokenBalances);
+            staker.depositIntoEigenlayer(strategies, initTokenBalances);
+            initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);
+            check_Deposit_State_SubsequentDeposit_WithRounding(staker, strategies, initDepositShares);
+        }
+
+        // Check that the DSF is still bounded without overflow
+        for (uint i = 0; i < strategies.length; i++) {
+            assertGe(delegationManager.depositScalingFactor(address(staker), strategies[i]), WAD, "DSF should be >= WAD");
+            // theoretical upper bound on DSF is 1e74
+            assertLt(delegationManager.depositScalingFactor(address(staker), strategies[i]), 1e74, "DSF should be < 1e74");
+        }
+    }
+}

--- a/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
+++ b/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
@@ -59,7 +59,7 @@ contract Integration_HighDSF_Multiple_Deposits is IntegrationCheckUtils {
     /// with repeat deposits to increase the DSF. Limiting number of fuzzed runs to speed up tests since this
     /// for loops several times.
     /// forge-config: default.fuzz.runs = 10
-    function test_multiple_deposits_verifyWC(uint24 _r) public rand(_r) {
+    function test_multiple_deposits(uint24 _r) public rand(_r) {
         // deposit initial assets into strategies
         staker.depositIntoEigenlayer(strategies, initTokenBalances);
         initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);

--- a/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
+++ b/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
@@ -133,9 +133,11 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // 5. undelegate results in 0 delegated shares removed since operator has 0 magnitude and staker is fully slashed too
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, 0.toArrayU256());
+
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, withdrawableShares);
 
         // 6. redeposit (start/complete checkpoint)
         beaconChain.advanceEpoch();
@@ -163,9 +165,10 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // 5. undelegate results in 0 delegated shares removed since operator has 0 magnitude and staker is fully slashed too
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, 0.toArrayU256());
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, withdrawableShares);
 
         // 6. complete withdrawals as shares(although amount 0 from fully slashed operator)
         _rollBlocksForCompleteWithdrawals(withdrawals);
@@ -199,9 +202,10 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 
         // 5. undelegate results in 0 delegated shares removed since operator has 0 magnitude and staker is fully slashed too
+        uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, 0.toArrayU256());
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, withdrawableShares);
 
         // 6. complete withdrawals as tokens(although amount 0 from fully slashed operator)
         // This also exits validators on the beacon chain

--- a/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
+++ b/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/IntegrationChecks.t.sol";
+
+/// @notice Testing the rounding behavior when operator magnitude is initially 1
+contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
+    using ArrayLib for *;
+    
+    AVS avs;
+    OperatorSet operatorSet;
+
+    User operator;
+    IAllocationManagerTypes.AllocateParams allocateParams;
+
+    User staker;
+    IStrategy[] strategies;
+    // uint[] initTokenBalances;
+    uint[] initDepositShares;
+    uint40[] validators;
+    uint64 beaconBalanceGwei;
+    uint64 slashedGwei;
+
+    /**
+     * 1. Create an operatorSet and register the operator allocating all magnitude
+     * 2. slash operator to 1 magnitude remaining
+     * 3. delegate staker to operator
+     * 4. deposit (verify withdrawal credentials)
+     */
+    function _init() internal override {
+        _configAssetTypes(HOLDS_ETH);
+        (staker, strategies, initDepositShares) = _newRandomStaker();
+        (operator,,) = _newRandomOperator();
+        (avs,) = _newRandomAVS();
+
+        cheats.assume(initDepositShares[0] >= 64 ether);
+
+        // 1. Create an operator set and register an operator
+        operatorSet = avs.createOperatorSet(strategies);
+        operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
+        // Allocate all magnitude to the operator set
+        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
+        operator.modifyAllocations(allocateParams);
+        check_IncrAlloc_State_Slashable_NoDelegatedStake(operator, allocateParams);
+        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
+
+        // 2. Fully slash operator
+        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
+        slashParams.wadsToSlash[0] = WAD - 1;
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // 3. Delegate to an operator
+        staker.delegateTo(operator);
+        // delegate staker without any depositShares in beaconChainETHStrategy yet
+        IStrategy[] memory emptyStrategies;
+        uint256[] memory emptyTokenBalances;
+        check_Delegation_State(staker, operator, emptyStrategies, emptyTokenBalances);
+
+        // 4. deposit/verify withdrawal credentials
+        (validators, beaconBalanceGwei) = staker.startValidators();
+        beaconChain.advanceEpoch_NoRewards();
+        staker.verifyWithdrawalCredentials(validators);
+    }
+
+    /**
+     * Test sequence following _init()
+     * 4. slash validators on beacon chain (start/complete checkpoint)
+     * 5. queue withdrawal
+     * 6. complete withdrawal
+     * Given the operator has 1 magnitude remaining, the being slashed on the beacon chain
+     * and calculating a non-WAD BCSF, their slashing factor should be rounded down to 0. Resulting in
+     * the staker having 0 withdrawable shares.
+     */
+    function test_slashBC_startCompleteCP_queue_complete(uint24 _r) public rand(_r) {
+        // 4. slash validators on beacon chain (start/complete checkpoint)
+        uint40[] memory slashedValidators = _choose(validators);
+        slashedGwei = beaconChain.slashValidators(slashedValidators);
+        // ensure non zero amount slashed gwei so that we can test rounding down behavior
+        cheats.assume(slashedGwei > 0);
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        // start and complete checkpoint
+        staker.startCheckpoint();
+        check_StartCheckpoint_State(staker);
+
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_WithCLSlashing_HandleRoundDown_State(staker, slashedGwei);
+
+        // 5. queue withdrawal
+        ( , uint[] memory withdrawShares) = _randWithdrawal(strategies, initDepositShares);
+
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, withdrawShares);
+        bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State({
+            staker: staker,
+            operator: operator,
+            strategies: strategies,
+            depositShares: withdrawShares, // amount of deposit shares to withdraw
+            withdrawableShares: 0.toArrayU256(), // amount of withdrawable shares is 0 due to slashing factor being 0
+            withdrawals: withdrawals,
+            withdrawalRoots: roots
+        });
+
+        // Operator's maxMagnitude is 1 and staker was slashed to non-WAD BCSF. Therefore
+        // staker should have been rounded down to 0
+        uint256 slashingFactor = staker.getSlashingFactor(beaconChainETHStrategy);
+        assertEq(slashingFactor, 0, "slashing factor should be rounded down to 0");
+
+        // 6. complete withdrawal
+        // only strategy is beaconChainETHStrategy
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        staker.completeWithdrawalAsShares(withdrawals[0]);
+        check_Withdrawal_AsShares_State(staker, operator, withdrawals[0], strategies, 0.toArrayU256());
+    }
+
+    /**
+     * Test sequence following _init()
+     * 4. fully slash operator on opSet again to 0 magnitude
+     * 5. undelegate
+     * 6. redeposit (start/complete checkpoint)
+     * This is testing when an operator is fully slashed with 0 magnitude, the staker can still undelegate
+     * and "redeposit" to Eigenlayer.
+     */
+    function test_slash_undelegate_redeposit(uint24 _r) public rand(_r) {
+        // 4. AVS slashes operator again to 0 magnitude and fully slashed
+        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
+        slashParams.wadsToSlash[0] = WAD;
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // 5. undelegate results in 0 delegated shares removed since operator has 0 magnitude and staker is fully slashed too
+        Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, 0.toArrayU256());
+
+        // 6. redeposit (start/complete checkpoint)
+        beaconChain.advanceEpoch();
+        staker.startCheckpoint();
+        check_StartCheckpoint_State(staker);
+
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_State(staker);
+    }
+
+    /**
+     * Test sequence following _init()
+     * 4. fully slash operator on opSet again to 0 magnitude
+     * 5. undelegate
+     * 6. complete withdrawals as shares(although amount 0 from fully slashed operator)
+     * 7. redeposit (start/complete checkpoint)
+     * This is testing when an operator is fully slashed with 0 magnitude, the staker can still undelegate,
+     * complete withdrawals as shares(0 shares though), and redeposit to Eigenlayer.
+     */
+    function test_slash_undelegate_completeAsShares_startCompleteCP(uint24 _r) public rand(_r) {
+        // 4. AVS slashes operator again to 0 magnitude and fully slashed
+        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
+        slashParams.wadsToSlash[0] = WAD;
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // 5. undelegate results in 0 delegated shares removed since operator has 0 magnitude and staker is fully slashed too
+        Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, 0.toArrayU256());
+
+        // 6. complete withdrawals as shares(although amount 0 from fully slashed operator)
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+
+        staker.completeWithdrawalAsShares(withdrawals[0]);
+        check_Withdrawal_AsShares_State(staker, operator, withdrawals[0], strategies, 0.toArrayU256());
+
+        // 7. redeposit (start/complete checkpoint)
+        beaconChain.advanceEpoch();
+        staker.startCheckpoint();
+        check_StartCheckpoint_State(staker);
+
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_State(staker);
+    }
+}

--- a/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
+++ b/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
@@ -139,13 +139,23 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
 
         check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, withdrawableShares);
 
-        // 6. redeposit (start/complete checkpoint)
-        beaconChain.advanceEpoch();
-        staker.startCheckpoint();
-        check_StartCheckpoint_State(staker);
+        // 6. redeposit (start/complete checkpoint or verifyWC)
+        if (_randBool()) {
+            // Verify WC
+            (validators, beaconBalanceGwei) = staker.startValidators(uint8(_randUint(3, 10)));
+            beaconChain.advanceEpoch();
 
-        staker.completeCheckpoint();
-        check_CompleteCheckpoint_State(staker);
+            staker.verifyWithdrawalCredentials(validators);
+            check_VerifyWC_State(staker, validators, beaconBalanceGwei);
+        } else {
+            // Start/complete CP
+            beaconChain.advanceEpoch();
+            staker.startCheckpoint();
+            check_StartCheckpoint_State(staker);
+
+            staker.completeCheckpoint();
+            check_CompleteCheckpoint_State(staker);
+        }
     }
 
     /**

--- a/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
+++ b/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
@@ -47,8 +47,7 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
         _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
 
         // 2. Fully slash operator
-        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
-        slashParams.wadsToSlash[0] = WAD - 1;
+        SlashingParams memory slashParams = _genSlashing_Custom(operator, operatorSet, WAD - 1);
         avs.slashOperator(slashParams);
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 

--- a/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
+++ b/src/test/integration/tests/eigenpod/Register_Allocate_Slash_VerifyWC_.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
+import "src/test/integration/mocks/BeaconChainMock.t.sol";
 import "src/test/integration/IntegrationChecks.t.sol";
 
 /// @notice Testing the rounding behavior when operator magnitude is initially 1
@@ -76,7 +77,7 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
     function test_slashBC_startCompleteCP_queue_complete(uint24 _r) public rand(_r) {
         // 4. slash validators on beacon chain (start/complete checkpoint)
         uint40[] memory slashedValidators = _choose(validators);
-        slashedGwei = beaconChain.slashValidators(slashedValidators);
+        slashedGwei = beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
         // ensure non zero amount slashed gwei so that we can test rounding down behavior
         cheats.assume(slashedGwei > 0);
         beaconChain.advanceEpoch_NoWithdrawNoRewards();
@@ -85,7 +86,7 @@ contract Integration_Register_Allocate_Slash_VerifyWC is IntegrationCheckUtils {
         check_StartCheckpoint_State(staker);
 
         staker.completeCheckpoint();
-        check_CompleteCheckpoint_WithCLSlashing_HandleRoundDown_State(staker, slashedGwei);
+        check_CompleteCheckPoint_WithSlashing_LowMagnitude_State(staker, slashedGwei);
 
         // 5. queue withdrawal
         ( , uint[] memory withdrawShares) = _randWithdrawal(strategies, initDepositShares);

--- a/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
+++ b/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
@@ -98,7 +98,7 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
         // 5. deposit expecting revert (randomly pick to verifyWC, start/complete CP)
         if (_randBool()) {
             // Verify WC
-            (validators, ) = staker.startValidators(uint8(_randUint(1, 10)));
+            (validators, ) = staker.startValidators(uint8(_randUint(3, 10)));
             beaconChain.advanceEpoch();
 
             cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);

--- a/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
+++ b/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
@@ -29,7 +29,7 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
      * rounding down to 0 in a single slash even with increased MaxEB to 2048 is not possible and would require several
      * iterations of slashing to do so. Using a harness to set the beaconChainSlashingFactor to 1 is the easiest way for this test.
      * 2. create a new staker, operator, and avs
-     * 3. verify withdrawal credentials
+     * 3. start validators and verify withdrawal credentials
      */
     function _init() internal override {
         // 1. etch a new implementation to set staker's beaconChainSlashingFactor to 1
@@ -83,7 +83,7 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
     
     /// @notice Test that a staker is slashed to 0 BCSF from a minor slash and that they can't deposit more shares
     /// from their EigenPod (either through verifyWC or start/complete CP)
-    function test_slashFullyBC_deposit(uint24 _r) public rand(_r) {
+    function test_slashFullyBC_revert_deposit(uint24 _r) public rand(_r) {
         // 4. slash validators on beacon chain (start/complete checkpoint)
         uint40[] memory slashedValidators = _choose(validators);
         slashedGwei = beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
@@ -125,7 +125,7 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
      * 6. delegate to operator
      * 7. deposit expecting revert (randomly pick to verifyWC, start/complete CP)
      */
-    function test_slashAVS_delegate_startCompleteCP(uint24 _r) public rand(_r) {
+    function test_slashAVS_delegate_revert_startCompleteCP(uint24 _r) public rand(_r) {
         // 4. Create an operator set and register an operator
         operatorSet = avs.createOperatorSet(strategies);
         operator.registerForOperatorSet(operatorSet);
@@ -137,8 +137,7 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
         _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
 
         // 5. slash operator to 1 magnitude remaining
-        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
-        slashParams.wadsToSlash[0] = WAD - 1;
+        SlashingParams memory slashParams = _genSlashing_Custom(operator, operatorSet, WAD - 1);
         avs.slashOperator(slashParams);
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 

--- a/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
+++ b/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import "src/test/integration/mocks/BeaconChainMock.t.sol";
+import "src/test/integration/IntegrationChecks.t.sol";
+import "src/test/harnesses/EigenPodManagerWrapper.sol";
+
+/// @notice Testing the rounding behavior when beacon chain slashing factor is initially 1
+contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
+    using ArrayLib for *;
+    
+    AVS avs;
+    OperatorSet operatorSet;
+
+    User operator;
+    IAllocationManagerTypes.AllocateParams allocateParams;
+
+    User staker;
+    IStrategy[] strategies;
+    uint[] initDepositShares;
+    uint40[] validators;
+    uint64 beaconBalanceGwei;
+    uint64 slashedGwei;
+
+    /**
+     * Shared setup:
+     * 1. Update the EPM implementation to manually set the beaconChainSlashingFactor to 1
+     * Note: Slashing the EigenPod enough (in units of gwei) to reduce the beaconChainSlashingFactor to 1 without
+     * rounding down to 0 in a single slash even with increased MaxEB to 2048 is not possible and would require several
+     * iterations of slashing to do so. Using a harness to set the beaconChainSlashingFactor to 1 is the easiest way for this test.
+     * 2. create a new staker, operator, and avs
+     * 3. verify withdrawal credentials
+     */
+    function _init() internal override {
+        // 1. etch a new implementation to set staker's beaconChainSlashingFactor to 1
+        EigenPodManagerWrapper eigenPodManagerWrapper = new EigenPodManagerWrapper(
+            DEPOSIT_CONTRACT,
+            eigenPodBeacon,
+            delegationManager,
+            eigenLayerPauserReg,
+            "v9.9.9"
+        );
+        address targetAddr = address(eigenPodManagerImplementation);
+        cheats.etch(targetAddr, address(eigenPodManagerWrapper).code);
+
+        // 2. create a new staker, operator, and avs
+        _configAssetTypes(HOLDS_ETH);
+        (staker, strategies, initDepositShares) = _newRandomStaker();
+        (operator,,) = _newRandomOperator();
+        (avs,) = _newRandomAVS();
+
+        cheats.assume(initDepositShares[0] >= 64 ether);
+
+        EigenPodManagerWrapper(address(eigenPodManager)).setBeaconChainSlashingFactor(address(staker), 1);
+        assertEq(eigenPodManager.beaconChainSlashingFactor(address(staker)), 1);
+
+        // 3. start validators and verify withdrawal credentials
+        (validators, beaconBalanceGwei) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(validators);
+        check_VerifyWC_State(staker, validators, beaconBalanceGwei);
+    }
+
+    /// @notice Test that a staker can still verify WC, start/complete CP even if the operator has 1 magnitude remaining
+    function test_verifyWC_startCompleteCP(uint24 _r) public rand(_r) {
+        // 4. start validators and verify withdrawal credentials
+        (validators, beaconBalanceGwei) = staker.startValidators(uint8(_randUint(1, 10)));
+        beaconChain.advanceEpoch_NoRewards();
+        staker.verifyWithdrawalCredentials(validators);
+        check_VerifyWC_State(staker, validators, beaconBalanceGwei);
+
+        // 5. start/complete checkpoint
+        beaconChain.advanceEpoch();
+        staker.startCheckpoint();
+        beaconChain.advanceEpoch();
+
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_State(staker);
+
+        // 6. Assert BCSF is still 1
+        assertEq(eigenPodManager.beaconChainSlashingFactor(address(staker)), 1);
+    }
+    
+    /// @notice Test that a staker is slashed to 0 BCSF from a minor slash and that they can't deposit more shares
+    /// from their EigenPod (either through verifyWC or start/complete CP)
+    function test_slashFullyBC_deposit(uint24 _r) public rand(_r) {
+        // 4. slash validators on beacon chain (start/complete checkpoint)
+        uint40[] memory slashedValidators = _choose(validators);
+        slashedGwei = beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+
+        staker.startCheckpoint();
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, slashedValidators, slashedGwei);
+        // BCSF should be 0 now
+        assertEq(eigenPodManager.beaconChainSlashingFactor(address(staker)), 0);
+
+        // 5. deposit expecting revert (randomly pick to verifyWC, start/complete CP)
+        if (_randBool()) {
+            // Verify WC
+            (validators, ) = staker.startValidators(uint8(_randUint(1, 10)));
+            beaconChain.advanceEpoch();
+
+            cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
+            staker.verifyWithdrawalCredentials(validators);
+        } else {
+            // Start/complete CP
+            beaconChain.advanceEpoch();
+            staker.startCheckpoint();
+
+            cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
+            staker.completeCheckpoint();
+        }
+    }
+
+    /**
+     * @notice Test that a staker with 1 maxMagnitude and 1 BCSF has slashingFactor rounded down to 0
+     * and further deposits are not possible
+     * Test sequence following _init()
+     * 4. Create an operator set and register an operator
+     * 5. slash operator to 1 magnitude remaining
+     * 6. delegate to operator
+     * 7. deposit expecting revert (randomly pick to verifyWC, start/complete CP)
+     */
+    function test_slashAVS_delegate_startCompleteCP(uint24 _r) public rand(_r) {
+        // 4. Create an operator set and register an operator
+        operatorSet = avs.createOperatorSet(strategies);
+        operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
+        // Allocate all magnitude to the operator set
+        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
+        operator.modifyAllocations(allocateParams);
+        check_IncrAlloc_State_Slashable_NoDelegatedStake(operator, allocateParams);
+        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
+
+        // 5. slash operator to 1 magnitude remaining
+        SlashingParams memory slashParams = _genSlashing_Full(operator, operatorSet);
+        slashParams.wadsToSlash[0] = WAD - 1;
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // assert operator has 1 magnitude remaining
+        assertEq(allocationManager.getMaxMagnitude(address(operator), beaconChainETHStrategy), 1);
+
+        // 6. delegate to operator
+        staker.delegateTo(operator);
+        check_Delegation_State(staker, operator, strategies, initDepositShares);
+
+        // 7. deposit expecting revert (randomly pick to verifyWC, start/complete CP)
+        if (_randBool()) {
+            // Verify WC
+            (validators, ) = staker.startValidators(uint8(_randUint(1, 10)));
+            beaconChain.advanceEpoch();
+
+            cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
+            staker.verifyWithdrawalCredentials(validators);
+        } else {
+            // Start/complete CP
+            beaconChain.advanceEpoch();
+            staker.startCheckpoint();
+
+            cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
+            staker.completeCheckpoint();
+        }
+    }
+}

--- a/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
+++ b/src/test/integration/tests/eigenpod/SlashBC_OneBCSF.t.sol
@@ -105,6 +105,9 @@ contract Integration_SlashBC_OneBCSF is IntegrationCheckUtils {
             staker.verifyWithdrawalCredentials(validators);
         } else {
             // Start/complete CP
+            // Ensure that not all validators were slashed so that some rewards can be generated when
+            // we advance epoch
+            cheats.assume(slashedValidators.length < validators.length);
             beaconChain.advanceEpoch();
             staker.startCheckpoint();
 

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -375,6 +375,24 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
         return _startValidators();
     }
 
+    /// @dev Starts a specified number of validators on the beacon chain
+    /// @param numValidators The number of validators to start
+    /// @return A list of created validator indices
+    /// @return The amount of wei sent to the beacon chain
+    function startValidators(
+        uint8 numValidators
+    ) public virtual createSnapshot returns (uint40[] memory, uint64) {
+        require(numValidators > 0 && numValidators <= 10, "startValidators: numValidators must be between 1 and 10");
+        uint256 balanceWei = address(this).balance;
+
+        // given a number of validators, the current balance, calculate the amount of ETH needed to start that many validators
+        uint256 ethNeeded = numValidators * 32 ether - balanceWei;
+        cheats.deal(address(this), ethNeeded);
+
+        print.method("startValidators");
+        return _startValidators();
+    }
+
     function exitValidators(
         uint40[] memory _validators
     ) public virtual createSnapshot returns (uint64 exitedBalanceGwei) {

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -472,7 +472,7 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
     }
 
     /// -----------------------------------------------------------------------
-    /// Internal Methods
+    /// View Methods
     /// -----------------------------------------------------------------------
 
     function allocationManager() public view returns (AllocationManager) {
@@ -482,6 +482,14 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
     function permissionController() public view returns (PermissionController) {
         return PermissionController(address(delegationManager.permissionController()));
     }
+
+    function getSlashingFactor(IStrategy strategy) public view returns (uint256) {
+        return _getSlashingFactor(address(this), strategy);
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Internal Methods
+    /// -----------------------------------------------------------------------
 
     function _completeQueuedWithdrawal(
         Withdrawal memory withdrawal,

--- a/src/test/integration/users/User.t.sol
+++ b/src/test/integration/users/User.t.sol
@@ -671,6 +671,18 @@ contract User is Logger, IDelegationManagerTypes, IAllocationManagerTypes {
         return abi.encodePacked(bytes1(uint8(1)), bytes11(0), address(pod));
     }
 
+    function _getSlashingFactor(
+        address staker,
+        IStrategy strategy
+    ) internal view returns (uint256) {
+        address operator = delegationManager.delegatedTo(staker);
+        uint64 maxMagnitude = allocationManager().getMaxMagnitudes(operator, strategy.toArray())[0];
+        if (strategy == beaconChainETHStrategy) {
+            return maxMagnitude.mulWad(eigenPodManager.beaconChainSlashingFactor(staker));
+        }
+        return maxMagnitude;
+    }
+
     /// @notice Gets the expected withdrawals to be created when the staker is undelegated via a call to `DelegationManager.undelegate()`
     /// @notice Assumes staker and withdrawer are the same and that all strategies and shares are withdrawn
     function _getExpectedWithdrawalStructsForStaker(


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**

Testing coverage for rounding edge cases.

**Modifications:**

Added test file in `Register_Allocate_Slash_VerifyWC_.t.sol`
The _init setup creates an Operator registered to an OperatorSet who gets slashed down to 1 maxMagnitude.

- Removed duplicate function `assert_Snap_StakeBecomeUnslashable`
- Added setter for BCSF on EPMWrapper
- Fixed `assert_Snap_DSF_State_WithdrawalAsShares()` for when fully slashed
- Fixed `assert_Snap_DSF_State_Delegation()` to use staker's operator magnitudes instead of staker's magnitude itself
- Additional checks helpers
- Added helper `getSlashingFactor` for User.t.sol

**Result:**
Integration Tests with 1 operator MaxMagnitude
`test_slashBC_startCompleteCP_queue_complete`
`test_slash_undelegate_redeposit`
`test_slash_undelegate_completeAsTokens_verifyWC`
`test_slash_undelegate_completeAsShares_startCompleteCP`
`test_queueAllShares_completeAsTokens`

Integration Tests with 1 BCSF
`test_verifyWC_startCompleteCP`
`test_slashFullyBC_deposit`
`test_slashAVS_delegate_startCompleteCP`

Integration Tests with High DSF and repeat deposits
`test_multiple_deposits`
