### PR TITLE
feat(draft): `AllocationManager` redistribution support

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -343,7 +343,7 @@ contract AllocationManager is
         operatorSetIds = new uint32[](params.length);
         for (uint256 i = 0; i < params.length; i++) {
             operatorSetIds[i] = params[i].operatorSetId;
-            _createOperatorSet(avs, params[i], address(0));
+            _createOperatorSet(avs, params[i], DEFAULT_BURN_ADDRESS);
         }
     }
 
@@ -418,12 +418,11 @@ contract AllocationManager is
 
         // Create the operator set, ensuring it does not already exist.
         require(_operatorSets[avs].add(operatorSet.id), InvalidOperatorSet());
+        emit OperatorSetCreated(operatorSet);
 
-        if (redistributionRecipient != address(0)) {
+        if (redistributionRecipient != DEFAULT_BURN_ADDRESS) {
             _redistributionRecipients[operatorSet.key()] = redistributionRecipient;
-            emit RedistributingOperatorSetCreated(operatorSet, redistributionRecipient);
-        } else {
-            emit OperatorSetCreated(operatorSet);
+            emit RedistributionAddressSet(operatorSet, redistributionRecipient);
         }
 
         // Add strategies to the operator set

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -67,7 +67,7 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING) checkCanCall(avs) {
         // Check that the operator set exists and the operator is registered to it
         OperatorSet memory operatorSet = OperatorSet(avs, params.operatorSetId);
-        require(params.strategies.length == params.wadsToSlash.length, InputArrayLengthMismatch());
+        _checkArrayLengthsMatch(params.strategies.length, params.wadsToSlash.length);
         _checkIsOperatorSet(operatorSet);
         require(isOperatorSlashable(params.operator, operatorSet), OperatorNotSlashable());
 
@@ -166,7 +166,7 @@ contract AllocationManager is
         }
 
         for (uint256 i = 0; i < params.length; i++) {
-            require(params[i].strategies.length == params[i].newMagnitudes.length, InputArrayLengthMismatch());
+            _checkArrayLengthsMatch(params[i].strategies.length, params[i].newMagnitudes.length);
 
             // Check that the operator set exists and get the operator's registration status
             // Operators do not need to be registered for an operator set in order to allocate
@@ -246,8 +246,7 @@ contract AllocationManager is
         IStrategy[] calldata strategies,
         uint16[] calldata numToClear
     ) external onlyWhenNotPaused(PAUSED_MODIFY_ALLOCATIONS) {
-        require(strategies.length == numToClear.length, InputArrayLengthMismatch());
-
+        _checkArrayLengthsMatch(strategies.length, numToClear.length);
         for (uint256 i = 0; i < strategies.length; ++i) {
             _clearDeallocationQueue({operator: operator, strategy: strategies[i], numToClear: numToClear[i]});
         }
@@ -353,7 +352,7 @@ contract AllocationManager is
         CreateSetParams[] calldata params,
         address[] calldata redistributionRecipients
     ) external checkCanCall(avs) returns (uint32[] memory operatorSetIds) {
-        require(params.length == redistributionRecipients.length, InputArrayLengthMismatch());
+        _checkArrayLengthsMatch(params.length, redistributionRecipients.length);
         require(_avsRegisteredMetadata[avs], NonexistentAVSMetadata());
         operatorSetIds = new uint32[](params.length);
         for (uint256 i = 0; i < params.length; i++) {
@@ -643,6 +642,10 @@ contract AllocationManager is
 
     function _checkIsOperatorSet(OperatorSet memory operatorSet) internal view {
         require(_operatorSets[operatorSet.avs].contains(operatorSet.id), InvalidOperatorSet());
+    }
+
+    function _checkArrayLengthsMatch(uint256 left, uint256 right) internal pure {
+        require(left == right, InputArrayLengthMismatch());
     }
 
     /**

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -155,7 +155,7 @@ contract AllocationManager is
     ) external onlyWhenNotPaused(PAUSED_MODIFY_ALLOCATIONS) {
         // Check that the caller is allowed to modify allocations on behalf of the operator
         // We do not use a modifier to avoid `stack too deep` errors
-        require(_checkCanCall(operator), InvalidCaller());
+        _checkCanCall(operator);
 
         // Check that the operator exists and has configured an allocation delay
         uint32 operatorAllocationDelay;
@@ -284,7 +284,7 @@ contract AllocationManager is
         DeregisterParams calldata params
     ) external onlyWhenNotPaused(PAUSED_OPERATOR_SET_REGISTRATION_AND_DEREGISTRATION) {
         // Check that the caller is either authorized on behalf of the operator or AVS
-        require(_checkCanCall(params.operator) || _checkCanCall(params.avs), InvalidCaller());
+        require(_canCall(params.operator) || _canCall(params.avs), InvalidCaller());
 
         for (uint256 i = 0; i < params.operatorSetIds.length; i++) {
             // Check the operator set exists and the operator is registered to it
@@ -312,7 +312,7 @@ contract AllocationManager is
     /// @inheritdoc IAllocationManager
     function setAllocationDelay(address operator, uint32 delay) external {
         if (msg.sender != address(delegation)) {
-            require(_checkCanCall(operator), InvalidCaller());
+            _checkCanCall(operator);
             require(delegation.isOperator(operator), InvalidOperator());
         }
         _setAllocationDelay(operator, delay);
@@ -640,7 +640,9 @@ contract AllocationManager is
         return uint256(int256(int128(uint128(a)) + b)).toUint64();
     }
 
-    function _checkIsOperatorSet(OperatorSet memory operatorSet) internal view {
+    function _checkIsOperatorSet(
+        OperatorSet memory operatorSet
+    ) internal view {
         require(_operatorSets[operatorSet.avs].contains(operatorSet.id), InvalidOperatorSet());
     }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -344,10 +344,7 @@ contract AllocationManager is
     }
 
     /// @inheritdoc IAllocationManager
-    function createOperatorSets(
-        address avs,
-        CreateSetParams[] calldata params
-    ) external checkCanCall(avs) {
+    function createOperatorSets(address avs, CreateSetParams[] calldata params) external checkCanCall(avs) {
         require(_avsRegisteredMetadata[avs], NonexistentAVSMetadata());
         for (uint256 i = 0; i < params.length; i++) {
             _createOperatorSet(avs, params[i], DEFAULT_BURN_ADDRESS);
@@ -659,7 +656,9 @@ contract AllocationManager is
     }
 
     /// @dev Reverts if the operator is not registered.
-    function _checkIsOperator(address operator) internal view {
+    function _checkIsOperator(
+        address operator
+    ) internal view {
         require(delegation.isOperator(operator), InvalidOperator());
     }
 

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -404,6 +404,7 @@ contract AllocationManager is
      * @param redistributionRecipient Address to receive redistributed funds when operators are slashed.
      * @dev If `redistributionRecipient` is address(0), the operator set is considered non-redistributing
      * and slashed funds are sent to the `DEFAULT_BURN_ADDRESS`.
+     * @dev Providing `BEACONCHAIN_ETH_STRAT` as a strategy will revert since it's not currently supported.
      */
     function _createOperatorSet(
         address avs,

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -98,6 +98,7 @@ abstract contract AllocationManagerStorage is IAllocationManager {
 
     /// @notice Returns the number of slashes for a given operator set.
     /// @dev This is also used as a unique slash identifier.
+    /// @dev This tracks the number of slashes after the redistribution release.
     mapping(bytes32 operatorSetKey => uint256 slashId) public slashCount;
 
     /// @notice Returns the address where slashed funds will be sent for a given operator set.

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -14,8 +14,11 @@ abstract contract AllocationManagerStorage is IAllocationManager {
 
     // Constants
 
-    /// @dev The default burn address for EigenLayer
+    /// @dev The default burn address for slashed funds.
     address internal constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000000E16E4;
+
+    /// @dev The beacon chain ETH strategy.
+    IStrategy internal constant BEACONCHAIN_ETH_STRAT = IStrategy(0xbeaC0eeEeeeeEEeEeEEEEeeEEeEeeeEeeEEBEaC0);
 
     /// @dev Index for flag that pauses operator allocations/deallocations when set.
     uint8 internal constant PAUSED_MODIFY_ALLOCATIONS = 0;

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -102,7 +102,7 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @notice Returns the number of slashes for a given operator set.
     /// @dev This is also used as a unique slash identifier.
     /// @dev This tracks the number of slashes after the redistribution release.
-    mapping(bytes32 operatorSetKey => uint256 slashId) public slashCount;
+    mapping(bytes32 operatorSetKey => uint256 slashId) public _slashCount;
 
     /// @notice Returns the address where slashed funds will be sent for a given operator set.
     /// @dev For redistributing Operator Sets, returns the configured redistribution address set during Operator Set creation.

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -14,6 +14,9 @@ abstract contract AllocationManagerStorage is IAllocationManager {
 
     // Constants
 
+    /// @dev The default burn address for EigenLayer
+    address internal constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000000E16E4;
+
     /// @dev Index for flag that pauses operator allocations/deallocations when set.
     uint8 internal constant PAUSED_MODIFY_ALLOCATIONS = 0;
 
@@ -92,6 +95,15 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     /// @dev Lists the AVSs who has registered metadata and claimed itself as an AVS
     /// @notice bool is not used and is always true if the avs has registered metadata
     mapping(address avs => bool) internal _avsRegisteredMetadata;
+
+    /// @notice Returns the number of slashes for a given operator set.
+    /// @dev This is also used as a unique slash identifier.
+    mapping(bytes32 operatorSetKey => uint256 slashId) public slashCount;
+
+    /// @notice Returns the address where slashed funds will be sent for a given operator set.
+    /// @dev For redistributing Operator Sets, returns the configured redistribution address set during Operator Set creation.
+    ///      For non-redistributing operator sets, returns the `DEFAULT_BURN_ADDRESS`.
+    mapping(bytes32 operatorSetKey => address redistributionAddr) internal _redistributionRecipients;
 
     // Construction
 

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -102,7 +102,7 @@ abstract contract AllocationManagerStorage is IAllocationManager {
 
     /// @notice Returns the address where slashed funds will be sent for a given operator set.
     /// @dev For redistributing Operator Sets, returns the configured redistribution address set during Operator Set creation.
-    ///      For non-redistributing operator sets, returns the `DEFAULT_BURN_ADDRESS`.
+    ///      For non-redistributing or non-existing operator sets, returns `address(0)`.
     mapping(bytes32 operatorSetKey => address redistributionAddr) internal _redistributionRecipients;
 
     // Construction

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -118,5 +118,5 @@ abstract contract AllocationManagerStorage is IAllocationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[36] private __gap;
+    uint256[34] private __gap;
 }

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -158,7 +158,7 @@ contract DelegationManager is
         if (msg.sender != staker) {
             address operator = delegatedTo[staker];
 
-            require(_checkCanCall(operator) || msg.sender == delegationApprover(operator), CallerCannotUndelegate());
+            require(_canCall(operator) || msg.sender == delegationApprover(operator), CallerCannotUndelegate());
             emit StakerForceUndelegated(staker, operator);
         }
 

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -20,8 +20,6 @@ interface IAllocationManagerErrors {
 
     /// Caller
 
-    /// @dev Thrown when caller is not authorized to call a function.
-    error InvalidCaller();
     /// @dev Thrown when an invalid strategy is provided.
     error InvalidStrategy();
 
@@ -249,7 +247,10 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
      *      rounding, which will result in small amounts of tokens locked in the contract
      *      rather than fully burning through the burn mechanism.
      */
-    function slashOperator(address avs, SlashingParams calldata params) external;
+    function slashOperator(
+        address avs,
+        SlashingParams calldata params
+    ) external returns (uint256 slashId, uint256[] memory shares);
 
     /**
      * @notice Modifies the proportions of slashable stake allocated to an operator set from a list of strategies
@@ -331,7 +332,7 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     function createOperatorSets(
         address avs,
         CreateSetParams[] calldata params
-    ) external returns (uint32[] memory operatorSetIds);
+    ) external;
 
     /**
      * @notice Allows an AVS to create new Redistribution operator sets.
@@ -345,7 +346,7 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
         address avs,
         CreateSetParams[] calldata params,
         address[] calldata redistributionRecipients
-    ) external returns (uint32[] memory operatorSetIds);
+    ) external;
 
     /**
      * @notice Allows an AVS to add strategies to an operator set
@@ -644,4 +645,13 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     function isRedistributingOperatorSet(
         OperatorSet memory operatorSet
     ) external view returns (bool);
+
+    /**
+     * @notice Returns the number of slashes for a given operator set.
+     * @param operatorSet The operator set to query.
+     * @return The number of slashes for the operator set.
+     */
+    function getSlashCount(
+        OperatorSet memory operatorSet
+    ) external view returns (uint256);
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -22,6 +22,8 @@ interface IAllocationManagerErrors {
 
     /// @dev Thrown when caller is not authorized to call a function.
     error InvalidCaller();
+    /// @dev Thrown when an invalid strategy is provided.
+    error InvalidStrategy();
 
     /// Operator Status
 

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -209,6 +209,9 @@ interface IAllocationManagerEvents is IAllocationManagerTypes {
     /// @notice Emitted when an operator is removed from an operator set.
     event OperatorRemovedFromOperatorSet(address indexed operator, OperatorSet operatorSet);
 
+    /// @notice Emitted when a redistributing operator set is created by an AVS.
+    event RedistributingOperatorSetCreated(OperatorSet operatorSet, address redistributionRecipient);
+
     /// @notice Emitted when a strategy is added to an operator set.
     event StrategyAddedToOperatorSet(OperatorSet operatorSet, IStrategy strategy);
 
@@ -323,7 +326,24 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     /**
      * @notice Allows an AVS to create new operator sets, defining strategies that the operator set uses
      */
-    function createOperatorSets(address avs, CreateSetParams[] calldata params) external;
+    function createOperatorSets(
+        address avs,
+        CreateSetParams[] calldata params
+    ) external returns (uint32[] memory operatorSetIds);
+
+    /**
+     * @notice Allows an AVS to create new Redistribution operator sets.
+     * @param avs The AVS creating the new operator sets.
+     * @param params An array of operator set creation parameters.
+     * @param redistributionRecipients An array of addresses that will receive redistributed funds when operators are slashed.
+     * @dev Same logic as `createOperatorSets`, except `redistributionRecipients` corresponding to each operator set are stored.
+     *      Additionally, emits `RedistributionOperatorSetCreated` event instead of `OperatorSetCreated` for each created operator set.
+     */
+    function createRedistributingOperatorSets(
+        address avs,
+        CreateSetParams[] calldata params,
+        address[] calldata redistributionRecipients
+    ) external returns (uint32[] memory operatorSetIds);
 
     /**
      * @notice Allows an AVS to add strategies to an operator set
@@ -601,4 +621,25 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
      * @param operatorSet the operator set to check slashability for
      */
     function isOperatorSlashable(address operator, OperatorSet memory operatorSet) external view returns (bool);
+
+    /**
+     * @notice Returns the address where slashed funds will be sent for a given operator set.
+     * @param operatorSet The Operator Set to query.
+     * @return For redistributing Operator Sets, returns the configured redistribution address set during Operator Set creation.
+     *         For non-redistributing operator sets, returns the `DEFAULT_BURN_ADDRESS`.
+     */
+    function getRedistributionRecipient(
+        OperatorSet memory operatorSet
+    ) external view returns (address);
+
+    /**
+     * @notice Returns whether a given operator set supports redistribution
+     * or not when funds are slashed and burned from EigenLayer.
+     * @param operatorSet The Operator Set to query.
+     * @return For redistributing Operator Sets, returns true.
+     *         For non-redistributing Operator Sets, returns false.
+     */
+    function isRedistributingOperatorSet(
+        OperatorSet memory operatorSet
+    ) external view returns (bool);
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -210,7 +210,7 @@ interface IAllocationManagerEvents is IAllocationManagerTypes {
     event OperatorRemovedFromOperatorSet(address indexed operator, OperatorSet operatorSet);
 
     /// @notice Emitted when a redistributing operator set is created by an AVS.
-    event RedistributingOperatorSetCreated(OperatorSet operatorSet, address redistributionRecipient);
+    event RedistributionAddressSet(OperatorSet operatorSet, address redistributionRecipient);
 
     /// @notice Emitted when a strategy is added to an operator set.
     event StrategyAddedToOperatorSet(OperatorSet operatorSet, IStrategy strategy);

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -329,10 +329,7 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     /**
      * @notice Allows an AVS to create new operator sets, defining strategies that the operator set uses
      */
-    function createOperatorSets(
-        address avs,
-        CreateSetParams[] calldata params
-    ) external;
+    function createOperatorSets(address avs, CreateSetParams[] calldata params) external;
 
     /**
      * @notice Allows an AVS to create new Redistribution operator sets.

--- a/src/contracts/mixins/PermissionControllerMixin.sol
+++ b/src/contracts/mixins/PermissionControllerMixin.sol
@@ -16,23 +16,35 @@ abstract contract PermissionControllerMixin {
         permissionController = _permissionController;
     }
 
-    /// @notice Checks if the caller (msg.sender) can call on behalf of an account.
+    /// @notice Reverts if the caller does not have permission to call on behalf of `account`.
     modifier checkCanCall(
         address account
     ) {
-        require(_checkCanCall(account), InvalidPermissions());
+        _checkCanCall(account);
         _;
     }
 
     /**
      * @notice Checks if the caller is allowed to call a function on behalf of an account.
-     * @param account the account to check
+     * @param account The account to check permissions for.
      * @dev `msg.sender` is the caller to check that can call the function on behalf of `account`.
-     * @dev Returns a bool, instead of reverting
+     * @dev Returns whether the caller has permission to call the function on behalf of the account.
      */
-    function _checkCanCall(
+    function _canCall(
         address account
     ) internal returns (bool) {
         return permissionController.canCall(account, msg.sender, address(this), msg.sig);
+    }
+
+    /**
+     * @notice Checks if the caller is allowed to call a function on behalf of an account.
+     * @param account The account to check permissions for.
+     * @dev `msg.sender` is the caller to check that can call the function on behalf of `account`.
+     * @dev Reverts if the caller does not have permission.
+     */
+    function _checkCanCall(
+        address account
+    ) internal {
+        require(_canCall(account), InvalidPermissions());
     }
 }

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -13,6 +13,8 @@ contract AllocationManagerUnitTests is EigenLayerUnitTestSetup, IAllocationManag
     /// Constants
     /// -----------------------------------------------------------------------
 
+    error InvalidPermissions();
+
     /// NOTE: Raising these values directly increases cpu time for tests.
     uint internal constant FUZZ_MAX_ALLOCATIONS = 8;
     uint internal constant FUZZ_MAX_STRATS = 8;
@@ -1784,9 +1786,9 @@ contract AllocationManagerUnitTests_ModifyAllocations is AllocationManagerUnitTe
         allocationManager.modifyAllocations(address(this), new AllocateParams[](0));
     }
 
-    function test_revert_invalidCaller() public {
+    function test_revert_invalidPermissions() public {
         address invalidOperator = address(0x2);
-        cheats.expectRevert(InvalidCaller.selector);
+        cheats.expectRevert(InvalidPermissions.selector);
         allocationManager.modifyAllocations(invalidOperator, new AllocateParams[](0));
     }
 
@@ -3271,7 +3273,7 @@ contract AllocationManagerUnitTests_SetAllocationDelay is AllocationManagerUnitT
     }
 
     function test_revert_callerNotAuthorized() public {
-        cheats.expectRevert(InvalidCaller.selector);
+        cheats.expectRevert(InvalidPermissions.selector);
         allocationManager.setAllocationDelay(operatorToSet, 1);
     }
 
@@ -3483,7 +3485,7 @@ contract AllocationManagerUnitTests_deregisterFromOperatorSets is AllocationMana
         address randomOperator = address(0x1);
         defaultDeregisterParams.operator = randomOperator;
 
-        cheats.expectRevert(InvalidCaller.selector);
+        cheats.expectRevert(InvalidPermissions.selector);
         allocationManager.deregisterFromOperatorSets(defaultDeregisterParams);
     }
 
@@ -3491,7 +3493,7 @@ contract AllocationManagerUnitTests_deregisterFromOperatorSets is AllocationMana
         address randomAVS = address(0x1);
 
         cheats.prank(randomAVS);
-        cheats.expectRevert(InvalidCaller.selector);
+        cheats.expectRevert(InvalidPermissions.selector);
         allocationManager.deregisterFromOperatorSets(defaultDeregisterParams);
     }
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3691,7 +3691,7 @@ contract AllocationManagerUnitTests_createRedistributingOperatorSets is Allocati
             createSetParams[i].operatorSetId = r.Uint32(1, type(uint32).max);
             createSetParams[i].strategies = r.StrategyArray(numStrategies);
             redistributionRecipients[i] = r.Address();
-            
+
             cheats.expectEmit(true, true, true, true, address(allocationManager));
             emit RedistributingOperatorSetCreated(OperatorSet(avs, createSetParams[i].operatorSetId), redistributionRecipients[i]);
             for (uint j; j < numStrategies; ++j) {
@@ -3708,7 +3708,9 @@ contract AllocationManagerUnitTests_createRedistributingOperatorSets is Allocati
             assertTrue(allocationManager.isOperatorSet(opSet), "should be operator set");
             assertTrue(allocationManager.isRedistributingOperatorSet(opSet), "should be redistributing operator set");
             assertEq(
-                allocationManager.getRedistributionRecipient(opSet), redistributionRecipients[k], "should have correct redistribution recipient"
+                allocationManager.getRedistributionRecipient(opSet),
+                redistributionRecipients[k],
+                "should have correct redistribution recipient"
             );
 
             IStrategy[] memory strategiesInSet = allocationManager.getStrategiesInOperatorSet(opSet);

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -3722,7 +3722,9 @@ contract AllocationManagerUnitTests_createRedistributingOperatorSets is Allocati
             redistributionRecipients[i] = r.Address();
 
             cheats.expectEmit(true, true, true, true, address(allocationManager));
-            emit RedistributingOperatorSetCreated(OperatorSet(avs, createSetParams[i].operatorSetId), redistributionRecipients[i]);
+            emit OperatorSetCreated(OperatorSet(avs, createSetParams[i].operatorSetId));
+            cheats.expectEmit(true, true, true, true, address(allocationManager));
+            emit RedistributionAddressSet(OperatorSet(avs, createSetParams[i].operatorSetId), redistributionRecipients[i]);
             for (uint j; j < numStrategies; ++j) {
                 cheats.expectEmit(true, true, true, true, address(allocationManager));
                 emit StrategyAddedToOperatorSet(OperatorSet(avs, createSetParams[i].operatorSetId), createSetParams[i].strategies[j]);


### PR DESCRIPTION
**Motivation:**

Add support for redistributing slashed funds to specified recipients instead of burning them, while optimizing code size and improving test coverage.

**Modifications:**

Added a new redistribution system that allows AVSs to specify recipients for slashed funds. Code optimizations were made to reduce codesize, including consolidating repeated logic and a small `PermissionControllerMixin` refactor.

**Result:**

Slashed funds can now be redirected to specified recipients instead of being burned, with improved code efficiency and test coverage.