### PR TITLE
fix: prevent `globalTableRoot` certificate replay upon newly instantiated CertificateVerifiers/OperatorTables

### DIFF
--- a/docs/multichain/destination/CertificateVerifier.md
+++ b/docs/multichain/destination/CertificateVerifier.md
@@ -530,4 +530,4 @@ The operator table is updated every 10 days. The staleness period is 5 days. The
 3. Day 6: Certificate verification *fails*
 4. Day 7: A certificate is re-generated. However, this will stale fail as the `referenceTimestamp` would still be day 1 given that was the latest table update
 
-Note that we cannot re-generate a certificate on Day 7. This is why we prevent the `stalenessPeriod` from being less than 10 days `CrossChainRegistry`.
+Note that we cannot re-generate a certificate on Day 7. This is why we prevent the `stalenessPeriod` from being less than 10 days in the `CrossChainRegistry`.

--- a/docs/multichain/destination/OperatorTableUpdater.md
+++ b/docs/multichain/destination/OperatorTableUpdater.md
@@ -29,8 +29,9 @@ The following values are set upon initialization:
 * `operatorSetConfig`: A configuration for the `generator` 
     * `maxStalenessPeriod`: 0 (`GENERATOR_MAX_STALENESS_PERIOD`). Set to zero to allow confirmation of generator certificates regardless of `referenceTimestamp`. See [`CertificateVerifier`](./CertificateVerifier.md#overview) for speccifics
     * `owner`: Unused parameter for `Generator`. Set to the address of the `OperatorTableUpdater`
-* The `latestReferenceTimestamp` for the `Generator` is 1 (`GENERATOR_REFERENCE_TIMESTAMP`)
+* The `latestReferenceTimestamp` for the `Generator` is 1 (`GENERATOR_REFERENCE_TIMESTAMP`). This value is stored in the `BN254CertificateVerifier`
 * The `globalTableRoot` for the `Generator` is `GENERATOR_GLOBAL_TABLE_ROOT`
+* The `latestReferenceTimestamp` for the `OperatorTableUpdater` is set to `block.timestamp`. Doing so prevents past certificates for `globalTableRoots` to be used on a new destination chain deployment of the `OperatorTableUpdater`
 
 Operator tables are updated daily on testnet and weekly on mainnet. 
 ---
@@ -50,6 +51,8 @@ Global table roots must be confirmed by the `generator` before operator tables c
  * @param referenceBlockNumber block number, corresponding to the `referenceTimestamp` of the global table root
  * @dev Any entity can submit with a valid certificate signed off by the `Generator`
  * @dev The `msgHash` in the `globalOperatorTableRootCert` is the hash of the `globalTableRoot`, `referenceTimestamp`, and `referenceBlockNumber`
+ * @dev The `referenceTimestamp` nested in the `globalTableRootCert` should be `getGeneratorReferenceTimestamp`, whereas
+ *      the `referenceTimestamp` passed directly in the calldata is the block timestamp at which the global table root was calculated
  */
 function confirmGlobalTableRoot(
     BN254Certificate calldata globalTableRootCert,

--- a/script/releases/v1.7.0-multichain/4-instantiateDestinationChainProxies.s.sol
+++ b/script/releases/v1.7.0-multichain/4-instantiateDestinationChainProxies.s.sol
@@ -123,10 +123,10 @@ contract InstantiateDestinationChainProxies is DeployDestinationChainImpls {
             operatorTableUpdater.GENERATOR_GLOBAL_TABLE_ROOT(),
             "operatorTableUpdater.generatorGlobalTableRoot invalid"
         );
-        assertEq(
-            operatorTableUpdater.getLatestReferenceTimestamp(),
-            0,
-            "operatorTableUpdater.latestReferenceTimestamp invalid"
+        // latestReferenceTimestamp is set to block.timestamp during initialization
+        assertTrue(
+            operatorTableUpdater.getLatestReferenceTimestamp() > 0,
+            "operatorTableUpdater.latestReferenceTimestamp should be > 0"
         );
         assertTrue(
             operatorTableUpdater.isRootValid(operatorTableUpdater.GENERATOR_GLOBAL_TABLE_ROOT()),

--- a/src/contracts/interfaces/IOperatorTableUpdater.sol
+++ b/src/contracts/interfaces/IOperatorTableUpdater.sol
@@ -80,6 +80,8 @@ interface IOperatorTableUpdater is
      * @param referenceBlockNumber block number, corresponding to the `referenceTimestamp` of the global table root
      * @dev Any entity can submit with a valid certificate signed off by the `Generator`
      * @dev The `msgHash` in the `globalOperatorTableRootCert` is the hash of the `globalTableRoot`, `referenceTimestamp`, and `referenceBlockNumber`
+     * @dev The `referenceTimestamp` nested in the `globalTableRootCert` should be `getGeneratorReferenceTimestamp`, whereas
+     *      the `referenceTimestamp` passed directly in the calldata is the block timestamp at which the global table root was calculated
      */
     function confirmGlobalTableRoot(
         BN254Certificate calldata globalTableRootCert,

--- a/src/contracts/multichain/OperatorTableUpdater.sol
+++ b/src/contracts/multichain/OperatorTableUpdater.sol
@@ -42,6 +42,7 @@ contract OperatorTableUpdater is
      * @param _globalRootConfirmationThreshold The threshold, in bps, for a global root to be signed off on and updated
      * @param generatorInfo The operatorSetInfo for the Generator
      * @dev We also update the operator table for the Generator, to begin signing off on global roots
+     * @dev We set the `_latestReferenceTimestamp` to the current timestamp, so that only *new* roots can be confirmed
      */
     function initialize(
         address owner,
@@ -63,6 +64,9 @@ contract OperatorTableUpdater is
         // Set the `operatorSetConfig` for the `Generator`
         _generatorConfig.maxStalenessPeriod = GENERATOR_MAX_STALENESS_PERIOD;
         _generatorConfig.owner = address(this);
+
+        // Set the `latestReferenceTimestamp` so that only *new* roots can be confirmed
+        _latestReferenceTimestamp = uint32(block.timestamp);
     }
 
     /**

--- a/src/test/unit/OperatorTableUpdaterUnit.t.sol
+++ b/src/test/unit/OperatorTableUpdaterUnit.t.sol
@@ -192,7 +192,11 @@ contract OperatorTableUpdaterUnitTests_initialize is OperatorTableUpdaterUnitTes
         assertEq(confirmerSet.avs, address(0xDEADBEEF));
         assertEq(confirmerSet.id, 0);
         // _latestReferenceTimestamp is set to block.timestamp during initialization
-        assertEq(operatorTableUpdater.getLatestReferenceTimestamp(), uint32(block.timestamp) - 1, "latestReferenceTimestamp should be block.timestamp - 1");
+        assertEq(
+            operatorTableUpdater.getLatestReferenceTimestamp(),
+            uint32(block.timestamp) - 1,
+            "latestReferenceTimestamp should be block.timestamp - 1"
+        );
         // Generator reference timestamp is set to 1 in _updateGenerator
         assertEq(operatorTableUpdater.getGeneratorReferenceTimestamp(), 1, "generatorReferenceTimestamp should be 1");
         // Check that the GENERATOR_GLOBAL_TABLE_ROOT is valid

--- a/src/test/unit/OperatorTableUpdaterUnit.t.sol
+++ b/src/test/unit/OperatorTableUpdaterUnit.t.sol
@@ -258,13 +258,6 @@ contract OperatorTableUpdaterUnitTests_confirmGlobalTableRoot is OperatorTableUp
 
     function testFuzz_revert_staleCertificate(Randomness r) public rand(r) {
         uint32 referenceBlockNumber = uint32(block.number);
-        // Use a timestamp greater than the latestReferenceTimestamp set during initialization
-        uint32 newReferenceTimestamp = operatorTableUpdater.getLatestReferenceTimestamp() + 1;
-        mockCertificate.messageHash =
-            operatorTableUpdater.getGlobalTableUpdateMessageHash(bytes32(0), newReferenceTimestamp, referenceBlockNumber);
-        _setIsValidCertificate(mockCertificate, true);
-        operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), newReferenceTimestamp, referenceBlockNumber);
-
         uint32 referenceTimestamp = r.Uint32(0, operatorTableUpdater.getLatestReferenceTimestamp() - 1);
         cheats.expectRevert(GlobalTableRootStale.selector);
         operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), referenceTimestamp, referenceBlockNumber);

--- a/src/test/unit/OperatorTableUpdaterUnit.t.sol
+++ b/src/test/unit/OperatorTableUpdaterUnit.t.sol
@@ -65,6 +65,9 @@ contract OperatorTableUpdaterUnitTests is
 
         // Configure the BN254CertificateVerifierMock to point to the actual OperatorTableUpdater
         bn254CertificateVerifierMock.setOperatorTableUpdater(IOperatorTableUpdater(address(operatorTableUpdater)));
+
+        // Warp past the latest reference timestamp so that only *new* roots can be confirmed
+        cheats.warp(operatorTableUpdater.getLatestReferenceTimestamp() + 1);
     }
 
     function _setLatestReferenceTimestampBN254(OperatorSet memory operatorSet, uint32 referenceTimestamp) internal {
@@ -188,8 +191,8 @@ contract OperatorTableUpdaterUnitTests_initialize is OperatorTableUpdaterUnitTes
         OperatorSet memory confirmerSet = operatorTableUpdater.getGenerator();
         assertEq(confirmerSet.avs, address(0xDEADBEEF));
         assertEq(confirmerSet.id, 0);
-        // _latestReferenceTimestamp is not updated during generator initialization
-        assertEq(operatorTableUpdater.getLatestReferenceTimestamp(), 0, "latestReferenceTimestamp should be 0");
+        // _latestReferenceTimestamp is set to block.timestamp during initialization
+        assertEq(operatorTableUpdater.getLatestReferenceTimestamp(), uint32(block.timestamp) - 1, "latestReferenceTimestamp should be block.timestamp - 1");
         // Generator reference timestamp is set to 1 in _updateGenerator
         assertEq(operatorTableUpdater.getGeneratorReferenceTimestamp(), 1, "generatorReferenceTimestamp should be 1");
         // Check that the GENERATOR_GLOBAL_TABLE_ROOT is valid
@@ -225,11 +228,11 @@ contract OperatorTableUpdaterUnitTests_confirmGlobalTableRoot is OperatorTableUp
     }
 
     function testFuzz_revert_futureTableRoot(Randomness r) public rand(r) {
-        uint32 referenceTimestamp = r.Uint32(uint32(block.timestamp + 1), type(uint32).max);
+        uint32 referenceTimestamp = r.Uint32(operatorTableUpdater.getLatestReferenceTimestamp() + 1, type(uint32).max);
         uint32 referenceBlockNumber = r.Uint32();
 
         cheats.expectRevert(GlobalTableRootInFuture.selector);
-        operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), referenceTimestamp + 1, referenceBlockNumber);
+        operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), referenceTimestamp, referenceBlockNumber);
     }
 
     function testFuzz_revert_paused(Randomness r) public rand(r) {
@@ -251,10 +254,12 @@ contract OperatorTableUpdaterUnitTests_confirmGlobalTableRoot is OperatorTableUp
 
     function testFuzz_revert_staleCertificate(Randomness r) public rand(r) {
         uint32 referenceBlockNumber = uint32(block.number);
+        // Use a timestamp greater than the latestReferenceTimestamp set during initialization
+        uint32 newReferenceTimestamp = operatorTableUpdater.getLatestReferenceTimestamp() + 1;
         mockCertificate.messageHash =
-            operatorTableUpdater.getGlobalTableUpdateMessageHash(bytes32(0), uint32(block.timestamp), referenceBlockNumber);
+            operatorTableUpdater.getGlobalTableUpdateMessageHash(bytes32(0), newReferenceTimestamp, referenceBlockNumber);
         _setIsValidCertificate(mockCertificate, true);
-        operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), uint32(block.timestamp), referenceBlockNumber);
+        operatorTableUpdater.confirmGlobalTableRoot(mockCertificate, bytes32(0), newReferenceTimestamp, referenceBlockNumber);
 
         uint32 referenceTimestamp = r.Uint32(0, operatorTableUpdater.getLatestReferenceTimestamp() - 1);
         cheats.expectRevert(GlobalTableRootStale.selector);


### PR DESCRIPTION
**Motivation:**

Currently, for new destination chain deployments, the following vulnerability exists:

1. We post an certificate with an invalid global table root
2. The root is invalidated
3. We start up a new chain
4. That invalid certificate is replayed on the new chain
5. AVS is exploited somehow

We need to prevent previous certificates from being replayed

**Modifications:**

In the initialize function of `OperatorTableUpdater`, set the `_latestReferenceTimestamp` to the `block.timestamp`

**Result:**

Preventing replay of past global roots on new deployments 
