### PR TITLE
fix(audit): out-of-gas issue

### DIFF
--- a/docs/core/SlashEscrowFactory.md
+++ b/docs/core/SlashEscrowFactory.md
@@ -121,7 +121,7 @@ To accommodate the unlimited number of strategies that can be added to an operat
     * Remove the `strategy` from the `_pendingStrategiesForSlashId`
 * If all strategies from an operatorSet/slashId have been released:
     * Remove the `slashId` from `_pendingSlashIds`
-    * Delete the start block for the `slashId`
+    * Delete the complete block for the `slashId`
 * If the `operatorSet` has no more pending slashes, remove it from `pendingOperatorSets` 
 
 *Requirements*:

--- a/docs/core/SlashEscrowFactory.md
+++ b/docs/core/SlashEscrowFactory.md
@@ -30,7 +30,6 @@ An escrow is initiated for each slash triggered by an AVS. A slash can contain m
 *[`SlashEscrowFactory.releaseSlashEscrowByStrategy`](#releaseslashescrow)
 
 #### `initiateSlashEscrow`
-
 ```solidity
 /**
  * @notice Locks up a escrow.
@@ -177,13 +176,14 @@ The following methods concern the `owner` and its abilities in the `SlashEscrowF
 ```solidity
 /**
  * @notice Sets the delay for the escrow of all strategies underlying tokens globally.
+ * @dev This delay setting only applies to new slashes and does not affect existing ones.
  * @param delay The delay for the escrow.
  */
 function setGlobalEscrowDelay(
     uint32 delay
 ) external onlyOwner;
 ```
-Sets the global escrow delay observed by all strategies. *Note: If this value is updated, all previous escrows will observe the new delay.*
+Sets the global escrow delay observed by all strategies. *Note: If this value is updated, previously existing escrows will not be affected.*
 
 *Effects*:
 * Sets the `_globalEscrowDelayBlocks`
@@ -198,6 +198,7 @@ Sets the global escrow delay observed by all strategies. *Note: If this value is
 /**
  * @notice Sets the delay for the escrow of a strategies underlying token.
  * @dev The maximum of the strategy and global delay is used
+ * @dev This delay setting only applies to new slashes and does not affect existing ones.
  * @param strategy The strategy whose escrow delay is being set.
  * @param delay The delay for the escrow.
  */
@@ -207,7 +208,7 @@ function setStrategyEscrowDelay(
 ) external onlyOwner;
 ```
 
-Sets the delay for a given strategy. *Note: If this value is updated, all previous escrows will observe the new delay.* 
+Sets the delay for a given strategy. *Note: If this value is updated, previously existing escrows will not be affected.*
 
 *Effects*:
 * Updates the `_strategyEscrowDelayBlocks` for the given `strategy`

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -82,6 +82,9 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
         pendingStrategiesForSlashId.add(address(strategy));
 
         // Calculate the complete block for the strategy, and fetch the current complete block.
+        // The escrow delay for a strategy is determined by taking the maximum of:
+        // 1. The global escrow delay (applies to all strategies).
+        // 2. The strategy-specific delay (if set).
         uint32 completeBlock = uint32(block.number + getStrategyEscrowDelay(strategy) + 1);
         uint32 currentCompleteBlock = _slashIdToCompleteBlock[operatorSet.key()][slashId];
 

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -77,15 +77,15 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
             _pendingOperatorSets.add(operatorSet.key());
             pendingSlashIds.add(slashId);
 
-            // Calculate the maturity block for the strategy, and fetch the current maturity block.
-            uint32 maturityBlock = uint32(block.number + getStrategyEscrowDelay(strategy));
-            uint32 currentMaturityBlock = _slashIdToMaturityBlock[operatorSet.key()][slashId];
+            // Calculate the complete block for the strategy, and fetch the current complete block.
+            uint32 completeBlock = uint32(block.number + getStrategyEscrowDelay(strategy) + 1);
+            uint32 currentCompleteBlock = _slashIdToCompleteBlock[operatorSet.key()][slashId];
 
             // Only update the maturity block if the new calculated maturity block (with the strategy delay)
             // is further in the future than the currently stored value. This ensures the escrow cannot be released
             // before the longest required delay among all strategies for this slashId.
-            if (maturityBlock > currentMaturityBlock) {
-                _slashIdToMaturityBlock[operatorSet.key()][slashId] = maturityBlock;
+            if (completeBlock > currentCompleteBlock) {
+                _slashIdToCompleteBlock[operatorSet.key()][slashId] = completeBlock;
             }
         }
 
@@ -260,7 +260,7 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
             pendingSlashIds.remove(slashId);
 
             // Delete the start block for the slash ID.
-            delete _slashIdToMaturityBlock[operatorSet.key()][slashId];
+            delete _slashIdToCompleteBlock[operatorSet.key()][slashId];
 
             // If there are no more slash IDs for the operator set, remove the operator set from the pending operator sets set.
             if (pendingSlashIds.length() == 0) {
@@ -427,7 +427,7 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
 
     /// @inheritdoc ISlashEscrowFactory
     function getEscrowCompleteBlock(OperatorSet memory operatorSet, uint256 slashId) public view returns (uint32) {
-        return _slashIdToMaturityBlock[operatorSet.key()][slashId];
+        return _slashIdToCompleteBlock[operatorSet.key()][slashId];
     }
 
     /// @inheritdoc ISlashEscrowFactory

--- a/src/contracts/core/SlashEscrowFactory.sol
+++ b/src/contracts/core/SlashEscrowFactory.sol
@@ -76,21 +76,21 @@ contract SlashEscrowFactory is Initializable, SlashEscrowFactoryStorage, Ownable
             // Update the pending mappings.
             _pendingOperatorSets.add(operatorSet.key());
             pendingSlashIds.add(slashId);
-
-            // Calculate the complete block for the strategy, and fetch the current complete block.
-            uint32 completeBlock = uint32(block.number + getStrategyEscrowDelay(strategy) + 1);
-            uint32 currentCompleteBlock = _slashIdToCompleteBlock[operatorSet.key()][slashId];
-
-            // Only update the maturity block if the new calculated maturity block (with the strategy delay)
-            // is further in the future than the currently stored value. This ensures the escrow cannot be released
-            // before the longest required delay among all strategies for this slashId.
-            if (completeBlock > currentCompleteBlock) {
-                _slashIdToCompleteBlock[operatorSet.key()][slashId] = completeBlock;
-            }
         }
 
         // Add the strategy to the pending strategies for the slash ID.
         pendingStrategiesForSlashId.add(address(strategy));
+
+        // Calculate the complete block for the strategy, and fetch the current complete block.
+        uint32 completeBlock = uint32(block.number + getStrategyEscrowDelay(strategy) + 1);
+        uint32 currentCompleteBlock = _slashIdToCompleteBlock[operatorSet.key()][slashId];
+
+        // Only update the maturity block if the new calculated maturity block (with the strategy delay)
+        // is further in the future than the currently stored value. This ensures the escrow cannot be released
+        // before the longest required delay among all strategies for this slashId.
+        if (completeBlock > currentCompleteBlock) {
+            _slashIdToCompleteBlock[operatorSet.key()][slashId] = completeBlock;
+        }
 
         // Emit the start escrow event. We can use the block.number here because all strategies
         // in a given operatorSet/slashId will have their escrow initiated in the same transaction.

--- a/src/contracts/core/SlashEscrowFactoryStorage.sol
+++ b/src/contracts/core/SlashEscrowFactoryStorage.sol
@@ -43,7 +43,7 @@ abstract contract SlashEscrowFactoryStorage is ISlashEscrowFactory {
         _pendingStrategiesForSlashId;
 
     /// @dev Returns the start block for a given slash ID.
-    mapping(bytes32 operatorSetKey => mapping(uint256 slashId => uint32 startBlock)) internal _slashIdToMaturityBlock;
+    mapping(bytes32 operatorSetKey => mapping(uint256 slashId => uint32 completeBlock)) internal _slashIdToCompleteBlock;
 
     /// @notice Returns the paused status for a given operator set and slash ID.
     mapping(bytes32 operatorSetKey => mapping(uint256 slashId => bool paused)) internal _paused;

--- a/src/contracts/core/SlashEscrowFactoryStorage.sol
+++ b/src/contracts/core/SlashEscrowFactoryStorage.sol
@@ -43,7 +43,7 @@ abstract contract SlashEscrowFactoryStorage is ISlashEscrowFactory {
         _pendingStrategiesForSlashId;
 
     /// @dev Returns the start block for a given slash ID.
-    mapping(bytes32 operatorSetKey => mapping(uint256 slashId => uint32 startBlock)) internal _slashIdToStartBlock;
+    mapping(bytes32 operatorSetKey => mapping(uint256 slashId => uint32 startBlock)) internal _slashIdToMaturityBlock;
 
     /// @notice Returns the paused status for a given operator set and slash ID.
     mapping(bytes32 operatorSetKey => mapping(uint256 slashId => bool paused)) internal _paused;

--- a/src/contracts/interfaces/ISlashEscrowFactory.sol
+++ b/src/contracts/interfaces/ISlashEscrowFactory.sol
@@ -99,6 +99,7 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
     /**
      * @notice Sets the delay for the escrow of a strategies underlying token.
      * @dev The largest of all strategy delays or global delay will be used.
+     * @dev This delay setting only applies to new slashes and does not affect existing ones.
      * @param strategy The strategy whose escrow delay is being set.
      * @param delay The delay for the escrow.
      */
@@ -106,6 +107,7 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
 
     /**
      * @notice Sets a global delay applicable to all strategies.
+     * @dev This delay setting only applies to new slashes and does not affect existing ones.
      * @param delay The delay for the escrow.
      */
     function setGlobalEscrowDelay(

--- a/src/contracts/interfaces/ISlashEscrowFactory.sol
+++ b/src/contracts/interfaces/ISlashEscrowFactory.sol
@@ -230,14 +230,6 @@ interface ISlashEscrowFactory is ISlashEscrowFactoryErrors, ISlashEscrowFactoryE
     function isEscrowPaused(OperatorSet calldata operatorSet, uint256 slashId) external view returns (bool);
 
     /**
-     * @notice Returns the start block for a slash ID.
-     * @param operatorSet The operator set whose start block is being queried.
-     * @param slashId The slash ID of the start block that is being queried.
-     * @return The start block.
-     */
-    function getEscrowStartBlock(OperatorSet calldata operatorSet, uint256 slashId) external view returns (uint256);
-
-    /**
      * @notice Returns the block at which the escrow can be released.
      * @param operatorSet The operator set whose start block is being queried.
      * @param slashId The slash ID of the start block that is being queried.

--- a/src/test/integration/IntegrationBase.t.sol
+++ b/src/test/integration/IntegrationBase.t.sol
@@ -1432,9 +1432,6 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
             assertTrue(_getIsPendingSlashId(operatorSet, slashId), "slash id should be pending");
             assertFalse(_getPrevIsPendingSlashId(operatorSet, slashId), "slash id should not be pending");
 
-            assertEq(_getEscrowStartBlock(operatorSet, slashId), block.number, "escrow start block should be current block");
-            assertEq(_getPrevEscrowStartBlock(operatorSet, slashId), 0, "escrow start block should be 0");
-
             assertTrue(_getIsDeployedSlashEscrow(operatorSet, slashId), "escrow should be deployed");
             assertFalse(_getPrevIsDeployedSlashEscrow(operatorSet, slashId), "escrow should not be deployed");
         }
@@ -2798,12 +2795,12 @@ abstract contract IntegrationBase is IntegrationDeployer, TypeImporter {
         return slashEscrowFactory.isPendingSlashId(operatorSet, slashId);
     }
 
-    function _getPrevEscrowStartBlock(OperatorSet memory operatorSet, uint slashId) internal timewarp returns (uint) {
-        return _getEscrowStartBlock(operatorSet, slashId);
+    function _getPrevEscrowCompleteBlock(OperatorSet memory operatorSet, uint slashId) internal timewarp returns (uint) {
+        return _getEscrowCompleteBlock(operatorSet, slashId);
     }
 
-    function _getEscrowStartBlock(OperatorSet memory operatorSet, uint slashId) internal view returns (uint) {
-        return slashEscrowFactory.getEscrowStartBlock(operatorSet, slashId);
+    function _getEscrowCompleteBlock(OperatorSet memory operatorSet, uint slashId) internal view returns (uint) {
+        return slashEscrowFactory.getEscrowCompleteBlock(operatorSet, slashId);
     }
 
     function _getPrevIsDeployedSlashEscrow(OperatorSet memory operatorSet, uint slashId) internal timewarp returns (bool) {

--- a/src/test/integration/IntegrationChecks.t.sol
+++ b/src/test/integration/IntegrationChecks.t.sol
@@ -1123,7 +1123,7 @@ contract IntegrationCheckUtils is IntegrationBase {
         );
 
         assertFalse(_getIsPendingSlashId(operatorSet, slashId), "slash id should not be pending");
-        assertEq(_getEscrowStartBlock(operatorSet, slashId), 0, "escrow start block should be deleted after");
+        assertEq(_getEscrowCompleteBlock(operatorSet, slashId), 0, "escrow complete block should be deleted after");
         assertTrue(_getIsDeployedSlashEscrow(operatorSet, slashId), "escrow should be deployed after");
     }
 

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -152,9 +152,6 @@ contract SlashEscrowFactoryUnitTests is EigenLayerUnitTestSetup, ISlashEscrowFac
         assertEq(strategies.length, expectedCount);
         assertEq(factory.getTotalPendingStrategiesForSlashId(operatorSet, slashId), expectedCount);
 
-        // Assert that the start block for the (operator set, slash ID) is correct.
-        assertEq(factory.getEscrowStartBlock(operatorSet, slashId), uint32(block.number));
-
         // Assert that the escrow is deployed
         assertEq(factory.computeSlashEscrowSalt(operatorSet, slashId), keccak256(abi.encodePacked(operatorSet.key(), slashId)));
         assertTrue(factory.isDeployedSlashEscrow(operatorSet, slashId));
@@ -306,7 +303,7 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
         }
 
         // Assert that the start block for the (operator set, slash ID) is no longer set.
-        assertEq(factory.getEscrowStartBlock(defaultOperatorSet, defaultSlashId), 0);
+        assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, defaultSlashId), 0);
     }
 
     /// @dev Tests that multiple strategies with different delays are processed correctly
@@ -375,7 +372,7 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrow is SlashEscrowFactoryUni
         }
 
         // Verify that the start block is cleared
-        assertEq(factory.getEscrowStartBlock(defaultOperatorSet, defaultSlashId), 0);
+        assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, defaultSlashId), 0);
     }
 
     /// @dev Tests that operatorSets are only cleared once all slash IDs are released
@@ -539,7 +536,7 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
         }
 
         // Assert that the start block for the (operator set, slash ID) is no longer set.
-        assertEq(factory.getEscrowStartBlock(defaultOperatorSet, defaultSlashId), 0);
+        assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, defaultSlashId), 0);
     }
 
     /// @dev Tests that multiple strategies can be burned or redistributed across multiple calls
@@ -599,7 +596,7 @@ contract SlashEscrowFactoryUnitTests_releaseSlashEscrowByStrategy is SlashEscrow
         }
 
         // Assert that the start block for the (operator set, slash ID) is no longer set.
-        assertEq(factory.getEscrowStartBlock(defaultOperatorSet, defaultSlashId), 0);
+        assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, defaultSlashId), 0);
     }
 }
 

--- a/src/test/unit/SlashEscrowFactoryUnit.t.sol
+++ b/src/test/unit/SlashEscrowFactoryUnit.t.sol
@@ -717,7 +717,7 @@ contract SlashEscrowFactoryUnitTests_getEscrowDelay is SlashEscrowFactoryUnitTes
         uint[] memory underlyingAmounts = new uint[](1);
         strategies[0] = IStrategy(cheats.randomAddress());
         tokens[0] = new MockERC20();
-        underlyingAmounts[0] = cheats.randomUint();
+        underlyingAmounts[0] = uint96(cheats.randomUint());
 
         cheats.prank(defaultOwner);
         factory.setGlobalEscrowDelay(firstDelay);
@@ -732,6 +732,14 @@ contract SlashEscrowFactoryUnitTests_getEscrowDelay is SlashEscrowFactoryUnitTes
 
         assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, defaultSlashId), startBlock + firstDelay + 1);
         assertEq(factory.getEscrowCompleteBlock(defaultOperatorSet, secondSlashId), startBlock + secondDelay + 1);
+
+        cheats.roll(startBlock + firstDelay + 1);
+        _mockStrategyUnderlyingTokenCall(strategies[0], address(tokens[0]));
+        _releaseSlashEscrow(defaultOperatorSet, defaultSlashId);
+
+        cheats.roll(startBlock + secondDelay + 1);
+        _mockStrategyUnderlyingTokenCall(strategies[0], address(tokens[0]));
+        _releaseSlashEscrow(defaultOperatorSet, secondSlashId);
     }
 }
 


### PR DESCRIPTION
**Motivation:**

Previously, we stored `startBlock` and computed the `completeBlock` at runtime by iterating through the list of added strategies for a given `slashId`. This approach required recalculating the `completeBlock` each time.

**Modifications:**

We now store `completeBlock` directly instead of `startBlock`. During each call to `initiateSlashEscrow`, we compare the delay of the newly added strategy to the current `completeBlock` for the `slashId`. If the new delay is larger, we update `completeBlock` accordingly. This ensures that the maximum delay is always preserved.

**Result:**

The `completeBlock` for each `slashId` is now computed and maintained incrementally, eliminating the need for runtime iteration over all strategies.