### PR TITLE
Fix SignatureUtils link in DelegationManager.md

### DIFF
--- a/docs/core/DelegationManager.md
+++ b/docs/core/DelegationManager.md
@@ -11,7 +11,7 @@ Libraries and Mixins:
 | File | Notes |
 | -------- | -------- |
 | [`PermissionControllerMixin.sol`](../../src/contracts/mixins/PermissionControllerMixin.sol) | account delegation |
-| [`SignatureUtils.sol`](../../src/contracts/mixins/SignatureUtils.sol) | signature validation |
+| [`SignatureUtilsMixin.sol`](../../src/contracts/mixins/SignatureUtilsMixin.sol) | signature validation |
 | [`Pausable.sol`](../../src/contracts/permissions/Pausable.sol) | |
 | [`SlashingLib.sol`](../../src/contracts/libraries/SlashingLib.sol) | slashing math |
 | [`Snapshots.sol`](../../src/contracts/libraries/Snapshots.sol) | historical state |


### PR DESCRIPTION
The documentation in DelegationManager.md was referring to a file "SignatureUtils.sol" that doesn't exist in the codebase. The correct file name is "SignatureUtilsMixin.sol". This commit updates the link in the documentation to point to the correct file.
This fix ensures that the documentation correctly references the actual files in the codebase, making it more accurate and easier for developers to navigate the project.