### PR TITLE
ci: enable auto delete branch upon eigengit launch

### DIFF
--- a/.github/workflows/delete-unauthrized-branches.yml
+++ b/.github/workflows/delete-unauthrized-branches.yml
@@ -1,7 +1,6 @@
 name: Delete Unauthorized Branches
 
-# Due to internal reasons, we cannot disable default write access for the repo.
-# As an alternative, this workflow is used to delete unauthorized branches that are created 
+# This workflow deletes unauthorized branches that are created 
 # without following the branch policy.
 
 on:
@@ -43,7 +42,7 @@ jobs:
         run: |
           BRANCH="${{ steps.branch.outputs.branch }}"
           echo "Deleting unauthorized branch: $BRANCH"
-#          curl -s -X DELETE \
-#            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-#            -H "Accept: application/vnd.github+json" \
-#            https://api.github.com/repos/${{ github.repository }}/git/refs/heads/$BRANCH
+          curl -s -X DELETE \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/git/refs/heads/$BRANCH

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ EigenLayer is a set of smart contracts deployed on Ethereum that enable restakin
 
 ## Get Started
 
-See [CONTRIBUTING](CONTRIBUTING.md). Contributions that do not follow our fork base PR practices will be automatically immediately closed and deleted, preventing branch pollution, keeping our repository clean, tidy, more readable and searchable.
+See [CONTRIBUTING](CONTRIBUTING.md). 
+
+Contributions that do not follow our fork base PR practices will be either rejected or immediately deleted based on your role, preventing branch pollution, keeping our repository clean, make it more readable and searchable.
+
 
 ## Branching
 


### PR DESCRIPTION
**Motivation:**

enable auto delete branch upon eigengit launch

**Modifications:**

enable auto delete branch upon eigengit launch

**Result:**

in repo branch that is not `release-dev/*` or `vx.y.z` will be auto deleted upon pr creation.
fork based pr is not impacted