### PR TITLE
Chore: Remove `solc` key from confs

### DIFF
--- a/.github/workflows/certora-prover.yml
+++ b/.github/workflows/certora-prover.yml
@@ -70,7 +70,7 @@ jobs:
             certora/confs/strategies/StrategyBase.conf
           use-beta: true
           solc-versions: 0.8.27
-          solc-remove-version-prefix: "0."
+          solc-remove-version-prefix: "0.8.27"
           job-name: "Eigenlayer Contracts"
           certora-key: ${{ secrets.CERTORAKEY }}
           # Only compile, don't run verification yet
@@ -126,7 +126,7 @@ jobs:
             certora/confs/strategies/StrategyBase.conf
           use-beta: true
           solc-versions: 0.8.27
-          solc-remove-version-prefix: "0."
+          solc-remove-version-prefix: "0.8.27"
           job-name: "Eigenlayer Contracts"
           certora-key: ${{ secrets.CERTORAKEY }}
         env:

--- a/certora/.bin/verify.sh
+++ b/certora/.bin/verify.sh
@@ -24,7 +24,7 @@ module=$(basename $scriptDir)
 projectBase=$scriptDir/../../..
 confDir=$projectBase/certora/confs/$module
 
-devFlags=""
+devFlags="--solc solc"
 certoraRun="certoraRun"
 
 while [ $# -gt 0 ]; do

--- a/certora/confs/core/AllocationManager.conf
+++ b/certora/confs/core/AllocationManager.conf
@@ -38,7 +38,6 @@
     "prover_args": [
         " -recursionErrorAsAssert false -recursionEntryLimit 3"
     ],
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "verify": "AllocationManager:certora/specs/core/AllocationManagerRules.spec",
     "server": "production",

--- a/certora/confs/core/AllocationManagerSanity.conf
+++ b/certora/confs/core/AllocationManagerSanity.conf
@@ -38,7 +38,6 @@
     "prover_args": [
         " -recursionErrorAsAssert false -recursionEntryLimit 3"
     ],
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "AllocationManager:certora/specs/core/AllocationManagerSanity.spec"

--- a/certora/confs/core/DelegationManager.conf
+++ b/certora/confs/core/DelegationManager.conf
@@ -43,7 +43,6 @@
     ],
     "rule_sanity": "basic",
     "process": "emv",
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "DelegationManagerHarness:certora/specs/core/DelegationManager.spec"

--- a/certora/confs/core/DelegationManagerValidState.conf
+++ b/certora/confs/core/DelegationManagerValidState.conf
@@ -36,7 +36,6 @@
     ],
    "rule_sanity": "basic",
     "process": "emv",
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "DelegationManagerHarness:certora/specs/core/DelegationManagerValidState.spec"

--- a/certora/confs/core/StrategyManager.conf
+++ b/certora/confs/core/StrategyManager.conf
@@ -29,7 +29,6 @@
         "StrategyManagerHarness"
     ],
     "process": "emv",
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "StrategyManagerHarness:certora/specs/core/StrategyManager.spec",

--- a/certora/confs/permissions/Pausable.conf
+++ b/certora/confs/permissions/Pausable.conf
@@ -13,7 +13,6 @@
     "prover_args": [
         " -recursionErrorAsAssert false -recursionEntryLimit 3"
     ],
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "PausableHarness:certora/specs/permissions/Pausable.spec"

--- a/certora/confs/pods/EigenPodManagerRules.conf
+++ b/certora/confs/pods/EigenPodManagerRules.conf
@@ -48,7 +48,6 @@
     "prover_args": [
         " -recursionErrorAsAssert false -recursionEntryLimit 3"
     ],
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "EigenPodManager:certora/specs/pods/EigenPodManagerRules.spec",

--- a/certora/confs/strategies/StrategyBase.conf
+++ b/certora/confs/strategies/StrategyBase.conf
@@ -21,7 +21,6 @@
     "process": "emv",
     "prover_args": [
     ],
-    "solc": "solc8.27",
     "solc_optimize": "1",
     "solc_via_ir": true,
     "verify": "StrategyBase:certora/specs/strategies/StrategyBase.spec"


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**

Currently in order to run certora verification scripts locally (not through CI) the user needs to provide the name of the `solc` binary to use, e.g., `--solc solc`.  This is error prone and unnecessary.  We are working on a generic solution for the problem, but for the time being have this somewhat temporary workaround to allow user not to specify the binary name.

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

**Modifications:**

- Removing the `solc` key from `.conf`s
- Modify the key in github action yaml to remove version related information in the CI environment.

**Result:**

Users will not have to specify solc binary name or modify locally `.conf`s.  
