### PR TITLE
ci: disable auto labeler to prepare for enabling fork-based pr

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -5,21 +5,21 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  triage:
-    runs-on: protocol-x64-16core
-    name: Labels
-    permissions:
-      contents: read
-      pull-requests: write
+  # triage:
+  #   runs-on: protocol-x64-16core
+  #   name: Labels
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
     
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
         
-      - uses: actions/labeler@v5
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+  #     - uses: actions/labeler@v5
+  #       with:
+  #         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+  #         sync-labels: true
 
   lint-pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Motivation:**

fork-based pr cannot use secrets or github token

**Modifications:**

disable auto labeler to prepare for enabling fork-based pr

**Result:**

auto labeler is disabled, will be potentially removed in future soon
