### PR TITLE
ci: use pr target instead of pr to run ci

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -2,7 +2,7 @@ name: Foundry
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - "dev"


### PR DESCRIPTION
**Motivation:**

This runs the workflow in the context of the base repository, allowing access to secrets

**Modifications:**

in github, when submitting a pr, if the pr is submitted from the repo, the github workflows can load proper secrets

but when the pr is submitted from a forked repo, github workflow cannot load secrets b/c it's not running the context in base repository

**Result:**

enables CI to run and load context for PR submitted from a fork repo
which is a prerequisite for our new branch and release model i'm working on