### PR TITLE
chore: update `foundry.toml` to include `forge lint` config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -117,6 +117,8 @@
     ]
 
 [profile.default.lint]
+    # Whether to run the linter when building.
+    lint_on_build = false
     # Specifies which lints to run based on severity.
     severity = [
         "high", 
@@ -146,7 +148,7 @@
 
         # Gas
         # "asm-keccak256",
-        # "unwrapped-modifier"
+        # "unwrapped-modifier-logic"
     ]
     # List of files or patterns to ignore when running the linter (can use glob patterns)
     ignore = [

--- a/foundry.toml
+++ b/foundry.toml
@@ -140,6 +140,7 @@
 [profile.coverage.fuzz]
     optimizer = false
     runs = 1
+    gas_limit = "18446744073709551615" # u64::MAX
 
 [profile.medium.fuzz]
     optimizer = false

--- a/foundry.toml
+++ b/foundry.toml
@@ -125,8 +125,29 @@
         "info", 
         "gas"
     ]
-    # List of lint IDs to exclude from checking (e.g., "mixed-case-function").
-    exclude_lints = []
+    # List of lints to exclude from linting.
+    exclude_lints = [
+        # High
+        # "incorrect-shift",
+        # "unchecked-call",
+        # "erc20-unchecked-transfer",
+
+        # Medium
+        # "divide-before-multiply",
+
+        # Info
+        # "unused-import",
+        # "unaliased-plain-import",
+        # "mixed-case-function",
+        # "mixed-case-variable",
+        # "pascal-case-struct",
+        # "screaming-snake-case-const",
+        # "screaming-snake-case-immutable",
+
+        # Gas
+        # "asm-keccak256",
+        # "unwrapped-modifier"
+    ]
     # List of files or patterns to ignore when running the linter (can use glob patterns)
     ignore = [
         "src/test/**/*",

--- a/foundry.toml
+++ b/foundry.toml
@@ -116,6 +116,23 @@
         "./src/contracts/**/*"
     ]
 
+[profile.default.lint]
+    # Specifies which lints to run based on severity.
+    severity = [
+        "high", 
+        "med", 
+        "low", 
+        "info", 
+        "gas"
+    ]
+    # List of lint IDs to exclude from checking (e.g., "mixed-case-function").
+    exclude_lints = []
+    # List of files or patterns to ignore when running the linter (can use glob patterns)
+    ignore = [
+        "src/test/**/*",
+        "script/**/*"
+    ]
+
 [profile.forktest.fuzz]    
     optimizer = false
     runs = 16
@@ -123,7 +140,6 @@
 [profile.coverage.fuzz]
     optimizer = false
     runs = 1
-    gas_limit = "18446744073709551615" # u64::MAX
 
 [profile.medium.fuzz]
     optimizer = false


### PR DESCRIPTION
**Motivation:**

Foundry will be adding `forge lint` to stable soon, I want to support `forge lint` config beforehand. 

**Modifications:**

- Added `forge lint` related config to `Foundry.toml`.
- Disabled linting for `script` and `src/test`.

**Result:**

Can configure `forge lint`.