### PR TITLE
ci: add CI to auto validate deployment scripts

### DIFF
--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -2,10 +2,6 @@ name: Validate Deployment Scripts
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - 'script/**'
-      - '.github/workflows/validate-deployment-scripts.yml'
   pull_request:
     paths:
       - 'script/**'

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Validate Solidity Scripts
         run: |
-          # Find all .sol files under /script/deploy and /script/release
-          RELEASE_FILES=$(find script/release -type f -name "*.sol" 2>/dev/null || echo "")
+          # Find all .sol files under /script/releases
+          RELEASE_FILES=$(find script/releases -type f -name "*.sol" 2>/dev/null || echo "")
           
           # Combine file lists
           FILES="$RELEASE_FILES"
@@ -47,7 +47,7 @@ jobs:
           
           # Exit with success if no files are found
           if [ -z "$FILES" ]; then
-            echo "No .sol files found under /script/deploy or /script/release directories"
+            echo "No .sol files found under /script/releases directories"
             exit 0
           fi
           

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -91,5 +91,5 @@ jobs:
           # Run zeus test on each file with the specified environment and RPC URL
           for file in $FILES; do
             echo "Testing $file in ${{ matrix.env }} environment with RPC $RPC_URL..."
-            zeus test --env ${{ matrix.env }} "$file" --rpc-url "$RPC_URL"
+            zeus test --env ${{ matrix.env }} --rpcUrl "$RPC_URL" "$file" 
           done

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -5,10 +5,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - 'script/**'
-      - '.github/workflows/validate-deployment-scripts.yml'
   pull_request:
     paths:
       - 'script/**'

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Validate Solidity Scripts
         run: |
           # Find all .sol files under /script/releases
-          RELEASE_FILES=$(find script/releases -type f -name "*.sol" 2>/dev/null || echo "")
+          RELEASE_FILES=$(find script/releases -type f -name "*.sol" ! -name "Env.sol" 2>/dev/null || echo "")
           
           # Combine file lists
           FILES="$RELEASE_FILES"

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -5,6 +5,10 @@ permissions:
 
 on:
   workflow_dispatch:
+  push:
+    paths:
+      - 'script/**'
+      - '.github/workflows/validate-deployment-scripts.yml'
   pull_request:
     paths:
       - 'script/**'

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        env: [preprod, testnet, mainnet, testnet-sepolia, testnet-hoodi]
+        env: [preprod, testnet, mainnet]
 
     steps:
       # Check out repository with all submodules for complete codebase access.

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -1,5 +1,8 @@
 name: Validate Deployment Scripts
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -33,6 +33,36 @@ jobs:
 
       - name: Install Zeus
         run: npm install -g @layr-labs/zeus
+      
+        # Restore Forge cache
+      - name: Cache Forge Build
+        uses: actions/cache@v3
+        with:
+          path: |
+            cache/
+            out/
+          key: ${{ runner.os }}-forge-${{ hashFiles('**/foundry.toml', '**/remappings.txt', 'src/**/*.sol', 'lib/**/*.sol') }}
+          restore-keys: |
+            ${{ runner.os }}-forge-
+
+      # Install the Foundry toolchain.
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      # Run Forge's formatting checker to ensure consistent code style.
+      - name: "Forge Fmt"
+        run: |
+          forge fmt --check
+          FOUNDRY_PROFILE=test forge fmt --check
+        id: fmt
+
+      # Build the project and display contract sizes.
+      - name: Forge Build
+        run: |
+          forge --version
+          forge build --sizes
 
       - name: Validate Solidity Scripts
         run: |

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -81,8 +81,15 @@ jobs:
             exit 0
           fi
           
-          # Run zeus test on each file with the specified environment
+          # Set RPC URL based on environment
+          if [ "${{ matrix.env }}" = "mainnet" ]; then
+            RPC_URL="${{ secrets.RPC_MAINNET }}"
+          else
+            RPC_URL="${{ secrets.RPC_HOLESKY }}"
+          fi
+          
+          # Run zeus test on each file with the specified environment and RPC URL
           for file in $FILES; do
-            echo "Testing $file in ${{ matrix.env }} environment..."
-            zeus test --env ${{ matrix.env }} "$file"
+            echo "Testing $file in ${{ matrix.env }} environment with RPC $RPC_URL..."
+            zeus test --env ${{ matrix.env }} "$file" --rpc-url "$RPC_URL"
           done

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -1,0 +1,59 @@
+name: Validate Deployment Scripts
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'script/**'
+      - '.github/workflows/validate-deployment-scripts.yml'
+  pull_request:
+    paths:
+      - 'script/**'
+      - '.github/workflows/validate-deployment-scripts.yml'
+
+
+jobs:
+
+  test:
+    runs-on: protocol-x64-16core
+    strategy:
+      fail-fast: true
+      matrix:
+        env: [preprod, testnet, mainnet, testnet-sepolia, testnet-hoodi]
+
+    steps:
+      # Check out repository with all submodules for complete codebase access.
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install Zeus
+        run: npm install -g @layr-labs/zeus
+
+      - name: Validate Solidity Scripts
+        run: |
+          # Find all .sol files under /script/deploy and /script/release
+          RELEASE_FILES=$(find script/release -type f -name "*.sol" 2>/dev/null || echo "")
+          
+          # Combine file lists
+          FILES="$RELEASE_FILES"
+          
+          # Trim leading/trailing whitespace
+          FILES=$(echo "$FILES" | xargs)
+          
+          # Exit with success if no files are found
+          if [ -z "$FILES" ]; then
+            echo "No .sol files found under /script/deploy or /script/release directories"
+            exit 0
+          fi
+          
+          # Run zeus test on each file with the specified environment
+          for file in $FILES; do
+            echo "Testing $file in ${{ matrix.env }} environment..."
+            zeus test --env ${{ matrix.env }} "$file"
+          done


### PR DESCRIPTION
**Motivation:**

curently there's no ci coverage for deployment scripts. scripts can be only validated manually by devs offline by running `zeus test` on terminal

pain points:
1/ no quality control of scripts that got merged in
2/ manual testing is time intensive and not scalable

i feel these pain points as i'm writing deploy scripts of elip5 (v1.6.0 release)

**Modifications:**

add a new ci workflow to auto validate deployment scripts under /scripts/release/ in all 5 envs, currently mainnet, testnet, preprod. testnet-sepolia and testnet-hoodi to be added

the ci will only run if a pr touches anything under /scripts

**Result:**

- quality control is put in place for all deployment scripts
- fully automated, to save devs time
