### PR TITLE
ci: add CI to validate deployment script

### DIFF
--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -37,12 +37,19 @@ jobs:
 
       - name: Validate Solidity Scripts
         run: |
-          # Find all .sol files under /script
-          FILES=$(find script -type f -name "*.sol")
+          # Find all .sol files under /script/deploy and /script/release
+          DEPLOY_FILES=$(find script/deploy -type f -name "*.sol" 2>/dev/null || echo "")
+          RELEASE_FILES=$(find script/release -type f -name "*.sol" 2>/dev/null || echo "")
           
-          # Exit with error if no files are found
+          # Combine file lists
+          FILES="$DEPLOY_FILES $RELEASE_FILES"
+          
+          # Trim leading/trailing whitespace
+          FILES=$(echo "$FILES" | xargs)
+          
+          # Exit with success if no files are found
           if [ -z "$FILES" ]; then
-            echo "No .sol files found under /script directory"
+            echo "No .sol files found under /script/deploy or /script/release directories"
             exit 0
           fi
           

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -34,4 +34,18 @@ jobs:
         run: npm install -g @layr-labs/zeus
 
       - name: Validate Solidity Scripts
-        run: zeus validate script/**/*.sol
+        run: |
+          # Find all .sol files under /script
+          FILES=$(find script -type f -name "*.sol")
+          
+          # Exit with error if no files are found
+          if [ -z "$FILES" ]; then
+            echo "No .sol files found under /script directory"
+            exit 0
+          fi
+          
+          # Run zeus test on each file
+          for file in $FILES; do
+            echo "Testing $file..."
+            zeus test "$file"
+          done

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -38,11 +38,10 @@ jobs:
       - name: Validate Solidity Scripts
         run: |
           # Find all .sol files under /script/deploy and /script/release
-          DEPLOY_FILES=$(find script/deploy -type f -name "*.sol" 2>/dev/null || echo "")
           RELEASE_FILES=$(find script/release -type f -name "*.sol" 2>/dev/null || echo "")
           
           # Combine file lists
-          FILES="$DEPLOY_FILES $RELEASE_FILES"
+          FILES="$RELEASE_FILES"
           
           # Trim leading/trailing whitespace
           FILES=$(echo "$FILES" | xargs)

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -5,9 +5,11 @@ on:
   push:
     paths:
       - 'script/**'
+      - '.github/workflows/validate-deployment-scripts.yml'
   pull_request:
     paths:
       - 'script/**'
+      - '.github/workflows/validate-deployment-scripts.yml'
 
 
 jobs:

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -1,0 +1,32 @@
+name: Validate Deployment Scripts
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'script/**'
+
+
+jobs:
+
+  validate-scripts:
+    name: Test (Intense)
+    runs-on: protocol-x64-16core
+    strategy:
+      fail-fast: true
+    steps:
+      # Check out repository with all submodules for complete codebase access.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Zeus
+        run: npm install -g @layr-labs/zeus
+
+      - name: Validate Solidity Scripts
+        run: zeus validate script/**/*.sol

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -14,11 +14,13 @@ on:
 
 jobs:
 
-  validate-scripts:
-    name: Test (Intense)
+  test:
     runs-on: protocol-x64-16core
     strategy:
       fail-fast: true
+      matrix:
+        env: [preprod, testnet, mainnet]
+
     steps:
       # Check out repository with all submodules for complete codebase access.
       - uses: actions/checkout@v4
@@ -44,8 +46,8 @@ jobs:
             exit 0
           fi
           
-          # Run zeus test on each file
+          # Run zeus test on each file with the specified environment
           for file in $FILES; do
-            echo "Testing $file..."
-            zeus test "$file"
+            echo "Testing $file in ${{ matrix.env }} environment..."
+            zeus test --env ${{ matrix.env }} "$file"
           done

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -5,6 +5,9 @@ on:
   push:
     paths:
       - 'script/**'
+  pull_request:
+    paths:
+      - 'script/**'
 
 
 jobs:


### PR DESCRIPTION
**Motivation:**

curently there's no ci coverage for deployment scripts. scripts can be only validated manually by devs offline by running `zeus test` on terminal

pain points:
1/ no quality control on scripts merged in
2/ manual testing is time intensive and not scalable

**Modifications:**

add a new ci workflow to auto validate deployment scripts in all envs, currently mainnet, testnet, preprod, testnet-hoodi, testnet-sepolia

**Result:**

- quality control is put in place for all deployment scripts
- fully automated, to save devs time
