### PR TITLE
test: bc full slash tests and partial slash state validation

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1745,6 +1745,9 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         // For each strategy, check (prev - removed == cur)
         for (uint i = 0; i < strategies.length; i++) {
+            console.log("prevShares[i]", prevShares[i]);
+            console.log("addedShares[i]", addedShares[i]);
+            console.log("curShares[i]", curShares[i]);
             assertEq(prevShares[i] + addedShares[i], curShares[i], err);
         }
     }

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1745,9 +1745,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
 
         // For each strategy, check (prev - removed == cur)
         for (uint i = 0; i < strategies.length; i++) {
-            console.log("prevShares[i]", prevShares[i]);
-            console.log("addedShares[i]", addedShares[i]);
-            console.log("curShares[i]", curShares[i]);
             assertEq(prevShares[i] + addedShares[i], curShares[i], err);
         }
     }
@@ -2778,7 +2775,8 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             IStrategy strat = strategies[i];
 
             if (strat == BEACONCHAIN_ETH_STRAT) {
-                expectedTokens[i] = shares[i];
+                // We round down expected tokens to the nearest gwei
+                expectedTokens[i] = (shares[i] / GWEI_TO_WEI) * GWEI_TO_WEI;
             } else {
                 expectedTokens[i] = strat.sharesToUnderlying(shares[i]);
             }

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -283,23 +283,26 @@ contract IntegrationCheckUtils is IntegrationBase {
         // ... check that each withdrawal was successfully enqueued, that the returned roots
         //     match the hashes of each withdrawal, and that the staker and operator have
         //     reduced shares.
-        check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
-        assert_Snap_Removed_OperatorShares(operator, strategies, withdrawableShares,
-            "check_QueuedWithdrawal_State: failed to remove operator shares");
-        assert_Snap_Increased_SlashableSharesInQueue(operator, withdrawals,
-            "check_QueuedWithdrawal_State: failed to increase slashable shares in queue");
-        check_Decreased_SlashableStake(operator, withdrawableShares, strategies);
+        _check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        if (delegationManager.isDelegated(address(staker))) {
+            assert_Snap_Removed_OperatorShares(operator, strategies, withdrawableShares,
+                "check_QueuedWithdrawal_State: failed to remove operator shares");
+            assert_Snap_Increased_SlashableSharesInQueue(operator, withdrawals,
+                "check_QueuedWithdrawal_State: failed to increase slashable shares in queue");
+            check_Decreased_SlashableStake(operator, withdrawableShares, strategies);
+        }
     }
 
-    /// @dev Basic queued withdrawal checks if the staker is not delegated
-    function check_QueuedWithdrawal_State_NotDelegated(
+    /// @dev Basic queued withdrawal checks if the staker is not delegated, should be called by the above function only
+    function _check_QueuedWithdrawal_State_NotDelegated(
         User staker,
         IStrategy[] memory strategies,
         uint[] memory depositShares,
         uint[] memory withdrawableShares,
         Withdrawal[] memory withdrawals,
         bytes32[] memory withdrawalRoots
-    ) internal {
+    ) private {
         assertEq(withdrawalRoots.length, 1, "check_QueuedWithdrawal_State: should only have 1 withdrawal root after queueing"); 
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_QueuedWithdrawal_State: staker withdrawals should now be pending");

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -27,9 +27,6 @@ contract IntegrationCheckUtils is IntegrationBase {
         // assert_Snap_Added_Staker_WithdrawableShares(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256(), "staker should have added withdrawable shares to beacon chain strat");
         assert_Snap_Added_ActiveValidatorCount(staker, validators.length, "staker should have increased active validator count");
         assert_Snap_Added_ActiveValidators(staker, validators, "validators should each be active");
-
-        // uint[] memory addedWithdrawableShares = _getExpectedWithdrawableSharesAdded(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256());
-        // assert_Snap_Added_Staker_WithdrawableShares(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256(), "staker should have added withdrawable shares");
     }
 
     function check_StartCheckpoint_State(

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -140,8 +140,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_DSF(staker, BEACONCHAIN_ETH_STRAT.toArray(), "DSF should be unchanged");
         assert_SlashableStake_Decrease_BCSlash(staker);
         // TODO - currently only used after a `NoWithdrawNoRewards` action. Investigate re-adding in future.
-        assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
-        assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+        // assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
+        // assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
     }
 
     function check_CompleteCheckpoint_WithCLSlashing_HandleRoundDown_State(

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -17,17 +17,6 @@ contract IntegrationCheckUtils is IntegrationBase {
     *******************************************************************************/
 
     function check_VerifyWC_State(
-        User_M2 staker,
-        uint40[] memory validators,
-        uint64 beaconBalanceGwei
-    ) internal {
-        uint beaconBalanceWei = beaconBalanceGwei * GWEI_TO_WEI;
-        assert_Snap_Added_Staker_DepositShares(staker, BEACONCHAIN_ETH_STRAT, beaconBalanceWei, "staker should have added deposit shares to beacon chain strat");
-        assert_Snap_Added_ActiveValidatorCount(staker, validators.length, "staker should have increased active validator count");
-        assert_Snap_Added_ActiveValidators(staker, validators, "validators should each be active");
-    }
-
-    function check_VerifyWC_State(
         User staker,
         uint40[] memory validators,
         uint64 beaconBalanceGwei
@@ -38,6 +27,9 @@ contract IntegrationCheckUtils is IntegrationBase {
         // assert_Snap_Added_Staker_WithdrawableShares(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256(), "staker should have added withdrawable shares to beacon chain strat");
         assert_Snap_Added_ActiveValidatorCount(staker, validators.length, "staker should have increased active validator count");
         assert_Snap_Added_ActiveValidators(staker, validators, "validators should each be active");
+
+        // uint[] memory addedWithdrawableShares = _getExpectedWithdrawableSharesAdded(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256());
+        // assert_Snap_Added_Staker_WithdrawableShares(staker, BEACONCHAIN_ETH_STRAT.toArray(), beaconBalanceWei.toArrayU256(), "staker should have added withdrawable shares");
     }
 
     function check_StartCheckpoint_State(

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -143,8 +143,8 @@ contract IntegrationCheckUtils is IntegrationBase {
         assert_Snap_Unchanged_DSF(staker, BEACONCHAIN_ETH_STRAT.toArray(), "DSF should be unchanged");
         assert_SlashableStake_Decrease_BCSlash(staker);
         // TODO - currently only used after a `NoWithdrawNoRewards` action. Investigate re-adding in future.
-        // assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
-        // assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
+        assert_Snap_Removed_ActiveValidatorCount(staker, slashedValidators.length, "should have decreased active validator count");
+        assert_Snap_Removed_ActiveValidators(staker, slashedValidators, "exited validators should each be WITHDRAWN");
     }
 
     function check_CompleteCheckpoint_WithCLSlashing_HandleRoundDown_State(

--- a/src/test/integration/tests/FullySlashed_EigenPod.t.sol
+++ b/src/test/integration/tests/FullySlashed_EigenPod.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.27;
 
 import "src/test/integration/IntegrationChecks.t.sol";
 
-contract Integration_FullySlashedEigenpod is IntegrationCheckUtils {
+contract Integration_FullySlashedEigenpod_Base is IntegrationCheckUtils {
     using ArrayLib for *;
 
     User staker;
@@ -11,24 +11,30 @@ contract Integration_FullySlashedEigenpod is IntegrationCheckUtils {
     uint[] initTokenBalances;
     uint[] initDepositShares;
     uint64 slashedGwei;
+    uint40[] validators;
 
-    function _init() internal override {
+    function _init() internal virtual override {
         _configAssetTypes(HOLDS_ETH);
         (staker, strategies, initTokenBalances) = _newRandomStaker();
-
         cheats.assume(initTokenBalances[0] >= 64 ether);
 
         // Deposit staker
-        (uint40[] memory validators,) = staker.startValidators();
-        beaconChain.advanceEpoch_NoRewards();
-        staker.verifyWithdrawalCredentials(validators);
         uint[] memory shares = _calculateExpectedShares(strategies, initTokenBalances);
-        initDepositShares = shares;
+        staker.depositIntoEigenlayer(strategies, initTokenBalances);
         check_Deposit_State(staker, strategies, shares);
+        initDepositShares = shares;
+        validators = staker.getActiveValidators();
 
         // Slash all validators fully
         slashedGwei = beaconChain.slashValidators(validators, BeaconChainMock.SlashType.Full);
         beaconChain.advanceEpoch_NoRewards(); // Withdraw slashed validators to pod
+    }
+}
+
+contract Integration_FullySlashedEigenpod_Checkpointed is Integration_FullySlashedEigenpod_Base {
+
+    function _init() internal override {
+        super._init();
 
         // Start & complete a checkpoint
         staker.startCheckpoint();
@@ -37,7 +43,7 @@ contract Integration_FullySlashedEigenpod is IntegrationCheckUtils {
         check_CompleteCheckpoint_FullySlashed_State(staker, validators, slashedGwei);
     }
 
-    function test_fullSlash_Delegate(uint24 _rand) public rand(_rand) {
+    function testFuzz_fullSlash_Delegate(uint24 _rand) public rand(_rand) {
         (User operator,,) = _newRandomOperator();
 
         // Delegate to an operator - should succeed given that delegation only checks the operator's slashing factor
@@ -45,14 +51,124 @@ contract Integration_FullySlashedEigenpod is IntegrationCheckUtils {
         check_Delegation_State(staker, operator, strategies, initDepositShares);
     }
 
-    function test_fullSlash_Revert_Redeposit(uint24 _rand) public rand(_rand) {
+    function testFuzz_fullSlash_Revert_Redeposit(uint24 _rand) public rand(_rand) {
         // Start a new validator & verify withdrawal credentials
         cheats.deal(address(staker), 32 ether);
-        (uint40[] memory newValidators, uint64 addedBeaconBalanceGwei) = staker.startValidators();
+        (uint40[] memory newValidators,) = staker.startValidators();
         beaconChain.advanceEpoch_NoRewards();
 
         // We should revert on verifyWithdrawalCredentials since the staker's slashing factor is 0
         cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
         staker.verifyWithdrawalCredentials(newValidators);
+    }
+
+    function testFuzz_fullSlash_registerStakerAsOperator_Revert_Redeposit(uint24 _rand) public rand(_rand) {
+        // Register staker as operator
+        staker.registerAsOperator();
+
+        // Start a new validator & verify withdrawal credentials
+        cheats.deal(address(staker), 32 ether);
+        (uint40[] memory newValidators,) = staker.startValidators();
+        beaconChain.advanceEpoch_NoRewards();
+
+        // We should revert on verifyWithdrawalCredentials since the staker's slashing factor is 0
+        cheats.expectRevert(IDelegationManagerErrors.FullySlashed.selector);
+        staker.verifyWithdrawalCredentials(newValidators);
+    }
+
+    function testFuzz_fullSlash_registerStakerAsOperator_delegate_undelegate_completeAsShares(uint24 _rand) public rand(_rand) {
+        // Register staker as operator
+        staker.registerAsOperator();
+        User operator = User(payable(address(staker)));
+        
+        // Initialize new staker
+        (User staker2, IStrategy[] memory strategies2, uint[] memory initTokenBalances2) = _newRandomStaker();
+        uint[] memory shares = _calculateExpectedShares(strategies2, initTokenBalances2);
+        staker2.depositIntoEigenlayer(strategies2, initTokenBalances2);
+        check_Deposit_State(staker2, strategies2, shares);
+
+        // Delegate to an operator who has now become a staker, this should succeed as slashed operator's BCSF should not affect the staker
+        staker2.delegateTo(operator);
+        check_Delegation_State(staker2, operator, strategies2, shares);
+        
+        // Register as operator and undelegate - the equivalent of redelegating to yourself
+        Withdrawal[] memory withdrawals = staker2.undelegate();
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_Undelegate_State(staker2, operator, withdrawals, withdrawalRoots, strategies2, shares);
+
+        // Complete withdrawals as shares
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            staker2.completeWithdrawalAsShares(withdrawals[i]);
+            check_Withdrawal_AsShares_Undelegated_State(staker2, operator, withdrawals[i], strategies2, shares);
+        }
+    }
+}
+
+contract Integration_FullySlashedEigenpod_NotCheckpointed is Integration_FullySlashedEigenpod_Base {
+
+    /// @dev Adding funds prior to checkpointing allows the pod to not be "bricked"
+    function testFuzz_proveValidator_checkpoint_queue_completeAsTokens(uint24 _rand) public rand(_rand) {
+        // Deal ETH to staker
+        uint amount = 32 ether;
+        cheats.deal(address(staker), amount);
+        uint[] memory initTokenBalances2 = new uint[](1);
+        initTokenBalances2[0] = amount;
+
+        // Deposit staker
+        uint[] memory shares = _calculateExpectedShares(strategies, initTokenBalances2);
+        staker.depositIntoEigenlayer(strategies, initTokenBalances2);
+        check_Deposit_State(staker, strategies, shares);
+
+        // Checkpoint slashed EigenPod
+        staker.startCheckpoint();
+        check_StartCheckpoint_WithPodBalance_State(staker, 0);
+        staker.completeCheckpoint();
+        check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, validators, slashedGwei);
+
+        // Queue Full Withdrawal
+        uint[] memory depositShares = _getStakerDepositShares(staker, strategies);
+        uint[] memory withdrawableShares = _getWithdrawableShares(staker, strategies);
+        Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositShares);
+        bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
+        check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+
+        // Complete withdrawal as tokens
+        _rollBlocksForCompleteWithdrawals(withdrawals);
+        for (uint i = 0; i < withdrawals.length; i++) {
+            IERC20[] memory tokens = _getUnderlyingTokens(withdrawals[i].strategies);
+            uint[] memory expectedTokens = _calculateExpectedTokens(withdrawals[i].strategies, withdrawableShares);
+            staker.completeWithdrawalAsTokens(withdrawals[i]);
+            check_Withdrawal_AsTokens_State(staker, User(payable(address(0))), withdrawals[i], withdrawals[i].strategies, withdrawableShares, tokens, expectedTokens);
+        }
+    }
+
+    function testFuzz_depositMinimumAmount_checkpoint(uint24 _rand) public rand(_rand) {
+        // Deal ETH to staker, minimum amount to be checkpointed
+        uint64 podBalanceGwei = 1;
+        uint amountToDeal = 1 * GWEI_TO_WEI;
+        bool isBricked;
+
+        // Randomly deal 1 less than minimum amount to be checkpointed such that the pod is bricked
+        if (_randBool()) {
+            amountToDeal -= 1;
+            podBalanceGwei -= 1;
+            isBricked = true;
+        }
+
+        // Send ETH to pod
+        cheats.prank(address(staker));
+        address(staker.pod()).call{value: amountToDeal}("");
+
+        // Checkpoint slashed EigenPod
+        staker.startCheckpoint();
+        check_StartCheckpoint_WithPodBalance_State(staker, podBalanceGwei);
+        staker.completeCheckpoint();
+        if (isBricked) {
+            // BCSF is asserted to be zero here
+            check_CompleteCheckpoint_FullySlashed_State(staker, validators, slashedGwei);
+        } else {
+            check_CompleteCheckpoint_WithSlashing_HandleRoundDown_State(staker, validators, slashedGwei);
+        }
     }
 }

--- a/src/test/integration/tests/FullySlashed_EigenPod.t.sol
+++ b/src/test/integration/tests/FullySlashed_EigenPod.t.sol
@@ -131,7 +131,7 @@ contract Integration_FullySlashedEigenpod_NotCheckpointed is Integration_FullySl
         uint[] memory withdrawableShares = _getWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, User(payable(address(0))), strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // Complete withdrawal as tokens
         _rollBlocksForCompleteWithdrawals(withdrawals);

--- a/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod_BC.t.sol
@@ -307,7 +307,7 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, User(payable(address(0))), strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // Complete withdrawal as tokens
         // Fast forward to when we can complete the withdrawal
@@ -333,7 +333,7 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         uint[] memory withdrawableShares = _getStakerWithdrawableShares(staker, strategies);
         Withdrawal[] memory withdrawals = staker.queueWithdrawals(strategies, depositShares);
         bytes32[] memory withdrawalRoots = _getWithdrawalHashes(withdrawals);
-        check_QueuedWithdrawal_State_NotDelegated(staker, strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
+        check_QueuedWithdrawal_State(staker, User(payable(address(0))), strategies, depositShares, withdrawableShares, withdrawals, withdrawalRoots);
 
         // Complete withdrawal as shares
         // Fast forward to when we can complete the withdrawal


### PR DESCRIPTION
**Motivation:**

Additional tests on beacon chain slashing

**Modifications:**

Full slash tests:

- [x] testFuzz_proveValidator_checkpoint_queue_completeAsTokens
- [x] test_fullSlash_Revert_Redeposit
- [x] testFuzz_fullSlash_registerStakerAsOperator_Revert_Redeposit
- [x] testFuzz_fullSlash_registerStakerAsOperator_delegate_undelegate_completeAsShares

Partial Slash Tests:

- [x] testFuzz_redeposit_queue_completeAsTokens
- [x] testFuzz_redeposit_queue_completeAsShares

Additionally:
- Updated `_getExpectedTokenBalances` to factor in gwei rounding down for EigenPods
- Updated `queuedWithdrawal` check when delegated or undelegated 
- Got rid of unnecessary checkpointing in `SlashedEigenPod.t.sol`

**Result:**

All single beacon chain slashing state validation complete. 
