### PR TITLE
docs(AVS-Guide.md): Fix broken withdrawal flow doc link

### DIFF
--- a/docs/experimental/AVS-Guide.md
+++ b/docs/experimental/AVS-Guide.md
@@ -72,7 +72,7 @@ EigenLayer is a dynamic system where stakers and operators are constantly adjust
 Let us illustrate the usage of this facility with an example: A staker has delegated to an operator, who has opted-in to serving an AVS. Whenever the staker withdraws some or all of its stake from EigenLayer, this withdrawal affects all the AVSs uniformly that the staker's delegated operator is participating in. The series of steps for withdrawing stake is as follows:
  - The staker queues their withdrawal request with EigenLayer. The staker can place this request by calling  `StrategyManager.queueWithdrawal(..)`.
  - The operator, noticing an upcoming change in their delegated stake, notifies the AVS about this change. To do this, the operator triggers the AVS to call the `ServiceManager.recordStakeUpdate(..)` which in turn accesses `Slasher.recordStakeUpdate(..)`.  On successful execution of this call, the event `MiddlewareTimesAdded(..)` is emitted.
-- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs/EigenLayer-withdrawal-flow.md) for more details
+- The AVS provider now is aware of the change in stake, and the staker can eventually complete their withdrawal.  Refer [here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/main/docs/README.md) for more details
 
 The following figure illustrates the above flow: 
 ![Stake update](../images/staker_withdrawing.png)


### PR DESCRIPTION
**Motivation:**

The previous withdrawal flow documentation link in `AVS-Guide.md` pointed to `EigenLayer-withdrawal-flow.md`, which was deleted in commit [#90a0f6a](https://github.com/Layr-Labs/eigenlayer-contracts/commit/90a0f6aee79b4a38e1b63b32f9627f21b1162fbb) when all markdown docs were consolidated into `README.md`. This caused a broken link in the documentation.

**Modifications:**

- Updated the outdated link in `AVS-Guide.md` to point to the relevant section in `README.md` instead of the deleted file.

**Result:**

The withdrawal flow documentation link in `AVS-Guide.md` now correctly points to `README.md`, ensuring users can access the intended information without encountering a broken link.