### PR TITLE
Potential fix for code scanning alert no. 425: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 
 env:
   FOUNDRY_PROFILE: medium


### PR DESCRIPTION
Potential fix for [https://github.com/Layr-Labs/eigenlayer-contracts/security/code-scanning/425](https://github.com/Layr-Labs/eigenlayer-contracts/security/code-scanning/425)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, as they primarily involve checking out the repository, caching dependencies, and running commands locally. If any specific job requires additional permissions, we will define them within the job's `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
