### PR TITLE
fix: mock certificate verifiers

### DIFF
--- a/src/test/mocks/MockBN254CertificateVerifier.sol
+++ b/src/test/mocks/MockBN254CertificateVerifier.sol
@@ -107,4 +107,8 @@ contract MockBN254CertificateVerifier is IBN254CertificateVerifier {
             totalWeights: totalWeights
         });
     }
+
+    function isReferenceTimestampSet(OperatorSet memory, uint32) external pure returns (bool) {
+        return true;
+    }
 }

--- a/src/test/mocks/MockBN254CertificateVerifierFailure.sol
+++ b/src/test/mocks/MockBN254CertificateVerifierFailure.sol
@@ -112,4 +112,8 @@ contract MockBN254CertificateVerifierFailure is IBN254CertificateVerifier {
             totalWeights: totalWeights
         });
     }
+
+    function isReferenceTimestampSet(OperatorSet memory, uint32) external pure returns (bool) {
+        return true;
+    }
 }

--- a/src/test/mocks/MockECDSACertificateVerifier.sol
+++ b/src/test/mocks/MockECDSACertificateVerifier.sol
@@ -106,4 +106,16 @@ contract MockECDSACertificateVerifier is IECDSACertificateVerifier {
     function calculateCertificateDigest(uint32, /*referenceTimestamp*/ bytes32 /*messageHash*/ ) external pure returns (bytes32) {
         return bytes32(0);
     }
+
+    function getTotalStakeWeights(OperatorSet calldata, uint32) external pure returns (uint[] memory) {
+        return new uint[](0);
+    }
+
+    function calculateCertificateDigestBytes(uint32, bytes32) external pure returns (bytes memory) {
+        return "";
+    }
+
+    function isReferenceTimestampSet(OperatorSet memory, uint32) external pure returns (bool) {
+        return true;
+    }
 }

--- a/src/test/mocks/MockECDSACertificateVerifierFailure.sol
+++ b/src/test/mocks/MockECDSACertificateVerifierFailure.sol
@@ -106,4 +106,16 @@ contract MockECDSACertificateVerifierFailure is IECDSACertificateVerifier {
     function calculateCertificateDigest(uint32, /*referenceTimestamp*/ bytes32 /*messageHash*/ ) external pure returns (bytes32) {
         return bytes32(0);
     }
+
+    function getTotalStakeWeights(OperatorSet calldata, uint32) external pure returns (uint[] memory) {
+        return new uint[](0);
+    }
+
+    function calculateCertificateDigestBytes(uint32, bytes32) external pure returns (bytes memory) {
+        return "";
+    }
+
+    function isReferenceTimestampSet(OperatorSet memory, uint32) external pure returns (bool) {
+        return true;
+    }
 }


### PR DESCRIPTION
**Motivation:**

We needed to fix the build as a result of the rebase. There were some new functions added to the Certificate verifier interfaces which need to be reflected in the Mocks.

**Modifications:**

Updated Mock certificate verifiers

**Result:**

Successful build
