### PR TITLE
ci: remove chain id from secrets and env vars

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -12,7 +12,6 @@ env:
   FOUNDRY_PROFILE: medium
   RPC_MAINNET: ${{ secrets.RPC_MAINNET }}
   RPC_HOLESKY: ${{ secrets.RPC_HOLESKY }}
-  CHAIN_ID: ${{ secrets.CHAIN_ID }}
 
 jobs:
   # -----------------------------------------------------------------------


### PR DESCRIPTION

**Motivation:**

chain_id is currently an github secrets, but not used anywhere

**Modifications:**

remove chain id from secrets and env vars 

**Result:**

one less useless secret, no impact on ci
