### PR TITLE
chore(ci): lint pr titles

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -30,10 +30,10 @@ jobs:
           PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
           echo "PR title: $PR_TITLE"
 
-          # Define the valid pattern (supports both with and without parentheses)
-          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf)(\(\))?\:\ .* ]]; then
+          # Define the valid pattern (supports conventional commit format)
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf)(\([a-z0-9-]+\))?\:\ .* ]]; then
             echo "❌ Invalid PR title: '$PR_TITLE'"
-            echo "Expected format: 'type: description' or 'type(): description'"
+            echo "Expected format: 'type: description' or 'type(scope): description'"
             echo "Allowed types: feat, fix, chore, docs, refactor, test, style, ci, perf."
             exit 1
           fi

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,14 +1,13 @@
-name: PR Labeler
+name: PR
 
 on:
   pull_request:
+    types: [opened, edited, synchronize]
 
 jobs:
   triage:
     runs-on: protocol-x64-16core
-
-    name: Bot
-
+    name: Labels
     permissions:
       contents: read
       pull-requests: write
@@ -21,3 +20,22 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
+
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    name: Title
+    steps:
+      - name: Fetch PR Title
+        run: |
+          PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          echo "PR title: $PR_TITLE"
+
+          # Define the valid pattern (customize as needed)
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci):\ .* ]]; then
+            echo "❌ Invalid PR title: '$PR_TITLE'"
+            echo "Expected format: 'type: description'"
+            echo "Allowed types: feat, fix, chore, docs, refactor, test, style, ci."
+            exit 1
+          fi
+
+          echo "✅ PR title is valid"

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -31,10 +31,10 @@ jobs:
           echo "PR title: $PR_TITLE"
 
           # Define the valid pattern (customize as needed)
-          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci):\ .* ]]; then
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf):\ .* ]]; then
             echo "❌ Invalid PR title: '$PR_TITLE'"
             echo "Expected format: 'type: description'"
-            echo "Allowed types: feat, fix, chore, docs, refactor, test, style, ci."
+            echo "Allowed types: feat, fix, chore, docs, refactor, test, style, ci, perf."
             exit 1
           fi
 

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -30,10 +30,10 @@ jobs:
           PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
           echo "PR title: $PR_TITLE"
 
-          # Define the valid pattern (customize as needed)
-          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf):\ .* ]]; then
+          # Define the valid pattern (supports both with and without parentheses)
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|chore|docs|refactor|test|style|ci|perf)(\(\))?\:\ .* ]]; then
             echo "❌ Invalid PR title: '$PR_TITLE'"
-            echo "Expected format: 'type: description'"
+            echo "Expected format: 'type: description' or 'type(): description'"
             echo "Allowed types: feat, fix, chore, docs, refactor, test, style, ci, perf."
             exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,15 +21,6 @@ jobs:
         with:
           config: .github/configs/typos-cli.toml
 
-  pr-name-linter:
-    name: Pull Request Name Linting
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Install Dependencies
-      run: npm install @commitlint/config-conventional
-    - uses: JulienKode/pull-request-name-linter-action@v0.5.0
-
   go-bindings:
     name: Bindings
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,12 +21,14 @@ jobs:
         with:
           config: .github/configs/typos-cli.toml
 
-  commitlint:
-    name: Commit Linting
+  pr-name-linter:
+    name: Pull Request Name Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: wagoid/commitlint-github-action@v6
+    - uses: actions/checkout@v4
+    - name: Install Dependencies
+      run: npm install @commitlint/config-conventional
+    - uses: JulienKode/pull-request-name-linter-action@v0.5.0
 
   go-bindings:
     name: Bindings


### PR DESCRIPTION
**Motivation:**

Improve developer experience by implementing consistent PR title validation. 

Before we were validating the commits in a PR, rather than the PR's title.

**Modifications:**

- Removed `commitlint` job from `.github/workflows/checks.yml`
- Added PR title validation for conventional commit format: `type: description`

**Result:**

We now enforce standardized PR titles following conventional commit format.