### PR TITLE
docs: update `effectBlock` on allocation delay; add undelegate dual slash edge case

### DIFF
--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -796,7 +796,7 @@ The allocation delay's primary purpose is to give stakers delegated to an operat
 
 *Effects*:
 * Sets the operator's `pendingDelay` to the proposed `delay`, and save the `effectBlock` at which the `pendingDelay` can be activated
-    * `effectBlock = uint32(block.number) + ALLOCATION_CONFIGURATION_DELAY`
+    * `effectBlock = uint32(block.number) + ALLOCATION_CONFIGURATION_DELAY + 1`
 * If the operator has a `pendingDelay`, and if the `effectBlock` has passed, sets the operator's `delay` to the `pendingDelay` value
     * This also sets the `isSet` boolean to `true` to indicate that the operator's `delay`, even if 0, was set intentionally
 * Emits an `AllocationDelaySet` event

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -44,10 +44,9 @@ In the above scenario, let's say the Alice now proves a checkpoint.
 
 The checkpoint slash has devalued Alice's currently withdrawable assets by 50%. The AVS slashes from what's left due to the BC getting priority burning rights. Thus, AVSs must factor Native ETH (or an LST) being slashed by the beacon chain when designing their slashing conditions. The below diagram illustrates this behavior:
 
-<figure>
-    <img src="../../images/avs-bc-slash.png" alt="AVS and Beacon Chain Slashing Behavior">
-    <figcaption>Diagram showing how AVS slashing is applied after Beacon Chain slashing, with BC having priority burning rights</figcaption>
-</figure>
+| ![AVS and Beacon Chain Slashing Behavior](../../images/avs-bc-slash.png) |
+|:--:|
+| *Diagram showing how AVS slashing is applied after Beacon Chain slashing, with BC having priority burning rights* |
 
 Note that the portion that is marked as BC Slash and BC + AVS Slash has priority burning rights by the beacon chain. 12 ETH has been slashed "twice", but this is by design given our definition of restaking.
 

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -115,3 +115,24 @@ Scenario B:
 In scenario B, 50% of Alice’s currently proven assets are slashed, along with a commensurate decrease in the AVSs attributable slashed amount. In both cases Alice’s withdrawable shares and the AVSs attributable slashed amount decrease by the same percentage.
 
 We acknowledge this edge case. A benefit of this system is that stakers are incentivized to immediately prove BC slashed. Eigen Labs runs an off-chain process (EigenPod Health Checker) that monitors BC slashings and starts checkpoints as needed. Conversely, when Native-ETH burning is implemented, AVSs are incentivized to immediately exit stakers from the BC to recoup the maximum possible attributable slashed amount.  
+
+This edge case also applies if Alice undelegates after being slashed on the beacon chain, and then continues along with Scenario A, exiting her position fully. See below for details:
+<details>
+<summary>Scenario</summary>
+
+1. Alice verifies a validator: `withdrawble: 32 ETH`
+2. Alice's operator is slashed for 100%. `withdrawble: 0 ETH` 
+3. Alice is slashed by 16 ETH on the beacon chain. 
+4. Alice undelegates. `depositShares = 0` 
+5. Alice verifies another validator. `withdrawble: 32 ETH`. `depositShares: 32 ETH` 
+6. Alice checkpoints her slash from step 3. `withdrawble: 24 ETH`
+    - `restakedExecutionLayerGwei = 16`. This is the AVSs attributable slashed amount, but it increases once Alice completely exits. 
+    - BCSF: 48/64 = 0.75
+7. Alice completes her withdrawal as shares from undelegaiton. No affect sicne the operator's magnitude was 0
+8. Alice exits her validator from step 5. `withdrawble: 24 ETH`
+    - `restakedExecutionLayerGwei = 48` 
+9. Alice queues a withdrawal for all shares. `scaledShares = 32` 
+10. Alice completes her withdrawal. Alice receives 24 ETH
+    - `scaledShares * slashingFacotr = 32 * 0.75 = 24` 
+11. There is 24 ETH locked up in the pod. 
+</details>

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -12,7 +12,7 @@ This document describes edge cases surrounding the slashing of a staker for nati
 
 Consider a staker, Alice who is in the following state:
 
-1. Alice has verified a validator. `withdrawble: 32 ETH`
+1. Alice has verified a validator. `withdrawable: 32 ETH`
 2. Alice's operator is slashed for 75%. `withdrawable: 8 ETH`
     <details>
     <summary>Calculation</summary>
@@ -119,19 +119,19 @@ This edge case also applies if Alice undelegates after being slashed on the beac
 <details>
 <summary>Scenario</summary>
 
-1. Alice verifies a validator: `withdrawble: 32 ETH`
-2. Alice's operator is slashed for 100%. `withdrawble: 0 ETH` 
+1. Alice verifies a validator: `withdrawable: 32 ETH`
+2. Alice's operator is slashed for 100%. `withdrawable: 0 ETH` 
 3. Alice is slashed by 16 ETH on the beacon chain. 
 4. Alice undelegates. `depositShares = 0` 
-5. Alice verifies another validator. `withdrawble: 32 ETH`. `depositShares: 32 ETH` 
-6. Alice checkpoints her slash from step 3. `withdrawble: 24 ETH`
+5. Alice verifies another validator. `withdrawable: 32 ETH`. `depositShares: 32 ETH` 
+6. Alice checkpoints her slash from step 3. `withdrawable: 24 ETH`
     - `restakedExecutionLayerGwei = 16`. This is the AVSs attributable slashed amount, but it increases once Alice completely exits. 
-    - BCSF: 48/64 = 0.75
+    - `BCSF= 48/64 = 0.75`
 7. Alice completes her withdrawal as shares from undelegaiton. No affect since the operator's magnitude was 0
-8. Alice exits her validator from step 5. `withdrawble: 24 ETH`
+8. Alice exits her validator from step 5. `withdrawable: 24 ETH`
     - `restakedExecutionLayerGwei = 48` 
 9. Alice queues a withdrawal for all shares. `scaledShares = 32` 
 10. Alice completes her withdrawal. Alice receives 24 ETH
-    - `scaledShares * slashingFacotr = 32 * 0.75 = 24` 
+    - `scaledShares * slashingFactor = 32 * 0.75 = 24` 
 11. There is 24 ETH locked up in the pod. 
 </details>

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -127,7 +127,7 @@ This edge case also applies if Alice undelegates after being slashed on the beac
 6. Alice checkpoints her slash from step 3. `withdrawable: 24 ETH`
     - `restakedExecutionLayerGwei = 16`. This is the AVSs attributable slashed amount, but it increases once Alice completely exits. 
     - `BCSF= 48/64 = 0.75`
-7. Alice completes her withdrawal as shares from undelegaiton. No affect since the operator's magnitude was 0
+7. Alice completes her withdrawal as shares from undelegation. No affect since the operator's magnitude was 0
 8. Alice exits her validator from step 5. `withdrawable: 24 ETH`
     - `restakedExecutionLayerGwei = 48` 
 9. Alice queues a withdrawal for all shares. `scaledShares = 32` 

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -127,7 +127,7 @@ This edge case also applies if Alice undelegates after being slashed on the beac
 6. Alice checkpoints her slash from step 3. `withdrawble: 24 ETH`
     - `restakedExecutionLayerGwei = 16`. This is the AVSs attributable slashed amount, but it increases once Alice completely exits. 
     - BCSF: 48/64 = 0.75
-7. Alice completes her withdrawal as shares from undelegaiton. No affect sicne the operator's magnitude was 0
+7. Alice completes her withdrawal as shares from undelegaiton. No affect since the operator's magnitude was 0
 8. Alice exits her validator from step 5. `withdrawble: 24 ETH`
     - `restakedExecutionLayerGwei = 48` 
 9. Alice queues a withdrawal for all shares. `scaledShares = 32` 

--- a/docs/core/accounting/SlashingEdgeCase.md
+++ b/docs/core/accounting/SlashingEdgeCase.md
@@ -45,8 +45,8 @@ In the above scenario, let's say the Alice now proves a checkpoint.
 The checkpoint slash has devalued Alice's currently withdrawable assets by 50%. The AVS slashes from what's left due to the BC getting priority burning rights. Thus, AVSs must factor Native ETH (or an LST) being slashed by the beacon chain when designing their slashing conditions. The below diagram illustrates this behavior:
 
 <figure>
-<img src="../../images/avs-bc-slash.png" alt="AVS and Beacon Chain Slashing Behavior">
-<figcaption>Diagram showing how AVS slashing is applied after Beacon Chain slashing, with BC having priority burning rights</figcaption>
+    <img src="../../images/avs-bc-slash.png" alt="AVS and Beacon Chain Slashing Behavior">
+    <figcaption>Diagram showing how AVS slashing is applied after Beacon Chain slashing, with BC having priority burning rights</figcaption>
 </figure>
 
 Note that the portion that is marked as BC Slash and BC + AVS Slash has priority burning rights by the beacon chain. 12 ETH has been slashed "twice", but this is by design given our definition of restaking.
@@ -85,7 +85,7 @@ Scenario A:
     * `withdrawable = 64 * 0.25 * 0.75 * 2.5 = 30 ETH`
     </details>
 
-In this scenario, 25% of Alice’s currently proven assets are slashed. Similarly, the AVSs attributable slashed amount has been decreased by 25% (24 → 18 ETH). 
+In this scenario, 25% of Alice's currently proven assets are slashed. Similarly, the AVSs attributable slashed amount has been decreased by 25% (24 → 18 ETH). 
 
 
 Scenario B:
@@ -112,7 +112,7 @@ Scenario B:
     * `withdrawable = 64 * 0.25 * 0.5 * 4.5 = 36 ETH`
     </details>
 
-In scenario B, 50% of Alice’s currently proven assets are slashed, along with a commensurate decrease in the AVSs attributable slashed amount. In both cases Alice’s withdrawable shares and the AVSs attributable slashed amount decrease by the same percentage.
+In scenario B, 50% of Alice's currently proven assets are slashed, along with a commensurate decrease in the AVSs attributable slashed amount. In both cases Alice's withdrawable shares and the AVSs attributable slashed amount decrease by the same percentage.
 
 We acknowledge this edge case. A benefit of this system is that stakers are incentivized to immediately prove BC slashed. Eigen Labs runs an off-chain process (EigenPod Health Checker) that monitors BC slashings and starts checkpoints as needed. Conversely, when Native-ETH burning is implemented, AVSs are incentivized to immediately exit stakers from the BC to recoup the maximum possible attributable slashed amount.  
 


### PR DESCRIPTION
**Motivation:**

We need to properly document when the new allocation delay is active and when undelegate dual slash edge case

**Modifications:**

- Updated `AllocationManager.md` for + 1 on `effectBlock` for `setAllocationDelay`
- Updated `SlashingEdgeCase` with undelegate applied to `Ordering of EigenPod Actions`

**Result:**

More comprehensive docs. 
