### PR TITLE
feat: invalid staleness period prevention

### DIFF
--- a/docs/multichain/destination/CertificateVerifier.md
+++ b/docs/multichain/destination/CertificateVerifier.md
@@ -26,7 +26,7 @@ The CertificateVerifier contracts are responsible for verifying certificates fro
 
 Both verifiers implement staleness checks based on a `maxStalenessPeriod` to ensure certificates are not verified against outdated operator information. 
 
-**Note: Setting a max staleness period to 0 enables certificates to be confirmed against any `referenceTimestamp`. In addition, setting a `maxStalenessPeriod` that is greater than 0 and less than the frequency of table updates (daily on testnet, weekly on mainnet) is impossible due to [`CrossChainRegistry.minimumStalessPeriod`](../source/CrossChainRegistry.md#parameterization).** See the [staleness period](#staleness-period) in the appendix for some examples. 
+**Note: Setting a max staleness period to 0 enables certificates to be confirmed against any `referenceTimestamp`. In addition, setting a `maxStalenessPeriod` that is greater than 0 and less than the frequency of table updates (daily on testnet, weekly on mainnet) is impossible due bounds enfroced by the [`CrossChainRegistry`](../source/CrossChainRegistry.md#parameterization).** See the [staleness period](#staleness-period) in the appendix for some examples. 
 
 ---
 

--- a/docs/multichain/destination/CertificateVerifier.md
+++ b/docs/multichain/destination/CertificateVerifier.md
@@ -26,7 +26,7 @@ The CertificateVerifier contracts are responsible for verifying certificates fro
 
 Both verifiers implement staleness checks based on a `maxStalenessPeriod` to ensure certificates are not verified against outdated operator information. 
 
-**Note: Setting a max staleness period to 0 enables certificates to be confirmed against any `referenceTimestamp`. In addition, setting a `maxStalenessPeriod` that is greater than 0 and less than the frequency of table updates (daily on testnet, weekly on mainnet) can result in certificates be unable to be confirmed.** See the [staleness period](#staleness-period) in the appendix for some examples. 
+**Note: Setting a max staleness period to 0 enables certificates to be confirmed against any `referenceTimestamp`. In addition, setting a `maxStalenessPeriod` that is greater than 0 and less than the frequency of table updates (daily on testnet, weekly on mainnet) is impossible due to [`CrossChainRegistry.minimumStalessPeriod`](../source/CrossChainRegistry.md#parameterization).** See the [staleness period](#staleness-period) in the appendix for some examples. 
 
 ---
 
@@ -517,4 +517,4 @@ The operator table is updated every 10 days. The staleness period is 5 days. The
 3. Day 6: Certificate verification *fails*
 4. Day 7: A certificate is re-generated. However, this will stale fail as the `referenceTimestamp` would still be day 1 given that was the latest table update
 
-Note that we cannot re-generate a certificate on Day 7. This is why we recommend that the `stalenessPeriod` is greater than or equal to the update cadence of operator tables.
+Note that we cannot re-generate a certificate on Day 7. This is why we prevent the `stalenessPeriod` from being less than 10 days in the `CrossChainRegistry`.

--- a/docs/multichain/destination/CertificateVerifier.md
+++ b/docs/multichain/destination/CertificateVerifier.md
@@ -517,4 +517,4 @@ The operator table is updated every 10 days. The staleness period is 5 days. The
 3. Day 6: Certificate verification *fails*
 4. Day 7: A certificate is re-generated. However, this will stale fail as the `referenceTimestamp` would still be day 1 given that was the latest table update
 
-Note that we cannot re-generate a certificate on Day 7. This is why we prevent the `stalenessPeriod` from being less than 10 days in the `CrossChainRegistry`.
+Note that we cannot re-generate a certificate on Day 7. This is why we prevent the `stalenessPeriod` from being less than 10 days `CrossChainRegistry`.

--- a/docs/multichain/source/CrossChainRegistry.md
+++ b/docs/multichain/source/CrossChainRegistry.md
@@ -36,6 +36,11 @@ struct OperatorSetConfig {
 * `SupportedChains` (via `getSupportedChains`) are `Mainnet` and `Base`
     * These are chains to which tables can be transported to
     * On Testnet, the supported chains are `Sepolia` and `Base-Sepolia`
+* `MinimumStalenessPeriod` is the global minimum staleness period. It corresponds to the frequency at which tables are transported to destination chains
+    * When setting an operator set config, the `maxStalenessPeriod` must be either:
+        * 0 (special case allowing certificates to always be valid)
+        * Greater than or equal to the minimum staleness period
+    * The minimum staleness period itself cannot be 0
 
 ---
 
@@ -175,6 +180,9 @@ Updates the operator set configuration for a given `operatorSet`. The config con
 * Caller MUST be UAM permissioned for `operatorSet.avs`
 * The `operatorSet` MUST exist in the `AllocationManager`
 * A generation reservation MUST exist for the `operatorSet`
+* The `maxStalenessPeriod` MUST be either:
+  * 0 (special case allowing certificates to always be valid)
+  * Greater than or equal to the global minimum staleness period
 
 ### `addTransportDestinations` 
 
@@ -290,6 +298,29 @@ Removes chain IDs from the global whitelist, preventing them from being used as 
 * Caller MUST be the `owner` of the contract
 * The global paused status MUST NOT be set: `PAUSED_CHAIN_WHITELIST`
 * Each `chainID` MUST be currently whitelisted 
+
+### `setMinimumStalenessPeriod`
+
+```solidity
+/**
+ * @notice Sets the global minimum staleness period
+ * @param minimumStalenessPeriod The minimum staleness period to set
+ * @dev msg.sender must be the owner of the CrossChainRegistry
+ */
+function setMinimumStalenessPeriod(
+    uint32 minimumStalenessPeriod
+) external;
+```
+
+Sets the global minimum staleness period that operator set configurations must respect. This value acts as a floor for all non-zero `maxStalenessPeriod` values in operator set configurations.
+
+*Effects*:
+* Updates the `_minimumStalenessPeriod` storage variable
+* Emits a `MinimumStalenessPeriodSet` event
+
+*Requirements*:
+* Caller MUST be the `owner` of the contract
+* The `minimumStalenessPeriod` MUST be greater than 0 (cannot be 0 as that is reserved for the special case in operator set configs)
 
 ---
 

--- a/docs/multichain/source/CrossChainRegistry.md
+++ b/docs/multichain/source/CrossChainRegistry.md
@@ -36,10 +36,11 @@ struct OperatorSetConfig {
 * `SupportedChains` (via `getSupportedChains`) are `Mainnet` and `Base`
     * These are chains to which tables can be transported to
     * On Testnet, the supported chains are `Sepolia` and `Base-Sepolia`
-* `MinimumStalenessPeriod` is the global minimum staleness period. It corresponds to the frequency at which tables are transported to destination chains
-    * When an AVS sets an operator set config, the `maxStalenessPeriod` must be either:
+* `TableUpdateCadence` is the frequency at which tables are transported to destination chains
+    * When setting an operator set config, the `maxStalenessPeriod` must be either:
         * 0 (special case allowing certificates to always be valid)
-        * Greater than or equal to the minimum staleness period
+        * Greater than or equal to the table update cadence
+    * The table update cadence itself cannot be 0
 
 ---
 
@@ -181,7 +182,7 @@ Updates the operator set configuration for a given `operatorSet`. The config con
 * A generation reservation MUST exist for the `operatorSet`
 * The `maxStalenessPeriod` MUST be either:
   * 0 (special case allowing certificates to always be valid)
-  * Greater than or equal to the global minimum staleness period
+  * Greater than or equal to the table update cadence
 
 ### `addTransportDestinations` 
 
@@ -298,28 +299,28 @@ Removes chain IDs from the global whitelist, preventing them from being used as 
 * The global paused status MUST NOT be set: `PAUSED_CHAIN_WHITELIST`
 * Each `chainID` MUST be currently whitelisted 
 
-### `setMinimumStalenessPeriod`
+### `setTableUpdateCadence`
 
 ```solidity
 /**
- * @notice Sets the global minimum staleness period
- * @param minimumStalenessPeriod The minimum staleness period to set
+ * @notice Sets the global table update cadence
+ * @param tableUpdateCadence The table update cadence to set
  * @dev msg.sender must be the owner of the CrossChainRegistry
  */
-function setMinimumStalenessPeriod(
-    uint32 minimumStalenessPeriod
+function setTableUpdateCadence(
+    uint32 tableUpdateCadence
 ) external;
 ```
 
-Sets the global minimum staleness period that operator set configurations must respect. This value acts as a floor for all non-zero `maxStalenessPeriod` values in operator set configurations.
+Sets the global table update cadence that operator set configurations must respect. This value acts as a floor for all non-zero `maxStalenessPeriod` values in operator set configurations.
 
 *Effects*:
-* Updates the `_minimumStalenessPeriod` storage variable
-* Emits a `MinimumStalenessPeriodSet` event
+* Updates the `_tableUpdateCadence` storage variable
+* Emits a `TableUpdateCadenceSet` event
 
 *Requirements*:
 * Caller MUST be the `owner` of the contract
-* The `minimumStalenessPeriod` MUST be greater than 0 (cannot be 0 as that is reserved for the special case in operator set configs)
+* The `tableUpdateCadence` MUST be greater than 0
 
 ---
 

--- a/docs/multichain/source/CrossChainRegistry.md
+++ b/docs/multichain/source/CrossChainRegistry.md
@@ -36,7 +36,7 @@ struct OperatorSetConfig {
 * `SupportedChains` (via `getSupportedChains`) are `Mainnet` and `Base`
     * These are chains to which tables can be transported to
     * On Testnet, the supported chains are `Sepolia` and `Base-Sepolia`
-* `TableUpdateCadence` is the frequency at which tables are transported to destination chains
+* `TableUpdateCadence` is the frequency at which tables are *expected* to be transported to destination chains
     * When setting an operator set config, the `maxStalenessPeriod` must be either:
         * 0 (special case allowing certificates to always be valid)
         * Greater than or equal to the table update cadence
@@ -312,7 +312,7 @@ function setTableUpdateCadence(
 ) external;
 ```
 
-Sets the global table update cadence that operator set configurations must respect. This value acts as a floor for all non-zero `maxStalenessPeriod` values in operator set configurations.
+Sets the global table update cadence - the cadence at which operator tables are *expected* to be updated. This value acts as a floor for all non-zero `maxStalenessPeriod` values in operator set configurations.
 
 *Effects*:
 * Updates the `_tableUpdateCadence` storage variable

--- a/docs/multichain/source/CrossChainRegistry.md
+++ b/docs/multichain/source/CrossChainRegistry.md
@@ -37,10 +37,9 @@ struct OperatorSetConfig {
     * These are chains to which tables can be transported to
     * On Testnet, the supported chains are `Sepolia` and `Base-Sepolia`
 * `MinimumStalenessPeriod` is the global minimum staleness period. It corresponds to the frequency at which tables are transported to destination chains
-    * When setting an operator set config, the `maxStalenessPeriod` must be either:
+    * When an AVS sets an operator set config, the `maxStalenessPeriod` must be either:
         * 0 (special case allowing certificates to always be valid)
         * Greater than or equal to the minimum staleness period
-    * The minimum staleness period itself cannot be 0
 
 ---
 

--- a/script/releases/v1.7.0-multichain/1-deploySourceChain.s.sol
+++ b/script/releases/v1.7.0-multichain/1-deploySourceChain.s.sol
@@ -68,6 +68,7 @@ contract DeploySourceChain is EOADeployer {
                         CrossChainRegistry.initialize,
                         (
                             Env.opsMultisig(), // initialOwner
+                            1 days, // initialMinimumStalenessPeriod
                             Env.CROSS_CHAIN_REGISTRY_PAUSE_STATUS()
                         )
                     )
@@ -197,7 +198,7 @@ contract DeploySourceChain is EOADeployer {
         /// CrossChainRegistry
         CrossChainRegistry crossChainRegistry = Env.impl.crossChainRegistry();
         vm.expectRevert(errInit);
-        crossChainRegistry.initialize(address(0), 0);
+        crossChainRegistry.initialize(address(0), 1 days, 0);
     }
 
     function _validateProxyConstructors() internal view {
@@ -243,7 +244,7 @@ contract DeploySourceChain is EOADeployer {
         /// CrossChainRegistry
         CrossChainRegistry crossChainRegistry = Env.proxy.crossChainRegistry();
         vm.expectRevert(errInit);
-        crossChainRegistry.initialize(address(0), 0);
+        crossChainRegistry.initialize(address(0), 1 days, 0);
 
         // ReleaseManager and KeyRegistrar don't have initialize functions
     }

--- a/src/contracts/interfaces/ICrossChainRegistry.sol
+++ b/src/contracts/interfaces/ICrossChainRegistry.sol
@@ -41,8 +41,8 @@ interface ICrossChainRegistryErrors {
     /// @notice Thrown when the staleness period set by an operatorSet is invalid
     error InvalidStalenessPeriod();
 
-    /// @notice Thrown when the minimum staleness period is invalid
-    error InvalidMinimumStalenessPeriod();
+    /// @notice Thrown when the table update cadence is invalid
+    error InvalidTableUpdateCadence();
 }
 
 interface ICrossChainRegistryTypes {
@@ -95,8 +95,8 @@ interface ICrossChainRegistryEvents is ICrossChainRegistryTypes {
     /// @notice Emitted when a chainID is removed from the whitelist
     event ChainIDRemovedFromWhitelist(uint256 chainID);
 
-    /// @notice Emitted when the minimum staleness period is set
-    event MinimumStalenessPeriodSet(uint32 minimumStalenessPeriod);
+    /// @notice Emitted when the table update cadence is set
+    event TableUpdateCadenceSet(uint32 tableUpdateCadence);
 }
 
 interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryEvents {
@@ -182,13 +182,13 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
     ) external;
 
     /**
-     * @notice Sets the minimum staleness period
-     * @param minimumStalenessPeriod the minimum staleness period
+     * @notice Sets the table update cadence
+     * @param tableUpdateCadence the table update cadence
      * @dev msg.sender must be the owner of the CrossChainRegistry
-     * @dev The minimum staleness period cannot be 0 as that is special-cased to allow for certificates to ALWAYS be valid
+     * @dev The table update cadence cannot be 0
      */
-    function setMinimumStalenessPeriod(
-        uint32 minimumStalenessPeriod
+    function setTableUpdateCadence(
+        uint32 tableUpdateCadence
     ) external;
 
     /**
@@ -259,10 +259,9 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
     function getSupportedChains() external view returns (uint256[] memory, address[] memory);
 
     /**
-     * @notice Gets the minimum staleness period
-     * @return The minimum staleness period
-     * @dev The minimum staleness period is applicable to all chains
-     * @dev The staleness period of 0 is special case and is allowed
+     * @notice Gets the table update cadence
+     * @return The table update cadence
+     * @dev The table update cadence is applicable to all chains
      */
-    function getMinimumStalenessPeriod() external view returns (uint32);
+    function getTableUpdateCadence() external view returns (uint32);
 }

--- a/src/contracts/interfaces/ICrossChainRegistry.sol
+++ b/src/contracts/interfaces/ICrossChainRegistry.sol
@@ -37,6 +37,12 @@ interface ICrossChainRegistryErrors {
 
     /// @notice Thrown when the lengths between two arrays are not the same
     error ArrayLengthMismatch();
+
+    /// @notice Thrown when the staleness period set by an operatorSet is invalid
+    error InvalidStalenessPeriod();
+
+    /// @notice Thrown when the minimum staleness period is invalid
+    error InvalidMinimumStalenessPeriod();
 }
 
 interface ICrossChainRegistryTypes {
@@ -88,6 +94,9 @@ interface ICrossChainRegistryEvents is ICrossChainRegistryTypes {
 
     /// @notice Emitted when a chainID is removed from the whitelist
     event ChainIDRemovedFromWhitelist(uint256 chainID);
+
+    /// @notice Emitted when the minimum staleness period is set
+    event MinimumStalenessPeriodSet(uint32 minimumStalenessPeriod);
 }
 
 interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryEvents {
@@ -173,6 +182,16 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
     ) external;
 
     /**
+     * @notice Sets the minimum staleness period
+     * @param minimumStalenessPeriod the minimum staleness period
+     * @dev msg.sender must be the owner of the CrossChainRegistry
+     * @dev The minimum staleness period cannot be 0 as that is special-cased to allow for certificates to ALWAYS be valid
+     */
+    function setMinimumStalenessPeriod(
+        uint32 minimumStalenessPeriod
+    ) external;
+
+    /**
      *
      *                         VIEW FUNCTIONS
      *
@@ -238,4 +257,12 @@ interface ICrossChainRegistry is ICrossChainRegistryErrors, ICrossChainRegistryE
      * @return An array of operatorTableUpdaters corresponding to each chainID
      */
     function getSupportedChains() external view returns (uint256[] memory, address[] memory);
+
+    /**
+     * @notice Gets the minimum staleness period
+     * @return The minimum staleness period
+     * @dev The minimum staleness period is applicable to all chains
+     * @dev The staleness period of 0 is special case and is allowed
+     */
+    function getMinimumStalenessPeriod() external view returns (uint32);
 }

--- a/src/contracts/multichain/CrossChainRegistry.sol
+++ b/src/contracts/multichain/CrossChainRegistry.sol
@@ -84,15 +84,16 @@ contract CrossChainRegistry is
     /**
      * @notice Initializes the contract with the initial paused status and owner
      * @param initialOwner The initial owner of the contract
+     * @param initialTableUpdateCadence The initial table update cadence
      * @param initialPausedStatus The initial paused status bitmap
      */
     function initialize(
         address initialOwner,
-        uint32 initialMinimumStalenessPeriod,
+        uint32 initialTableUpdateCadence,
         uint256 initialPausedStatus
     ) external initializer {
         _transferOwnership(initialOwner);
-        _setMinimumStalenessPeriod(initialMinimumStalenessPeriod);
+        _setTableUpdateCadence(initialTableUpdateCadence);
         _setPausedStatus(initialPausedStatus);
     }
 
@@ -249,10 +250,10 @@ contract CrossChainRegistry is
     }
 
     /// @inheritdoc ICrossChainRegistry
-    function setMinimumStalenessPeriod(
-        uint32 minimumStalenessPeriod
+    function setTableUpdateCadence(
+        uint32 tableUpdateCadence
     ) external onlyOwner {
-        _setMinimumStalenessPeriod(minimumStalenessPeriod);
+        _setTableUpdateCadence(tableUpdateCadence);
     }
 
     /**
@@ -282,8 +283,7 @@ contract CrossChainRegistry is
      */
     function _setOperatorSetConfig(OperatorSet memory operatorSet, OperatorSetConfig memory config) internal {
         require(
-            config.maxStalenessPeriod == 0 || config.maxStalenessPeriod >= _minimumStalenessPeriod,
-            InvalidStalenessPeriod()
+            config.maxStalenessPeriod == 0 || config.maxStalenessPeriod >= _tableUpdateCadence, InvalidStalenessPeriod()
         );
         _operatorSetConfigs[operatorSet.key()] = config;
         emit OperatorSetConfigSet(operatorSet, config);
@@ -337,16 +337,16 @@ contract CrossChainRegistry is
     }
 
     /**
-     * @dev Internal function to set the minimum staleness period
-     * @param minimumStalenessPeriod the minimum staleness period
-     * @dev The minimum staleness period cannot be 0 as that is special-cased to allow for certificates to ALWAYS be valid
+     * @dev Internal function to set the table update cadence
+     * @param tableUpdateCadence the table update cadence
+     * @dev The table update cadence cannot be 0 as that is special-cased to allow for certificates to ALWAYS be valid
      */
-    function _setMinimumStalenessPeriod(
-        uint32 minimumStalenessPeriod
+    function _setTableUpdateCadence(
+        uint32 tableUpdateCadence
     ) internal {
-        require(minimumStalenessPeriod > 0, InvalidMinimumStalenessPeriod());
-        _minimumStalenessPeriod = minimumStalenessPeriod;
-        emit MinimumStalenessPeriodSet(minimumStalenessPeriod);
+        require(tableUpdateCadence > 0, InvalidTableUpdateCadence());
+        _tableUpdateCadence = tableUpdateCadence;
+        emit TableUpdateCadenceSet(tableUpdateCadence);
     }
 
     /**
@@ -458,7 +458,7 @@ contract CrossChainRegistry is
     }
 
     /// @inheritdoc ICrossChainRegistry
-    function getMinimumStalenessPeriod() external view returns (uint32) {
-        return _minimumStalenessPeriod;
+    function getTableUpdateCadence() external view returns (uint32) {
+        return _tableUpdateCadence;
     }
 }

--- a/src/contracts/multichain/CrossChainRegistry.sol
+++ b/src/contracts/multichain/CrossChainRegistry.sol
@@ -281,7 +281,10 @@ contract CrossChainRegistry is
      * @dev The 0 staleness period is special case and is allowed, since it allows for certificates to ALWAYS be valid
      */
     function _setOperatorSetConfig(OperatorSet memory operatorSet, OperatorSetConfig memory config) internal {
-        require(config.maxStalenessPeriod == 0 || config.maxStalenessPeriod >= _minimumStalenessPeriod, InvalidStalenessPeriod());
+        require(
+            config.maxStalenessPeriod == 0 || config.maxStalenessPeriod >= _minimumStalenessPeriod,
+            InvalidStalenessPeriod()
+        );
         _operatorSetConfigs[operatorSet.key()] = config;
         emit OperatorSetConfigSet(operatorSet, config);
     }

--- a/src/contracts/multichain/CrossChainRegistryStorage.sol
+++ b/src/contracts/multichain/CrossChainRegistryStorage.sol
@@ -50,7 +50,7 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
 
     /// GENERATION RESERVATIONS
 
-    /// @dev Set of operator sets with active generation reservations
+    /// @notice Mapping of generation reservations for operator sets
     EnumerableSet.Bytes32Set internal _activeGenerationReservations;
 
     /// @dev Mapping from operator set key to operator table calculator for active reservations
@@ -67,8 +67,8 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
     /// @dev Map of whitelisted chain IDs to operator table updaters
     EnumerableMap.UintToAddressMap internal _whitelistedChainIDs;
 
-    /// @dev Minimum staleness period, applicable to all chains
-    uint32 internal _minimumStalenessPeriod;
+    /// @notice Table update cadence for all chains
+    uint32 internal _tableUpdateCadence;
 
     // Construction
 

--- a/src/contracts/multichain/CrossChainRegistryStorage.sol
+++ b/src/contracts/multichain/CrossChainRegistryStorage.sol
@@ -67,6 +67,9 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
     /// @dev Map of whitelisted chain IDs to operator table updaters
     EnumerableMap.UintToAddressMap internal _whitelistedChainIDs;
 
+    /// @dev Minimum staleness period, applicable to all chains
+    uint32 internal _minimumStalenessPeriod;
+
     // Construction
 
     constructor(IAllocationManager _allocationManager, IKeyRegistrar _keyRegistrar) {

--- a/src/test/integration/MultichainIntegrationBase.t.sol
+++ b/src/test/integration/MultichainIntegrationBase.t.sol
@@ -86,6 +86,7 @@ abstract contract MultichainIntegrationBase is IntegrationBase {
         // Initialize CrossChainRegistry
         crossChainRegistry.initialize(
             address(this), // owner
+            0, // initialMinimumStalenessPeriod
             0 // initialPausedStatus
         );
 

--- a/src/test/integration/MultichainIntegrationBase.t.sol
+++ b/src/test/integration/MultichainIntegrationBase.t.sol
@@ -86,7 +86,7 @@ abstract contract MultichainIntegrationBase is IntegrationBase {
         // Initialize CrossChainRegistry
         crossChainRegistry.initialize(
             address(this), // owner
-            0, // initialMinimumStalenessPeriod
+            1 hours, // initialMinimumStalenessPeriod (1 hour = 3600 seconds)
             0 // initialPausedStatus
         );
 

--- a/src/test/integration/MultichainIntegrationBase.t.sol
+++ b/src/test/integration/MultichainIntegrationBase.t.sol
@@ -86,7 +86,7 @@ abstract contract MultichainIntegrationBase is IntegrationBase {
         // Initialize CrossChainRegistry
         crossChainRegistry.initialize(
             address(this), // owner
-            1 hours, // initialMinimumStalenessPeriod (1 hour = 3600 seconds)
+            1 hours, // initialTableUpdateCadence (1 hour = 3600 seconds)
             0 // initialPausedStatus
         );
 

--- a/src/test/tree/CrossChainRegistry.tree
+++ b/src/test/tree/CrossChainRegistry.tree
@@ -4,7 +4,7 @@
     │   ├── given that the contract is already initialized
     │   │   └── it should revert
     │   └── given that the contract is not initialized
-    │       └── it should set the owner and paused status correctly
+    │       └── it should set the owner, minimum staleness period, and paused status correctly
     ├── when createGenerationReservation is called
     │   ├── given that the function is paused
     │   │   └── it should revert
@@ -17,6 +17,8 @@
     │   ├── given that the chain IDs array is empty
     │   │   └── it should revert
     │   ├── given that a chain ID is not whitelisted
+    │   │   └── it should revert
+    │   ├── given that the config staleness period is invalid
     │   │   └── it should revert
     │   └── given that all parameters are valid
     │       └── it should create the reservation, set calculator, config, and destinations & emit events
@@ -50,6 +52,8 @@
     │   ├── given that the operator set is invalid
     │   │   └── it should revert
     │   ├── given that the generation reservation does not exist
+    │   │   └── it should revert
+    │   ├── given that the config staleness period is invalid
     │   │   └── it should revert
     │   └── given that all parameters are valid
     │       └── it should update the config and emit event
@@ -100,12 +104,19 @@
     │   │   └── it should revert
     │   └── given that all parameters are valid
     │       └── it should add chains to whitelist and emit events
-    └── when removeChainIDsFromWhitelist is called
+    ├── when removeChainIDsFromWhitelist is called
+    │   ├── given that the caller is not the owner
+    │   │   └── it should revert
+    │   ├── given that the function is paused
+    │   │   └── it should revert
+    │   ├── given that a chain ID is not whitelisted
+    │   │   └── it should revert
+    │   └── given that all parameters are valid
+    │       └── it should remove chains from whitelist and emit events
+    └── when setMinimumStalenessPeriod is called
         ├── given that the caller is not the owner
         │   └── it should revert
-        ├── given that the function is paused
+        ├── given that the minimum staleness period is zero
         │   └── it should revert
-        ├── given that a chain ID is not whitelisted
-        │   └── it should revert
-        └── given that all parameters are valid
-            └── it should remove chains from whitelist and emit events 
+        └── given that the caller is the owner
+            └── it should update the minimum staleness period and emit event 

--- a/src/test/unit/CrossChainRegistryUnit.t.sol
+++ b/src/test/unit/CrossChainRegistryUnit.t.sol
@@ -161,7 +161,9 @@ contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
                 new TransparentUpgradeableProxy(
                     address(freshImplementation),
                     address(eigenLayerProxyAdmin),
-                    abi.encodeWithSelector(CrossChainRegistry.initialize.selector, newOwner, initialMinimumStalenessPeriod, initialPausedStatus)
+                    abi.encodeWithSelector(
+                        CrossChainRegistry.initialize.selector, newOwner, initialMinimumStalenessPeriod, initialPausedStatus
+                    )
                 )
             )
         );
@@ -1154,7 +1156,7 @@ contract CrossChainRegistryUnitTests_getSupportedChains is CrossChainRegistryUni
 contract CrossChainRegistryUnitTests_setMinimumStalenessPeriod is CrossChainRegistryUnitTests {
     function test_Revert_NotOwner() public {
         uint32 newMinimumStalenessPeriod = 14 days;
-        
+
         cheats.prank(notPermissioned);
         cheats.expectRevert("Ownable: caller is not the owner");
         crossChainRegistry.setMinimumStalenessPeriod(newMinimumStalenessPeriod);
@@ -1190,7 +1192,7 @@ contract CrossChainRegistryUnitTests_setMinimumStalenessPeriod is CrossChainRegi
         // Verify setting a valid config works
         OperatorSetConfig memory validConfig = _createOperatorSetConfig(cheats.randomAddress(), 3 days);
         crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, validConfig);
-        
+
         OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
         assertEq(retrievedConfig.maxStalenessPeriod, 3 days, "Valid config should be set");
     }

--- a/src/test/unit/CrossChainRegistryUnit.t.sol
+++ b/src/test/unit/CrossChainRegistryUnit.t.sol
@@ -59,6 +59,7 @@ contract CrossChainRegistryUnitTests is
                     abi.encodeWithSelector(
                         CrossChainRegistry.initialize.selector,
                         address(this), // initial owner
+                        1 days, // initial minimum staleness period
                         0 // initial paused status
                     )
                 )
@@ -138,7 +139,7 @@ contract CrossChainRegistryUnitTests is
 contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
     function test_initialize_AlreadyInitialized() public {
         cheats.expectRevert("Initializable: contract is already initialized");
-        crossChainRegistry.initialize(address(this), 0);
+        crossChainRegistry.initialize(address(this), 0, 0);
     }
 
     function test_initialize_CorrectOwnerAndPausedStatus() public {
@@ -152,6 +153,7 @@ contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
         );
 
         address newOwner = cheats.randomAddress();
+        uint32 initialMinimumStalenessPeriod = 7 days;
         uint initialPausedStatus = (1 << PAUSED_GENERATION_RESERVATIONS) | (1 << PAUSED_TRANSPORT_DESTINATIONS);
 
         CrossChainRegistry freshRegistry = CrossChainRegistry(
@@ -159,12 +161,13 @@ contract CrossChainRegistryUnitTests_initialize is CrossChainRegistryUnitTests {
                 new TransparentUpgradeableProxy(
                     address(freshImplementation),
                     address(eigenLayerProxyAdmin),
-                    abi.encodeWithSelector(CrossChainRegistry.initialize.selector, newOwner, initialPausedStatus)
+                    abi.encodeWithSelector(CrossChainRegistry.initialize.selector, newOwner, initialMinimumStalenessPeriod, initialPausedStatus)
                 )
             )
         );
 
         assertEq(freshRegistry.owner(), newOwner, "Owner not set correctly");
+        assertEq(freshRegistry.getMinimumStalenessPeriod(), initialMinimumStalenessPeriod, "Minimum staleness period not set correctly");
         assertTrue(freshRegistry.paused(PAUSED_GENERATION_RESERVATIONS), "PAUSED_GENERATION_RESERVATIONS not set");
         assertTrue(freshRegistry.paused(PAUSED_TRANSPORT_DESTINATIONS), "PAUSED_TRANSPORT_DESTINATIONS not set");
         assertFalse(freshRegistry.paused(PAUSED_OPERATOR_TABLE_CALCULATOR), "PAUSED_OPERATOR_TABLE_CALCULATOR should not be set");
@@ -220,6 +223,18 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, nonWhitelistedChains);
     }
 
+    function test_Revert_InvalidStalenessPeriod() public {
+        // Set a minimum staleness period
+        uint32 minimumStalenessPeriod = 7 days;
+        crossChainRegistry.setMinimumStalenessPeriod(minimumStalenessPeriod);
+
+        // Try to create with a config that has staleness period less than minimum (but not 0)
+        OperatorSetConfig memory invalidConfig = _createOperatorSetConfig(cheats.randomAddress(), 1 days);
+
+        cheats.expectRevert(InvalidStalenessPeriod.selector);
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, invalidConfig, defaultChainIDs);
+    }
+
     function test_createGenerationReservation_Success() public {
         // Expect events
         cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
@@ -258,6 +273,22 @@ contract CrossChainRegistryUnitTests_createGenerationReservation is CrossChainRe
         for (uint i = 0; i < destinations.length; i++) {
             assertEq(destinations[i], defaultChainIDs[i], "Transport destination mismatch");
         }
+    }
+
+    function test_createGenerationReservation_ZeroStalenessPeriod() public {
+        // Set a minimum staleness period
+        uint32 minimumStalenessPeriod = 7 days;
+        crossChainRegistry.setMinimumStalenessPeriod(minimumStalenessPeriod);
+
+        // Create config with 0 staleness period (should be allowed as special case)
+        OperatorSetConfig memory zeroStalenessConfig = _createOperatorSetConfig(cheats.randomAddress(), 0);
+
+        // Should succeed
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, zeroStalenessConfig, defaultChainIDs);
+
+        // Verify the config was set
+        OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
+        assertEq(retrievedConfig.maxStalenessPeriod, 0, "Zero staleness period should be allowed");
     }
 
     function testFuzz_createGenerationReservation_MultipleChainIDs(uint8 numChainIDs) public {
@@ -481,13 +512,41 @@ contract CrossChainRegistryUnitTests_setOperatorSetConfig is CrossChainRegistryU
     }
 
     function testFuzz_setOperatorSetConfig_StalenessPeriod(uint32 stalenessPeriod) public {
-        stalenessPeriod = uint32(bound(stalenessPeriod, 1, 365 days));
+        stalenessPeriod = uint32(bound(stalenessPeriod, 1 days, 365 days));
         OperatorSetConfig memory fuzzConfig = _createOperatorSetConfig(cheats.randomAddress(), stalenessPeriod);
 
         crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, fuzzConfig);
 
         OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
         assertEq(retrievedConfig.maxStalenessPeriod, stalenessPeriod, "Staleness period not set correctly");
+    }
+
+    function test_Revert_InvalidStalenessPeriod() public {
+        // Set a minimum staleness period
+        uint32 minimumStalenessPeriod = 7 days;
+        crossChainRegistry.setMinimumStalenessPeriod(minimumStalenessPeriod);
+
+        // Try to set config with staleness period less than minimum (but not 0)
+        OperatorSetConfig memory invalidConfig = _createOperatorSetConfig(cheats.randomAddress(), 1 days);
+
+        cheats.expectRevert(InvalidStalenessPeriod.selector);
+        crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, invalidConfig);
+    }
+
+    function test_setOperatorSetConfig_ZeroStalenessPeriod() public {
+        // Set a minimum staleness period
+        uint32 minimumStalenessPeriod = 7 days;
+        crossChainRegistry.setMinimumStalenessPeriod(minimumStalenessPeriod);
+
+        // Create config with 0 staleness period (should be allowed as special case)
+        OperatorSetConfig memory zeroStalenessConfig = _createOperatorSetConfig(cheats.randomAddress(), 0);
+
+        // Should succeed
+        crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, zeroStalenessConfig);
+
+        // Verify the config was set
+        OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
+        assertEq(retrievedConfig.maxStalenessPeriod, 0, "Zero staleness period should be allowed");
     }
 }
 
@@ -1085,5 +1144,66 @@ contract CrossChainRegistryUnitTests_getSupportedChains is CrossChainRegistryUni
                 "Operator table updater count after remove mismatch"
             );
         }
+    }
+}
+
+/**
+ * @title CrossChainRegistryUnitTests_setMinimumStalenessPeriod
+ * @notice Unit tests for CrossChainRegistry.setMinimumStalenessPeriod
+ */
+contract CrossChainRegistryUnitTests_setMinimumStalenessPeriod is CrossChainRegistryUnitTests {
+    function test_Revert_NotOwner() public {
+        uint32 newMinimumStalenessPeriod = 14 days;
+        
+        cheats.prank(notPermissioned);
+        cheats.expectRevert("Ownable: caller is not the owner");
+        crossChainRegistry.setMinimumStalenessPeriod(newMinimumStalenessPeriod);
+    }
+
+    function test_setMinimumStalenessPeriod_Success() public {
+        uint32 newMinimumStalenessPeriod = 14 days;
+
+        // Expect event
+        cheats.expectEmit(true, true, true, true, address(crossChainRegistry));
+        emit MinimumStalenessPeriodSet(newMinimumStalenessPeriod);
+
+        // Set minimum staleness period
+        crossChainRegistry.setMinimumStalenessPeriod(newMinimumStalenessPeriod);
+
+        // Verify state
+        assertEq(crossChainRegistry.getMinimumStalenessPeriod(), newMinimumStalenessPeriod, "Minimum staleness period not set correctly");
+    }
+
+    function test_setMinimumStalenessPeriod_AffectsConfigValidation() public {
+        // Create a reservation with a config
+        crossChainRegistry.createGenerationReservation(defaultOperatorSet, defaultCalculator, defaultConfig, defaultChainIDs);
+
+        // Update minimum staleness period to be higher than existing config
+        uint32 newMinimumStalenessPeriod = 2 days;
+        crossChainRegistry.setMinimumStalenessPeriod(newMinimumStalenessPeriod);
+
+        // Try to set a config with staleness period less than new minimum
+        OperatorSetConfig memory invalidConfig = _createOperatorSetConfig(cheats.randomAddress(), 1 days);
+        cheats.expectRevert(InvalidStalenessPeriod.selector);
+        crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, invalidConfig);
+
+        // Verify setting a valid config works
+        OperatorSetConfig memory validConfig = _createOperatorSetConfig(cheats.randomAddress(), 3 days);
+        crossChainRegistry.setOperatorSetConfig(defaultOperatorSet, validConfig);
+        
+        OperatorSetConfig memory retrievedConfig = crossChainRegistry.getOperatorSetConfig(defaultOperatorSet);
+        assertEq(retrievedConfig.maxStalenessPeriod, 3 days, "Valid config should be set");
+    }
+
+    function testFuzz_setMinimumStalenessPeriod(uint32 minimumStalenessPeriod) public {
+        minimumStalenessPeriod = uint32(bound(minimumStalenessPeriod, 1, 365 days));
+
+        crossChainRegistry.setMinimumStalenessPeriod(minimumStalenessPeriod);
+        assertEq(crossChainRegistry.getMinimumStalenessPeriod(), minimumStalenessPeriod, "Minimum staleness period not set correctly");
+    }
+
+    function test_Revert_MinimumStalenessPeriodZero() public {
+        cheats.expectRevert(InvalidMinimumStalenessPeriod.selector);
+        crossChainRegistry.setMinimumStalenessPeriod(0);
     }
 }


### PR DESCRIPTION
**Motivation:**

We should be preventing an invalid staleness period from being set by an operatorSet. A staleness period is invalid if it is less than the cadence at which tables are updated. 

**Modifications:**

- Add requirement to `minimumStalenessPeriod` in `CrossChainRegistry`
- Prevent staleness periods less than `tableUpdateCadence`
- Add setter for `tableUpdateCadence`
- Update docs

**Result:**

Less likelihood for footguns by devs