### PR TITLE
feat: support all characters after colon

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -31,7 +31,7 @@ jobs:
           echo "PR title: $PR_TITLE"
 
           # Define the valid pattern (supports conventional commit format)
-          if [[ ! "$PR_TITLE" =~ ^(release|feat|fix|chore|docs|refactor|test|style|ci|perf)(\([a-z0-9-]+\))?\:\ .* ]]; then
+          if [[ ! "$PR_TITLE" =~ ^(release|feat|fix|chore|docs|refactor|test|style|ci|perf)(\(.*?\))?:\ .* ]]; then
             echo "❌ Invalid PR title: '$PR_TITLE'"
             echo "Expected format: 'type: description' or 'type(scope): description'"
             echo "Allowed types: release, feat, fix, chore, docs, refactor, test, style, ci, perf."


### PR DESCRIPTION
**Motivation:**

There's a small bug present in the PR title check, it does not support all characters  after the colon.

**Modifications:**

- Modified regex to support all characters. 

**Result:**

*Should* now support all characters.
