### PR TITLE
chore: update undelegate/redelegate checks for 0 deposit shares

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -236,6 +236,31 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
+    /// @dev Check that all the staker's deposit shares have been removed
+    function assert_RemovedAll_Staker_DepositShares(
+        User user,
+        IStrategy[] memory strategies,
+        string memory err
+    ) internal view {
+        uint[] memory depositShares = _getStakerDepositShares(user, strategies);
+        for (uint i = 0; i < strategies.length; i++) {
+            assertEq(depositShares[i], 0, err);
+        }
+    }
+
+    /// @dev Check that all the staker's withdrawable shares have been removed
+    function assert_RemovedAll_Staker_WithdrawableShares(
+        User staker, 
+        IStrategy[] memory strategies, 
+        string memory err
+    ) internal view {
+        uint[] memory curShares = _getStakerWithdrawableShares(staker, strategies);
+        // For each strategy, check all shares have been withdrawn
+        for (uint i = 0; i < strategies.length; i++) {
+            assertEq(0, curShares[i], err);
+        }
+    }
+
     function assert_HasOperatorShares(
         User user, 
         IStrategy[] memory strategies, 
@@ -1514,20 +1539,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         // For each strategy, check (prev - removed == cur)
         for (uint i = 0; i < strategies.length; i++) {
             assertEq(prevShares[i] - removedShares[i], curShares[i], err);
-        }
-    }
-
-    /// @dev Check that all the staker's withdrawable shares have been removed
-    /// TODO - this is not a snap assertion, investigate usage
-    function assert_Snap_RemovedAll_Staker_WithdrawableShares(
-        User staker, 
-        IStrategy[] memory strategies, 
-        string memory err
-    ) internal view {
-        uint[] memory curShares = _getStakerWithdrawableShares(staker, strategies);
-        // For each strategy, check all shares have been withdrawn
-        for (uint i = 0; i < strategies.length; i++) {
-            assertEq(0, curShares[i], err);
         }
     }
 

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -318,7 +318,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         Withdrawal[] memory withdrawals,
         bytes32[] memory withdrawalRoots,
         IStrategy[] memory strategies,
-        uint[] memory stakerDepositShares,
         uint[] memory stakerDelegatedShares 
     ) internal {
         /// Undelegate from an operator
@@ -339,9 +338,8 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_Undelegate_State: staker should have increased nonce by withdrawals.length");
         assert_Snap_Removed_OperatorShares(operator, strategies, stakerDelegatedShares,
             "check_Undelegate_State: failed to remove operator shares");
-        assert_Snap_Removed_Staker_DepositShares(staker, strategies, stakerDepositShares,
-            "check_Undelegate_State: failed to remove staker shares");
-        assert_Snap_RemovedAll_Staker_WithdrawableShares(staker, strategies,
+        assert_RemovedAll_Staker_DepositShares(staker, strategies, "check_Undelegate_State: failed to remove staker shares");
+        assert_RemovedAll_Staker_WithdrawableShares(staker, strategies,
             "check_QueuedWithdrawal_State: failed to remove staker withdrawable shares");
     }
 
@@ -352,7 +350,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         IDelegationManagerTypes.Withdrawal[] memory withdrawals,
         bytes32[] memory withdrawalRoots,
         IStrategy[] memory strategies,
-        uint[] memory stakerDepositShares,
         uint[] memory stakerDelegatedShares  
     ) internal {
         /// Redelegate to a new operator
@@ -373,9 +370,8 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_Redelegate_State: staker should have increased nonce by withdrawals.length");
         assert_Snap_Removed_OperatorShares(oldOperator, strategies, stakerDelegatedShares,
             "check_Redelegate_State: failed to remove operator shares");
-        assert_Snap_Removed_Staker_DepositShares(staker, strategies, stakerDepositShares,
-            "check_Redelegate_State: failed to remove staker shares");
-        assert_Snap_RemovedAll_Staker_WithdrawableShares(staker, strategies,
+        assert_RemovedAll_Staker_DepositShares(staker, strategies, "check_Undelegate_State: failed to remove staker shares");
+        assert_RemovedAll_Staker_WithdrawableShares(staker, strategies,
             "check_QueuedWithdrawal_State: failed to remove staker withdrawable shares");
         assert_Snap_Unchanged_OperatorShares(newOperator,
             "check_Redelegate_State: new operator shares should not have changed");

--- a/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Redelegate_Complete.t.sol
@@ -48,7 +48,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -114,7 +114,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -205,7 +205,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
             // 3. Undelegate from an operator
             Withdrawal[] memory withdrawals = staker.undelegate();
             bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-            check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, halfShares, delegatableShares);
+            check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
             // 4. Complete withdrawal as shares
             // Fast forward to when we can complete the withdrawal
@@ -293,7 +293,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
                 // 3. Undelegate from an operator
                 Withdrawal[] memory withdrawals = staker.undelegate();
                 bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-                check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, sharesFromFirstDeposit, delegatableShares);
+                check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
                 // 4. Complete withdrawal as shares
                 // Fast forward to when we can complete the withdrawal
@@ -369,7 +369,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal as tokens
         // Fast forward to when we can complete the withdrawal
@@ -439,7 +439,7 @@ contract Integration_Deposit_Delegate_Redelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator1, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal as Tokens
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Undelegate_Complete.t.sol
@@ -42,7 +42,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -98,7 +98,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -148,7 +148,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         // 3. Force undelegate
         Withdrawal[] memory withdrawals = operator.forceUndelegate(staker);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -198,7 +198,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         // 3. Force undelegate
         Withdrawal[] memory withdrawals = operator.forceUndelegate(staker);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal
@@ -242,7 +242,7 @@ contract Integration_Deposit_Delegate_Undelegate_Complete is IntegrationCheckUti
         // 3. Undelegate from an operator
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, shares, delegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, delegatableShares);
 
         // 4. Complete withdrawal
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/Slashed_Eigenpod.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod.t.sol
@@ -68,7 +68,7 @@ contract Integration_SlashedEigenpod is IntegrationCheckUtils {
         // Undelegate from an operator
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, initDelegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDelegatableShares);
 
         // Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -119,7 +119,7 @@ contract Integration_SlashedEigenpod is IntegrationCheckUtils {
         // Undelegate from an operator
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDepositShares, initDelegatableShares);
+        check_Undelegate_State(staker, operator, withdrawals, withdrawalRoots, strategies, initDelegatableShares);
 
         // Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal
@@ -237,7 +237,7 @@ contract Integration_SlashedEigenpod is IntegrationCheckUtils {
         // Undelegate from an operator
         IDelegationManagerTypes.Withdrawal[] memory withdrawals = staker.redelegate(operator2);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, initDepositShares, delegatedShares);
+        check_Redelegate_State(staker, operator, operator2, withdrawals, withdrawalRoots, strategies, delegatedShares);
 
         // Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal

--- a/src/test/integration/tests/SlashingWithdrawals.t.sol
+++ b/src/test/integration/tests/SlashingWithdrawals.t.sol
@@ -152,7 +152,7 @@ contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
@@ -169,7 +169,7 @@ contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.redelegate(operatorB);
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, shares);
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
@@ -204,7 +204,7 @@ contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.undelegate();
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Undelegate_State(staker, operator, withdrawals, roots, strategies, shares);
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 
@@ -220,7 +220,7 @@ contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
         uint[] memory shares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.redelegate(operatorB);
         bytes32[] memory roots = _getWithdrawalHashes(withdrawals);
-        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, initDepositShares, shares);
+        check_Redelegate_State(staker, operator, operatorB, withdrawals, roots, strategies, shares);
 
         _rollBlocksForCompleteWithdrawals(withdrawals);
 


### PR DESCRIPTION
**Motivation:**

On undelegation, deposit shares should be zero, there is no need to check the diff. 

**Modifications:**

Added `assert_RemovedAll_Staker_DepositShares` and updated `assert_Snap_RemovedAll_Staker_WithdrawableShares` to be non-snap. 

**Result:**

Stricter undelegate/redelegate invariants
