### PR TITLE
Fix Typo in Documentation and Correct Variable Naming Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ EigenLayer is a set of smart contracts deployed on Ethereum that enable restakin
 The main branches we use are:
 * [`dev (default)`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/dev): The most up-to-date branch, containing the work-in-progress code for upcoming releases
 * [`testnet-holesky`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/testnet-holesky): Our current testnet deployment
-* [`mainnet`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/mainnet): Our current mainnet deloyment
+* [`mainnet`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/mainnet): Our current mainnet deployment
 
 ## Documentation
 

--- a/certora/specs/core/AllocationManagerRules.spec
+++ b/certora/specs/core/AllocationManagerRules.spec
@@ -9,7 +9,7 @@ use invariant negativePendingDiffAtMostCurrentMagnitude;
 use invariant deallocationQueueDataUniqueness;
 use invariant noZeroKeyInDealocationQ;
 use invariant deallocationQueueEffectBlocLessThanCurrBlockNumberPlushDelayPlusOne;
-use invariant deallocationQueueEffectBlockAscesndingOrder;
+use invariant deallocationQueueEffectBlockAscendingOrder;
 use invariant noPositivePendingDiffInDeallocationQ;
 use invariant effectBlockZeroHasNoPendingDiff;
 


### PR DESCRIPTION
1. Fixing Typo in Documentation
Change:
Before:
* [`mainnet`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/mainnet): Our current mainnet deloyment
After:
* [`mainnet`](https://github.com/Layr-Labs/eigenlayer-contracts/tree/mainnet): Our current mainnet deployment
Reason for Change:
The word "deloyment" was a typo. The correct spelling is "deployment".
Ensuring proper spelling enhances readability and maintains a professional presentation of the documentation.
2. Correcting Variable Naming Consistency in Code
Change:
Before:
use invariant deallocationQueueEffectBlockAscesndingOrder;
After:
use invariant deallocationQueueEffectBlockAscendingOrder;
Reason for Change:
The word "Ascesnding" was incorrectly spelled.
The correct spelling is "Ascending", ensuring consistency with standard English spelling and improving code readability.
This change also maintains uniformity with other variable and function naming conventions within the codebase.
