### PR TITLE
feat: add calculateCertificateDigestBytes to ECDSA cert verifier

### DIFF
--- a/src/contracts/interfaces/IECDSACertificateVerifier.sol
+++ b/src/contracts/interfaces/IECDSACertificateVerifier.sol
@@ -152,6 +152,23 @@ interface IECDSACertificateVerifier is IECDSACertificateVerifierEvents, IBaseCer
     function domainSeparator() external view returns (bytes32);
 
     /**
+     * @notice Calculate the EIP-712 digest bytes for a certificate
+     * @param referenceTimestamp The reference timestamp
+     * @param messageHash The message hash
+     * @return The EIP-712 digest
+     * @dev This function is public to allow offchain tools to calculate the same digest
+     * @dev Note: This does not support smart contract based signatures for multichain
+     * @dev This is a chain-agnostic digest, so it can be used to verify certificates across
+     *      multiple destination chains
+     * @dev this function returns the raw bytes of the digest, which still need to be hashed
+     *      before signing with ECDSA
+     */
+    function calculateCertificateDigestBytes(
+        uint32 referenceTimestamp,
+        bytes32 messageHash
+    ) external view returns (bytes memory);
+
+    /**
      * @notice Calculate the EIP-712 digest for a certificate
      * @param referenceTimestamp The reference timestamp
      * @param messageHash The message hash

--- a/src/contracts/multichain/ECDSACertificateVerifier.sol
+++ b/src/contracts/multichain/ECDSACertificateVerifier.sol
@@ -196,6 +196,18 @@ contract ECDSACertificateVerifier is Initializable, ECDSACertificateVerifierStor
     }
 
     /**
+     * @notice Calculate the EIP-712 digest bytes for a certificate
+     * @param referenceTimestamp The reference timestamp of the certificate
+     * @param messageHash The hash of the message that was signed
+     * @return The EIP-712 digest bytes
+     */
+    function _calculateCertificateDigestBytes(uint32 referenceTimestamp, bytes32 messageHash) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(abi.encode(ECDSA_CERTIFICATE_TYPEHASH, referenceTimestamp, messageHash));
+        return abi.encodePacked("\x19\x01", domainSeparator(), structHash);
+    }
+
+
+    /**
      *
      *                         VIEW FUNCTIONS
      *
@@ -337,8 +349,12 @@ contract ECDSACertificateVerifier is Initializable, ECDSACertificateVerifierStor
     }
 
     /// @inheritdoc IECDSACertificateVerifier
+    function calculateCertificateDigestBytes(uint32 referenceTimestamp, bytes32 messageHash) public view returns (bytes memory) {
+        return _calculateCertificateDigestBytes(referenceTimestamp, messageHash);
+    }
+
+    /// @inheritdoc IECDSACertificateVerifier
     function calculateCertificateDigest(uint32 referenceTimestamp, bytes32 messageHash) public view returns (bytes32) {
-        bytes32 structHash = keccak256(abi.encode(ECDSA_CERTIFICATE_TYPEHASH, referenceTimestamp, messageHash));
-        return _calculateSignableDigest(structHash);
+        return keccak256(_calculateCertificateDigestBytes(referenceTimestamp, messageHash));
     }
 }


### PR DESCRIPTION
**Motivation:**

Most Ethereum signers, especially the Web3Signer, expect to hash a message payload on their own when signing. This PR adds a version of `calculateCertificateDigest` that doesnt hash the cert digest bytes in order to be compatible with signing libraries that want to hash the payload.

**Modifications:**

Added `calculateCertificateDigestBytes` to the ECDSA Certificate Verifier

**Result:**

We can now use the Web3Signer for signing multichain ECDSA certificates 🎉
