### PR TITLE
chore: fix extra space in error message for eigenPodManager

### DIFF
--- a/script/deploy/devnet/deploy_from_scratch.s.sol
+++ b/script/deploy/devnet/deploy_from_scratch.s.sol
@@ -510,7 +510,7 @@ contract DeployFromScratch is Script, Test {
         );
         require(
             eigenPodManagerContract.ethPOS() == ethPOSDeposit,
-            " eigenPodManager: ethPOSDeposit contract address not set correctly"
+            "eigenPodManager: ethPOSDeposit contract address not set correctly"
         );
         require(
             eigenPodManagerContract.eigenPodBeacon() == eigenPodBeacon,


### PR DESCRIPTION
**Motivation:**  
There was an extra space before `eigenPodManager` in the error message, which, while not critical, could reduce the readability of the output. This small fix ensures cleaner and more consistent error messaging.  

**Modifications:**  
- Removed the extra space before `eigenPodManager` in the error message.  

**Result:**  
The error message now displays correctly without unnecessary spacing, improving readability.