### PR TITLE
feat: no consensus set

### DIFF
--- a/src/contracts/interfaces/IAVSTaskHook.sol
+++ b/src/contracts/interfaces/IAVSTaskHook.sol
@@ -45,12 +45,11 @@ interface IAVSTaskHook {
 
     /**
      * @notice Handles a task result submission
+     * @param caller Address that submitted the result
      * @param taskHash Unique identifier of the task
      * @dev This function can be used to perform additional validation or update AVS-specific state
      */
-    function handlePostTaskResultSubmission(
-        bytes32 taskHash
-    ) external;
+    function handlePostTaskResultSubmission(address caller, bytes32 taskHash) external;
 
     /**
      * @notice Calculates the fee for a task payload against a specific fee market

--- a/src/contracts/interfaces/ITaskMailbox.sol
+++ b/src/contracts/interfaces/ITaskMailbox.sol
@@ -114,8 +114,8 @@ interface ITaskMailboxTypes {
  * @notice Interface defining errors that can be thrown by the TaskMailbox
  */
 interface ITaskMailboxErrors is ITaskMailboxTypes {
-    /// @notice Thrown when a certificate verification fails
-    error CertificateVerificationFailed();
+    /// @notice Thrown when a certificate verification threshold is not met
+    error ThresholdNotMet();
 
     /// @notice Thrown when an executor operator set is not registered
     error ExecutorOperatorSetNotRegistered();

--- a/src/test/mocks/AVSTaskHookReentrantAttacker.sol
+++ b/src/test/mocks/AVSTaskHookReentrantAttacker.sol
@@ -81,7 +81,7 @@ contract AVSTaskHookReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
 
     function validatePreTaskResultSubmission(address, bytes32, bytes memory, bytes memory) external view {}
 
-    function handlePostTaskResultSubmission(bytes32) external {
+    function handlePostTaskResultSubmission(address, bytes32) external {
         if (!attackOnPost) {
             if (attackCreateTask) {
                 // Reconstruct TaskParams for the attack

--- a/src/test/mocks/MockAVSTaskHook.sol
+++ b/src/test/mocks/MockAVSTaskHook.sol
@@ -27,7 +27,7 @@ contract MockAVSTaskHook is IAVSTaskHook {
         //TODO: Implement
     }
 
-    function handlePostTaskResultSubmission(bytes32 /*taskHash*/ ) external {
+    function handlePostTaskResultSubmission(address, /*caller*/ bytes32 /*taskHash*/ ) external {
         //TODO: Implement
     }
 


### PR DESCRIPTION
**Motivation:**

The TaskMailbox needs an option to allow no consensus config to be set, such that the AVS can define their own consensus logic in their `handlePostTaskResultSubmission` hook. 

**Modifications:**

* Consensus.NONE is a valid consensus option.
* Updated `handlePostTaskResultSubmission` to take `msg.sender` field as well. 

**Result:**

More flexible consensus configs.
