### PR TITLE
feat: add view fn to query operator sets for an avs

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -612,16 +612,26 @@ contract AllocationManager is
      */
 
     /// @inheritdoc IAllocationManager
-    function getOperatorSetCount(
-        address avs
-    ) external view returns (uint256) {
+    function getOperatorSetCount(address avs) external view returns (uint256) {
         return _operatorSets[avs].length();
     }
 
+    /// @notice Returns all operator sets for a given AVS
+    /// @param avs The address of the AVS
+    /// @return operatorSets Array of operator set IDs
+    function getAVSOperatorSets(address avs) external view returns (uint32[] memory) {
+        uint256 length = _operatorSets[avs].length();
+        uint32[] memory sets = new uint32[](length);
+        
+        for (uint256 i = 0; i < length; i++) {
+            sets[i] = _operatorSets[avs].at(i);
+        }
+        
+        return sets;
+    }
+
     /// @inheritdoc IAllocationManager
-    function getAllocatedSets(
-        address operator
-    ) external view returns (OperatorSet[] memory) {
+    function getAllocatedSets(address operator) external view returns (OperatorSet[] memory) {
         uint256 length = allocatedSets[operator].length();
 
         OperatorSet[] memory operatorSets = new OperatorSet[](length);

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -362,6 +362,13 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     ) external view returns (uint256);
 
     /**
+     * @notice Returns all operator sets for a given AVS
+     * @param avs The address of the AVS
+     * @return Array of operator set IDs
+     */
+    function getAVSOperatorSets(address avs) external view returns (uint32[] memory);
+
+    /**
      * @notice Returns the list of operator sets the operator has current or pending allocations/deallocations in
      * @param operator the operator to query
      * @return the list of operator sets the operator has current or pending allocations/deallocations in


### PR DESCRIPTION
#1161 

**Motivation:**

The mapping `_operatorSets` in AllocationManagerStorage.sol needs to be accessible to check if an operator is registered for a particular AVS. Currently, there is no direct way to access all operator sets for a given AVS, which makes it difficult to verify operator registration status.

**Modifications:**

1. Added new view function `getAVSOperatorSets(address avs)` to IAllocationManager interface
2. Implemented the function in AllocationManager contract
3. Function returns an array of operator set IDs for a given AVS address
4. Added NatSpec documentation for the new function

**Result:**

After this change:
- External contracts and users can query all operator sets for any AVS address
- Makes it easier to verify operator registration status for a particular AVS
- Improves contract interoperability and transparency
- Maintains consistent code style with existing view functions
- No security implications as this is a read-only function accessing existing public state