### PR TITLE
fix: storage gap in `CrossChainRegistry`

### DIFF
--- a/src/contracts/multichain/CrossChainRegistryStorage.sol
+++ b/src/contracts/multichain/CrossChainRegistryStorage.sol
@@ -76,5 +76,5 @@ abstract contract CrossChainRegistryStorage is ICrossChainRegistry {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[43] private __gap;
+    uint256[42] private __gap;
 }


### PR DESCRIPTION
**Motivation:**

Chore: fix storage gap in CCR. Vars take up 8 slots total

**Modifications:**

Update storage gap to be size 42

**Result:**

Correct gap