### PR TITLE
feat: add TokenWrapped and TokenUnwrapped events in Eigen for observability

### DIFF
--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -10,12 +10,6 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     /// @notice the address of the backing Eigen token bEIGEN
     IERC20 public immutable bEIGEN;
 
-    /// EVENTS
-    /// @notice Emitted when bEIGEN tokens are wrapped into EIGEN
-    event TokenWrapped(address indexed account, uint256 amount);
-    /// @notice Emitted when EIGEN tokens are unwrapped into bEIGEN
-    event TokenUnwrapped(address indexed account, uint256 amount);
-
     /// STORAGE
     /// @dev Do not remove, deprecated storage.
     /// @notice mapping of minter addresses to the timestamp after which they are allowed to mint
@@ -32,6 +26,12 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     /// @dev Do not remove, deprecated storage.
     /// @notice mapping of addresses that are allowed to receive tokens from any address
     mapping(address => bool) internal __deprecated_allowedTo;
+
+    /// EVENTS
+    /// @notice Emitted when bEIGEN tokens are wrapped into EIGEN
+    event TokenWrapped(address indexed account, uint256 amount);
+    /// @notice Emitted when EIGEN tokens are unwrapped into bEIGEN
+    event TokenUnwrapped(address indexed account, uint256 amount);
 
     constructor(
         IERC20 _bEIGEN

--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -10,6 +10,12 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     /// @notice the address of the backing Eigen token bEIGEN
     IERC20 public immutable bEIGEN;
 
+    /// EVENTS
+    /// @notice Emitted when bEIGEN tokens are wrapped into EIGEN
+    event TokenWrapped(address indexed account, uint256 amount);
+    /// @notice Emitted when EIGEN tokens are unwrapped into bEIGEN
+    event TokenUnwrapped(address indexed account, uint256 amount);
+
     /// STORAGE
     /// @dev Do not remove, deprecated storage.
     /// @notice mapping of minter addresses to the timestamp after which they are allowed to mint
@@ -54,6 +60,7 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     ) external {
         require(bEIGEN.transferFrom(msg.sender, address(this), amount), "Eigen.wrap: bEIGEN transfer failed");
         _mint(msg.sender, amount);
+        emit TokenWrapped(msg.sender, amount);
     }
 
     /**
@@ -64,6 +71,7 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     ) external {
         _burn(msg.sender, amount);
         require(bEIGEN.transfer(msg.sender, amount), "Eigen.unwrap: bEIGEN transfer failed");
+        emit TokenUnwrapped(msg.sender, amount);
     }
 
     /**

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -29,6 +29,12 @@ contract EigenWrappingTests is Test {
     /// @notice event emitted when a minter status is modified
     event IsMinterModified(address indexed minterAddress, bool newStatus);
 
+    // EVENTS FROM Eigen.sol
+    /// @notice event emitted when bEIGEN tokens are wrapped into EIGEN
+    event TokenWrapped(address indexed account, uint256 amount);
+    /// @notice event emitted when EIGEN tokens are unwrapped into bEIGEN
+    event TokenUnwrapped(address indexed account, uint256 amount);
+
     modifier filterAddress(address fuzzedAddress) {
         vm.assume(!fuzzedOutAddresses[fuzzedAddress]);
         _;
@@ -69,6 +75,8 @@ contract EigenWrappingTests is Test {
         vm.startPrank(minter1);
         bEIGEN.mint(minter1, totalSupply / 2);
         bEIGEN.approve(address(eigen), totalSupply / 2);
+        vm.expectEmit(true, false, false, false);
+        emit TokenWrapped(minter1, totalSupply / 2);
         eigen.wrap(totalSupply / 2);
         vm.stopPrank();
 
@@ -76,6 +84,8 @@ contract EigenWrappingTests is Test {
         vm.startPrank(minter2);
         bEIGEN.mint(minter2, totalSupply / 2);
         bEIGEN.approve(address(eigen), totalSupply / 2);
+        vm.expectEmit(true, false, false, false);
+        emit TokenWrapped(minter2, totalSupply / 2);
         eigen.wrap(totalSupply / 2);
         vm.stopPrank();
 
@@ -106,6 +116,8 @@ contract EigenWrappingTests is Test {
         // unwrap amount should be less than minter1 balance
         unwrapAmount = unwrapAmount % minter1Balance;
         vm.prank(unwrapper);
+        vm.expectEmit(true, false, false, false);
+        emit TokenUnwrapped(unwrapper, unwrapAmount);
         eigen.unwrap(unwrapAmount);
 
         // check total supply and balance changes
@@ -145,6 +157,8 @@ contract EigenWrappingTests is Test {
         // approve bEIGEN
         bEIGEN.approve(address(eigen), wrapAmount);
         // wrap
+        vm.expectEmit(true, false, false, false);
+        emit TokenWrapped(wrapper, wrapAmount);
         eigen.wrap(wrapAmount);
         vm.stopPrank();
 

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -31,9 +31,9 @@ contract EigenWrappingTests is Test {
 
     // EVENTS FROM Eigen.sol
     /// @notice event emitted when bEIGEN tokens are wrapped into EIGEN
-    event TokenWrapped(address indexed account, uint256 amount);
+    event TokenWrapped(address indexed account, uint amount);
     /// @notice event emitted when EIGEN tokens are unwrapped into bEIGEN
-    event TokenUnwrapped(address indexed account, uint256 amount);
+    event TokenUnwrapped(address indexed account, uint amount);
 
     modifier filterAddress(address fuzzedAddress) {
         vm.assume(!fuzzedOutAddresses[fuzzedAddress]);

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -60,11 +60,11 @@ contract EigenWrappingTests is Test {
         bEIGEN.initialize(minter1);
 
         // set minters (for future minting if needed)
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, true);
         emit IsMinterModified(minter1, true);
         bEIGEN.setIsMinter(minter1, true);
 
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, true);
         emit IsMinterModified(minter2, true);
         bEIGEN.setIsMinter(minter2, true);
 
@@ -75,7 +75,7 @@ contract EigenWrappingTests is Test {
         vm.startPrank(minter1);
         bEIGEN.mint(minter1, totalSupply / 2);
         bEIGEN.approve(address(eigen), totalSupply / 2);
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, true);
         emit TokenWrapped(minter1, totalSupply / 2);
         eigen.wrap(totalSupply / 2);
         vm.stopPrank();
@@ -84,7 +84,7 @@ contract EigenWrappingTests is Test {
         vm.startPrank(minter2);
         bEIGEN.mint(minter2, totalSupply / 2);
         bEIGEN.approve(address(eigen), totalSupply / 2);
-        vm.expectEmit(true, false, false, false);
+        vm.expectEmit(true, true, true, true);
         emit TokenWrapped(minter2, totalSupply / 2);
         eigen.wrap(totalSupply / 2);
         vm.stopPrank();


### PR DESCRIPTION
**Motivation:**

add TokenWrapped and TokenUnwrapped events in Eigen for observability

**Modifications:**

- add TokenWrapped and TokenUnwrapped events in Eigen
- add corresponding tests

**Result:**

we can track wrapping/unwrapping actions between Eigen and BackingEigen