### PR TITLE
docs: bump deployment matrix to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,37 +5,6 @@
 EigenLayer is a set of smart contracts deployed on Ethereum that enable restaking of assets to secure new services (AVSs).
 
 
-## Get Started
-
-See [CONTRIBUTING](CONTRIBUTING.md). 
-
-Contributions that do not follow our fork base PR practices will be either rejected or immediately deleted based on your role, preventing branch pollution, keeping our repository clean, make it more readable and searchable.
-
-
-## Branching
-
-Branches we use:
-* `main`: The canonical, most up-to-date branch, containing the work-in-progress code for upcoming releases
-* `Vx.y.z`: Release branch with version `x.y.z` that matches a release of EigenLayer, release branch is always cut from `main` via cherry-picking
-* `release-dev/xxx`: A development branch for a large feature to be released, the branch should eventually be deleted after merge to `main`
-
-
-## Documentation
-
-### Basics
-
-To get a basic understanding of EigenLayer, check out [You Could've Invented EigenLayer](https://www.blog.eigenlayer.xyz/ycie/). Note that some of the document's content describes features that do not exist yet (like the Slasher). To understand more about how restakers and operators interact with EigenLayer, check out these guides:
-* [Restaking User Guide](https://docs.eigenlayer.xyz/eigenlayer/restaking-guides/overview)
-* [Operator Guide](https://docs.eigenlayer.xyz/operator-guides/operator-introduction)
-
-### Deep Dive
-
-The most up-to-date and technical documentation can be found in [/docs](/docs). If you're a shadowy super coder, this is a great place to get an overview of the contracts before diving into the code.
-
-To get an idea of how users interact with these contracts, check out our integration tests: [/src/test/integration](./src/test/integration/).
-
-
-
 ## Deployments
 
 ### Deployment Version By Environments
@@ -270,3 +239,34 @@ The following strategies differ significantly from the other strategies deployed
 | [`OZ: Proxy Admin`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.1/contracts/proxy/transparent/ProxyAdmin.sol) | - | [`0x56E8...6Fa1`](https://sepolia.etherscan.io/address/0x56E88cb4f0136fC27D95499dE4BE2acf47946Fa1) | |
 
 </details>
+
+
+## Get Started
+
+See [CONTRIBUTING](CONTRIBUTING.md). 
+
+Contributions that do not follow our fork base PR practices will be either rejected or immediately deleted based on your role, preventing branch pollution, keeping our repository clean, make it more readable and searchable.
+
+
+## Branching
+
+Branches we use:
+* `main`: The canonical, most up-to-date branch, containing the work-in-progress code for upcoming releases
+* `Vx.y.z`: Release branch with version `x.y.z` that matches a release of EigenLayer, release branch is always cut from `main` via cherry-picking
+* `release-dev/xxx`: A development branch for a large feature to be released, the branch should eventually be deleted after merge to `main`
+
+
+## Documentation
+
+### Basics
+
+To get a basic understanding of EigenLayer, check out [You Could've Invented EigenLayer](https://www.blog.eigenlayer.xyz/ycie/). Note that some of the document's content describes features that do not exist yet (like the Slasher). To understand more about how restakers and operators interact with EigenLayer, check out these guides:
+* [Restaking User Guide](https://docs.eigenlayer.xyz/eigenlayer/restaking-guides/overview)
+* [Operator Guide](https://docs.eigenlayer.xyz/operator-guides/operator-introduction)
+
+### Deep Dive
+
+The most up-to-date and technical documentation can be found in [/docs](/docs). If you're a shadowy super coder, this is a great place to get an overview of the contracts before diving into the code.
+
+To get an idea of how users interact with these contracts, check out our integration tests: [/src/test/integration](./src/test/integration/).
+


### PR DESCRIPTION
**Motivation:**

bump deployment matrix to top of README for better readibility

