### PR TITLE
chore: update .gitattributes with Certora .spec/.conf formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 pkg/**/*.go linguist-generated=true
+
+# Certora formatting settings
+*.spec linguist-language=Solidity
+*.conf linguist-detectable
+*.conf linguist-language=JSON5


### PR DESCRIPTION
**Motivation:**

To enable Certora `.spec`/`.conf` highlighting as described in their [documentation](https://docs.certora.com/en/latest/docs/user-guide/github_highlighting.html).

**Modifications:**

Two additional lines added to `.gitattributes`

**Result:**

Better `.spec`/`.conf` highlighting within GitHub for ease of use
