### PR TITLE
Clarify AVS Meaning for AllocationManager and Effect of invoking updateAVSMetadataURI

### DIFF
--- a/docs/core/AllocationManager.md
+++ b/docs/core/AllocationManager.md
@@ -22,7 +22,11 @@ Libraries and Mixins:
 
 ## Overview
 
-The `AllocationManager` manages AVS metadata registration, registration and deregistration of operators to operator sets, handles allocation and slashing of operators' slashable stake, and is the entry point an AVS uses to slash an operator. The `AllocationManager's` responsibilities are broken down into the following concepts:
+The `AllocationManager` manages AVS metadata registration, registration and deregistration of operators to operator sets, handles allocation and slashing of operators' slashable stake, and is the entry point an AVS uses to slash an operator. An AVS in the context of `AllocationManager` is defined as the `address` of the contract that implements [ServiceManagerBase](https://github.com/Layr-Labs/eigenlayer-middleware/blob/mainnet/docs/ServiceManagerBase.md). For `PermissionController` purposes, this AVS address is also the AVS [account](https://github.com/Layr-Labs/eigenlayer-contracts/blob/dev/docs/permissions/PermissionController.md#accounts).
+
+
+
+The `AllocationManager's` responsibilities are broken down into the following concepts:
 
 * [AVS Metadata](#avs-metadata)
 * [Operator Sets](#operator-sets)
@@ -67,6 +71,8 @@ function updateAVSMetadataURI(
 ```
 
 _Note: this method can be called directly by an AVS, or by a caller authorized by the AVS. See [`PermissionController.md`](../permissions/PermissionController.md) for details._
+
+Invoking this function effectively "enshrines" the AVS address in the core protocol.
 
 Below is the format AVSs should use when updating their metadata URI initially. This is not validated onchain.
 


### PR DESCRIPTION
**Motivation:**

Per Slack DM with @ypatil12 we wish to further clarify what an "AVS" means for an AllocationManager.
And per Yash: setting its updateAVSMetadataURI .. doing this "enshrines" the AVS address in the core protocol. In UAM-terminology, it is the "account" of the AVS

**Modifications:**

Added documentation language to more clearly specify both "What an AVS means for ALM" and what is the purpose of invoking updateAVSMetadataURI function.

**Result:**

Our core contract docs will be more clear for the user.
