### PR TITLE
docs: non-standard erc20 note

### DIFF
--- a/docs/core/RewardsCoordinator.md
+++ b/docs/core/RewardsCoordinator.md
@@ -26,6 +26,8 @@ The typical user flow is as follows:
 
 This entire flow will repeat periodically as AVSs submit rewards submissions, `DistributionRoots` are submitted, and Stakers/Operators claim their accumulated earnings. Note that `DistributionRoots` contain *cumulative earnings*, meaning Stakers/Operators aren't required to claim against every root - simply claiming against the most recent root will claim anything not yet claimed.
 
+**NOTE: Use caution when using reward tokens that do not strictly conform to ERC20 standards. Please DYOR if your token falls outside of ERC20 norms.** Specific things to look out for include (but are not limited to): exotic rebasing tokens, fee-on-transfer tokens, tokens that support reentrant behavior (like ERC-777), and other nonstandard ERC20 derivatives.
+
 #### High-level Concepts
 
 This document is organized according to the following themes (click each to be taken to the relevant section):


### PR DESCRIPTION
**Motivation:**

We need to add a note about not using non-standard ERC20 tokens as reward tokens.

**Modifications:**

Updated RewardsCoordinator docs.

**Result:**

More clarity.
