### PR TITLE
refactor: remove only redistribution recipient check

### DIFF
--- a/docs/core/SlashEscrowFactory.md
+++ b/docs/core/SlashEscrowFactory.md
@@ -82,6 +82,7 @@ SlashEscrows are deployed deterministically using [Open Zeppelin's Clones Upgrad
  * @notice Releases an escrow by transferring tokens from the `SlashEscrow` to the operator set's redistribution recipient.
  * @param operatorSet The operator set whose escrow is being released.
  * @param slashId The slash ID of the escrow that is being released.
+ * @dev This method is permissionless, anyone can call it.
  * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
  */
 function releaseSlashEscrow(
@@ -94,6 +95,7 @@ external onlyWhenNotPaused(PAUSED_RELEASE_ESCROW);
  * @param operatorSet The operator set whose escrow is being released.
  * @param slashId The slash ID of the escrow that is being released.
  * @param strategy The strategy whose escrow is being released.
+ * @dev This method is permissionless, anyone can call it.
  * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
  */
 function releaseSlashEscrowByStrategy(

--- a/docs/core/SlashEscrowFactory.md
+++ b/docs/core/SlashEscrowFactory.md
@@ -82,8 +82,6 @@ SlashEscrows are deployed deterministically using [Open Zeppelin's Clones Upgrad
  * @notice Releases an escrow by transferring tokens from the `SlashEscrow` to the operator set's redistribution recipient.
  * @param operatorSet The operator set whose escrow is being released.
  * @param slashId The slash ID of the escrow that is being released.
- * @dev The caller must be the escrow recipient, unless the escrow recipient
- * is the default burn address in which case anyone can call.
  * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
  */
 function releaseSlashEscrow(
@@ -96,8 +94,6 @@ external onlyWhenNotPaused(PAUSED_RELEASE_ESCROW);
  * @param operatorSet The operator set whose escrow is being released.
  * @param slashId The slash ID of the escrow that is being released.
  * @param strategy The strategy whose escrow is being released.
- * @dev The caller must be the redistribution recipient, unless the redistribution recipient
- * is the default burn address in which case anyone can call.
  * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
  */
 function releaseSlashEscrowByStrategy(
@@ -126,7 +122,6 @@ To accommodate the unlimited number of strategies that can be added to an operat
 *Requirements*:
 * The global paused status MUST NOT be set: `PAUSED_RELEASE_ESCROW`
 * The escrow paused status MUST NOT be set: `pauseEscrow`
-* If the operatorSet is redistributable, caller MUST be the `redistributionRecipient`
 * The escrow delay MUST have elapsed
 
 ## SlashEscrow

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -123,13 +123,16 @@ contract SlashEscrowFactory is
 
         // Cache the redistribution recipient.
         address redistributionRecipient = allocationManager.getRedistributionRecipient(operatorSet);
+        // Cache the computed slash escrow address.
+        ISlashEscrow slashEscrow = getSlashEscrow(operatorSet, slashId);
+
         // Process the slash escrow for each strategy.
         address[] memory strategies = _pendingStrategiesForSlashId[operatorSet.key()][slashId].values();
         for (uint256 i = 0; i < strategies.length; ++i) {
             _processSlashEscrowByStrategy({
                 operatorSet: operatorSet,
                 slashId: slashId,
-                slashEscrow: getSlashEscrow(operatorSet, slashId),
+                slashEscrow: slashEscrow,
                 redistributionRecipient: redistributionRecipient,
                 strategy: IStrategy(strategies[i])
             });

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -121,6 +121,8 @@ contract SlashEscrowFactory is
         // the tokens from being released).
         strategyManager.clearBurnOrRedistributableShares(operatorSet, slashId);
 
+        // Cache the redistribution recipient.
+        address redistributionRecipient = allocationManager.getRedistributionRecipient(operatorSet);
         // Process the slash escrow for each strategy.
         address[] memory strategies = _pendingStrategiesForSlashId[operatorSet.key()][slashId].values();
         for (uint256 i = 0; i < strategies.length; ++i) {
@@ -128,7 +130,7 @@ contract SlashEscrowFactory is
                 operatorSet: operatorSet,
                 slashId: slashId,
                 slashEscrow: getSlashEscrow(operatorSet, slashId),
-                redistributionRecipient: allocationManager.getRedistributionRecipient(operatorSet),
+                redistributionRecipient: redistributionRecipient,
                 strategy: IStrategy(strategies[i])
             });
         }

--- a/src/contracts/interfaces/ISlashEscrowFactory.sol
+++ b/src/contracts/interfaces/ISlashEscrowFactory.sol
@@ -9,9 +9,6 @@ interface ISlashEscrowFactoryErrors {
     /// @notice Thrown when a caller is not the strategy manager.
     error OnlyStrategyManager();
 
-    /// @notice Thrown when a caller is not the redistribution recipient.
-    error OnlyRedistributionRecipient();
-
     /// @notice Thrown when a escrow is not mature.
     error EscrowNotMature();
 
@@ -61,8 +58,6 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
      * @notice Releases an escrow by transferring tokens from the `SlashEscrow` to the operator set's redistribution recipient.
      * @param operatorSet The operator set whose escrow is being released.
      * @param slashId The slash ID of the escrow that is being released.
-     * @dev The caller must be the escrow recipient, unless the escrow recipient
-     * is the default burn address in which case anyone can call.
      * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
      */
     function releaseSlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) external;
@@ -72,8 +67,6 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
      * @param operatorSet The operator set whose escrow is being released.
      * @param slashId The slash ID of the escrow that is being released.
      * @param strategy The strategy whose escrow is being released.
-     * @dev The caller must be the redistribution recipient, unless the redistribution recipient
-     * is the default burn address in which case anyone can call.
      * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
      */
     function releaseSlashEscrowByStrategy(

--- a/src/contracts/interfaces/ISlashEscrowFactory.sol
+++ b/src/contracts/interfaces/ISlashEscrowFactory.sol
@@ -58,6 +58,7 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
      * @notice Releases an escrow by transferring tokens from the `SlashEscrow` to the operator set's redistribution recipient.
      * @param operatorSet The operator set whose escrow is being released.
      * @param slashId The slash ID of the escrow that is being released.
+     * @dev This method is permissionless, anyone can call it.
      * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
      */
     function releaseSlashEscrow(OperatorSet calldata operatorSet, uint256 slashId) external;
@@ -67,6 +68,7 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
      * @param operatorSet The operator set whose escrow is being released.
      * @param slashId The slash ID of the escrow that is being released.
      * @param strategy The strategy whose escrow is being released.
+     * @dev This method is permissionless, anyone can call it.
      * @dev The slash escrow is released once the delay for ALL strategies has elapsed.
      */
     function releaseSlashEscrowByStrategy(

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -107,10 +107,6 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
     /// - Asserts that the `Escrow` event is emitted
     function _releaseSlashEscrowByStrategy(OperatorSet memory operatorSet, uint slashId, IStrategy strategy) internal {
         address redistributionRecipient = allocationManagerMock.getRedistributionRecipient(operatorSet);
-        // If the redistribution recipient is any address
-        if (redistributionRecipient != DEFAULT_BURN_ADDRESS) cheats.prank(redistributionRecipient);
-        else cheats.prank(cheats.randomAddress());
-
         cheats.expectEmit(true, true, true, true);
         emit EscrowComplete(operatorSet, slashId, strategy, redistributionRecipient);
 

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -99,9 +99,7 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
             emit EscrowComplete(operatorSet, slashId, strategies[i], redistributionRecipient);
         }
 
-        // If the redistribution recipient is any address
-        if (redistributionRecipient != DEFAULT_BURN_ADDRESS) cheats.prank(defaultRedistributionRecipient);
-        else cheats.prank(cheats.randomAddress());
+        cheats.prank(cheats.randomAddress());
         factory.releaseSlashEscrow(operatorSet, slashId);
     }
 
@@ -208,18 +206,10 @@ contract SlashEscrowFactoryUnitTests_initiateSlashEscrow is SlashEscrowFactoryUn
 }
 
 contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUnitTests {
-    /// @dev Asserts that the function reverts if the caller is not the redistribution recipient.
-    function testFuzz_releaseSlashEscrow_OnlyRedistributionRecipient(uint underlyingAmount) public {
-        _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
-        cheats.expectRevert(ISlashEscrowFactoryErrors.OnlyRedistributionRecipient.selector);
-        factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
-    }
-
     function testFuzz_releaseSlashEscrow_globalPause(uint underlyingAmount) public {
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.prank(pauser);
         factory.pause(2 ** PAUSED_RELEASE_ESCROW);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
     }
@@ -229,7 +219,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.prank(pauser);
         factory.pauseEscrow(defaultOperatorSet, defaultSlashId);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
     }
@@ -237,7 +226,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
     /// @dev Asserts that the function reverts if the operator set and slash ID do not exist.
     /// NOTE: `releaseSlashEscrow` does not revert when a slash ID does not exist for an operator set.
     function testFuzz_releaseSlashEscrow_nonexistentSlashIdForOperatorSet(uint underlyingAmount) public {
-        cheats.prank(defaultRedistributionRecipient);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
         assertFalse(factory.isPendingOperatorSet(defaultOperatorSet));
         assertFalse(factory.isPendingSlashId(defaultOperatorSet, defaultSlashId));
@@ -246,7 +234,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
     function testFuzz_releaseSlashEscrow_delayNotElapsed(uint underlyingAmount) public {
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.roll(block.number + defaultGlobalDelayBlocks);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(ISlashEscrowFactoryErrors.EscrowDelayNotElapsed.selector);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
     }
@@ -420,18 +407,10 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
 }
 
 contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrowFactoryUnitTests {
-    /// @dev Asserts that the function reverts if the caller is not the redistribution recipient.
-    function testFuzz_releaseSlashEscrowByStrategy_OnlyRedistributionRecipient(uint underlyingAmount) public {
-        _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
-        cheats.expectRevert(ISlashEscrowFactoryErrors.OnlyRedistributionRecipient.selector);
-        factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
-    }
-
     function testFuzz_releaseSlashEscrowByStrategy_globalPause(uint underlyingAmount) public {
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.prank(pauser);
         factory.pause(2 ** PAUSED_RELEASE_ESCROW);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
     }
@@ -441,7 +420,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.prank(pauser);
         factory.pauseEscrow(defaultOperatorSet, defaultSlashId);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
     }
@@ -449,7 +427,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
     /// @dev Asserts that the function reverts if the operator set and slash ID do not exist.
     /// NOTE: `releaseSlashEscrowByStrategy` DOES revert when a slash ID does not exist for an operator set.
     function testFuzz_releaseSlashEscrowByStrategy_nonexistentSlashIdForOperatorSet(uint underlyingAmount) public {
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert();
         factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
         assertFalse(factory.isPendingOperatorSet(defaultOperatorSet));
@@ -459,7 +436,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
     function testFuzz_releaseSlashEscrowByStrategy_delayNotElapsed(uint underlyingAmount) public {
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.roll(block.number + defaultGlobalDelayBlocks);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(ISlashEscrowFactoryErrors.EscrowDelayNotElapsed.selector);
         factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
     }
@@ -467,7 +443,6 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
     function testFuzz_releaseSlashEscrowByStrategy_multipleStrategies(uint underlyingAmount) public {
         _initiateSlashEscrow(defaultOperatorSet, defaultSlashId, defaultStrategy, defaultToken, underlyingAmount);
         cheats.roll(block.number + defaultGlobalDelayBlocks);
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(ISlashEscrowFactoryErrors.EscrowDelayNotElapsed.selector);
         factory.releaseSlashEscrowByStrategy(defaultOperatorSet, defaultSlashId, defaultStrategy);
     }
@@ -616,7 +591,6 @@ contract SlashEscrowFactoryUnitTests_pauseEscrow is SlashEscrowFactoryUnitTests 
 
         _rollForwardDefaultEscrowDelay();
 
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
     }
@@ -638,7 +612,6 @@ contract SlashEscrowFactoryUnitTests_unpauseEscrow is SlashEscrowFactoryUnitTest
 
         _rollForwardDefaultEscrowDelay();
 
-        cheats.prank(defaultRedistributionRecipient);
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
         factory.releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
 

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -99,7 +99,6 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
             emit EscrowComplete(operatorSet, slashId, strategies[i], redistributionRecipient);
         }
 
-        cheats.prank(cheats.randomAddress());
         factory.releaseSlashEscrow(operatorSet, slashId);
     }
 


### PR DESCRIPTION
**Motivation:**

We want to make `releaseSlashEscrow` and `releaseSlashEscrowByStrategy` permissionless.

**Modifications:**

- Removed `onlyRedistributionRecipient` check.

**Result:**

Escrow can be released by anyone.