### PR TITLE
test: bc state validation tests

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1995,11 +1995,12 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     /// @dev On a delegation, the DSF should be increased if the operator magnitude is non-WAD
     function assert_Snap_DSF_State_Delegation(
         User staker,
+        User operator,
         IStrategy[] memory strategies,
         uint[] memory delegatableShares,
         string memory err
     ) internal {
-        uint64[] memory maxMags = _getMaxMagnitudes(staker, strategies);
+        uint64[] memory maxMags = _getMaxMagnitudes(operator, strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
             IStrategy[] memory stratArray = strategies[i].toArray();

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -2000,16 +2000,12 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
                 assert_Snap_Unchanged_DSF(staker, stratArray, err);
                 assert_DSF_WAD(staker, stratArray, err);
             }
-            // If there was a slashing and we complete a withdrawal for non-zero shares..
+            // If there was a slashing and we complete a withdrawal for non-zero shares, normalize the DSF
             else {
-                // Normalize the DSF if prevDepositShares is 0
-                if (prevDepositShares[i] == 0) {
-                    assert_Snap_Increased_DSF(staker, stratArray, err);
-                }
-                // If prevDepositShares is not 0, the DSF has already been normalized, so we just check within error bounds
-                else {
-                    assert_Snap_WithinErrorBounds_DSF(staker, stratArray, err);
-                }
+                assert_Snap_Increased_DSF(staker, stratArray, err);
+                /// @dev Note there may be cases when the DSF `stays` the same, such as when a withdrawal is 
+                ///      queued, we deposit, and then complete as shares. THe DSF would stay the same. That test should use 
+                ///      `assert_Snap_WithinErrorBounds_DSF`
             }
         }
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1839,11 +1839,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             if (prevShares[i] == 0 && depositSharesAdded[i] > 0){
                 expectedWithdrawableShares[i] = _getExpectedWithdrawableSharesDeposit(staker, operator, strategies[i], depositSharesAdded[i]);
                 assertEq(curShares[i], expectedWithdrawableShares[i], err);
-            }
-            // TODO bound this properly 
-            else if (_getSlashingFactor(staker, strategies[i]) != WAD){
-                // If we are depositing again with a non-WAD slashing factor and a non-zero balance, we assume some rounding down
-                assertApproxEqAbs(curShares[i], prevShares[i] + depositSharesAdded[i], 1e3, err);
             } else {
                 uint[] memory prevDepositShares = _getPrevStakerDepositShares(staker, strategies);
                 assertEq((prevDepositShares[i] + depositSharesAdded[i]).mulWad(_getDepositScalingFactor(staker, strategies[i])).mulWad(_getSlashingFactor(staker, strategies[i])), curShares[i], err);
@@ -3381,7 +3376,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         (uint[] memory _withdrawableShares, ) =  delegationManager.getWithdrawableShares(address(staker), strategy.toArray());
         return _withdrawableShares[0];
     }
-    
+
     /// @dev Assumes that the staker has one withdrawal queued
     function _getWithdrawableSharesAfterCompletion(User staker) internal view returns (uint[] memory withdrawableShares) {
         bytes32 root = delegationManager.getQueuedWithdrawalRoots(address(staker))[0];

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1839,6 +1839,11 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             if (prevShares[i] == 0 && depositSharesAdded[i] > 0){
                 expectedWithdrawableShares[i] = _getExpectedWithdrawableSharesDeposit(staker, operator, strategies[i], depositSharesAdded[i]);
                 assertEq(curShares[i], expectedWithdrawableShares[i], err);
+            }
+            // TODO bound this properly 
+            else if (_getSlashingFactor(staker, strategies[i]) != WAD){
+                // If we are depositing again with a non-WAD slashing factor and a non-zero balance, we assume some rounding down
+                assertApproxEqAbs(curShares[i], prevShares[i] + depositSharesAdded[i], 1e3, err);
             } else {
                 uint[] memory prevDepositShares = _getPrevStakerDepositShares(staker, strategies);
                 assertEq((prevDepositShares[i] + depositSharesAdded[i]).mulWad(_getDepositScalingFactor(staker, strategies[i])).mulWad(_getSlashingFactor(staker, strategies[i])), curShares[i], err);
@@ -3375,6 +3380,12 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     function _getWithdrawableShares(User staker, IStrategy strategy) internal view returns (uint withdrawableShares) {
         (uint[] memory _withdrawableShares, ) =  delegationManager.getWithdrawableShares(address(staker), strategy.toArray());
         return _withdrawableShares[0];
+    }
+    
+    /// @dev Assumes that the staker has one withdrawal queued
+    function _getWithdrawableSharesAfterCompletion(User staker) internal view returns (uint[] memory withdrawableShares) {
+        bytes32 root = delegationManager.getQueuedWithdrawalRoots(address(staker))[0];
+        (, withdrawableShares) = delegationManager.getQueuedWithdrawal(root);
     }
 
     function _getActiveValidatorCount(User staker) internal view returns (uint) {

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -251,7 +251,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         uint256[] memory delegatableShares = _getPrevStakerWithdrawableShares(staker, strategies);
         assert_Snap_Added_OperatorShares(operator, strategies, delegatableShares, "operator should have received shares");
         check_Added_SlashableStake(operator, strategies, delegatableShares);
-        assert_Snap_DSF_State_Delegation(staker, strategies, delegatableShares, "staker's DSF not updated correctly");
+        assert_Snap_DSF_State_Delegation(staker, operator, strategies, delegatableShares, "staker's DSF not updated correctly");
     }
 
     function check_Added_SlashableStake(

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -505,14 +505,14 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_DSF_State_WithdrawalAsShares(staker, strategies, "staker's DSF not updated correctly");
     }
 
-    function check_Withdrawal_AsShares_Redelegated_State(
+    function check_Withdrawal_AsShares_Redelegated_State_Base(
         User staker,
         User operator,
         User newOperator,
         Withdrawal memory withdrawal,
         IStrategy[] memory strategies,
         uint[] memory withdrawableShares
-    ) internal {
+    ) internal { 
         /// Complete withdrawal(s):
         // The staker will complete the withdrawal as shares
         // 
@@ -527,6 +527,16 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Added_OperatorShares(newOperator, strategies, withdrawableShares, "new operator should have received shares");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
         assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, newOperator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
+    }
+
+    function check_Withdrawal_AsShares_Redelegated_State(
+        User staker,
+        User operator,
+        User newOperator,
+        Withdrawal memory withdrawal,
+        IStrategy[] memory strategies,
+        uint[] memory withdrawableShares
+    ) internal {
         assert_Snap_DSF_State_WithdrawalAsShares(staker, strategies, "staker's DSF not updated correctly");
     }
 

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -442,7 +442,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Common checks
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         
-        assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
+        // assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have changed");
         assert_Snap_Unchanged_DSF(staker, strategies, "dsf should not be changed");
         assert_Snap_Removed_StrategyShares(strategies, shares, "strategies should have total shares decremented");
@@ -509,7 +509,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         User staker,
         User operator,
         User newOperator,
-        IDelegationManagerTypes.Withdrawal memory withdrawal,
+        Withdrawal memory withdrawal,
         IStrategy[] memory strategies,
         uint[] memory withdrawableShares
     ) internal {
@@ -523,7 +523,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_TokenBalances(staker, "staker should not have any change in underlying token balances");
         assert_Snap_Unchanged_TokenBalances(operator, "operator should not have any change in underlying token balances");
         assert_Snap_Added_Staker_DepositShares(staker, strategies, withdrawableShares, "staker should have received expected shares");
-        assert_Snap_Unchanged_OperatorShares(operator, "operator should have shares unchanged");
+        assert_Snap_Unchanged_OperatorShares(operator, "old operator should have shares unchanged");
+        assert_Snap_Added_OperatorShares(newOperator, strategies, withdrawableShares, "new operator should have received shares");
         assert_Snap_Unchanged_StrategyShares(strategies, "strategies should have total shares unchanged");
         assert_Snap_Expected_Staker_WithdrawableShares_Deposit(staker, newOperator, strategies, withdrawableShares, "staker should have received expected withdrawable shares");
         assert_Snap_DSF_State_WithdrawalAsShares(staker, strategies, "staker's DSF not updated correctly");

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -442,7 +442,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         // Common checks
         assert_WithdrawalNotPending(delegationManager.calculateWithdrawalRoot(withdrawal), "staker withdrawal should no longer be pending");
         
-        // assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
+        assert_Snap_Added_TokenBalances(staker, tokens, expectedTokens, "staker should have received expected tokens");
         assert_Snap_Unchanged_Staker_DepositShares(staker, "staker shares should not have changed");
         assert_Snap_Unchanged_DSF(staker, strategies, "dsf should not be changed");
         assert_Snap_Removed_StrategyShares(strategies, shares, "strategies should have total shares decremented");

--- a/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
@@ -568,7 +568,9 @@ contract Integration_Redelegate_SlashOperator_SlashEigenpod is Integration_Slash
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint256 i = 0; i < withdrawals.length; ++i) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+            check_Withdrawal_AsShares_Redelegated_State_Base(staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+            // DSF actually decreases a bit because we deposited after the withdrawal, which normalized, and then deposited again
+            assert_Snap_WithinErrorBounds_DSF(staker, withdrawals[i].strategies, "staker's DSF not updated correctly");
         }
     }
 

--- a/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
@@ -10,7 +10,7 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
     OperatorSet operatorSet;
 
     User operator;
-    IAllocationManagerTypes.AllocateParams allocateParams;
+    AllocateParams allocateParams;
 
     User staker;
     IStrategy[] strategies;
@@ -53,17 +53,6 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         staker.delegateTo(operator);
         check_Delegation_State(staker, operator, strategies, initDepositShares);
 
-        // Create an operator set and register an operator.
-        operatorSet = avs.createOperatorSet(strategies);
-        operator.registerForOperatorSet(operatorSet);
-        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
-        
-        // Allocate to operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
-        operator.modifyAllocations(allocateParams);
-        check_IncrAlloc_State_Slashable(operator, allocateParams);
-        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
-
         (uint256[] memory withdrawableSharesBefore, ) = delegationManager.getWithdrawableShares(address(staker), strategies);
 
         // Undelegate from an operator
@@ -94,22 +83,12 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
 
         uint256[] memory initDelegatableShares = _getWithdrawableShares(staker, strategies);
         uint256[] memory initDepositShares = _getStakerDepositShares(staker, strategies);
+        
         // Delegate to an operator
         staker.delegateTo(operator);
         check_Delegation_State(staker, operator, strategies, initDepositShares);
 
         uint256[] memory withdrawableSharesAfterDelegation = _getWithdrawableShares(staker, strategies);
-
-        // Create an operator set and register an operator.
-        operatorSet = avs.createOperatorSet(strategies);
-        operator.registerForOperatorSet(operatorSet);
-        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
-        
-        // Allocate to operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
-        operator.modifyAllocations(allocateParams);
-        check_IncrAlloc_State_Slashable(operator, allocateParams);
-        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
 
         (uint256[] memory withdrawableSharesBefore, ) = delegationManager.getWithdrawableShares(address(staker), strategies);
         // Undelegate from an operator
@@ -215,17 +194,6 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         check_Delegation_State(staker, operator, strategies, initDepositShares);
         (uint256[] memory delegatedShares, ) = delegationManager.getWithdrawableShares(address(staker), strategies);
 
-        // Create an operator set and register an operator.
-        operatorSet = avs.createOperatorSet(strategies);
-        operator.registerForOperatorSet(operatorSet);
-        check_Registration_State_NoAllocation(operator, operatorSet, strategies);
-        
-        // Allocate to operator set
-        allocateParams = _genAllocation_AllAvailable(operator, operatorSet, strategies);
-        operator.modifyAllocations(allocateParams);
-        check_IncrAlloc_State_Slashable(operator, allocateParams);
-        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
-
         // Undelegate from an operator
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = staker.redelegate(operator2);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
@@ -260,8 +228,8 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         operator.registerForOperatorSet(operatorSet);
         check_Registration_State_NoAllocation(operator, operatorSet, strategies);
 
-        //Slash operator before delegation
-        IAllocationManagerTypes.SlashingParams memory slashingParams;
+        // Slash operator before delegation
+        SlashingParams memory slashingParams;
         uint wadToSlash = _randWadToSlash();
         slashingParams = avs.slashOperator(operator, operatorSet.id, strategies, wadToSlash.toArrayU256());
         assert_Snap_Allocations_Slashed(slashingParams, operatorSet, true, "operator allocations should be slashed");
@@ -342,5 +310,333 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
             staker.completeWithdrawalAsShares(withdrawals[i]);
             check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, withdrawableShares);
         }
+    }
+
+    function testFuzz_verifyAdditionalValidator_delegateSlashedStaker(uint24 _random) public rand(_random){
+        // Create operatorSet
+        operatorSet = avs.createOperatorSet(strategies);
+
+        // Allocate to operatorSet
+        allocateParams = _genAllocation_AllAvailable(operator, operatorSet);
+        operator.modifyAllocations(allocateParams);
+        check_Base_IncrAlloc_State(operator, allocateParams); // No increase in allocated stake since staker not delegated
+        _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
+
+        // Register to opSet
+        operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_PendingAllocation(operator, allocateParams);
+
+        // Slash operator - should have non-WAD magnitude
+        SlashingParams memory slashParams = _genSlashing_Rand(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // Verify additional validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
+        uint[] memory initDepositShares = _getStakerDepositShares(staker, strategies); // Deposit shares increased after verifying validator
+
+        // Delegate to operator
+        staker.delegateTo(operator);
+        check_Delegation_State(staker, operator, strategies, initDepositShares);
+    }
+}
+
+contract Integration_SlashedOperator_SlashedEigenpod_Base is IntegrationCheckUtils {
+    using ArrayLib for *;
+    
+    AVS avs;
+    OperatorSet operatorSet;
+    AllocateParams allocateParams;
+
+    User operator;
+
+    User staker;
+    IStrategy[] strategies;
+    uint[] initTokenBalances;
+    uint[] initDepositShares;
+
+    function _init() internal virtual override {
+        _configAssetTypes(HOLDS_ETH);
+        (staker, strategies, initTokenBalances) = _newRandomStaker();
+        operator = _newRandomOperator_NoAssets();
+        (avs,) = _newRandomAVS();
+
+        // 1. Deposit Into Strategies
+        staker.depositIntoEigenlayer(strategies, initTokenBalances);
+        initDepositShares = _calculateExpectedShares(strategies, initTokenBalances);
+        check_Deposit_State(staker, strategies, initDepositShares);
+
+        // 2. Create an operator set and register an operator.
+        operatorSet = avs.createOperatorSet(strategies);
+
+        // Steps 3-4-5
+        // 3. Allocate to operatorSet
+        // 4. Register to opSet
+        // 5. Slash operator
+        allocateParams = _giveOperatorNonWadMagnitude(operator);
+    }
+
+    /// @dev Assumes operatorSet has been initialized with relevant strategies for staker
+    function _giveOperatorNonWadMagnitude(User _operator) internal returns (AllocateParams memory _allocateParams){
+        // Allocate to operatorSet
+        _allocateParams = _genAllocation_AllAvailable(_operator, operatorSet);
+        _operator.modifyAllocations(_allocateParams);
+        check_Base_IncrAlloc_State(_operator, _allocateParams); // No increase in allocated stake since staker not delegated
+        _rollBlocksForCompleteAllocation(_operator, operatorSet, strategies);
+
+        // Register to opSet 
+        _operator.registerForOperatorSet(operatorSet);
+        check_Registration_State_PendingAllocation(_operator, _allocateParams);
+
+        // Slash operator
+        SlashingParams memory slashParams = _genSlashing_Rand(_operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(_operator, _allocateParams, slashParams);
+    }
+}
+
+contract Integration_SlashedOperator_SlashedEigenpod is Integration_SlashedOperator_SlashedEigenpod_Base {
+    function _init() internal virtual override {
+        // 1-5
+        super._init();
+
+        // 6. Slash on BC
+        uint40[] memory validators = staker.getActiveValidators();
+        uint40[] memory slashedValidators = _choose(validators);
+        uint64 slashedGwei = beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.startCheckpoint();
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, slashedValidators, slashedGwei);
+
+        // 7. Delegate to operator
+        staker.delegateTo(operator);
+        check_Delegation_State(staker, operator, strategies, initDepositShares);
+
+        // 8. Verify Additional Validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
+        initDepositShares = _getStakerDepositShares(staker, strategies); // Deposit shares increased after verifying validator
+    }
+
+    function testFuzz_slashOnBC_delegate_verifyValidator_undelegate_completeAsTokens(uint24 _random) public rand(_random){        
+        // 9. Undelegate
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, stakerWithdrawableShares);
+
+        // 10. Complete withdrawal as tokens
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, stakerWithdrawableShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_slashOnBC_delegate_verifyValidator_undelegate_completeAsShares(uint24 _random) public rand(_random){
+        // 9. Undelegate
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.undelegate();
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, stakerWithdrawableShares);
+
+        // 10. Complete withdrawal as shares
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            staker.completeWithdrawalAsShares(withdrawals[i]);
+            check_Withdrawal_AsShares_Undelegated_State(staker, operator, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+        }
+    }
+
+    function testFuzz_slashOnBC_delegate_verifyValidator_redelegate_completeAsTokens(uint24 _random) public rand(_random){
+        // Create new operator
+        User operator2 = _newRandomOperator_NoAssets();
+
+        // Randomly give the operator a non-WAD magnitude
+        if(_randBool()){
+            _giveOperatorNonWadMagnitude(operator2);
+        }
+
+        // 9. Redelegate
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.redelegate(operator2);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, stakerWithdrawableShares);
+
+        // 10. Complete withdrawal as tokens
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, stakerWithdrawableShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_slashOnBC_delegate_verifyValidator_redelegate_completeAsShares(uint24 _random) public rand(_random){
+        // Create new operator
+        User operator2 = _newRandomOperator_NoAssets();
+
+        // Randomly give the operator a non-WAD magnitude
+        if(_randBool()){
+            _giveOperatorNonWadMagnitude(operator2);
+        }
+
+        // 9. Redelegate
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.redelegate(operator2);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, stakerWithdrawableShares);
+
+        // 10. Complete withdrawal as shares
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            staker.completeWithdrawalAsShares(withdrawals[i]);
+            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+        }
+    }
+}
+
+contract Integration_Redelegate_SlashOperator_SlashEigenpod is Integration_SlashedOperator_SlashedEigenpod_Base {
+    using ArrayLib for *;
+
+    User operator2;
+    Withdrawal withdrawal;
+    uint64 slashedGwei;
+
+    function _init() internal virtual override {
+        // 1-5. 
+        super._init();
+
+        // 6. Delegate staker
+        staker.delegateTo(operator);
+        check_Delegation_State(staker, operator, strategies, initDepositShares);
+
+        // 7. Create new operator & randomly give it a non-WAD magnitude
+        operator2 = _newRandomOperator_NoAssets();
+        if(_randBool()){
+            _giveOperatorNonWadMagnitude(operator2);
+        }
+
+        // 8. Redelegate
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.redelegate(operator2);
+        require(withdrawals.length == 1, "Expected 1 withdrawal");
+        withdrawal = withdrawals[0];
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, stakerWithdrawableShares);
+
+        // 9. Slash original operator
+        SlashingParams memory slashParams = _genSlashing_Half(operator, operatorSet);
+        avs.slashOperator(slashParams);
+        check_Base_Slashing_State(operator, allocateParams, slashParams);
+
+        // 10. Slash on BC
+        uint40[] memory validators = staker.getActiveValidators();
+        uint40[] memory slashedValidators = _choose(validators);
+        slashedGwei = beaconChain.slashValidators(slashedValidators, BeaconChainMock.SlashType.Minor);
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.startCheckpoint();
+        staker.completeCheckpoint();
+    }
+
+    function testFuzz_delegate_redelegate_slashAVS_slashBC_verifyValidator_completeAsShares(uint24 _random) public rand(_random){
+        // Populate withdrawal array
+        Withdrawal[] memory withdrawals = new Withdrawal[](1);
+        withdrawals[0] = withdrawal;
+
+        // 11. Verify additional validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
+
+        // 12. Complete withdrawal as shares
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableSharesAfterCompletion(staker);
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            staker.completeWithdrawalAsShares(withdrawals[i]);
+            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+        }
+    }
+
+    function testFuzz_delegate_redelegate_slashAVS_slashBC_verifyValidator_completeAsTokens(uint24 _random) public rand(_random){
+        // Populate withdrawal array
+        Withdrawal[] memory withdrawals = new Withdrawal[](1);
+        withdrawals[0] = withdrawal;
+        
+        // 11. Verify additional validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
+
+        // 12. Complete withdrawal as tokens
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableSharesAfterCompletion(staker);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, stakerWithdrawableShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_delegate_redelegate_slashAVS_slashBC_completeAsShares_verifyValidator(uint24 _random) public rand(_random){
+        // Populate withdrawal array
+        Withdrawal[] memory withdrawals = new Withdrawal[](1);
+        withdrawals[0] = withdrawal;
+
+        // 11. Complete withdrawal as shares
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableSharesAfterCompletion(staker);
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            staker.completeWithdrawalAsShares(withdrawals[i]);
+            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares);
+        }
+
+        // 12. Verify additional validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
+    }
+
+    function testFuzz_delegate_redelegate_slashAVS_slashBC_completeAsTokens_verifyValidator(uint24 _random) public rand(_random){
+        // Populate withdrawal array
+        Withdrawal[] memory withdrawals = new Withdrawal[](1);
+        withdrawals[0] = withdrawal;
+
+        // 11. Complete withdrawal as tokens
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        uint256[] memory stakerWithdrawableShares = _getWithdrawableSharesAfterCompletion(staker);
+        for (uint256 i = 0; i < withdrawals.length; ++i) {
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, stakerWithdrawableShares);
+            IERC20[] memory tokens = staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares, tokens, expectedTokens);
+        }
+
+        // 12. Verify additional validator
+        cheats.deal(address(staker), 32 ether);
+        uint64 beaconBalanceAddedGwei = uint64(32 ether / GWEI_TO_WEI);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoWithdrawNoRewards();
+        staker.verifyWithdrawalCredentials(newValidators);
+        check_VerifyWC_State(staker, newValidators, beaconBalanceAddedGwei);
     }
 }


### PR DESCRIPTION
**Motivation:**

State Validation tests around slashing on beacon chain, relegating, getting slashed by an operator. 

**Modifications:**

Adds the following tests, some are failing due to the DSF inflation bug. 

- [x] testFuzz_verifyAdditionalValidator_delegateSlashedStaker
- [x] testFuzz_slashOnBC_delegate_verifyValidator_undelegate_completeAsTokens
- [x] testFuzz_slashOnBC_delegate_verifyValidator_undelegate_completeAsShares
- [x] testFuzz_slashOnBC_delegate_verifyValidator_redelegate_completeAsTokens
- [x] testFuzz_slashOnBC_delegate_verifyValidator_redelegate_completeAsShares
- [x] testFuzz_delegate_redelegate_slashAVS_slashBC_verifyValidator_completeAsShares
- [x] testFuzz_delegate_redelegate_slashAVS_slashBC_verifyValidator_completeAsTokens
- [x] testFuzz_delegate_redelegate_slashAVS_slashBC_completeAsShares_verifyValidator
- [x] testFuzz_delegate_redelegate_slashAVS_slashBC_completeAsTokens_verifyValidator

Updates withdrawal as shares assertion to handle dsf rounding.

**Result:**

Beacon Chain State Validation 
