### PR TITLE
ci: add testnet envs sepolia and hoodi to validate-deployment-scripts

### DIFF
--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        env: [preprod, testnet, mainnet]
+        env: [preprod, testnet, mainnet, testnet-sepolia, testnet-hoodi]
 
     steps:
       # Check out repository with all submodules for complete codebase access.

--- a/.github/workflows/validate-deployment-scripts.yml
+++ b/.github/workflows/validate-deployment-scripts.yml
@@ -82,10 +82,14 @@ jobs:
           fi
           
           # Set RPC URL based on environment
-          if [ "${{ matrix.env }}" = "mainnet" ]; then
-            RPC_URL="${{ secrets.RPC_MAINNET }}"
-          else
+          if [ "${{ matrix.env }}" = "testnet" ] || [ "${{ matrix.env }}" = "preprod" ]; then
             RPC_URL="${{ secrets.RPC_HOLESKY }}"
+          elif [ "${{ matrix.env }}" = "testnet-sepolia" ]; then
+            RPC_URL="${{ secrets.RPC_SEPOLIA }}"
+          elif [ "${{ matrix.env }}" = "testnet-hoodi" ]; then
+            RPC_URL="${{ secrets.RPC_HOODI }}"
+          elif [ "${{ matrix.env }}" = "mainnet" ]; then
+            RPC_URL="${{ secrets.RPC_MAINNET }}"
           fi
           
           # Run zeus test on each file with the specified environment and RPC URL

--- a/script/releases/Env.sol
+++ b/script/releases/Env.sol
@@ -60,7 +60,7 @@ library Env {
     /**
      * env
      */
-    function deployEnv() internal view returns (string memory) {
+    function env() internal view returns (string memory) {
         return _string("ZEUS_ENV");
     }
 

--- a/script/releases/Env.sol
+++ b/script/releases/Env.sol
@@ -60,6 +60,10 @@ library Env {
     /**
      * env
      */
+    function deployEnv() internal view returns (string memory) {
+        return _string("ZEUS_ENV");
+    }
+
     function deployVersion() internal view returns (string memory) {
         return _string("ZEUS_DEPLOY_TO_VERSION");
     }

--- a/script/releases/v1.4.1-slashing/3-executeUpgrade.s.sol
+++ b/script/releases/v1.4.1-slashing/3-executeUpgrade.s.sol
@@ -97,7 +97,7 @@ contract Execute is QueueUpgrade {
         vm.expectRevert(errInit);
         eigenPodManager.initialize(address(0), 0);
         assertTrue(eigenPodManager.owner() == Env.executorMultisig(), "epm.owner invalid");
-        if (keccak256(bytes(Env.deployEnv())) != keccak256(bytes("testnet-sepolia"))) {
+        if (keccak256(bytes(Env.env())) != keccak256(bytes("testnet-sepolia"))) {
             assertTrue(eigenPodManager.paused() == 0, "epm.paused invalid");
         }
     }

--- a/script/releases/v1.4.1-slashing/3-executeUpgrade.s.sol
+++ b/script/releases/v1.4.1-slashing/3-executeUpgrade.s.sol
@@ -97,6 +97,8 @@ contract Execute is QueueUpgrade {
         vm.expectRevert(errInit);
         eigenPodManager.initialize(address(0), 0);
         assertTrue(eigenPodManager.owner() == Env.executorMultisig(), "epm.owner invalid");
-        assertTrue(eigenPodManager.paused() == 0, "epm.paused invalid");
+        if (keccak256(bytes(Env.deployEnv())) != keccak256(bytes("testnet-sepolia"))) {
+            assertTrue(eigenPodManager.paused() == 0, "epm.paused invalid");
+        }
     }
 }


### PR DESCRIPTION
**Motivation:**

add testnet envs sepolia and hoodi to validate-deployment-scripts, since both are deployed correctly now

**Modification:**

- add API `Env.env()` to expose zeus env to scripts
- change v1.4.1 script to skip EPM assertion on testnet-sepolia
- add testnet envs sepolia and hoodi to validate-deployment-scripts, since both are deployed correctly now