### PR TITLE
Rename assert_DSF_Reset to assert_DSF_WAD for clarity

### DIFF
--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -566,7 +566,7 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         }
     }
 
-    function assert_DSF_Reset(
+    function assert_DSF_WAD(
         User staker,
         IStrategy[] memory strategies,
         string memory err

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -254,7 +254,7 @@ contract IntegrationCheckUtils is IntegrationBase {
             "check_Undelegate_State: calculated withdrawal should match returned root");
         assert_AllWithdrawalsPending(withdrawalRoots,
             "check_Undelegate_State: stakers withdrawal should now be pending");
-        assert_DSF_Reset(staker, strategies,
+        assert_DSF_WAD(staker, strategies,
             "check_Undelegate_State: staker dsfs should be reset to wad");
         assert_Snap_Added_QueuedWithdrawals(staker, withdrawals,
             "check_Undelegate_State: staker should have increased nonce by withdrawals.length");


### PR DESCRIPTION
This PR renames the test helper function `assert_DSF_Reset` to `assert_DSF_WAD` to better reflect its purpose and maintain consistency with the codebase terminology.

Changes:
- Renamed `assert_DSF_Reset` to `assert_DSF_WAD` in IntegrationBase.t.sol
- Updated corresponding function calls in IntegrationChecks.t.sol
