### PR TITLE
feat: add TokenWrapped and TokenUnwrapped events in Eigen for observability

### DIFF
--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -32,6 +32,12 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     /// @notice event emitted when the transfer restrictions disabled
     event TransferRestrictionsDisabled();
 
+    /// EVENTS
+    /// @notice Emitted when bEIGEN tokens are wrapped into EIGEN
+    event TokenWrapped(address indexed account, uint256 amount);
+    /// @notice Emitted when EIGEN tokens are unwrapped into bEIGEN
+    event TokenUnwrapped(address indexed account, uint256 amount);
+
     constructor(
         IERC20 _bEIGEN
     ) {
@@ -128,6 +134,7 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     ) external {
         require(bEIGEN.transferFrom(msg.sender, address(this), amount), "Eigen.wrap: bEIGEN transfer failed");
         _mint(msg.sender, amount);
+        emit TokenWrapped(msg.sender, amount);
     }
 
     /**
@@ -138,6 +145,7 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable {
     ) external {
         _burn(msg.sender, amount);
         require(bEIGEN.transfer(msg.sender, amount), "Eigen.unwrap: bEIGEN transfer failed");
+        emit TokenUnwrapped(msg.sender, amount);
     }
 
     /**

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -35,6 +35,12 @@ contract EigenWrappingTests is Test {
     /// @notice event emitted when the transfer restrictions are disabled
     event TransferRestrictionsDisabled();
 
+    // EVENTS FROM Eigen.sol
+    /// @notice event emitted when bEIGEN tokens are wrapped into EIGEN
+    event TokenWrapped(address indexed account, uint amount);
+    /// @notice event emitted when EIGEN tokens are unwrapped into bEIGEN
+    event TokenUnwrapped(address indexed account, uint amount);
+
     modifier filterAddress(address fuzzedAddress) {
         vm.assume(!fuzzedOutAddresses[fuzzedAddress]);
         _;
@@ -56,6 +62,40 @@ contract EigenWrappingTests is Test {
         proxyAdmin.upgrade(ITransparentUpgradeableProxy(payable(address(eigen))), address(eigenImpl));
         proxyAdmin.upgrade(ITransparentUpgradeableProxy(payable(address(bEIGEN))), address(bEIGENImpl));
 
+<<<<<<< HEAD
+=======
+        // initialize bEIGEN - this will mint the entire supply to the Eigen contract
+        bEIGEN.initialize(minter1);
+
+        // set minters (for future minting if needed)
+        vm.expectEmit(true, true, true, true);
+        emit IsMinterModified(minter1, true);
+        bEIGEN.setIsMinter(minter1, true);
+
+        vm.expectEmit(true, true, true, true);
+        emit IsMinterModified(minter2, true);
+        bEIGEN.setIsMinter(minter2, true);
+
+        // initialize eigen with empty arrays since we don't need minting anymore
+        eigen.initialize(minter1);
+
+        // Mint and wrap tokens for minter1
+        vm.startPrank(minter1);
+        bEIGEN.mint(minter1, totalSupply / 2);
+        bEIGEN.approve(address(eigen), totalSupply / 2);
+        vm.expectEmit(true, true, true, true);
+        emit TokenWrapped(minter1, totalSupply / 2);
+        eigen.wrap(totalSupply / 2);
+        vm.stopPrank();
+
+        // Mint and wrap tokens for minter2
+        vm.startPrank(minter2);
+        bEIGEN.mint(minter2, totalSupply / 2);
+        bEIGEN.approve(address(eigen), totalSupply / 2);
+        vm.expectEmit(true, true, true, true);
+        emit TokenWrapped(minter2, totalSupply / 2);
+        eigen.wrap(totalSupply / 2);
+>>>>>>> cb0df903 (feat: add TokenWrapped and TokenUnwrapped events in Eigen for observability (#1331))
         vm.stopPrank();
 
         fuzzedOutAddresses[minter1] = true;
@@ -88,6 +128,8 @@ contract EigenWrappingTests is Test {
         // unwrap amount should be less than minter1 balance
         unwrapAmount = unwrapAmount % minter1Balance;
         vm.prank(unwrapper);
+        vm.expectEmit(true, false, false, false);
+        emit TokenUnwrapped(unwrapper, unwrapAmount);
         eigen.unwrap(unwrapAmount);
 
         // check total supply and balance changes
@@ -130,6 +172,8 @@ contract EigenWrappingTests is Test {
         // approve bEIGEN
         bEIGEN.approve(address(eigen), wrapAmount);
         // wrap
+        vm.expectEmit(true, false, false, false);
+        emit TokenWrapped(wrapper, wrapAmount);
         eigen.wrap(wrapAmount);
         vm.stopPrank();
 

--- a/src/test/token/EigenWrapping.t.sol
+++ b/src/test/token/EigenWrapping.t.sol
@@ -62,40 +62,6 @@ contract EigenWrappingTests is Test {
         proxyAdmin.upgrade(ITransparentUpgradeableProxy(payable(address(eigen))), address(eigenImpl));
         proxyAdmin.upgrade(ITransparentUpgradeableProxy(payable(address(bEIGEN))), address(bEIGENImpl));
 
-<<<<<<< HEAD
-=======
-        // initialize bEIGEN - this will mint the entire supply to the Eigen contract
-        bEIGEN.initialize(minter1);
-
-        // set minters (for future minting if needed)
-        vm.expectEmit(true, true, true, true);
-        emit IsMinterModified(minter1, true);
-        bEIGEN.setIsMinter(minter1, true);
-
-        vm.expectEmit(true, true, true, true);
-        emit IsMinterModified(minter2, true);
-        bEIGEN.setIsMinter(minter2, true);
-
-        // initialize eigen with empty arrays since we don't need minting anymore
-        eigen.initialize(minter1);
-
-        // Mint and wrap tokens for minter1
-        vm.startPrank(minter1);
-        bEIGEN.mint(minter1, totalSupply / 2);
-        bEIGEN.approve(address(eigen), totalSupply / 2);
-        vm.expectEmit(true, true, true, true);
-        emit TokenWrapped(minter1, totalSupply / 2);
-        eigen.wrap(totalSupply / 2);
-        vm.stopPrank();
-
-        // Mint and wrap tokens for minter2
-        vm.startPrank(minter2);
-        bEIGEN.mint(minter2, totalSupply / 2);
-        bEIGEN.approve(address(eigen), totalSupply / 2);
-        vm.expectEmit(true, true, true, true);
-        emit TokenWrapped(minter2, totalSupply / 2);
-        eigen.wrap(totalSupply / 2);
->>>>>>> cb0df903 (feat: add TokenWrapped and TokenUnwrapped events in Eigen for observability (#1331))
         vm.stopPrank();
 
         fuzzedOutAddresses[minter1] = true;
@@ -156,6 +122,8 @@ contract EigenWrappingTests is Test {
 
         // unwrap
         vm.startPrank(minter1);
+        vm.expectEmit(true, false, false, false);
+        emit TokenUnwrapped(minter1, minter1Balance);
         eigen.unwrap(minter1Balance);
 
         // send bEIGEN to wrapper
@@ -210,6 +178,8 @@ contract EigenWrappingTests is Test {
 
         // unwrap
         vm.startPrank(minter1);
+        vm.expectEmit(true, false, false, false);
+        emit TokenUnwrapped(minter1, wrapAmount);
         eigen.unwrap(wrapAmount);
         bEIGEN.transfer(wrapper, wrapAmount);
         vm.stopPrank();


### PR DESCRIPTION
**Motivation:**

add TokenWrapped and TokenUnwrapped events in Eigen for observability

**Modifications:**

add TokenWrapped and TokenUnwrapped events in Eigen add corresponding tests

**Result:**

we can track wrapping/unwrapping actions between Eigen and BackingEigen
