### PR TITLE
chore: bring back non-arrayified slashOperatorShares

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -63,12 +63,7 @@ contract AllocationManager is
     function slashOperator(
         address avs,
         SlashingParams calldata params
-    )
-        external
-        onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING)
-        checkCanCall(avs)
-        returns (uint256, uint256[] memory)
-    {
+    ) external onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING) checkCanCall(avs) returns (uint256, uint256[] memory) {
         // Check that the operator set exists and the operator is registered to it
         OperatorSet memory operatorSet = OperatorSet(avs, params.operatorSetId);
         require(params.strategies.length == params.wadsToSlash.length, InputArrayLengthMismatch());
@@ -320,7 +315,6 @@ contract AllocationManager is
      *                         INTERNAL FUNCTIONS
      *
      */
-
     function _slashOperator(
         SlashingParams calldata params,
         OperatorSet memory operatorSet

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -67,7 +67,7 @@ contract AllocationManager is
         external
         onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING)
         checkCanCall(avs)
-        returns (uint256 slashId, uint256[] memory shares)
+        returns (uint256, uint256[] memory)
     {
         // Check that the operator set exists and the operator is registered to it
         OperatorSet memory operatorSet = OperatorSet(avs, params.operatorSetId);
@@ -75,87 +75,7 @@ contract AllocationManager is
         require(_operatorSets[operatorSet.avs].contains(operatorSet.id), InvalidOperatorSet());
         require(isOperatorSlashable(params.operator, operatorSet), OperatorNotSlashable());
 
-        uint256[] memory wadSlashed = new uint256[](params.strategies.length);
-        shares = new uint256[](params.strategies.length);
-
-        // Increment the slash count for the operator set.
-        slashId = ++_slashCount[operatorSet.key()];
-
-        // For each strategy in the operator set, slash any existing allocation
-        for (uint256 i = 0; i < params.strategies.length; i++) {
-            // Check that `strategies` is in ascending order.
-            require(
-                i == 0 || uint160(address(params.strategies[i])) > uint160(address(params.strategies[i - 1])),
-                StrategiesMustBeInAscendingOrder()
-            );
-            // Check that `wadToSlash` is within acceptable bounds.
-            require(0 < params.wadsToSlash[i] && params.wadsToSlash[i] <= WAD, InvalidWadToSlash());
-            // Check that the operator set contains the strategy.
-            require(
-                _operatorSetStrategies[operatorSet.key()].contains(address(params.strategies[i])),
-                StrategyNotInOperatorSet()
-            );
-
-            // 1. Get the operator's allocation info for the strategy and operator set
-            (StrategyInfo memory info, Allocation memory allocation) =
-                _getUpdatedAllocation(params.operator, operatorSet.key(), params.strategies[i]);
-
-            // 2. Skip if the operator does not have a slashable allocation
-            // NOTE: this "if" is equivalent to: `if (!_isAllocationSlashable)`, because the other
-            // conditions in this method are already true (isOperatorSlashable + operatorSetStrategies.contains)
-            if (allocation.currentMagnitude == 0) {
-                continue;
-            }
-
-            // 3. Calculate the amount of magnitude being slashed, and subtract from
-            // the operator's currently-allocated magnitude, as well as the strategy's
-            // max and encumbered magnitudes
-            uint64 slashedMagnitude = uint64(uint256(allocation.currentMagnitude).mulWadRoundUp(params.wadsToSlash[i]));
-            uint64 prevMaxMagnitude = info.maxMagnitude;
-            wadSlashed[i] = uint256(slashedMagnitude).divWad(info.maxMagnitude);
-
-            allocation.currentMagnitude -= slashedMagnitude;
-            info.maxMagnitude -= slashedMagnitude;
-            info.encumberedMagnitude -= slashedMagnitude;
-
-            // 4. If there is a pending deallocation, reduce the pending deallocation proportionally.
-            // This ensures that when the deallocation is completed, less magnitude is freed.
-            if (allocation.pendingDiff < 0) {
-                uint64 slashedPending =
-                    uint64(uint256(uint128(-allocation.pendingDiff)).mulWadRoundUp(params.wadsToSlash[i]));
-                allocation.pendingDiff += int128(uint128(slashedPending));
-
-                emit AllocationUpdated(
-                    params.operator,
-                    operatorSet,
-                    params.strategies[i],
-                    _addInt128(allocation.currentMagnitude, allocation.pendingDiff),
-                    allocation.effectBlock
-                );
-            }
-
-            // 5. Update state
-            _updateAllocationInfo(params.operator, operatorSet.key(), params.strategies[i], info, allocation);
-
-            // Emit an event for the updated allocation
-            emit AllocationUpdated(
-                params.operator, operatorSet, params.strategies[i], allocation.currentMagnitude, uint32(block.number)
-            );
-
-            _updateMaxMagnitude(params.operator, params.strategies[i], info.maxMagnitude);
-
-            // 6. Slash operators shares in the DelegationManager
-            shares[i] = delegation.slashOperatorShares({
-                operator: params.operator,
-                operatorSet: operatorSet,
-                slashId: slashId,
-                strategy: params.strategies[i],
-                prevMaxMagnitude: prevMaxMagnitude,
-                newMaxMagnitude: info.maxMagnitude
-            });
-        }
-
-        emit OperatorSlashed(params.operator, operatorSet, params.strategies, wadSlashed, params.description);
+        return _slashOperator(params, operatorSet);
     }
 
     /// @inheritdoc IAllocationManager
@@ -400,6 +320,93 @@ contract AllocationManager is
      *                         INTERNAL FUNCTIONS
      *
      */
+
+    function _slashOperator(
+        SlashingParams calldata params,
+        OperatorSet memory operatorSet
+    ) internal returns (uint256 slashId, uint256[] memory shares) {
+        uint256[] memory wadSlashed = new uint256[](params.strategies.length);
+        shares = new uint256[](params.strategies.length);
+
+        // Increment the slash count for the operator set.
+        slashId = ++_slashCount[operatorSet.key()];
+
+        // For each strategy in the operator set, slash any existing allocation
+        for (uint256 i = 0; i < params.strategies.length; i++) {
+            // Check that `strategies` is in ascending order.
+            require(
+                i == 0 || uint160(address(params.strategies[i])) > uint160(address(params.strategies[i - 1])),
+                StrategiesMustBeInAscendingOrder()
+            );
+            // Check that `wadToSlash` is within acceptable bounds.
+            require(0 < params.wadsToSlash[i] && params.wadsToSlash[i] <= WAD, InvalidWadToSlash());
+            // Check that the operator set contains the strategy.
+            require(
+                _operatorSetStrategies[operatorSet.key()].contains(address(params.strategies[i])),
+                StrategyNotInOperatorSet()
+            );
+
+            // 1. Get the operator's allocation info for the strategy and operator set
+            (StrategyInfo memory info, Allocation memory allocation) =
+                _getUpdatedAllocation(params.operator, operatorSet.key(), params.strategies[i]);
+
+            // 2. Skip if the operator does not have a slashable allocation
+            // NOTE: this "if" is equivalent to: `if (!_isAllocationSlashable)`, because the other
+            // conditions in this method are already true (isOperatorSlashable + operatorSetStrategies.contains)
+            if (allocation.currentMagnitude == 0) {
+                continue;
+            }
+
+            // 3. Calculate the amount of magnitude being slashed, and subtract from
+            // the operator's currently-allocated magnitude, as well as the strategy's
+            // max and encumbered magnitudes
+            uint64 slashedMagnitude = uint64(uint256(allocation.currentMagnitude).mulWadRoundUp(params.wadsToSlash[i]));
+            uint64 prevMaxMagnitude = info.maxMagnitude;
+            wadSlashed[i] = uint256(slashedMagnitude).divWad(info.maxMagnitude);
+
+            allocation.currentMagnitude -= slashedMagnitude;
+            info.maxMagnitude -= slashedMagnitude;
+            info.encumberedMagnitude -= slashedMagnitude;
+
+            // 4. If there is a pending deallocation, reduce the pending deallocation proportionally.
+            // This ensures that when the deallocation is completed, less magnitude is freed.
+            if (allocation.pendingDiff < 0) {
+                uint64 slashedPending =
+                    uint64(uint256(uint128(-allocation.pendingDiff)).mulWadRoundUp(params.wadsToSlash[i]));
+                allocation.pendingDiff += int128(uint128(slashedPending));
+
+                emit AllocationUpdated(
+                    params.operator,
+                    operatorSet,
+                    params.strategies[i],
+                    _addInt128(allocation.currentMagnitude, allocation.pendingDiff),
+                    allocation.effectBlock
+                );
+            }
+
+            // 5. Update state
+            _updateAllocationInfo(params.operator, operatorSet.key(), params.strategies[i], info, allocation);
+
+            // Emit an event for the updated allocation
+            emit AllocationUpdated(
+                params.operator, operatorSet, params.strategies[i], allocation.currentMagnitude, uint32(block.number)
+            );
+
+            _updateMaxMagnitude(params.operator, params.strategies[i], info.maxMagnitude);
+
+            // 6. Slash operators shares in the DelegationManager
+            shares[i] = delegation.slashOperatorShares({
+                operator: params.operator,
+                operatorSet: operatorSet,
+                slashId: slashId,
+                strategy: params.strategies[i],
+                prevMaxMagnitude: prevMaxMagnitude,
+                newMaxMagnitude: info.maxMagnitude
+            });
+        }
+
+        emit OperatorSlashed(params.operator, operatorSet, params.strategies, wadSlashed, params.description);
+    }
 
     /**
      * @dev Adds a strategy to an operator set.

--- a/src/contracts/core/DelegationManager.sol
+++ b/src/contracts/core/DelegationManager.sol
@@ -285,16 +285,40 @@ contract DelegationManager is
         address operator,
         OperatorSet calldata operatorSet,
         uint256 slashId,
-        IStrategy[] calldata strategies,
-        uint64[] calldata prevMaxMagnitudes,
-        uint64[] calldata newMaxMagnitudes
-    ) external onlyAllocationManager nonReentrant returns (uint256[] memory totalDepositSharesToBurn) {
-        totalDepositSharesToBurn = new uint256[](strategies.length);
-        for (uint256 i = 0; i < strategies.length; i++) {
-            totalDepositSharesToBurn[i] = _slashOperatorShares(
-                operator, operatorSet, slashId, strategies[i], prevMaxMagnitudes[i], newMaxMagnitudes[i]
-            );
-        }
+        IStrategy strategy,
+        uint64 prevMaxMagnitude,
+        uint64 newMaxMagnitude
+    ) external onlyAllocationManager nonReentrant returns (uint256 totalDepositSharesToBurn) {
+        uint256 operatorSharesSlashed = SlashingLib.calcSlashedAmount({
+            operatorShares: operatorShares[operator][strategy],
+            prevMaxMagnitude: prevMaxMagnitude,
+            newMaxMagnitude: newMaxMagnitude
+        });
+
+        uint256 scaledSharesSlashedFromQueue = _getSlashableSharesInQueue({
+            operator: operator,
+            strategy: strategy,
+            prevMaxMagnitude: prevMaxMagnitude,
+            newMaxMagnitude: newMaxMagnitude
+        });
+
+        // Calculate the total deposit shares to burn - slashed operator shares plus still-slashable
+        // shares sitting in the withdrawal queue.
+        totalDepositSharesToBurn = operatorSharesSlashed + scaledSharesSlashedFromQueue;
+
+        // Remove shares from operator
+        _decreaseDelegation({
+            operator: operator,
+            staker: address(0), // we treat this as a decrease for the 0-staker (only used for events)
+            strategy: strategy,
+            sharesToDecrease: operatorSharesSlashed
+        });
+
+        // Emit event for operator shares being slashed
+        emit OperatorSharesSlashed(operator, strategy, totalDepositSharesToBurn);
+
+        _getShareManager(strategy).increaseBurnableShares(operatorSet, slashId, strategy, totalDepositSharesToBurn);
+
         return totalDepositSharesToBurn;
     }
 
@@ -667,54 +691,8 @@ contract DelegationManager is
         emit OperatorSharesDecreased(operator, staker, strategy, sharesToDecrease);
     }
 
-    /// @dev Slashes operator shares and queues a redistribution for the slashable shares in the queue.
-    /// See `slashOperatorShares` for more details.
-    function _slashOperatorShares(
-        address operator,
-        OperatorSet memory operatorSet,
-        uint256 slashId,
-        IStrategy strategy,
-        uint64 prevMaxMagnitude,
-        uint64 newMaxMagnitude
-    ) internal returns (uint256 totalDepositSharesToBurn) {
-        // Avoid emitting events if nothing has changed for sanitization.
-        if (prevMaxMagnitude == newMaxMagnitude) return 0;
-
-        uint256 operatorSharesSlashed = SlashingLib.calcSlashedAmount({
-            operatorShares: operatorShares[operator][strategy],
-            prevMaxMagnitude: prevMaxMagnitude,
-            newMaxMagnitude: newMaxMagnitude
-        });
-
-        uint256 scaledSharesSlashedFromQueue = _getSlashableSharesInQueue({
-            operator: operator,
-            strategy: strategy,
-            prevMaxMagnitude: prevMaxMagnitude,
-            newMaxMagnitude: newMaxMagnitude
-        });
-
-        // Calculate the total deposit shares to burn - slashed operator shares plus still-slashable
-        // shares sitting in the withdrawal queue.
-        totalDepositSharesToBurn = operatorSharesSlashed + scaledSharesSlashedFromQueue;
-
-        // Remove shares from operator
-        _decreaseDelegation({
-            operator: operator,
-            staker: address(0), // we treat this as a decrease for the 0-staker (only used for events)
-            strategy: strategy,
-            sharesToDecrease: operatorSharesSlashed
-        });
-
-        // Emit event for operator shares being slashed
-        emit OperatorSharesSlashed(operator, strategy, totalDepositSharesToBurn);
-
-        _getShareManager(strategy).increaseBurnableShares(operatorSet, slashId, strategy, totalDepositSharesToBurn);
-
-        return totalDepositSharesToBurn;
-    }
-
     /// @dev If `operator` has configured a `delegationApprover`, check that `signature` and `salt`
-    /// are a valid approval for `staker` delegating to `operator`.
+    /// are a valid appfroval for `staker` delegating to `operator`.
     function _checkApproverSignature(
         address staker,
         address operator,

--- a/src/contracts/interfaces/IDelegationManager.sol
+++ b/src/contracts/interfaces/IDelegationManager.sol
@@ -362,9 +362,9 @@ interface IDelegationManager is ISignatureUtilsMixin, IDelegationManagerErrors, 
      * @param operator The operator to decrease shares for.
      * @param operatorSet The operator set to decrease shares for.
      * @param slashId The slash id to decrease shares for.
-     * @param strategies The strategies to decrease shares for.
-     * @param prevMaxMagnitudes The previous maxMagnitudes of the operator.
-     * @param newMaxMagnitudes The new maxMagnitudes of the operator.
+     * @param strategy The strategy to decrease shares for.
+     * @param prevMaxMagnitude The previous maxMagnitude of the operator.
+     * @param newMaxMagnitude The new maxMagnitude of the operator.
      * @dev Callable only by the AllocationManager.
      * @dev Note: Assumes `prevMaxMagnitude <= newMaxMagnitude`. This invariant is maintained in
      * the AllocationManager.
@@ -374,10 +374,10 @@ interface IDelegationManager is ISignatureUtilsMixin, IDelegationManagerErrors, 
         address operator,
         OperatorSet calldata operatorSet,
         uint256 slashId,
-        IStrategy[] calldata strategies,
-        uint64[] calldata prevMaxMagnitudes,
-        uint64[] calldata newMaxMagnitudes
-    ) external returns (uint256[] memory totalDepositSharesToBurn);
+        IStrategy strategy,
+        uint64 prevMaxMagnitude,
+        uint64 newMaxMagnitude
+    ) external returns (uint256 totalDepositSharesToBurn);
 
     /**
      *

--- a/src/test/mocks/DelegationManagerMock.sol
+++ b/src/test/mocks/DelegationManagerMock.sol
@@ -36,8 +36,6 @@ contract DelegationManagerMock is Test {
         uint[] memory amountSlashed = new uint[](strategies.length);
 
         for (uint i = 0; i < strategies.length; i++) {
-            if (prevMaxMagnitudes[i] == newMaxMagnitudes[i]) continue;
-
             amountSlashed[i] = SlashingLib.calcSlashedAmount({
                 operatorShares: operatorShares[operator][strategies[i]],
                 prevMaxMagnitude: prevMaxMagnitudes[i],

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -3603,12 +3603,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             _setOperatorMagnitude(defaultOperator, strategy, newMaxMagnitude);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                strategy,
-                prevMaxMagnitude,
-                newMaxMagnitude
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategy, prevMaxMagnitude, newMaxMagnitude
             );
             (, uint operatorSharesAfterSlash) = _assertOperatorSharesAfterSlash({
                 operator: defaultOperator,
@@ -3719,9 +3714,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
         {
             _setOperatorMagnitude(defaultOperator, strategy, operatorMagnitude);
             cheats.prank(address(allocationManagerMock));
-            delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0)
-            );
+            delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0));
             operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategy);
             assertEq(operatorSharesAfterSlash, 0, "operator shares not fully slashed");
         }
@@ -3831,12 +3824,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
 
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                strategyMock,
-                prevMaxMagnitude,
-                newMaxMagnitude
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, prevMaxMagnitude, newMaxMagnitude
             );
             _assertOperatorSharesAfterSlash({
                 operator: defaultOperator,
@@ -4480,12 +4468,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         _setOperatorMagnitude(defaultOperator, strategyMock, newMaxMagnitude);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator,
-            defaultOperatorSet,
-            defaultSlashId,
-            strategyMock,
-            prevMaxMagnitude,
-            newMaxMagnitude
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, prevMaxMagnitude, newMaxMagnitude
         );
         // Assertions on amount burned
         (uint operatorSharesSlashed,) = _assertOperatorSharesAfterSlash({
@@ -4566,9 +4549,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         uint64 operatorMagnitude = 0;
         _setOperatorMagnitude(defaultOperator, strategyMock, operatorMagnitude);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0));
         _assertOperatorSharesAfterSlash({
             operator: defaultOperator,
             strategy: strategyMock,
@@ -4803,12 +4784,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         for (uint i = 0; i < strategies.length; i++) {
             uint operatorSharesBefore = delegationManager.operatorShares(defaultOperator, strategies[i]);
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                strategies[i],
-                prevMaxMagnitudes[i],
-                newMaxMagnitudes[i]
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategies[i], prevMaxMagnitudes[i], newMaxMagnitudes[i]
             );
             // Assert correct amount of shares slashed from operator
             (slashedOperatorShares[i],) = _assertOperatorSharesAfterSlash({
@@ -5118,9 +5094,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         // Slash all of operator's shares
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0));
 
         // Complete withdrawal as shares and check that withdrawal was cleared
         cheats.roll(block.number + 1);
@@ -5294,12 +5268,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             _setOperatorMagnitude(defaultOperator, strategyMock, newMaxMagnitude);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                withdrawal.strategies[0],
-                prevMaxMagnitude,
-                newMaxMagnitude
+                defaultOperator, defaultOperatorSet, defaultSlashId, withdrawal.strategies[0], prevMaxMagnitude, newMaxMagnitude
             );
             uint operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(
@@ -5491,12 +5460,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
             _setOperatorMagnitude(defaultOperator, withdrawal.strategies[0], operatorMagnitude);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                withdrawal.strategies[0],
-                WAD,
-                operatorMagnitude
+                defaultOperator, defaultOperatorSet, defaultSlashId, withdrawal.strategies[0], WAD, operatorMagnitude
             );
             uint operatorSharesAfterAVSSlash = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
             assertApproxEqAbs(
@@ -5650,9 +5614,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
 
         cheats.startPrank(invalidCaller);
         cheats.expectRevert(IDelegationManagerErrors.OnlyAllocationManager.selector);
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, uint64(0), uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, uint64(0), uint64(0));
     }
 
     /// @notice Verifies that there is no change in shares if the staker is not delegatedd
@@ -5660,9 +5622,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         _registerOperatorWithBaseDetails(defaultOperator);
 
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (WAD / 2)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (WAD / 2));
         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
     }
 
@@ -5692,9 +5652,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         // Slash all of operator's shares
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0));
 
         uint slashableSharesInQueueAfter = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
 
@@ -5744,9 +5702,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         // Slash all of operator's shares
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0));
 
         // Complete withdrawal as tokens and assert that we call back into the SM with 100 tokens
         IERC20[] memory tokens = strategyMock.underlyingToken().toArray();
@@ -5805,9 +5761,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
             strategyMock,
             depositAmount / 6 // 1 withdrawal not queued so decreased
         );
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0));
 
         // Assert slashable shares
         slashableSharesInQueue = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
@@ -5957,9 +5911,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         emit OperatorSharesSlashed(operator, strategyMock, sharesToBurn);
 
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            operator, defaultOperatorSet, defaultSlashId, strategyMock, initMagnitude, newMagnitude
-        );
+        delegationManager.slashOperatorShares(operator, defaultOperatorSet, defaultSlashId, strategyMock, initMagnitude, newMagnitude);
 
         uint queuedSlashableSharesAfter = delegationManager.getSlashableSharesInQueue(operator, strategyMock);
         uint operatorSharesAfter = delegationManager.operatorShares(operator, strategyMock);
@@ -6668,12 +6620,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                 _setOperatorMagnitude(defaultOperator, beaconChainETHStrategy, newMaxMagnitude);
                 cheats.prank(address(allocationManagerMock));
                 delegationManager.slashOperatorShares(
-                    defaultOperator,
-                    defaultOperatorSet,
-                    defaultSlashId,
-                    beaconChainETHStrategy,
-                    initialMagnitude,
-                    newMaxMagnitude
+                    defaultOperator, defaultOperatorSet, defaultSlashId, beaconChainETHStrategy, initialMagnitude, newMaxMagnitude
                 );
 
                 // save the outcome
@@ -6729,12 +6676,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                 _setOperatorMagnitude(defaultOperator2, beaconChainETHStrategy, newMaxMagnitude);
                 cheats.prank(address(allocationManagerMock));
                 delegationManager.slashOperatorShares(
-                    defaultOperator2,
-                    defaultOperatorSet,
-                    defaultSlashId,
-                    beaconChainETHStrategy,
-                    initialMagnitude,
-                    newMaxMagnitude
+                    defaultOperator2, defaultOperatorSet, defaultSlashId, beaconChainETHStrategy, initialMagnitude, newMaxMagnitude
                 );
 
                 uint expectedWithdrawable = _calcWithdrawableShares(
@@ -7375,9 +7317,7 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
         {
             _setOperatorMagnitude(defaultOperator, strategy, operatorMagnitude);
             cheats.prank(address(allocationManagerMock));
-            delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0)
-            );
+            delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0));
             operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategy);
             assertEq(operatorSharesAfterSlash, 0, "operator shares not fully slashed");
         }
@@ -7568,9 +7508,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             uint newStakerShares = depositShares[i] / 2;
             _setOperatorMagnitude(defaultOperator, strategies[i], 0.5 ether);
             cheats.prank(address(allocationManagerMock));
-            delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategies[i], WAD, (0.5 ether)
-            );
+            delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategies[i], WAD, (0.5 ether));
             uint afterSlash = delegationManager.operatorShares(defaultOperator, strategies[i]);
             assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
         }
@@ -7606,9 +7544,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         uint newStakerShares = totalDepositShares / 2;
         _setOperatorMagnitude(defaultOperator, strategyMock, 0.5 ether);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether));
         uint afterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
         assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
 
@@ -7683,12 +7619,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             _setOperatorMagnitude(defaultOperator, strategyMock, 50e16);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                withdrawal.strategies[0],
-                uint64(WAD),
-                (50e16)
+                defaultOperator, defaultOperatorSet, defaultSlashId, withdrawal.strategies[0], uint64(WAD), (50e16)
             );
             uint operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(
@@ -7716,12 +7647,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             _setOperatorMagnitude(defaultOperator, strategyMock, 25e16);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator,
-                defaultOperatorSet,
-                defaultSlashId,
-                withdrawal.strategies[0],
-                (50e16),
-                (25e16)
+                defaultOperator, defaultOperatorSet, defaultSlashId, withdrawal.strategies[0], (50e16), (25e16)
             );
             uint operatorSharesAfterSecondSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(operatorSharesAfterSecondSlash, operatorShares - sharesToDecrement, "operator shares should be decreased after slash");
@@ -7832,9 +7758,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         // Slash operator by 50%
         _setOperatorMagnitude(defaultOperator, strategyMock, 0.5 ether);
         cheats.prank(address(allocationManagerMock));
-        delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether)
-        );
+        delegationManager.slashOperatorShares(defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether));
 
         // Get shares from queued withdrawal
         (, uint[] memory shares) = delegationManager.getQueuedWithdrawal(withdrawalRoot);

--- a/src/test/unit/DelegationUnit.t.sol
+++ b/src/test/unit/DelegationUnit.t.sol
@@ -3606,9 +3606,9 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                strategy.toArray(),
-                prevMaxMagnitude.toArrayU64(),
-                newMaxMagnitude.toArrayU64()
+                strategy,
+                prevMaxMagnitude,
+                newMaxMagnitude
             );
             (, uint operatorSharesAfterSlash) = _assertOperatorSharesAfterSlash({
                 operator: defaultOperator,
@@ -3720,7 +3720,7 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
             _setOperatorMagnitude(defaultOperator, strategy, operatorMagnitude);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategy.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0)
             );
             operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategy);
             assertEq(operatorSharesAfterSlash, 0, "operator shares not fully slashed");
@@ -3834,9 +3834,9 @@ contract DelegationManagerUnitTests_undelegate is DelegationManagerUnitTests {
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                strategyMock.toArray(),
-                prevMaxMagnitude.toArrayU64(),
-                newMaxMagnitude.toArrayU64()
+                strategyMock,
+                prevMaxMagnitude,
+                newMaxMagnitude
             );
             _assertOperatorSharesAfterSlash({
                 operator: defaultOperator,
@@ -4483,9 +4483,9 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
             defaultOperator,
             defaultOperatorSet,
             defaultSlashId,
-            strategyMock.toArray(),
-            prevMaxMagnitude.toArrayU64(),
-            newMaxMagnitude.toArrayU64()
+            strategyMock,
+            prevMaxMagnitude,
+            newMaxMagnitude
         );
         // Assertions on amount burned
         (uint operatorSharesSlashed,) = _assertOperatorSharesAfterSlash({
@@ -4567,7 +4567,7 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
         _setOperatorMagnitude(defaultOperator, strategyMock, operatorMagnitude);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
         );
         _assertOperatorSharesAfterSlash({
             operator: defaultOperator,
@@ -4806,9 +4806,9 @@ contract DelegationManagerUnitTests_queueWithdrawals is DelegationManagerUnitTes
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                strategies[i].toArray(),
-                prevMaxMagnitudes[i].toArrayU64(),
-                newMaxMagnitudes[i].toArrayU64()
+                strategies[i],
+                prevMaxMagnitudes[i],
+                newMaxMagnitudes[i]
             );
             // Assert correct amount of shares slashed from operator
             (slashedOperatorShares[i],) = _assertOperatorSharesAfterSlash({
@@ -5119,7 +5119,7 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
         );
 
         // Complete withdrawal as shares and check that withdrawal was cleared
@@ -5297,9 +5297,9 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                withdrawal.strategies[0].toArray(),
-                prevMaxMagnitude.toArrayU64(),
-                newMaxMagnitude.toArrayU64()
+                withdrawal.strategies[0],
+                prevMaxMagnitude,
+                newMaxMagnitude
             );
             uint operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(
@@ -5494,9 +5494,9 @@ contract DelegationManagerUnitTests_completeQueuedWithdrawal is DelegationManage
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                withdrawal.strategies[0].toArray(),
-                WAD.toArrayU64(),
-                operatorMagnitude.toArrayU64()
+                withdrawal.strategies[0],
+                WAD,
+                operatorMagnitude
             );
             uint operatorSharesAfterAVSSlash = delegationManager.operatorShares(defaultOperator, beaconChainETHStrategy);
             assertApproxEqAbs(
@@ -5651,7 +5651,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         cheats.startPrank(invalidCaller);
         cheats.expectRevert(IDelegationManagerErrors.OnlyAllocationManager.selector);
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), uint64(0).toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, uint64(0), uint64(0)
         );
     }
 
@@ -5661,7 +5661,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
 
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), (WAD / 2).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (WAD / 2)
         );
         assertEq(delegationManager.operatorShares(defaultOperator, strategyMock), 0, "shares should not have changed");
     }
@@ -5693,7 +5693,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
         );
 
         uint slashableSharesInQueueAfter = delegationManager.getSlashableSharesInQueue(defaultOperator, strategyMock);
@@ -5745,7 +5745,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
         _setOperatorMagnitude(defaultOperator, strategyMock, 0);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
         );
 
         // Complete withdrawal as tokens and assert that we call back into the SM with 100 tokens
@@ -5806,7 +5806,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
             depositAmount / 6 // 1 withdrawal not queued so decreased
         );
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, uint64(0)
         );
 
         // Assert slashable shares
@@ -5886,9 +5886,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
     //                 defaultOperator,
     //                 defaultOperatorSet,
     //                 defaultSlashId,
-    //                 strategies[i].toArray(),
-    //                 prevMaxMagnitude.toArrayU64(),
-    //                 newMaxMagnitude.toArrayU64()
+    //                 strategies[i],
+    //                 prevMaxMagnitude,
+    //                 newMaxMagnitude
     //             );
 
     //             // Also update maxMagnitude in ALM mock
@@ -5958,7 +5958,7 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
 
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            operator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), initMagnitude.toArrayU64(), newMagnitude.toArrayU64()
+            operator, defaultOperatorSet, defaultSlashId, strategyMock, initMagnitude, newMagnitude
         );
 
         uint queuedSlashableSharesAfter = delegationManager.getSlashableSharesInQueue(operator, strategyMock);
@@ -6039,9 +6039,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
     //         operator: operator,
     //         operatorSet: defaultOperatorSet,
     //         slashId: defaultSlashId,
-    //         strategies: strategyMock.toArray(),
-    //         prevMaxMagnitudes: WAD.toArrayU64(),
-    //         newMaxMagnitudes: newMagnitude.toArrayU64()
+    //         strategy: strategyMock,
+    //         prevMaxMagnitude: WAD,
+    //         newMaxMagnitude: newMagnitude
     //     });
 
     //     // 5. Assert expected values
@@ -6203,9 +6203,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
     //         operator: operator,
     //         operatorSet: defaultOperatorSet,
     //         slashId: defaultSlashId,
-    //         strategies: strategyMock.toArray(),
-    //         prevMaxMagnitudes: WAD.toArrayU64(),
-    //         newMaxMagnitudes: newMagnitude.toArrayU64()
+    //         strategy: strategyMock,
+    //         prevMaxMagnitude: WAD,
+    //         newMaxMagnitude: newMagnitude
     //     });
 
     //     // 5. Assert expected values
@@ -6286,9 +6286,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                 operator: operator,
                 operatorSet: defaultOperatorSet,
                 slashId: defaultSlashId,
-                strategies: strategyMock.toArray(),
-                prevMaxMagnitudes: WAD.toArrayU64(),
-                newMaxMagnitudes: newMagnitude.toArrayU64()
+                strategy: strategyMock,
+                prevMaxMagnitude: WAD,
+                newMaxMagnitude: newMagnitude
             });
 
             // 3.3 Assert slashable shares and operator shares
@@ -6343,9 +6343,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                 operator: operator,
                 operatorSet: defaultOperatorSet,
                 slashId: defaultSlashId,
-                strategies: strategyMock.toArray(),
-                prevMaxMagnitudes: (newMagnitude * 2).toArrayU64(),
-                newMaxMagnitudes: newMagnitude.toArrayU64()
+                strategy: strategyMock,
+                prevMaxMagnitude: (newMagnitude * 2),
+                newMaxMagnitude: newMagnitude
             });
 
             // 4.3 Assert slashable shares and operator shares
@@ -6443,9 +6443,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
             operator: operator,
             operatorSet: defaultOperatorSet,
             slashId: defaultSlashId,
-            strategies: strategyMock.toArray(),
-            prevMaxMagnitudes: WAD.toArrayU64(),
-            newMaxMagnitudes: newMagnitude.toArrayU64()
+            strategy: strategyMock,
+            prevMaxMagnitude: WAD,
+            newMaxMagnitude: newMagnitude
         });
 
         // 5. Assert expected values
@@ -6574,9 +6574,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                strategyMock.toArray(),
-                (newOperatorMagnitude + slashMagnitude).toArrayU64(),
-                newOperatorMagnitude.toArrayU64()
+                strategyMock,
+                (newOperatorMagnitude + slashMagnitude),
+                newOperatorMagnitude
             );
 
             uint operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
@@ -6671,9 +6671,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                     defaultOperator,
                     defaultOperatorSet,
                     defaultSlashId,
-                    beaconChainETHStrategy.toArray(),
-                    initialMagnitude.toArrayU64(),
-                    newMaxMagnitude.toArrayU64()
+                    beaconChainETHStrategy,
+                    initialMagnitude,
+                    newMaxMagnitude
                 );
 
                 // save the outcome
@@ -6732,9 +6732,9 @@ contract DelegationManagerUnitTests_slashingShares is DelegationManagerUnitTests
                     defaultOperator2,
                     defaultOperatorSet,
                     defaultSlashId,
-                    beaconChainETHStrategy.toArray(),
-                    initialMagnitude.toArrayU64(),
-                    newMaxMagnitude.toArrayU64()
+                    beaconChainETHStrategy,
+                    initialMagnitude,
+                    newMaxMagnitude
                 );
 
                 uint expectedWithdrawable = _calcWithdrawableShares(
@@ -6832,9 +6832,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
 
                 // 2. deposit again
@@ -6922,9 +6922,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
 
                 // 2. deposit again
@@ -7012,9 +7012,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
             }
         }
@@ -7089,9 +7089,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
             }
         }
@@ -7165,9 +7165,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
             }
         }
@@ -7244,9 +7244,9 @@ contract DelegationManagerUnitTests_SharesUnderflowChecks is DelegationManagerUn
                     operator: defaultOperator,
                     operatorSet: defaultOperatorSet,
                     slashId: defaultSlashId,
-                    strategies: strategyMock.toArray(),
-                    prevMaxMagnitudes: (currMagnitude + slashMagnitude).toArrayU64(),
-                    newMaxMagnitudes: currMagnitude.toArrayU64()
+                    strategy: strategyMock,
+                    prevMaxMagnitude: (currMagnitude + slashMagnitude),
+                    newMaxMagnitude: currMagnitude
                 });
             }
         }
@@ -7376,7 +7376,7 @@ contract DelegationManagerUnitTests_Lifecycle is DelegationManagerUnitTests {
             _setOperatorMagnitude(defaultOperator, strategy, operatorMagnitude);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategy.toArray(), WAD.toArrayU64(), uint64(0).toArrayU64()
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategy, WAD, uint64(0)
             );
             operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategy);
             assertEq(operatorSharesAfterSlash, 0, "operator shares not fully slashed");
@@ -7569,7 +7569,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
             _setOperatorMagnitude(defaultOperator, strategies[i], 0.5 ether);
             cheats.prank(address(allocationManagerMock));
             delegationManager.slashOperatorShares(
-                defaultOperator, defaultOperatorSet, defaultSlashId, strategies[i].toArray(), WAD.toArrayU64(), (0.5 ether).toArrayU64()
+                defaultOperator, defaultOperatorSet, defaultSlashId, strategies[i], WAD, (0.5 ether)
             );
             uint afterSlash = delegationManager.operatorShares(defaultOperator, strategies[i]);
             assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
@@ -7607,7 +7607,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
         _setOperatorMagnitude(defaultOperator, strategyMock, 0.5 ether);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), (0.5 ether).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether)
         );
         uint afterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
         assertApproxEqAbs(afterSlash, newStakerShares, 1, "bad operator shares after slash");
@@ -7686,9 +7686,9 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                withdrawal.strategies[0].toArray(),
-                uint64(WAD).toArrayU64(),
-                (50e16).toArrayU64()
+                withdrawal.strategies[0],
+                uint64(WAD),
+                (50e16)
             );
             uint operatorSharesAfterSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(
@@ -7719,9 +7719,9 @@ contract DelegationManagerUnitTests_getQueuedWithdrawals is DelegationManagerUni
                 defaultOperator,
                 defaultOperatorSet,
                 defaultSlashId,
-                withdrawal.strategies[0].toArray(),
-                (50e16).toArrayU64(),
-                (25e16).toArrayU64()
+                withdrawal.strategies[0],
+                (50e16),
+                (25e16)
             );
             uint operatorSharesAfterSecondSlash = delegationManager.operatorShares(defaultOperator, strategyMock);
             assertEq(operatorSharesAfterSecondSlash, operatorShares - sharesToDecrement, "operator shares should be decreased after slash");
@@ -7833,7 +7833,7 @@ contract DelegationManagerUnitTests_getQueuedWithdrawal is DelegationManagerUnit
         _setOperatorMagnitude(defaultOperator, strategyMock, 0.5 ether);
         cheats.prank(address(allocationManagerMock));
         delegationManager.slashOperatorShares(
-            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock.toArray(), WAD.toArrayU64(), (0.5 ether).toArrayU64()
+            defaultOperator, defaultOperatorSet, defaultSlashId, strategyMock, WAD, (0.5 ether)
         );
 
         // Get shares from queued withdrawal


### PR DESCRIPTION
**Motivation:**

We want to minimize the diff between slashing and redistribution. Bring back the single call from ALM to DM for slashes. 

**Modifications:**

Bring back single call from ALM to DM for slash, instead of aggregating all mags. 

**Result:**

Smaller Diff