### PR TITLE
fix: compile warnings + ignore non-relevant errors

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -24,7 +24,7 @@
     # Specifies the exact version of Solidity to use, overriding auto-detection.
     solc_version = '0.8.27'
     # If enabled, treats Solidity compiler warnings as errors, preventing artifact generation if warnings are present.
-    deny_warnings = false 
+    deny_warnings = true 
     # If set to true, changes compilation pipeline to go through the new IR optimizer.
     via_ir = false
     # Whether or not to enable the Solidity optimizer.

--- a/foundry.toml
+++ b/foundry.toml
@@ -51,7 +51,7 @@
         # 2462, # constructor-visibility
         3860, # init-code-size
         # 2394, # transient-storage
-        # 4591  # too-many-warnings
+        4591  # too-many-warnings
     ]
     # An array of file paths from which warnings should be ignored during compilation.
     ignored_warnings_from = [

--- a/foundry.toml
+++ b/foundry.toml
@@ -33,6 +33,30 @@
     # across the life-time of the contract. This means it is a trade-off parameter between code size (deploy cost) 
     # and code execution cost (cost after deployment).
     optimizer_runs = 200
+    # An array of Solidity compiler error codes to ignore during build, such as warnings.
+    ignored_error_codes = [
+        # 1878, # license
+        5574, # code-size
+        # 2018, # func-mutability
+        # 2072, # unused-var
+        # 5667, # unused-param
+        # 9302, # unused-return
+        # 5815, # virtual-interfaces
+        # 3628, # missing-receive-ether
+        # 2519, # shadowing
+        # 8760, # same-varname
+        # 6321, # unnamed-return
+        # 5740, # unreachable
+        # 3420, # pragma-solidity
+        # 2462, # constructor-visibility
+        3860, # init-code-size
+        # 2394, # transient-storage
+        4591  # too-many-warnings
+    ]
+    # An array of file paths from which warnings should be ignored during compilation.
+    ignored_warnings_from = [
+        "src/test"
+    ]
 
     # Test Configuration
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -51,7 +51,7 @@
         # 2462, # constructor-visibility
         3860, # init-code-size
         # 2394, # transient-storage
-        4591  # too-many-warnings
+        # 4591  # too-many-warnings
     ]
     # An array of file paths from which warnings should be ignored during compilation.
     ignored_warnings_from = [

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1696,7 +1696,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     /// @dev When completing withdrawals as shares, we must also handle the case where a staker completes a withdrawal for 0 shares
     function assert_Snap_DSF_State_WithdrawalAsShares(User staker, IStrategy[] memory strategies, string memory err) internal {
         uint[] memory curDepositShares = _getStakerDepositShares(staker, strategies);
-        uint[] memory prevDepositShares = _getPrevStakerDepositShares(staker, strategies);
 
         for (uint i = 0; i < strategies.length; i++) {
             IStrategy[] memory stratArray = strategies[i].toArray();
@@ -1726,7 +1725,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
     /// @dev On a delegation, the DSF should be increased if the operator magnitude is non-WAD
     function assert_Snap_DSF_State_Delegation(
         User staker,
-        User operator,
         IStrategy[] memory strategies,
         uint[] memory delegatableShares,
         string memory err

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -607,10 +607,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         );
     }
 
-    function check_Withdrawal_AsShares_Redelegated_State(
-        User staker,
-        IStrategy[] memory strategies
-    ) internal {
+    function check_Withdrawal_AsShares_Redelegated_State(User staker, IStrategy[] memory strategies) internal {
         assert_Snap_DSF_State_WithdrawalAsShares(staker, strategies, "staker's DSF not updated correctly");
     }
 
@@ -988,9 +985,9 @@ contract IntegrationCheckUtils is IntegrationBase {
     /// where the input `params` represent a decrease in magnitude
     function check_Base_DecrAlloc_State(User operator, AllocateParams memory params) internal {
         check_MaxMag_Invariants(operator);
-        
+
         OperatorSet memory operatorSet = params.operatorSet;
-        
+
         // Decreasing Allocation should NOT change operator set registration, max magnitude
         assert_Snap_Unchanged_Registration(operator, operatorSet, "operator registration status should be unchanged");
         assert_Snap_Unchanged_Slashability(operator, operatorSet, "operator slashability should be unchanged");

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -300,11 +300,11 @@ contract IntegrationCheckUtils is IntegrationBase {
         );
         uint[] memory delegatableShares = _getPrevStakerWithdrawableShares(staker, strategies);
         assert_Snap_Added_OperatorShares(operator, strategies, delegatableShares, "operator should have received shares");
-        check_Added_SlashableStake(operator, strategies, delegatableShares);
-        assert_Snap_DSF_State_Delegation(staker, operator, strategies, delegatableShares, "staker's DSF not updated correctly");
+        check_Added_SlashableStake(operator, strategies);
+        assert_Snap_DSF_State_Delegation(staker, strategies, delegatableShares, "staker's DSF not updated correctly");
     }
 
-    function check_Added_SlashableStake(User operator, IStrategy[] memory strategies, uint[] memory shares) internal {
+    function check_Added_SlashableStake(User operator, IStrategy[] memory strategies) internal {
         for (uint i = 0; i < strategies.length; i++) {
             (OperatorSet[] memory operatorSets, Allocation[] memory allocations) = _getStrategyAllocations(operator, strategies[i]);
             for (uint j = 0; j < operatorSets.length; j++) {
@@ -609,11 +609,7 @@ contract IntegrationCheckUtils is IntegrationBase {
 
     function check_Withdrawal_AsShares_Redelegated_State(
         User staker,
-        User operator,
-        User newOperator,
-        Withdrawal memory withdrawal,
-        IStrategy[] memory strategies,
-        uint[] memory withdrawableShares
+        IStrategy[] memory strategies
     ) internal {
         assert_Snap_DSF_State_WithdrawalAsShares(staker, strategies, "staker's DSF not updated correctly");
     }
@@ -842,7 +838,6 @@ contract IntegrationCheckUtils is IntegrationBase {
 
         OperatorSet memory operatorSet = params.operatorSet;
         IStrategy[] memory strategies = params.strategies;
-        uint64[] memory newMagnitudes = params.newMagnitudes;
 
         // Increasing Allocation should NOT change operator set registration, max magnitude
         assert_Snap_Unchanged_Registration(operator, operatorSet, "operator registration status should be unchanged");
@@ -993,11 +988,9 @@ contract IntegrationCheckUtils is IntegrationBase {
     /// where the input `params` represent a decrease in magnitude
     function check_Base_DecrAlloc_State(User operator, AllocateParams memory params) internal {
         check_MaxMag_Invariants(operator);
-
+        
         OperatorSet memory operatorSet = params.operatorSet;
-        IStrategy[] memory strategies = params.strategies;
-        uint64[] memory newMagnitudes = params.newMagnitudes;
-
+        
         // Decreasing Allocation should NOT change operator set registration, max magnitude
         assert_Snap_Unchanged_Registration(operator, operatorSet, "operator registration status should be unchanged");
         assert_Snap_Unchanged_Slashability(operator, operatorSet, "operator slashability should be unchanged");

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -214,7 +214,7 @@ contract Integration_DualSlashing_AVSFirst is Integration_DualSlashing_Base {
         uint ethToDeposit = 32 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success,) = address(staker.pod()).call{value: ethToDeposit}("");
         require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 
@@ -243,7 +243,7 @@ contract Integration_DualSlashing_AVSFirst is Integration_DualSlashing_Base {
         uint ethToDeposit = 32 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success,) = address(staker.pod()).call{value: ethToDeposit}("");
         require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 
@@ -369,7 +369,7 @@ contract Integration_DualSlashing_FullSlashes is Integration_DualSlashing_Base {
         uint ethToDeposit = 1000 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success,) = address(staker.pod()).call{value: ethToDeposit}("");
         require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 

--- a/src/test/integration/tests/DualSlashing.t.sol
+++ b/src/test/integration/tests/DualSlashing.t.sol
@@ -214,7 +214,8 @@ contract Integration_DualSlashing_AVSFirst is Integration_DualSlashing_Base {
         uint ethToDeposit = 32 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 
         // 9. Checkpoint
@@ -242,7 +243,8 @@ contract Integration_DualSlashing_AVSFirst is Integration_DualSlashing_Base {
         uint ethToDeposit = 32 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 
         // 10. Checkpoint. This should immediately complete as there are no more active validators
@@ -367,7 +369,8 @@ contract Integration_DualSlashing_FullSlashes is Integration_DualSlashing_Base {
         uint ethToDeposit = 1000 ether;
         cheats.deal(address(staker), ethToDeposit);
         cheats.prank(address(staker));
-        address(staker.pod()).call{value: ethToDeposit}("");
+        (bool success, ) = address(staker.pod()).call{value: ethToDeposit}("");
+        require(success, "pod call failed");
         uint64 ethDepositedGwei = uint64(ethToDeposit / GWEI_TO_WEI);
 
         // 9. Checkpoint. This should revert as the slashing factor is 0

--- a/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
+++ b/src/test/integration/tests/HighDSF_Multiple_Deposits.t.sol
@@ -44,7 +44,7 @@ contract Integration_HighDSF_Multiple_Deposits is IntegrationCheckUtils {
         _rollBlocksForCompleteAllocation(operator, operatorSet, strategies);
 
         // 3. slash operator to 1 magnitude remaining
-        SlashingParams memory slashParams = _genSlashing_Custom(operator, operatorSet, WAD - 1);
+        slashParams = _genSlashing_Custom(operator, operatorSet, WAD - 1);
         avs.slashOperator(slashParams);
         check_Base_Slashing_State(operator, allocateParams, slashParams);
 

--- a/src/test/integration/tests/Slashed_Eigenpod_AVS.t.sol
+++ b/src/test/integration/tests/Slashed_Eigenpod_AVS.t.sol
@@ -162,8 +162,6 @@ contract Integration_SlashedEigenpod_AVS_Withdraw is Integration_SlashedEigenpod
     function testFuzz_deposit_delegate_allocate_slashAndQueue_checkPoint_completeAsShares(uint24 _rand) public rand(_rand) {
         Withdrawal[] memory withdrawals = _getQueuedWithdrawals(staker);
         _rollBlocksForCompleteWithdrawals(withdrawals);
-        uint slashingFactor = _getSlashingFactor(staker, BEACONCHAIN_ETH_STRAT);
-        uint depositScalingFactor = _getDepositScalingFactor(staker, BEACONCHAIN_ETH_STRAT);
         uint[] memory withdrawableShares = _calcWithdrawable(staker, strategies, initDepositShares);
 
         // 9.  Start & complete checkpoint, since the next step does not.

--- a/src/test/integration/tests/SlashingWithdrawals.t.sol
+++ b/src/test/integration/tests/SlashingWithdrawals.t.sol
@@ -226,7 +226,7 @@ contract Integration_SlashThenWithdraw is Integration_ALMSlashBase {
         // Complete withdrawal as shares
         staker.completeWithdrawalsAsShares(withdrawals);
         for (uint i = 0; i < withdrawals.length; i++) {
-            check_Withdrawal_AsShares_Redelegated_State(staker, operator, operatorB, withdrawals[i], strategies, shares);
+            check_Withdrawal_AsShares_Redelegated_State(staker, strategies);
         }
     }
 

--- a/src/test/integration/tests/eigenpod/FullySlashed_EigenPod.t.sol
+++ b/src/test/integration/tests/eigenpod/FullySlashed_EigenPod.t.sol
@@ -160,7 +160,7 @@ contract Integration_FullySlashedEigenpod_NotCheckpointed is Integration_FullySl
 
         // Send ETH to pod
         cheats.prank(address(staker));
-        (bool success, ) = address(staker.pod()).call{value: amountToDeal}("");
+        (bool success,) = address(staker.pod()).call{value: amountToDeal}("");
         require(success, "pod call failed");
 
         // Checkpoint slashed EigenPod

--- a/src/test/integration/tests/eigenpod/FullySlashed_EigenPod.t.sol
+++ b/src/test/integration/tests/eigenpod/FullySlashed_EigenPod.t.sol
@@ -160,7 +160,8 @@ contract Integration_FullySlashedEigenpod_NotCheckpointed is Integration_FullySl
 
         // Send ETH to pod
         cheats.prank(address(staker));
-        address(staker.pod()).call{value: amountToDeal}("");
+        (bool success, ) = address(staker.pod()).call{value: amountToDeal}("");
+        require(success, "pod call failed");
 
         // Checkpoint slashed EigenPod
         staker.startCheckpoint();

--- a/src/test/integration/tests/eigenpod/Slashed_Eigenpod_BC.t.sol
+++ b/src/test/integration/tests/eigenpod/Slashed_Eigenpod_BC.t.sol
@@ -204,9 +204,7 @@ contract Integration_SlashedEigenpod_BC is IntegrationCheckUtils {
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; ++i) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_Redelegated_State(
-                staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, delegatedShares
-            );
+            check_Withdrawal_AsShares_Redelegated_State(staker, strategies);
         }
 
         (uint[] memory withdrawableSharesAfter, uint[] memory depositSharesAfter) =
@@ -521,9 +519,7 @@ contract Integration_SlashedOperator_SlashedEigenpod is Integration_SlashedOpera
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; ++i) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_Redelegated_State(
-                staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares
-            );
+            check_Withdrawal_AsShares_Redelegated_State(staker, strategies);
         }
     }
 }
@@ -626,13 +622,10 @@ contract Integration_Redelegate_SlashOperator_SlashEigenpod is Integration_Slash
         withdrawals[0] = withdrawal;
 
         // 11. Complete withdrawal as shares
-        uint[] memory stakerWithdrawableShares = _getWithdrawableSharesAfterCompletion(staker);
         _rollBlocksForCompleteWithdrawals(withdrawals);
         for (uint i = 0; i < withdrawals.length; ++i) {
             staker.completeWithdrawalAsShares(withdrawals[i]);
-            check_Withdrawal_AsShares_Redelegated_State(
-                staker, operator, operator2, withdrawals[i], withdrawals[i].strategies, stakerWithdrawableShares
-            );
+            check_Withdrawal_AsShares_Redelegated_State(staker, strategies);
         }
 
         // 12. Verify additional validator

--- a/src/test/integration/tests/upgrade/Complete_PreSlashing_Withdrawal.t.sol
+++ b/src/test/integration/tests/upgrade/Complete_PreSlashing_Withdrawal.t.sol
@@ -17,7 +17,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Base is UpgradeTest
         bool completeAsTokens;
     }
 
-    function _init_(uint24 randomness, bool withOperator, bool withDelegation) internal virtual returns (TestState memory state) {
+    function _init_(bool withOperator, bool withDelegation) internal virtual returns (TestState memory state) {
         // Create staker
         (state.staker, state.strategies, state.tokenBalances) = _newRandomStaker();
         state.shares = _calculateExpectedShares(state.strategies, state.tokenBalances);
@@ -65,7 +65,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Base is UpgradeTest
 
 contract Integration_Upgrade_Complete_PreSlashing_Withdrawal is Integration_Upgrade_Complete_PreSlashing_Withdrawal_Base {
     function testFuzz_deposit_queue_upgrade_complete(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: false, withDelegation: false});
+        TestState memory state = _init_({withOperator: false, withDelegation: false});
         state.withdrawals = state.staker.queueWithdrawals(state.strategies, state.withdrawalShares);
         _upgradeEigenLayerContracts();
         _rollBlocksForCompleteWithdrawals(state.withdrawals);
@@ -73,7 +73,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal is Integration_Upgr
     }
 
     function testFuzz_delegate_deposit_queue_upgrade_complete(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
         state.withdrawals = state.staker.queueWithdrawals(state.strategies, state.withdrawalShares);
         _upgradeEigenLayerContracts();
         _rollBlocksForCompleteWithdrawals(state.withdrawals);
@@ -81,7 +81,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal is Integration_Upgr
     }
 
     function testFuzz_upgrade_delegate_queuePartial_complete(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: false});
+        TestState memory state = _init_({withOperator: true, withDelegation: false});
         _upgradeEigenLayerContracts();
         state.staker.delegateTo(state.operator);
         state.withdrawals = state.staker.queueWithdrawals(state.strategies, state.withdrawalShares);
@@ -90,7 +90,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal is Integration_Upgr
     }
 
     function testFuzz_delegate_deposit_queue_completeBeforeUpgrade(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
         state.withdrawals = state.staker.queueWithdrawals(state.strategies, state.withdrawalShares);
         _rollBlocksForCompleteWithdrawals(state.withdrawals);
         // We must roll forward by the delay twice since pre-upgrade delay is half as long as post-upgrade delay.
@@ -107,9 +107,9 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Slash is Integratio
     OperatorSet operatorSet;
     AllocateParams allocateParams;
 
-    function _init_(uint24 randomness, bool withOperator, bool withDelegation) internal override returns (TestState memory state) {
+    function _init_(bool withOperator, bool withDelegation) internal override returns (TestState memory state) {
         // Initialize state, queue a full withdrawal
-        state = super._init_({randomness: randomness, withOperator: withOperator, withDelegation: withDelegation});
+        state = super._init_({withOperator: withOperator, withDelegation: withDelegation});
 
         state.withdrawals = state.staker.queueWithdrawals(state.strategies, state.withdrawalShares);
 
@@ -132,7 +132,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Slash is Integratio
     }
 
     function testFuzz_delegate_deposit_queue_upgrade_slashFully_revertCompleteAsShares(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
 
         // Slash operator by AVS
         SlashingParams memory slashParams = _genSlashing_Full(state.operator, operatorSet);
@@ -147,7 +147,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Slash is Integratio
     }
 
     function testFuzz_delegate_deposit_queue_upgrade_slashFully_completeAsTokens(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
 
         // Slash operator by AVS
         SlashingParams memory slashParams = _genSlashing_Full(state.operator, operatorSet);
@@ -161,7 +161,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Slash is Integratio
     }
 
     function testFuzz_delegate_deposit_queue_upgrade_slash_completeAsShares(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
 
         // Slash operator by AVS
         SlashingParams memory slashParams = _genSlashing_Rand(state.operator, operatorSet);
@@ -176,7 +176,7 @@ contract Integration_Upgrade_Complete_PreSlashing_Withdrawal_Slash is Integratio
     }
 
     function testFuzz_delegate_deposit_queue_upgrade_slash_completeAsTokens(uint24 r) public rand(r) {
-        TestState memory state = _init_({randomness: r, withOperator: true, withDelegation: true});
+        TestState memory state = _init_({withOperator: true, withDelegation: true});
 
         // Slash operator by AVS
         SlashingParams memory slashParams = _genSlashing_Rand(state.operator, operatorSet);

--- a/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
+++ b/src/test/integration/tests/upgrade/Delegate_Upgrade_Allocate.t.sol
@@ -14,7 +14,7 @@ contract Integration_Upgrade_Deposit_Delegate_Allocate is UpgradeTest {
         AllocateParams allocateParams;
     }
 
-    function _init_(uint24 randomness) internal returns (TestState memory state) {
+    function _init_() internal returns (TestState memory state) {
         (state.staker, state.strategies, state.tokenBalances) = _newRandomStaker();
         (state.operator,,) = _newRandomOperator();
 
@@ -46,7 +46,7 @@ contract Integration_Upgrade_Deposit_Delegate_Allocate is UpgradeTest {
     }
 
     function testFuzz_deposit_delegate_upgrade_allocate(uint24 r) public rand(r) {
-        TestState memory state = _init_(r);
+        TestState memory state = _init_();
         _upgradeEigenLayerContracts();
         (state.avs,) = _newRandomAVS();
         _setupAllocation(state);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3968,7 +3968,7 @@ contract AllocationManagerUnitTests_isOperatorSlashable is AllocationManagerUnit
     using SlashingLib for *;
     using ArrayLib for *;
 
-    function test_registeredOperator() public {
+    function test_registeredOperator() public view {
         assertEq(
             allocationManager.isOperatorSlashable(defaultOperator, defaultOperatorSet), true, "registered operator should be slashable"
         );

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -7634,7 +7634,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
 
         // Alice queues withdrawal of all 100 shares while operator magnitude is 0.5
         // This means she should get back 50 shares (100 * 0.5)
-        (QueuedWithdrawalParams[] memory queuedWithdrawalParams, Withdrawal memory withdrawal, bytes32 withdrawalRoot) =
+        (QueuedWithdrawalParams[] memory queuedWithdrawalParams,, bytes32 withdrawalRoot) =
             _setUpQueueWithdrawalsSingleStrat({staker: defaultStaker, strategy: strategyMock, depositSharesToWithdraw: depositAmount});
 
         cheats.prank(defaultStaker);
@@ -7666,7 +7666,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         // Queue withdrawal
-        (QueuedWithdrawalParams[] memory queuedWithdrawalParams, Withdrawal memory withdrawal, bytes32 withdrawalRoot) =
+        (QueuedWithdrawalParams[] memory queuedWithdrawalParams,, bytes32 withdrawalRoot) =
             _setUpQueueWithdrawalsSingleStrat({staker: defaultStaker, strategy: strategyMock, depositSharesToWithdraw: depositAmount});
 
         cheats.prank(defaultStaker);
@@ -7690,7 +7690,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         // Queue withdrawal
-        (QueuedWithdrawalParams[] memory queuedWithdrawalParams, Withdrawal memory withdrawal, bytes32 withdrawalRoot) =
+        (QueuedWithdrawalParams[] memory queuedWithdrawalParams,, bytes32 withdrawalRoot) =
             _setUpQueueWithdrawalsSingleStrat({staker: defaultStaker, strategy: strategyMock, depositSharesToWithdraw: depositAmount});
 
         cheats.prank(defaultStaker);
@@ -7709,7 +7709,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         assertEq(shares[0], depositAmount / 2, "shares not properly slashed");
     }
 
-    function test_getQueuedWithdrawal_NonexistentWithdrawal() public {
+    function test_getQueuedWithdrawal_NonexistentWithdrawal() public view {
         bytes32 nonexistentRoot = bytes32(uint(1));
         (, uint[] memory shares) = delegationManager.getQueuedWithdrawal(nonexistentRoot);
         assertEq(shares.length, 0, "shares array should be empty");
@@ -7727,7 +7727,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         _delegateToOperatorWhoAcceptsAllStakers(defaultStaker, defaultOperator);
 
         // Queue withdrawals for multiple strategies
-        (QueuedWithdrawalParams[] memory queuedWithdrawalParams, Withdrawal memory withdrawal, bytes32 withdrawalRoot) =
+        (QueuedWithdrawalParams[] memory queuedWithdrawalParams,, bytes32 withdrawalRoot) =
             _setUpQueueWithdrawals({staker: defaultStaker, strategies: strategies, depositWithdrawalAmounts: depositShares});
 
         cheats.prank(defaultStaker);
@@ -7743,7 +7743,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         }
     }
 
-    function testFuzz_getQueuedWithdrawal_EmptyWithdrawal(bytes32 withdrawalRoot) public {
+    function testFuzz_getQueuedWithdrawal_EmptyWithdrawal(bytes32 withdrawalRoot) public view {
         (, uint[] memory shares) = delegationManager.getQueuedWithdrawal(withdrawalRoot);
         assertEq(shares.length, 0, "sanity check");
     }

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -1455,7 +1455,7 @@ contract StrategyManagerUnitTests_burnShares is StrategyManagerUnitTests {
         assertEq(burnAddressBalanceAfter, burnAddressBalanceBefore + sharesToBurn, "balanceAfter != balanceBefore + sharesAmount");
 
         // Verify strategy was removed from burnable shares
-        (address[] memory strategiesAfterBurn, uint[] memory sharesAfterBurn) = strategyManager.getStrategiesWithBurnableShares();
+        (address[] memory strategiesAfterBurn, ) = strategyManager.getStrategiesWithBurnableShares();
         assertEq(strategiesAfterBurn.length, 0, "Should have no strategies after burning");
         assertEq(strategyManager.getBurnableShares(strategy), 0, "getBurnableShares should return 0 after burning");
     }
@@ -1649,7 +1649,7 @@ contract StrategyManagerUnitTests_removeStrategiesFromDepositWhitelist is Strate
 }
 
 contract StrategyManagerUnitTests_getStrategiesWithBurnableShares is StrategyManagerUnitTests {
-    function test_getStrategiesWithBurnableShares_Empty() public {
+    function test_getStrategiesWithBurnableShares_Empty() public view {
         (address[] memory strategies, uint[] memory shares) = strategyManager.getStrategiesWithBurnableShares();
         assertEq(strategies.length, 0, "Should have no strategies when empty");
         assertEq(shares.length, 0, "Should have no shares when empty");

--- a/src/test/unit/StrategyManagerUnit.t.sol
+++ b/src/test/unit/StrategyManagerUnit.t.sol
@@ -1455,7 +1455,7 @@ contract StrategyManagerUnitTests_burnShares is StrategyManagerUnitTests {
         assertEq(burnAddressBalanceAfter, burnAddressBalanceBefore + sharesToBurn, "balanceAfter != balanceBefore + sharesAmount");
 
         // Verify strategy was removed from burnable shares
-        (address[] memory strategiesAfterBurn, ) = strategyManager.getStrategiesWithBurnableShares();
+        (address[] memory strategiesAfterBurn,) = strategyManager.getStrategiesWithBurnableShares();
         assertEq(strategiesAfterBurn.length, 0, "Should have no strategies after burning");
         assertEq(strategyManager.getBurnableShares(strategy), 0, "getBurnableShares should return 0 after burning");
     }

--- a/src/test/unit/mixins/SignatureUtilsUnit.t.sol
+++ b/src/test/unit/mixins/SignatureUtilsUnit.t.sol
@@ -43,7 +43,7 @@ contract SignatureUtilsMixinUnit is Test, SignatureUtilsMixin("v0.0.0") {
         );
     }
 
-    function test_domainSeparator_NonZero() public {
+    function test_domainSeparator_NonZero() public view {
         assertTrue(domainSeparator() != 0, "The domain separator should be non-zero");
         assertTrue(domainSeparator() == expectedDomainSeparator, "The domain separator should be as expected");
     }


### PR DESCRIPTION
**Motivation:**  

Fixing compile warnings across the repo to improve code clarity and maintainability.  

**Modifications:**  

- Resolved various Solidity compile warnings.    

**Result:**  

- No more compile warnings.  
- Cleaner and more maintainable code.