### PR TITLE
refactor: remove transport interface

### DIFF
--- a/docs/multichain/source/CrossChainRegistry.md
+++ b/docs/multichain/source/CrossChainRegistry.md
@@ -16,6 +16,8 @@ Libraries and Mixins:
 
 The `CrossChainRegistry` manages the registration/deregistration of operatorSets to the multichain protocol. The contract also exposes read-only functions to calculate an operator table, which is used offchain by the `Generator` to generate a `GlobalTableRoot` and `Transporter` to transport the operator table. See [ELIP-007](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-007.md) for more information.
 
+*Note: Operator tables are transported to all destination chains, regardless if the operatorSet is consumed on a destination chain.*
+
 ```solidity
 /**
  * @notice A per-operatorSet configuration struct that is transported from the CrossChainRegistry on L1.
@@ -46,28 +48,24 @@ A generation reservation registers the operatorSet to be included in the `Global
  * @param operatorSet the operatorSet to make a reservation for
  * @param operatorTableCalculator the address of the operatorTableCalculator
  * @param config the config to set for the operatorSet
- * @param chainIDs the chainIDs to add as transport destinations
  * @dev msg.sender must be UAM permissioned for operatorSet.avs
  */
 function createGenerationReservation(
     OperatorSet calldata operatorSet,
     IOperatorTableCalculator operatorTableCalculator,
-    OperatorSetConfig calldata config,
-    uint256[] calldata chainIDs
+    OperatorSetConfig calldata config
 ) external;
 ```
 
-Creates a generation reservation for a given `operatorSet`, which enables the operatorSet to be included in the `GlobalTableRoot` generation and transported to specified destination chains. This function sets up the complete configuration for cross-chain operations in a single transaction.
+Creates a generation reservation for a given `operatorSet`, which enables the operatorSet to be included in the `GlobalTableRoot` generation and transported to all destination chains. This function sets up the complete configuration for cross-chain operations in a single transaction.
 
 *Effects*:
 * Adds the `operatorSet` to `_activeGenerationReservations`
 * Sets the `operatorTableCalculator` for the `operatorSet`
 * Sets the `OperatorSetConfig` containing the `owner` and `maxStalenessPeriod`
-* Adds all specified `chainIDs` as transport destinations
 * Emits a `GenerationReservationCreated` event
 * Emits an `OperatorTableCalculatorSet` event
 * Emits an `OperatorSetConfigSet` event
-* Emits a `TransportDestinationChainAdded` event for each added chain
 
 *Requirements*:
 * The global paused status MUST NOT be set: `PAUSED_GENERATION_RESERVATIONS`
@@ -95,11 +93,9 @@ Removes a generation reservation for a given `operatorSet` and clears all associ
 *Effects*:
 * Removes the `operatorTableCalculator` mapping for the `operatorSet`
 * Removes the `operatorSetConfig` mapping for the `operatorSet`
-* Removes all transport destinations for the `operatorSet`
 * Removes the `operatorSet` from `_activeGenerationReservations`
 * Emits an `OperatorTableCalculatorRemoved` event
 * Emits an `OperatorSetConfigRemoved` event
-* Emits a `TransportDestinationsRemoved` event
 * Emits a `GenerationReservationRemoved` event
 
 *Requirements*:
@@ -171,67 +167,6 @@ Updates the operator set configuration for a given `operatorSet`. The config con
 * The `operatorSet` MUST exist in the `AllocationManager`
 * A generation reservation MUST exist for the `operatorSet`
 
-### `addTransportDestinations` 
-
-```solidity
-/**
- * @notice Adds destination chains to transport to
- * @param operatorSet the operatorSet to add transport destinations for
- * @param chainIDs to add transport to
- * @dev msg.sender must be UAM permissioned for operatorSet.avs
- * @dev Will create a transport reservation if one doesn't exist
- */
-function addTransportDestinations(
-    OperatorSet calldata operatorSet, 
-    uint256[] calldata chainIDs
-) external;
-```
-
-Adds destination chain IDs to the transport list for a given `operatorSet`. These chains will receive the operator table data during cross-chain transports.
-
-*Effects*:
-* Adds each `chainID` to the `_transportDestinations` set for the `operatorSet`
-* Emits a `TransportDestinationChainAdded` event for each successfully added chain
-
-*Requirements*:
-* The global paused status MUST NOT be set: `PAUSED_TRANSPORT_DESTINATIONS`
-* Caller MUST be UAM permissioned for `operatorSet.avs`
-* The `operatorSet` MUST exist in the `AllocationManager`
-* A generation reservation MUST exist for the `operatorSet`
-* At least one `chainID` MUST be provided
-* All provided `chainIDs` MUST be whitelisted
-* Each `chainID` MUST NOT already be a transport destination
-
-### `removeTransportDestinations`
-
-```solidity
-/**
- * @notice Removes destination chains to transport to
- * @param operatorSet the operatorSet to remove transport destinations for
- * @param chainIDs to remove transport to
- * @dev msg.sender must be UAM permissioned for operatorSet.avs
- * @dev Will remove the transport reservation if all destinations are removed
- */
-function removeTransportDestinations(
-    OperatorSet calldata operatorSet, 
-    uint256[] calldata chainIDs
-) external;
-```
-
-Removes destination chain IDs from the transport list for a given `operatorSet`. 
-
-*Effects*:
-* Removes each `chainID` from the `_transportDestinations` set for the `operatorSet`
-* Emits a `TransportDestinationChainRemoved` event for each successfully removed chain
-
-*Requirements*:
-* The global paused status MUST NOT be set: `PAUSED_TRANSPORT_DESTINATIONS`
-* Caller MUST be UAM permissioned for `operatorSet.avs`
-* The `operatorSet` MUST exist in the `AllocationManager`
-* A generation reservation MUST exist for the `operatorSet`
-* Each `chainID` MUST exist in the transport destinations
-* At least one transport destination MUST remain after removal (use `removeGenerationReservation` to remove all)
-
 ---
 
 ## System Configuration
@@ -249,7 +184,7 @@ The `owner` of the `CrossChainRegistry` can update the whitelisted chain IDs. If
 function addChainIDsToWhitelist(uint256[] calldata chainIDs, address[] calldata operatorTableUpdaters) external;
 ```
 
-Adds chain IDs to the global whitelist, enabling them as valid transport destinations. Each chain ID is associated with an operator table updater address that will be responsible for updating operator tables on that chain.
+Adds chain IDs to the global whitelist, enabling them as valid transport destinations. Each chain ID is associated with an `OperatorTableUpdater` address that will be responsible for updating operator tables on that chain. In practice, the `OperatorTableUpdater` address will be the same across all chains. 
 
 *Effects*:
 * Adds each `chainID` and its corresponding `operatorTableUpdater` to the `_whitelistedChainIDs` mapping
@@ -275,7 +210,7 @@ function removeChainIDsFromWhitelist(
 ) external;
 ```
 
-Removes chain IDs from the global whitelist, preventing them from being used as transport destinations. Note that existing transport destinations for operator sets will continue to filter out non-whitelisted chains when queried.
+Removes chain IDs from the global whitelist, preventing them from being used as transport destinations. 
 
 *Effects*:
 * Removes each `chainID` from the `_whitelistedChainIDs` mapping
@@ -320,13 +255,13 @@ function calculateOperatorTableBytes(
 ) external view returns (bytes memory);
 ```
 
-3. `getActiveTransportReservations`: Gets all operatorSets with active transport reservations and their destinations
+3. `getSupportedChains`: Gets all chains that can be transported to
 
 ```solidity
 /**
- * @notice Gets the active transport reservations
- * @return An array of operatorSets with active transport reservations
- * @return An array of chainIDs that the operatorSet is configured to transport to
+ * @notice Gets the list of chains that are supported by the CrossChainRegistry
+ * @return An array of chainIDs that are supported by the CrossChainRegistry
+ * @return An array of operatorTableUpdaters corresponding to each chainID
  */
-function getActiveTransportReservations() external view returns (OperatorSet[] memory, uint256[][] memory);
+function getSupportedChains() external view returns(uint256[] memory, address[] memory);
 ```

--- a/src/contracts/interfaces/ICrossChainRegistry.sol
+++ b/src/contracts/interfaces/ICrossChainRegistry.sol
@@ -14,12 +14,6 @@ interface ICrossChainRegistryErrors {
     /// @notice Thrown when a generation reservation does not exist for the operator set
     error GenerationReservationDoesNotExist();
 
-    /// @notice Thrown when a transport destination is already added for the operator set
-    error TransportDestinationAlreadyAdded();
-
-    /// @notice Thrown when a transport destination is not found for the operator set
-    error TransportDestinationNotFound();
-
     /// @notice Thrown when a chain ID is already whitelisted
     error ChainIDAlreadyWhitelisted();
 
@@ -31,9 +25,6 @@ interface ICrossChainRegistryErrors {
 
     /// @notice Thrown when the chainIDs array is empty
     error EmptyChainIDsArray();
-
-    /// @notice Thrown when a at least one transport destination is required
-    error RequireAtLeastOneTransportDestination();
 
     /// @notice Thrown when the lengths between two arrays are not the same
     error ArrayLengthMismatch();
@@ -70,15 +61,6 @@ interface ICrossChainRegistryEvents is ICrossChainRegistryTypes {
     /// @notice Emitted when an operatorSetConfig is removed, when a generation reservation is removed
     event OperatorSetConfigRemoved(OperatorSet operatorSet);
 
-    /// @notice Emitted when a transport destination is added
-    event TransportDestinationChainAdded(OperatorSet operatorSet, uint256 chainID);
-
-    /// @notice Emitted when a transport destination is removed
-    event TransportDestinationChainRemoved(OperatorSet operatorSet, uint256 chainID);
-
-    /// @notice Emitted when transport destinations are removed, when a generation reservation is removed
-    event TransportDestinationsRemoved(OperatorSet operatorSet);
-
     /// @notice Emitted when a chainID is added to the whitelist
     event ChainIDAddedToWhitelist(uint256 chainID, address operatorTableUpdater);
 
@@ -92,14 +74,13 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
      * @param operatorSet the operatorSet to make a reservation for
      * @param operatorTableCalculator the address of the operatorTableCalculator
      * @param config the config to set for the operatorSet
-     * @param chainIDs the chainIDs to add as transport destinations
      * @dev msg.sender must be UAM permissioned for operatorSet.avs
+     * @dev Once a generation reservation is created, the operator table will be transported to all chains that are whitelisted
      */
     function createGenerationReservation(
         OperatorSet calldata operatorSet,
         IOperatorTableCalculator operatorTableCalculator,
-        OperatorSetConfig calldata config,
-        uint256[] calldata chainIDs
+        OperatorSetConfig calldata config
     ) external;
 
     /**
@@ -131,24 +112,6 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
      * @dev operatorSet must have an active generation reservation
      */
     function setOperatorSetConfig(OperatorSet calldata operatorSet, OperatorSetConfig calldata config) external;
-
-    /**
-     * @notice Adds destination chains to transport to
-     * @param operatorSet the operatorSet to add transport destinations for
-     * @param chainIDs to add transport to
-     * @dev msg.sender must be UAM permissioned for operatorSet.avs
-     * @dev Will create a transport reservation if one doesn't exist
-     */
-    function addTransportDestinations(OperatorSet calldata operatorSet, uint256[] calldata chainIDs) external;
-
-    /**
-     * @notice Removes destination chains to transport to
-     * @param operatorSet the operatorSet to remove transport destinations for
-     * @param chainIDs to remove transport to
-     * @dev msg.sender must be UAM permissioned for operatorSet.avs
-     * @dev Will remove the transport reservation if all destinations are removed
-     */
-    function removeTransportDestinations(OperatorSet calldata operatorSet, uint256[] calldata chainIDs) external;
 
     /**
      * @notice Adds chainIDs to the whitelist of chainIDs that can be transported to
@@ -210,22 +173,6 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
     function calculateOperatorTableBytes(
         OperatorSet calldata operatorSet
     ) external view returns (bytes memory);
-
-    /**
-     * @notice Gets the active transport reservations
-     * @return An array of operatorSets with active transport reservations
-     * @return An array of chainIDs that the operatorSet is configured to transport to
-     */
-    function getActiveTransportReservations() external view returns (OperatorSet[] memory, uint256[][] memory);
-
-    /**
-     * @notice Gets the transport destinations for a given operatorSet
-     * @param operatorSet the operatorSet to get the transport destinations for
-     * @return An array of chainIDs that the operatorSet is configured to transport to
-     */
-    function getTransportDestinations(
-        OperatorSet memory operatorSet
-    ) external view returns (uint256[] memory);
 
     /**
      * @notice Gets the list of chains that are supported by the CrossChainRegistry

--- a/src/contracts/multichain/CrossChainRegistry.sol
+++ b/src/contracts/multichain/CrossChainRegistry.sol
@@ -101,8 +101,7 @@ contract CrossChainRegistry is
     function createGenerationReservation(
         OperatorSet calldata operatorSet,
         IOperatorTableCalculator operatorTableCalculator,
-        OperatorSetConfig calldata config,
-        uint256[] calldata chainIDs
+        OperatorSetConfig calldata config
     )
         external
         onlyWhenNotPaused(PAUSED_GENERATION_RESERVATIONS)
@@ -117,8 +116,6 @@ contract CrossChainRegistry is
         _setOperatorTableCalculator(operatorSet, operatorTableCalculator);
         // Set the operator set config
         _setOperatorSetConfig(operatorSet, config);
-        // Add transport destinations
-        _addTransportDestinations(operatorSet, chainIDs);
     }
 
     /// @inheritdoc ICrossChainRegistry
@@ -142,11 +139,7 @@ contract CrossChainRegistry is
         delete _operatorSetConfigs[operatorSetKey];
         emit OperatorSetConfigRemoved(operatorSet);
 
-        // 3. Remove all transport destinations
-        delete _transportDestinations[operatorSetKey];
-        emit TransportDestinationsRemoved(operatorSet);
-
-        // 4. Remove from active generation reservations
+        // 3. Remove from active generation reservations
         _activeGenerationReservations.remove(operatorSetKey);
         emit GenerationReservationRemoved(operatorSet);
     }
@@ -179,34 +172,6 @@ contract CrossChainRegistry is
     {
         // Set the operator set config
         _setOperatorSetConfig(operatorSet, config);
-    }
-
-    /// @inheritdoc ICrossChainRegistry
-    function addTransportDestinations(
-        OperatorSet calldata operatorSet,
-        uint256[] calldata chainIDs
-    )
-        external
-        onlyWhenNotPaused(PAUSED_TRANSPORT_DESTINATIONS)
-        checkCanCall(operatorSet.avs)
-        isValidOperatorSet(operatorSet)
-        hasActiveGenerationReservation(operatorSet)
-    {
-        _addTransportDestinations(operatorSet, chainIDs);
-    }
-
-    /// @inheritdoc ICrossChainRegistry
-    function removeTransportDestinations(
-        OperatorSet calldata operatorSet,
-        uint256[] calldata chainIDs
-    )
-        external
-        onlyWhenNotPaused(PAUSED_TRANSPORT_DESTINATIONS)
-        checkCanCall(operatorSet.avs)
-        isValidOperatorSet(operatorSet)
-        hasActiveGenerationReservation(operatorSet)
-    {
-        _removeTransportDestinations(operatorSet, chainIDs);
     }
 
     /// @inheritdoc ICrossChainRegistry
@@ -273,53 +238,6 @@ contract CrossChainRegistry is
     }
 
     /**
-     * @dev Internal function to add transport destinations for an operator set
-     * @param operatorSet The operator set to add destinations for
-     * @param chainIDs The chain IDs to add as destinations
-     */
-    function _addTransportDestinations(OperatorSet memory operatorSet, uint256[] memory chainIDs) internal {
-        // Validate chainIDs array is not empty. This is to prevent users from
-        // creating a generation reservation with no destinations.
-        require(chainIDs.length > 0, EmptyChainIDsArray());
-
-        bytes32 operatorSetKey = operatorSet.key();
-
-        for (uint256 i = 0; i < chainIDs.length; i++) {
-            uint256 chainID = chainIDs[i];
-
-            // Check if chainID is whitelisted
-            require(_whitelistedChainIDs.contains(chainID), ChainIDNotWhitelisted());
-
-            // Add transport destination
-            require(_transportDestinations[operatorSetKey].add(chainID), TransportDestinationAlreadyAdded());
-
-            emit TransportDestinationChainAdded(operatorSet, chainID);
-        }
-    }
-
-    /**
-     * @dev Internal function to remove transport destinations for an operator set
-     * @param operatorSet The operator set to remove destinations from
-     * @param chainIDs The chain IDs to remove as destinations
-     */
-    function _removeTransportDestinations(OperatorSet memory operatorSet, uint256[] memory chainIDs) internal {
-        bytes32 operatorSetKey = operatorSet.key();
-
-        for (uint256 i = 0; i < chainIDs.length; i++) {
-            uint256 chainID = chainIDs[i];
-
-            // Remove transport destination
-            require(_transportDestinations[operatorSetKey].remove(chainID), TransportDestinationNotFound());
-
-            emit TransportDestinationChainRemoved(operatorSet, chainID);
-        }
-
-        // Ensure that at least one destination remains
-        // If a user wants to remove all destinations, they should call `removeGenerationReservation` instead
-        require(_transportDestinations[operatorSetKey].length() > 0, RequireAtLeastOneTransportDestination());
-    }
-
-    /**
      *
      *                         VIEW FUNCTIONS
      *
@@ -367,53 +285,7 @@ contract CrossChainRegistry is
     }
 
     /// @inheritdoc ICrossChainRegistry
-    function getActiveTransportReservations() external view returns (OperatorSet[] memory, uint256[][] memory) {
-        uint256 length = _activeGenerationReservations.length();
-        OperatorSet[] memory operatorSets = new OperatorSet[](length);
-        uint256[][] memory chainIDs = new uint256[][](length);
-
-        for (uint256 i = 0; i < length; i++) {
-            bytes32 operatorSetKey = _activeGenerationReservations.at(i);
-            OperatorSet memory operatorSet = OperatorSetLib.decode(operatorSetKey);
-
-            operatorSets[i] = operatorSet;
-            chainIDs[i] = getTransportDestinations(operatorSet);
-        }
-
-        return (operatorSets, chainIDs);
-    }
-
-    /// @inheritdoc ICrossChainRegistry
-    function getTransportDestinations(
-        OperatorSet memory operatorSet
-    ) public view returns (uint256[] memory) {
-        EnumerableSet.UintSet storage chainIDs = _transportDestinations[operatorSet.key()];
-        uint256 length = chainIDs.length();
-
-        // Create result array with maximum possible size
-        uint256[] memory result = new uint256[](length);
-        uint256 count = 0;
-
-        // Single loop to filter whitelisted chains
-        for (uint256 i = 0; i < length; i++) {
-            uint256 chainID = chainIDs.at(i);
-            if (_whitelistedChainIDs.contains(chainID)) {
-                result[count] = chainID;
-                count++;
-            }
-        }
-
-        // Resize the array to the actual count using assembly
-        assembly {
-            mstore(result, count)
-        }
-
-        // Only return chains that are whitelisted
-        return result;
-    }
-
-    /// @inheritdoc ICrossChainRegistry
-    function getSupportedChains() external view returns (uint256[] memory, address[] memory) {
+    function getSupportedChains() public view returns (uint256[] memory, address[] memory) {
         uint256 length = _whitelistedChainIDs.length();
         uint256[] memory chainIDs = new uint256[](length);
         address[] memory operatorTableUpdaters = new address[](length);

--- a/src/contracts/multichain/CrossChainRegistryStorage.sol
+++ b/src/contracts/multichain/CrossChainRegistryStorage.sol
@@ -32,11 +32,8 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
     /// @dev Index for flag that pauses operator set config modifications when set
     uint8 internal constant PAUSED_OPERATOR_SET_CONFIG = 2;
 
-    /// @dev Index for flag that pauses transport destination modifications when set
-    uint8 internal constant PAUSED_TRANSPORT_DESTINATIONS = 3;
-
     /// @dev Index for flag that pauses chain whitelist modifications when set
-    uint8 internal constant PAUSED_CHAIN_WHITELIST = 4;
+    uint8 internal constant PAUSED_CHAIN_WHITELIST = 3;
 
     // Immutables
 
@@ -58,9 +55,6 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
 
     /// @dev Mapping from operator set key to operator set configuration
     mapping(bytes32 operatorSetKey => OperatorSetConfig) internal _operatorSetConfigs;
-
-    /// @dev Mapping from operator set key to set of chain IDs for transport destinations
-    mapping(bytes32 operatorSetKey => EnumerableSet.UintSet) internal _transportDestinations;
 
     /// CHAIN WHITELISTING
 

--- a/src/contracts/multichain/CrossChainRegistryStorage.sol
+++ b/src/contracts/multichain/CrossChainRegistryStorage.sol
@@ -73,5 +73,5 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[42] private __gap;
+    uint256[43] private __gap;
 }

--- a/src/test/unit/CrossChainRegistryUnit.t.sol
+++ b/src/test/unit/CrossChainRegistryUnit.t.sol
@@ -22,8 +22,7 @@ contract CrossChainRegistryUnitTests is
     uint8 constant PAUSED_GENERATION_RESERVATIONS = 0;
     uint8 constant PAUSED_OPERATOR_TABLE_CALCULATOR = 1;
     uint8 constant PAUSED_OPERATOR_SET_CONFIG = 2;
-    uint8 constant PAUSED_TRANSPORT_DESTINATIONS = 3;
-    uint8 constant PAUSED_CHAIN_WHITELIST = 4;
+    uint8 constant PAUSED_CHAIN_WHITELIST = 3;
 
     // Test state variables
     CrossChainRegistry crossChainRegistry;
@@ -36,7 +35,6 @@ contract CrossChainRegistryUnitTests is
     address defaultOperatorTableUpdater = address(0x1);
     uint[] defaultChainIDs;
     address[] defaultOperatorTableUpdaters;
-    uint[] emptyChainIDs;
 
     function setUp() public virtual override {
         EigenLayerMultichainUnitTestSetup.setUp();
@@ -103,8 +101,6 @@ contract CrossChainRegistryUnitTests is
         permissionController.setAppointee(avs, target, address(crossChainRegistry), crossChainRegistry.removeGenerationReservation.selector);
         permissionController.setAppointee(avs, target, address(crossChainRegistry), crossChainRegistry.setOperatorTableCalculator.selector);
         permissionController.setAppointee(avs, target, address(crossChainRegistry), crossChainRegistry.setOperatorSetConfig.selector);
-        permissionController.setAppointee(avs, target, address(crossChainRegistry), crossChainRegistry.addTransportDestinations.selector);
-        permissionController.setAppointee(avs, target, address(crossChainRegistry), crossChainRegistry.removeTransportDestinations.selector);
 
         // Set appointee for KeyRegistrar functions
         permissionController.setAppointee(avs, target, address(keyRegistrar), keyRegistrar.configureOperatorSet.selector);
@@ -152,7 +148,7 @@ contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
         );
 
         address newOwner = cheats.randomAddress();
-        uint initialPausedStatus = (1 << PAUSED_GENERATION_RESERVATIONS) | (1 << PAUSED_TRANSPORT_DESTINATIONS);
+        uint initialPausedStatus = (1 << PAUSED_GENERATION_RESERVATIONS) | (1 << PAUSED_OPERATOR_TABLE_CALCULATOR);
 
         CrossChainRegistry freshRegistry = CrossChainRegistry(
             address(
@@ -166,8 +162,7 @@ contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
 
         assertEq(freshRegistry.owner(), newOwner, "Owner not set correctly");
         assertTrue(freshRegistry.paused(PAUSED_GENERATION_RESERVATIONS), "PAUSED_GENERATION_RESERVATIONS not set");
-        assertTrue(freshRegistry.paused(PAUSED_TRANSPORT_DESTINATIONS), "PAUSED_TRANSPORT_DESTINATIONS not set");
-        assertFalse(freshRegistry.paused(PAUSED_OPERATOR_TABLE_CALCULATOR), "PAUSED_OPERATOR_TABLE_CALCULATOR should not be set");
+        assertTrue(freshRegistry.paused(PAUSED_OPERATOR_TABLE_CALCULATOR), "PAUSED_OPERATOR_TABLE_CALCULATOR should not be set");
     }
 }
 
@@ -181,13 +176,13 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         crossChainRegistry.pause(1 << PAUSED_GENERATION_RESERVATIONS);
 
         cheats.expectRevert(IPausable.CurrentlyPaused.selector);
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
     }
 
     function test_Revert_NotPermissioned() public {
         cheats.prank(notPermissioned);
         cheats.expectRevert(PermissionControllerMixin.InvalidPermissions.selector);
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
     }
 
     function test_Revert_InvalidOperatorSet() public {
@@ -197,27 +192,14 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         _grantUAMRole(address(this), invalidOperatorSet.avs);
 
         cheats.expectRevert(InvalidOperatorSet.selector);
-        crossChainRegistry.createGenerationReservation(invalidOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(invalidOperatorSet, defaultCalculator, defaultConfig);
     }
 
     function test_Revert_GenerationReservationAlreadyExists() public {
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
 
         cheats.expectRevert(GenerationReservationAlreadyExists.selector);
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
-    }
-
-    function test_Revert_EmptyChainIDs() public {
-        cheats.expectRevert(EmptyChainIDsArray.selector);
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, emptyChainIDs);
-    }
-
-    function test_Revert_ChainIDNotWhitelisted() public {
-        uint[] memory nonWhitelistedChains = new uint[](1);
-        nonWhitelistedChains[0] = 999;
-
-        cheats.expectRevert(ChainIDNotWhitelisted.selector);
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, nonWhitelistedChains);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
     }
 
     function test_createGenerationReservation_Success() public {
@@ -231,13 +213,8 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
         emit OperatorSetConfigSet(defaultOperatorSet, defaultConfig);
 
-        for (uint i = 0; i < defaultChainIDs.length; i++) {
-            cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
-            emit TransportDestinationChainAdded(defaultOperatorSet, defaultChainIDs[i]);
-        }
-
         // Make the call
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
 
         // Verify state
         OperatorSet[] memory activeReservations = crossChainRegistry.getActiveGenerationReservations();
@@ -252,25 +229,6 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
         assertEq(retrievedConfig.owner, defaultConfig.owner, "Config owner mismatch");
         assertEq(retrievedConfig.maxStalenessPeriod, defaultConfig.maxStalenessPeriod, "Config staleness period mismatch");
-
-        uint[] memory destinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(destinations.length, defaultChainIDs.length, "Transport destinations length mismatch");
-        for (uint i = 0; i < destinations.length; i++) {
-            assertEq(destinations[i], defaultChainIDs[i], "Transport destination mismatch");
-        }
-    }
-
-    function testFuzz_createGenerationReservation_MultipleChainIDs(uint8 numChainIDs) public {
-        numChainIDs = uint8(bound(numChainIDs, 1, 10));
-        uint[] memory chainIDs = _createAndWhitelistChainIDs(numChainIDs);
-
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, chainIDs);
-
-        uint[] memory retrievedChainIDs = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(retrievedChainIDs.length, chainIDs.length, "Chain IDs length mismatch");
-        for (uint i = 0; i < chainIDs.length; i++) {
-            assertEq(retrievedChainIDs[i], chainIDs[i], "Chain ID mismatch");
-        }
     }
 }
 
@@ -282,7 +240,7 @@ contract CrossChainRegistryUnitTests_removeGenerationReservation is CrossChainRe
     function setUp() public override {
         super.setUp();
         // Create a default reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
     }
 
     function test_Revert_Paused() public {
@@ -326,9 +284,6 @@ contract CrossChainRegistryUnitTests_removeGenerationReservation is CrossChainRe
         emit OperatorSetConfigRemoved(defaultOperatorSet);
 
         cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
-        emit TransportDestinationsRemoved(defaultOperatorSet);
-
-        cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
         emit GenerationReservationRemoved(defaultOperatorSet);
 
         // Remove the reservation
@@ -343,9 +298,6 @@ contract CrossChainRegistryUnitTests_removeGenerationReservation is CrossChainRe
         OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
         assertEq(retrievedConfig.owner, address(0), "Config owner should be zero");
         assertEq(retrievedConfig.maxStalenessPeriod, 0, "Config staleness period should be zero");
-
-        uint[] memory destinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(destinations.length, 0, "Should have no transport destinations");
     }
 }
 
@@ -359,7 +311,7 @@ contract CrossChainRegistryUnitTests_setOperatorTableCalculator is CrossChainReg
     function setUp() public override {
         super.setUp();
         // Create a default reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
         newCalculator = new OperatorTableCalculatorMock();
     }
 
@@ -430,7 +382,7 @@ contract CrossChainRegistryUnitTests_setOperatorSetConfig is CrossChainRegistryU
     function setUp() public override {
         super.setUp();
         // Create a default reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
         newConfig = _createOperatorSetConfig(cheats.randomAddress(), 2 days);
     }
 
@@ -488,246 +440,6 @@ contract CrossChainRegistryUnitTests_setOperatorSetConfig is CrossChainRegistryU
 
         OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
         assertEq(retrievedConfig.maxStalenessPeriod, stalenessPeriod, "Staleness period not set correctly");
-    }
-}
-
-/**
- * @title CrossChainRegistryUnitTests_addTransportDestinations
- * @notice Unit tests for CrossChainRegistry.addTransportDestinations
- */
-contract CrossChainRegistryUnitTests_addTransportDestinations is CrossChainRegistryUnitTests {
-    uint[] newChainIDs;
-    address[] newOperatorTableUpdaters;
-
-    function setUp() public override {
-        super.setUp();
-        // Create a default reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
-
-        // Setup new chain IDs to add
-        newChainIDs = new uint[](2);
-        newChainIDs[0] = 20;
-        newChainIDs[1] = 30;
-        newOperatorTableUpdaters = new address[](2);
-        newOperatorTableUpdaters[0] = defaultOperatorTableUpdater;
-        newOperatorTableUpdaters[1] = defaultOperatorTableUpdater;
-        crossChainRegistry.addChainIDsToWhitelist(newChainIDs, newOperatorTableUpdaters);
-    }
-
-    function test_Revert_Paused() public {
-        cheats.prank(pauser);
-        crossChainRegistry.pause(1 << PAUSED_TRANSPORT_DESTINATIONS);
-
-        cheats.expectRevert(IPausable.CurrentlyPaused.selector);
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, newChainIDs);
-    }
-
-    function test_Revert_NotPermissioned() public {
-        cheats.prank(notPermissioned);
-        cheats.expectRevert(PermissionControllerMixin.InvalidPermissions.selector);
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, newChainIDs);
-    }
-
-    function test_Revert_InvalidOperatorSet() public {
-        OperatorSet memory invalidOperatorSet = _createOperatorSet(cheats.randomAddress(), 999);
-
-        // Grant permission for the invalid operator set's AVS
-        _grantUAMRole(address(this), invalidOperatorSet.avs);
-
-        cheats.expectRevert(InvalidOperatorSet.selector);
-        crossChainRegistry.addTransportDestinations(invalidOperatorSet, newChainIDs);
-    }
-
-    function test_Revert_EmptyChainIDs() public {
-        cheats.expectRevert(EmptyChainIDsArray.selector);
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, emptyChainIDs);
-    }
-
-    function test_Revert_GenerationReservationDoesNotExist() public {
-        OperatorSet memory nonExistentOperatorSet = _createOperatorSet(defaultAVS, 999);
-        allocationManagerMock.setIsOperatorSet(nonExistentOperatorSet, true);
-
-        cheats.expectRevert(GenerationReservationDoesNotExist.selector);
-        crossChainRegistry.addTransportDestinations(nonExistentOperatorSet, newChainIDs);
-    }
-
-    function test_Revert_ChainIDNotWhitelisted() public {
-        uint[] memory nonWhitelistedChains = new uint[](1);
-        nonWhitelistedChains[0] = 999;
-
-        cheats.expectRevert(ChainIDNotWhitelisted.selector);
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, nonWhitelistedChains);
-    }
-
-    function test_Revert_TransportDestinationAlreadyAdded() public {
-        cheats.expectRevert(TransportDestinationAlreadyAdded.selector);
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, defaultChainIDs);
-    }
-
-    function test_addTransportDestinations_Success() public {
-        // Expect events
-        for (uint i = 0; i < newChainIDs.length; i++) {
-            cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
-            emit TransportDestinationChainAdded(defaultOperatorSet, newChainIDs[i]);
-        }
-
-        // Add new destinations
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, newChainIDs);
-
-        // Verify state
-        uint[] memory destinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(destinations.length, defaultChainIDs.length + newChainIDs.length, "Destinations count mismatch");
-
-        // Check all destinations are present
-        bool[] memory found = new bool[](defaultChainIDs.length + newChainIDs.length);
-        for (uint i = 0; i < destinations.length; i++) {
-            for (uint j = 0; j < defaultChainIDs.length; j++) {
-                if (destinations[i] == defaultChainIDs[j]) found[j] = true;
-            }
-            for (uint j = 0; j < newChainIDs.length; j++) {
-                if (destinations[i] == newChainIDs[j]) found[defaultChainIDs.length + j] = true;
-            }
-        }
-        for (uint i = 0; i < found.length; i++) {
-            assertTrue(found[i], "Chain ID not found");
-        }
-    }
-
-    function testFuzz_addTransportDestinations_MultipleChainIDs(uint8 numNewChainIDs) public {
-        numNewChainIDs = uint8(bound(numNewChainIDs, 1, 10));
-        uint[] memory fuzzChainIDs = _createAndWhitelistChainIDs(numNewChainIDs);
-
-        crossChainRegistry.addTransportDestinations(defaultOperatorSet, fuzzChainIDs);
-
-        uint[] memory destinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(destinations.length, defaultChainIDs.length + fuzzChainIDs.length, "Destinations count mismatch");
-    }
-}
-
-/**
- * @title CrossChainRegistryUnitTests_removeTransportDestinations
- * @notice Unit tests for CrossChainRegistry.removeTransportDestinations
- */
-contract CrossChainRegistryUnitTests_removeTransportDestinations is CrossChainRegistryUnitTests {
-    uint[] chainIDsToRemove;
-
-    function setUp() public override {
-        super.setUp();
-        // Create a default reservation with multiple chain IDs
-        uint[] memory manyChainIDs = new uint[](4);
-        manyChainIDs[0] = 1; // Already whitelisted in base setUp
-        manyChainIDs[1] = 10; // Already whitelisted in base setUp
-        manyChainIDs[2] = 20;
-        manyChainIDs[3] = 30;
-
-        // Only whitelist the new chain IDs
-        uint[] memory newChainIDs = new uint[](2);
-        newChainIDs[0] = 20;
-        newChainIDs[1] = 30;
-        address[] memory newOperatorTableUpdaters = new address[](2);
-        newOperatorTableUpdaters[0] = defaultOperatorTableUpdater;
-        newOperatorTableUpdaters[1] = defaultOperatorTableUpdater;
-        crossChainRegistry.addChainIDsToWhitelist(newChainIDs, newOperatorTableUpdaters);
-
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, manyChainIDs);
-
-        // Setup chain IDs to remove (subset)
-        chainIDsToRemove = new uint[](2);
-        chainIDsToRemove[0] = 10;
-        chainIDsToRemove[1] = 20;
-    }
-
-    function test_Revert_Paused() public {
-        cheats.prank(pauser);
-        crossChainRegistry.pause(1 << PAUSED_TRANSPORT_DESTINATIONS);
-
-        cheats.expectRevert(IPausable.CurrentlyPaused.selector);
-        crossChainRegistry.removeTransportDestinations(defaultOperatorSet, chainIDsToRemove);
-    }
-
-    function test_Revert_NotPermissioned() public {
-        cheats.prank(notPermissioned);
-        cheats.expectRevert(PermissionControllerMixin.InvalidPermissions.selector);
-        crossChainRegistry.removeTransportDestinations(defaultOperatorSet, chainIDsToRemove);
-    }
-
-    function test_Revert_InvalidOperatorSet() public {
-        OperatorSet memory invalidOperatorSet = _createOperatorSet(cheats.randomAddress(), 999);
-
-        // Grant permission for the invalid operator set's AVS
-        _grantUAMRole(address(this), invalidOperatorSet.avs);
-
-        cheats.expectRevert(InvalidOperatorSet.selector);
-        crossChainRegistry.removeTransportDestinations(invalidOperatorSet, chainIDsToRemove);
-    }
-
-    function test_Revert_GenerationReservationDoesNotExist() public {
-        OperatorSet memory nonExistentOperatorSet = _createOperatorSet(defaultAVS, 999);
-        allocationManagerMock.setIsOperatorSet(nonExistentOperatorSet, true);
-
-        cheats.expectRevert(GenerationReservationDoesNotExist.selector);
-        crossChainRegistry.removeTransportDestinations(nonExistentOperatorSet, chainIDsToRemove);
-    }
-
-    function test_Revert_TransportDestinationNotFound() public {
-        uint[] memory nonExistentChains = new uint[](1);
-        nonExistentChains[0] = 999;
-
-        cheats.expectRevert(TransportDestinationNotFound.selector);
-        crossChainRegistry.removeTransportDestinations(defaultOperatorSet, nonExistentChains);
-    }
-
-    function test_Revert_RequireAtLeastOneTransportDestination() public {
-        // Get all current destinations
-        uint[] memory allDestinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-
-        // Try to remove all of them
-        cheats.expectRevert(RequireAtLeastOneTransportDestination.selector);
-        crossChainRegistry.removeTransportDestinations(defaultOperatorSet, allDestinations);
-    }
-
-    function test_removeTransportDestinations_Success() public {
-        // Expect events
-        for (uint i = 0; i < chainIDsToRemove.length; i++) {
-            cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
-            emit TransportDestinationChainRemoved(defaultOperatorSet, chainIDsToRemove[i]);
-        }
-
-        // Remove destinations
-        crossChainRegistry.removeTransportDestinations(defaultOperatorSet, chainIDsToRemove);
-
-        // Verify state
-        uint[] memory remainingDestinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(remainingDestinations.length, 2, "Should have 2 remaining destinations");
-
-        // Verify the correct destinations remain (1 and 30)
-        assertTrue(
-            (remainingDestinations[0] == 1 && remainingDestinations[1] == 30)
-                || (remainingDestinations[0] == 30 && remainingDestinations[1] == 1),
-            "Incorrect remaining destinations"
-        );
-    }
-
-    function testFuzz_removeTransportDestinations_PartialRemoval(uint8 numToRemove) public {
-        // Setup with many destinations
-        uint[] memory manyChainIDs = _createAndWhitelistChainIDs(10);
-        OperatorSet memory fuzzOperatorSet = _createOperatorSet(cheats.randomAddress(), 100);
-        allocationManagerMock.setIsOperatorSet(fuzzOperatorSet, true);
-        _grantUAMRole(address(this), fuzzOperatorSet.avs);
-
-        crossChainRegistry.createGenerationReservation(fuzzOperatorSet, defaultCalculator, defaultConfig, manyChainIDs);
-
-        // Remove some but not all
-        numToRemove = uint8(bound(numToRemove, 1, 9)); // Leave at least one
-        uint[] memory toRemove = new uint[](numToRemove);
-        for (uint i = 0; i < numToRemove; i++) {
-            toRemove[i] = manyChainIDs[i];
-        }
-
-        crossChainRegistry.removeTransportDestinations(fuzzOperatorSet, toRemove);
-
-        uint[] memory remaining = crossChainRegistry.getTransportDestinations(fuzzOperatorSet);
-        assertEq(remaining.length, manyChainIDs.length - numToRemove, "Incorrect remaining count");
     }
 }
 
@@ -885,21 +597,6 @@ contract CrossChainRegistryUnitTests_removeChainIDsFromWhitelist is CrossChainRe
         assertEq(supportedChains.length, 0, "Should have no supported chains");
         assertEq(operatorTableUpdaters.length, 0, "Should have no operator table updaters");
     }
-
-    function test_removeChainIDsFromWhitelist_AffectsTransportDestinations() public {
-        // Create a reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
-
-        // Remove one chain from whitelist
-        uint[] memory chainToRemove = new uint[](1);
-        chainToRemove[0] = defaultChainIDs[0];
-        crossChainRegistry.removeChainIDsFromWhitelist(chainToRemove);
-
-        // Verify transport destinations only returns whitelisted chains
-        uint[] memory destinations = crossChainRegistry.getTransportDestinations(defaultOperatorSet);
-        assertEq(destinations.length, 1, "Should only return whitelisted destination");
-        assertEq(destinations[0], defaultChainIDs[1], "Wrong destination returned");
-    }
 }
 
 /**
@@ -913,7 +610,7 @@ contract CrossChainRegistryUnitTests_getActiveGenerationReservations is CrossCha
     }
 
     function test_getActiveGenerationReservations_Single() public {
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
 
         OperatorSet[] memory reservations = crossChainRegistry.getActiveGenerationReservations();
         assertEq(reservations.length, 1, "Should have 1 reservation");
@@ -929,7 +626,7 @@ contract CrossChainRegistryUnitTests_getActiveGenerationReservations is CrossCha
             allocationManagerMock.setIsOperatorSet(operatorSet, true);
             _grantUAMRole(address(this), operatorSet.avs);
 
-            crossChainRegistry.createGenerationReservation(operatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+            crossChainRegistry.createGenerationReservation(operatorSet, defaultCalculator, defaultConfig);
         }
 
         OperatorSet[] memory reservations = crossChainRegistry.getActiveGenerationReservations();
@@ -947,7 +644,7 @@ contract CrossChainRegistryUnitTests_calculateOperatorTableBytes is CrossChainRe
     function setUp() public override {
         super.setUp();
         // Create a default reservation
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig);
 
         // Set up mock data
         defaultCalculator.setOperatorTableBytes(defaultOperatorSet, testOperatorTableBytes);
@@ -981,60 +678,6 @@ contract CrossChainRegistryUnitTests_calculateOperatorTableBytes is CrossChainRe
         // Should revert when trying to call calculateOperatorTableBytes on a null calculator
         cheats.expectRevert();
         crossChainRegistry.calculateOperatorTableBytes(nonExistentOperatorSet);
-    }
-}
-
-/**
- * @title CrossChainRegistryUnitTests_getActiveTransportReservations
- * @notice Unit tests for CrossChainRegistry.getActiveTransportReservations
- */
-contract CrossChainRegistryUnitTests_getActiveTransportReservations is CrossChainRegistryUnitTests {
-    function test_getActiveTransportReservations_Empty() public {
-        (OperatorSet[] memory operatorSets, uint[][] memory chainIDs) = crossChainRegistry.getActiveTransportReservations();
-        assertEq(operatorSets.length, 0, "Should have no transport reservations");
-        assertEq(chainIDs.length, 0, "Should have no chain IDs");
-    }
-
-    function test_getActiveTransportReservations_Single() public {
-        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
-
-        (OperatorSet[] memory operatorSets, uint[][] memory chainIDs) = crossChainRegistry.getActiveTransportReservations();
-        assertEq(operatorSets.length, 1, "Should have 1 transport reservation");
-        assertEq(operatorSets[0].avs, defaultOperatorSet.avs, "AVS mismatch");
-        assertEq(operatorSets[0].id, defaultOperatorSet.id, "OperatorSetId mismatch");
-        assertEq(chainIDs[0].length, defaultChainIDs.length, "Chain IDs length mismatch");
-        for (uint i = 0; i < chainIDs[0].length; i++) {
-            assertEq(chainIDs[0][i], defaultChainIDs[i], "Chain ID mismatch");
-        }
-    }
-
-    function test_getActiveTransportReservations_Multiple() public {
-        uint numReservations = 3;
-
-        for (uint i = 0; i < numReservations; i++) {
-            OperatorSet memory operatorSet = _createOperatorSet(cheats.randomAddress(), uint32(i));
-            allocationManagerMock.setIsOperatorSet(operatorSet, true);
-            _grantUAMRole(address(this), operatorSet.avs);
-
-            // Create unique chain IDs for each iteration
-            uint[] memory chainIDs = new uint[](i + 1);
-            address[] memory operatorTableUpdaters = new address[](i + 1);
-            for (uint j = 0; j <= i; j++) {
-                // Use a formula that ensures unique chainIDs across iterations
-                chainIDs[j] = 100 + uint(i * 10 + j);
-                operatorTableUpdaters[j] = address(uint160(uint(100 + i * 10 + j)));
-            }
-            crossChainRegistry.addChainIDsToWhitelist(chainIDs, operatorTableUpdaters);
-
-            crossChainRegistry.createGenerationReservation(operatorSet, defaultCalculator, defaultConfig, chainIDs);
-        }
-
-        (OperatorSet[] memory operatorSets, uint[][] memory chainIDs) = crossChainRegistry.getActiveTransportReservations();
-        assertEq(operatorSets.length, numReservations, "Transport reservation count mismatch");
-
-        for (uint i = 0; i < numReservations; i++) {
-            assertEq(chainIDs[i].length, i + 1, "Chain IDs length mismatch for reservation");
-        }
     }
 }
 


### PR DESCRIPTION
**Motivation:**

For mainnet, we're transporting operator tables to all chains. Thus, we do not need any reference to destination chains. 

**Modifications:**

- Remove chainIds from `createGenerationReservation`
- Remove `addTransportDestinations` and `removeTransportDestinations`
- Remove all transport related events/errors 
- Remove all transport-related storage 

Remove following view functions:
- `getActiveTransportReservations` -> Offchain process can call `getSupportedChains `

**Result:**
Cleaner interface. For testnet, we will need to redeploy the `CrossChainRegistry` due to shifting the storage layout. 