### PR TITLE
feat: deploy escrow in `initiateSlashEscrow`

### DIFF
--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -77,6 +77,8 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
         // Add the strategy to the pending strategies for the slash ID.
         pendingStrategiesForSlashId.add(address(strategy));
 
+        // Emit the start escrow event. We can use the block.number here because all strategies
+        // in a given operatorSet/slashId will have their escrow initiated in the same transaction.
         emit StartEscrow(operatorSet, slashId, strategy, uint32(block.number));
     }
 

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -52,26 +52,31 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
      */
 
     /// @inheritdoc ISlashEscrowFactory
-    function initiateSlashEscrow(
-        OperatorSet calldata operatorSet,
-        uint256 slashId,
-        IStrategy strategy
-    ) external virtual {
+    function initiateSlashEscrow(OperatorSet calldata operatorSet, uint256 slashId, IStrategy strategy) external {
         require(msg.sender == address(strategyManager), OnlyStrategyManager());
 
         // Create storage pointers for readability.
-        EnumerableSet.Bytes32Set storage pendingOperatorSets = _pendingOperatorSets;
         EnumerableSet.UintSet storage pendingSlashIds = _pendingSlashIds[operatorSet.key()];
         EnumerableSet.AddressSet storage pendingStrategiesForSlashId =
             _pendingStrategiesForSlashId[operatorSet.key()][slashId];
 
-        // Add the slash ID, operator set, and strategy to their respective pending sets.
-        pendingSlashIds.add(slashId);
-        pendingOperatorSets.add(operatorSet.key());
+        // Note: Since this function can be called multiple times for the same operatorSet/slashId, we check
+        // if the slash escrow is already deployed. If it is not, we deploy it and update the pending mappings.
+        if (!isDeployedSlashEscrow(operatorSet, slashId)) {
+            // Deploy the `SlashEscrow`.
+            _deploySlashEscrow(operatorSet, slashId);
+
+            // Update the pending mappings
+            _pendingOperatorSets.add(operatorSet.key());
+            pendingSlashIds.add(slashId);
+
+            // Set the start block for the slash ID.
+            _slashIdToStartBlock[operatorSet.key()][slashId] = uint32(block.number);
+        }
+
+        // Add the strategy to the pending strategies for the slash ID.
         pendingStrategiesForSlashId.add(address(strategy));
 
-        // Set the start block for the slash ID.
-        _slashIdToStartBlock[operatorSet.key()][slashId] = uint32(block.number);
         emit StartEscrow(operatorSet, slashId, strategy, uint32(block.number));
     }
 
@@ -79,7 +84,7 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
     function releaseSlashEscrow(
         OperatorSet calldata operatorSet,
         uint256 slashId
-    ) external virtual onlyWhenNotPaused(PAUSED_RELEASE_ESCROW) {
+    ) external onlyWhenNotPaused(PAUSED_RELEASE_ESCROW) {
         address redistributionRecipient = allocationManager.getRedistributionRecipient(operatorSet);
 
         // If the redistribution recipient is not the default burn address...
@@ -99,25 +104,8 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
         // the tokens from being released).
         strategyManager.decreaseBurnOrRedistributableShares(operatorSet, slashId);
 
-        // Deploy the counterfactual `SlashEscrow`.
-        ISlashEscrow slashEscrow = deploySlashEscrow(operatorSet, slashId);
-
-        // Release the slashEscrow
-        _processSlashEscrow(operatorSet, slashId, slashEscrow, redistributionRecipient);
-    }
-
-    /// @inheritdoc ISlashEscrowFactory
-    function deploySlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) public returns (ISlashEscrow) {
-        ISlashEscrow slashEscrow = getSlashEscrow(operatorSet, slashId);
-
-        // If the slash escrow is not deployed...
-        if (!isDeployedSlashEscrow(slashEscrow)) {
-            return ISlashEscrow(
-                address(slashEscrowImplementation).cloneDeterministic(computeSlashEscrowSalt(operatorSet, slashId))
-            );
-        }
-
-        return slashEscrow;
+        // Release the slashEscrow. The counterfactual `SlashEscrow` is deployed in `initiateSlashEscrow`.
+        _processSlashEscrow(operatorSet, slashId, getSlashEscrow(operatorSet, slashId), redistributionRecipient);
     }
 
     /**
@@ -127,14 +115,14 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
      */
 
     /// @inheritdoc ISlashEscrowFactory
-    function pauseEscrow(OperatorSet calldata operatorSet, uint256 slashId) external virtual onlyPauser {
+    function pauseEscrow(OperatorSet calldata operatorSet, uint256 slashId) external onlyPauser {
         _checkNewPausedStatus(operatorSet, slashId, true);
         _paused[operatorSet.key()][slashId] = true;
         emit EscrowPaused(operatorSet, slashId);
     }
 
     /// @inheritdoc ISlashEscrowFactory
-    function unpauseEscrow(OperatorSet calldata operatorSet, uint256 slashId) external virtual onlyUnpauser {
+    function unpauseEscrow(OperatorSet calldata operatorSet, uint256 slashId) external onlyUnpauser {
         _checkNewPausedStatus(operatorSet, slashId, false);
         _paused[operatorSet.key()][slashId] = false;
         emit EscrowUnpaused(operatorSet, slashId);
@@ -226,6 +214,16 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
         bool newPauseStatus
     ) internal view {
         require(_paused[operatorSet.key()][slashId] != newPauseStatus, IPausable.InvalidNewPausedStatus());
+    }
+
+    /**
+     * @notice Deploys a `SlashEscrow`
+     * @param operatorSet The operator set whose slash escrow is being deployed.
+     * @param slashId The slash ID of the slash escrow that is being deployed.
+     * @dev The slash escrow is deployed in `initiateSlashEscrow`
+     */
+    function _deploySlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) internal {
+        address(slashEscrowImplementation).cloneDeterministic(computeSlashEscrowSalt(operatorSet, slashId));
     }
 
     /**

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -104,7 +104,7 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
         // the tokens from being released).
         strategyManager.decreaseBurnOrRedistributableShares(operatorSet, slashId);
 
-        // Release the slashEscrow. The counterfactual `SlashEscrow` is deployed in `initiateSlashEscrow`.
+        // Release the slashEscrow. The `SlashEscrow` is deployed in `initiateSlashEscrow`.
         _processSlashEscrow(operatorSet, slashId, getSlashEscrow(operatorSet, slashId), redistributionRecipient);
     }
 

--- a/src/contracts/interfaces/ISlashEscrowFactory.sol
+++ b/src/contracts/interfaces/ISlashEscrowFactory.sol
@@ -67,14 +67,6 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
     function releaseSlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) external;
 
     /**
-     * @notice Deploys a counterfactual `SlashEscrow` if code hasn't already been deployed.
-     * @param operatorSet The operator set whose slash escrow is being deployed.
-     * @param slashId The slash ID of the slash escrow that is being deployed.
-     * @return The deployed `SlashEscrow`.
-     */
-    function deploySlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) external returns (ISlashEscrow);
-
-    /**
      * @notice Pauses a escrow.
      * @param operatorSet The operator set whose escrow is being paused.
      * @param slashId The slash ID of the escrow that is being paused.

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -4395,20 +4395,32 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         // Assert defaultOperator is not redistributable
         assertFalse(allocationManager.isOperatorRedistributable(defaultOperator), "operator should not be redistributable");
     }
+<<<<<<< HEAD
 
+=======
+    
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
     function testFuzz_registered_notAllocated(Randomness r) public rand(r) {
         // Create redistributing operatorSet
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
         cheats.prank(defaultOperator);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should not be redistributable since it's not allocated
         assertTrue(allocationManager.isOperatorRedistributable(defaultOperator), "operator should be redistributable");
     }
@@ -4418,13 +4430,21 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should not be redistributable since it's not slashable
         assertFalse(allocationManager.isOperatorRedistributable(defaultOperator), "operator should not be redistributable");
     }
@@ -4434,24 +4454,42 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
+<<<<<<< HEAD
 
+=======
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
         cheats.prank(defaultOperator);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
+<<<<<<< HEAD
 
         // Deregister operator from redistributing operatorSet
         cheats.prank(defaultOperator);
         allocationManager.deregisterFromOperatorSets(DeregisterParams(defaultOperator, defaultAVS, operatorSetIds));
 
+=======
+        
+        // Deregister operator from redistributing operatorSet
+        cheats.prank(defaultOperator);
+        allocationManager.deregisterFromOperatorSets(
+            DeregisterParams(defaultOperator, defaultAVS, operatorSetIds)
+        );
+        
+>>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should be redistributable
         assertTrue(allocationManager.isOperatorRedistributable(defaultOperator), "operator should be redistributable");
 
@@ -4467,18 +4505,12 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
-
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
-
-        // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
-        cheats.prank(defaultOperator);
-        uint32[] memory operatorSetIds = new uint32[](1);
-        operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
 
         // Deallocate from redistributing operatorSet

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -4395,32 +4395,20 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         // Assert defaultOperator is not redistributable
         assertFalse(allocationManager.isOperatorRedistributable(defaultOperator), "operator should not be redistributable");
     }
-<<<<<<< HEAD
 
-=======
-    
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
     function testFuzz_registered_notAllocated(Randomness r) public rand(r) {
         // Create redistributing operatorSet
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
         cheats.prank(defaultOperator);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should not be redistributable since it's not allocated
         assertTrue(allocationManager.isOperatorRedistributable(defaultOperator), "operator should be redistributable");
     }
@@ -4430,21 +4418,13 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should not be redistributable since it's not slashable
         assertFalse(allocationManager.isOperatorRedistributable(defaultOperator), "operator should not be redistributable");
     }
@@ -4454,42 +4434,24 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
         cheats.prank(defaultOperator);
         uint32[] memory operatorSetIds = new uint32[](1);
         operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
-<<<<<<< HEAD
 
         // Deregister operator from redistributing operatorSet
         cheats.prank(defaultOperator);
         allocationManager.deregisterFromOperatorSets(DeregisterParams(defaultOperator, defaultAVS, operatorSetIds));
 
-=======
-        
-        // Deregister operator from redistributing operatorSet
-        cheats.prank(defaultOperator);
-        allocationManager.deregisterFromOperatorSets(
-            DeregisterParams(defaultOperator, defaultAVS, operatorSetIds)
-        );
-        
->>>>>>> 486caf4e (chore: styling + update isOperatorRedistributable)
         // Operator should be redistributable
         assertTrue(allocationManager.isOperatorRedistributable(defaultOperator), "operator should be redistributable");
 
@@ -4505,12 +4467,18 @@ contract AllocationManagerUnitTests_isOperatorRedistributable is AllocationManag
         OperatorSet memory redistributingOpSet = OperatorSet(defaultAVS, defaultOperatorSet.id + 1);
         address redistributionRecipient = r.Address();
         _createRedistributingOperatorSet(redistributingOpSet, defaultStrategies, redistributionRecipient);
+
         // Allocate to redistributing operatorSet
         AllocateParams[] memory allocateParams = _newAllocateParams(redistributingOpSet, 5e17);
         cheats.prank(defaultOperator);
         allocationManager.modifyAllocations(defaultOperator, allocateParams);
         cheats.roll(block.number + DEFAULT_OPERATOR_ALLOCATION_DELAY);
+
+        // Register operator to redistributing operatorSet
         _registerOperator(defaultOperator);
+        cheats.prank(defaultOperator);
+        uint32[] memory operatorSetIds = new uint32[](1);
+        operatorSetIds[0] = redistributingOpSet.id;
         allocationManager.registerForOperatorSets(defaultOperator, RegisterParams(defaultAVS, operatorSetIds, ""));
 
         // Deallocate from redistributing operatorSet

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -100,12 +100,6 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
         if (redistributionRecipient != DEFAULT_BURN_ADDRESS) cheats.prank(defaultRedistributionRecipient);
         else cheats.prank(cheats.randomAddress());
         factory.releaseSlashEscrow(operatorSet, slashId);
-
-        assertEq(factory.computeSlashEscrowSalt(operatorSet, slashId), keccak256(abi.encodePacked(operatorSet.key(), slashId)));
-        assertTrue(factory.isDeployedSlashEscrow(operatorSet, slashId));
-        ISlashEscrow slashEscrow = factory.getSlashEscrow(operatorSet, slashId);
-        assertTrue(factory.isDeployedSlashEscrow(slashEscrow));
-        assertTrue(slashEscrow.verifyDeploymentParameters(factory, slashEscrowImplementation, operatorSet, slashId));
     }
 
     /// @dev Asserts that the operator set and slash ID are pending, and that the strategy and underlying amount are in the pending burn or redistributions.
@@ -137,6 +131,13 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
 
         // Assert that the start block for the (operator set, slash ID) is correct.
         assertEq(factory.getEscrowStartBlock(operatorSet, slashId), uint32(block.number));
+
+        // Assert that the escrow is deployed
+        assertEq(factory.computeSlashEscrowSalt(operatorSet, slashId), keccak256(abi.encodePacked(operatorSet.key(), slashId)));
+        assertTrue(factory.isDeployedSlashEscrow(operatorSet, slashId));
+        ISlashEscrow slashEscrow = factory.getSlashEscrow(operatorSet, slashId);
+        assertTrue(factory.isDeployedSlashEscrow(slashEscrow));
+        assertTrue(slashEscrow.verifyDeploymentParameters(factory, slashEscrowImplementation, operatorSet, slashId));
     }
 }
 
@@ -708,7 +709,6 @@ contract SlashEscrowFactoryUnitTests_SlashEscrowProxy is SlashEscrowFactoryUnitT
     function setUp() public override {
         super.setUp();
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, 100);
-        factory.deploySlashEscrow(defaultOperatorSet, defaultSlashId);
         maliciousCaller = cheats.randomAddress();
     }
 


### PR DESCRIPTION
**Motivation:**

For clarity, let's deploy the `SlashEscrow` in `initiateEscrow`.

**Modifications:**

1. In `initiateEscrow `, deploy the `SlashEscrow` if it hasn't been deployed
2. Also add the startBlock, opSet to pending, and slashId to pending in this if block

**Result:**

No more counterfactual. Less redundant updates for multiple strategies in a slashID. 
