### PR TITLE
fix: ensure redistribution recipient is not burn address

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -275,8 +275,10 @@ contract AllocationManager is
         require(params.length == redistributionRecipients.length, InputArrayLengthMismatch());
         require(_avsRegisteredMetadata[avs], NonexistentAVSMetadata());
         for (uint256 i = 0; i < params.length; i++) {
-            require(redistributionRecipients[i] != address(0), InputAddressZero());
-            _createOperatorSet(avs, params[i], redistributionRecipients[i]);
+            address recipient = redistributionRecipients[i];
+            require(recipient != address(0), InputAddressZero());
+            require(recipient != DEFAULT_BURN_ADDRESS, InvalidRedistributionRecipient());
+            _createOperatorSet(avs, params[i], recipient);
         }
     }
 

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -19,6 +19,8 @@ interface IAllocationManagerErrors {
     error InvalidAVSRegistrar();
     /// @dev Thrown when an invalid strategy is provided.
     error InvalidStrategy();
+    /// @dev Thrown when an invalid redistribution recipient is provided.
+    error InvalidRedistributionRecipient();
 
     /// Caller
 

--- a/src/test/unit/AllocationManagerUnit.t.sol
+++ b/src/test/unit/AllocationManagerUnit.t.sol
@@ -13,6 +13,8 @@ contract AllocationManagerUnitTests is EigenLayerUnitTestSetup, IAllocationManag
     /// Constants
     /// -----------------------------------------------------------------------
 
+    address internal constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000000E16E4;
+
     /// NOTE: Raising these values directly increases cpu time for tests.
     uint internal constant FUZZ_MAX_ALLOCATIONS = 8;
     uint internal constant FUZZ_MAX_STRATS = 8;
@@ -3745,8 +3747,6 @@ contract AllocationManagerUnitTests_removeStrategiesFromOperatorSet is Allocatio
 contract AllocationManagerUnitTests_createOperatorSets is AllocationManagerUnitTests {
     using ArrayLib for *;
 
-    address internal constant DEFAULT_BURN_ADDRESS = 0x00000000000000000000000000000000000E16E4;
-
     function testRevert_createOperatorSets_InvalidOperatorSet() public {
         cheats.prank(defaultAVS);
         cheats.expectRevert(InvalidOperatorSet.selector);
@@ -3833,6 +3833,21 @@ contract AllocationManagerUnitTests_createRedistributingOperatorSets is Allocati
 
         cheats.prank(avs);
         cheats.expectRevert(IPausable.InputAddressZero.selector);
+        allocationManager.createRedistributingOperatorSets(
+            avs, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray(), redistributionRecipients
+        );
+    }
+
+    function testRevert_createRedistributingOperatorSets_InvalidRedistributionRecipient(Randomness r) public rand(r) {
+        address avs = r.Address();
+        address[] memory redistributionRecipients = new address[](1);
+        redistributionRecipients[0] = DEFAULT_BURN_ADDRESS;
+
+        cheats.prank(avs);
+        allocationManager.updateAVSMetadataURI(avs, "https://example.com");
+
+        cheats.prank(avs);
+        cheats.expectRevert(InvalidRedistributionRecipient.selector);
         allocationManager.createRedistributingOperatorSets(
             avs, CreateSetParams(defaultOperatorSet.id, defaultStrategies).toArray(), redistributionRecipients
         );


### PR DESCRIPTION
**Motivation:**

It was previously possible to set the redistribution recipient for a redistributing operator set to the burn address, meaning it's effectively a non-redistributing operator set.

**Modifications:**

- Ensure`redistributionRecipient != DEFAULT_BURN_ADDRESS`.

**Result:**

Sanitization.
