### PR TITLE
fix: storage checker

### DIFF
--- a/.github/configs/storage-diff.json
+++ b/.github/configs/storage-diff.json
@@ -1,6 +1,10 @@
 {
     "contracts": [
       {
+        "name": "AllocationManager",
+        "address": "0x948a420b8CC1d6BFd0B6087C2E7c344a2CD0bc39"
+      },
+      {
         "name": "AVSDirectory",
         "address": "0x135dda560e946695d6f155dacafc6f1f25c1f5af"
       },

--- a/src/contracts/mixins/Deprecated_OwnableUpgradeable.sol
+++ b/src/contracts/mixins/Deprecated_OwnableUpgradeable.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
+import "@openzeppelin-upgrades/contracts/utils/ContextUpgradeable.sol";
 
 /**
  * @title Deprecated_OwnableUpgradeable
@@ -16,7 +17,7 @@ import "@openzeppelin-upgrades/contracts/proxy/utils/Initializable.sol";
  * - It keeps the `_owner` storage variable in the same slot
  * - It maintains the same storage gap for future upgrades
  */
-abstract contract Deprecated_OwnableUpgradeable is Initializable {
+abstract contract Deprecated_OwnableUpgradeable is Initializable, ContextUpgradeable {
     address private _owner;
 
     /**


### PR DESCRIPTION
**Motivation:**

Storage checker didn't have ALM added. Also we needed to fix the deprecated ownable mixing. 

**Modifications:**

Fix mixing to inherit from `ContextUpgradeable`. Add ALM to storage-diff.json. 

**Result:**

Correct storage checks.  