### PR TITLE
fix: remove unused imports

### DIFF
--- a/src/contracts/avs/task/TaskMailbox.sol
+++ b/src/contracts/avs/task/TaskMailbox.sol
@@ -18,7 +18,7 @@ import {
 import {IBaseCertificateVerifier} from "../../interfaces/IBaseCertificateVerifier.sol";
 import {IKeyRegistrarTypes} from "../../interfaces/IKeyRegistrar.sol";
 import {ITaskMailbox} from "../../interfaces/ITaskMailbox.sol";
-import {OperatorSet, OperatorSetLib} from "../../libraries/OperatorSetLib.sol";
+import {OperatorSet} from "../../libraries/OperatorSetLib.sol";
 import {SemVerMixin} from "../../mixins/SemVerMixin.sol";
 import {TaskMailboxStorage} from "./TaskMailboxStorage.sol";
 

--- a/src/contracts/avs/task/TaskMailboxStorage.sol
+++ b/src/contracts/avs/task/TaskMailboxStorage.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.27;
 
 import {ITaskMailbox} from "../../interfaces/ITaskMailbox.sol";
-import {IKeyRegistrarTypes} from "../../interfaces/IKeyRegistrar.sol";
 
 /**
  * @title TaskMailboxStorage

--- a/src/contracts/interfaces/IAVSTaskHook.sol
+++ b/src/contracts/interfaces/IAVSTaskHook.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.27;
 
 import {ITaskMailboxTypes} from "./ITaskMailbox.sol";
-import {OperatorSet} from "../libraries/OperatorSetLib.sol";
 
 /**
  * @title IAVSTaskHook

--- a/src/contracts/interfaces/ITaskMailbox.sol
+++ b/src/contracts/interfaces/ITaskMailbox.sol
@@ -7,7 +7,7 @@ import {IAVSTaskHook} from "./IAVSTaskHook.sol";
 import {IBN254CertificateVerifierTypes} from "./IBN254CertificateVerifier.sol";
 import {IECDSACertificateVerifierTypes} from "./IECDSACertificateVerifier.sol";
 import {IKeyRegistrarTypes} from "./IKeyRegistrar.sol";
-import {OperatorSet, OperatorSetLib} from "../libraries/OperatorSetLib.sol";
+import {OperatorSet} from "../libraries/OperatorSetLib.sol";
 
 /**
  * @title ITaskMailboxTypes

--- a/src/contracts/multichain/BN254CertificateVerifierStorage.sol
+++ b/src/contracts/multichain/BN254CertificateVerifierStorage.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {OperatorSet} from "../libraries/OperatorSetLib.sol";
 import "../interfaces/IOperatorTableUpdater.sol";
 import "../interfaces/IBN254CertificateVerifier.sol";
 import "../interfaces/IBaseCertificateVerifier.sol";

--- a/src/contracts/multichain/ECDSACertificateVerifierStorage.sol
+++ b/src/contracts/multichain/ECDSACertificateVerifierStorage.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {OperatorSet} from "../libraries/OperatorSetLib.sol";
 import "../interfaces/IOperatorTableUpdater.sol";
 import "../interfaces/IECDSACertificateVerifier.sol";
 import "../interfaces/IBaseCertificateVerifier.sol";

--- a/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
+++ b/src/test/integration/tests/Deposit_Delegate_Allocate_Slash_Queue_Redeposit.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.27;
 
 import "src/test/integration/IntegrationChecks.t.sol";
 import "src/test/integration/users/User.t.sol";
-import {console} from "forge-std/console.sol";
 
 contract Integration_Deposit_Delegate_Allocate_Slash_Queue_Redeposit is IntegrationCheckUtils {
     AVS avs;

--- a/src/test/mocks/MockAVSTaskHook.sol
+++ b/src/test/mocks/MockAVSTaskHook.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {OperatorSet} from "src/contracts/libraries/OperatorSetLib.sol";
 import {IAVSTaskHook} from "src/contracts/interfaces/IAVSTaskHook.sol";
 import {ITaskMailboxTypes} from "src/contracts/interfaces/ITaskMailbox.sol";
 

--- a/src/test/mocks/MockBN254CertificateVerifier.sol
+++ b/src/test/mocks/MockBN254CertificateVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IBN254CertificateVerifier, IBN254CertificateVerifierTypes} from "src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {IBN254CertificateVerifier} from "src/contracts/interfaces/IBN254CertificateVerifier.sol";
 import {IOperatorTableCalculatorTypes} from "src/contracts/interfaces/IOperatorTableCalculator.sol";
 import {OperatorSet} from "src/contracts/libraries/OperatorSetLib.sol";
 import {BN254} from "src/contracts/libraries/BN254.sol";

--- a/src/test/mocks/MockBN254CertificateVerifierFailure.sol
+++ b/src/test/mocks/MockBN254CertificateVerifierFailure.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IBN254CertificateVerifier, IBN254CertificateVerifierTypes} from "src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {IBN254CertificateVerifier} from "src/contracts/interfaces/IBN254CertificateVerifier.sol";
 import {IOperatorTableCalculatorTypes} from "src/contracts/interfaces/IOperatorTableCalculator.sol";
 import {OperatorSet} from "src/contracts/libraries/OperatorSetLib.sol";
 import {BN254} from "src/contracts/libraries/BN254.sol";

--- a/src/test/mocks/MockECDSACertificateVerifier.sol
+++ b/src/test/mocks/MockECDSACertificateVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IECDSACertificateVerifier, IECDSACertificateVerifierTypes} from "src/contracts/interfaces/IECDSACertificateVerifier.sol";
+import {IECDSACertificateVerifier} from "src/contracts/interfaces/IECDSACertificateVerifier.sol";
 import {OperatorSet} from "src/contracts/libraries/OperatorSetLib.sol";
 
 contract MockECDSACertificateVerifier is IECDSACertificateVerifier {

--- a/src/test/mocks/MockECDSACertificateVerifierFailure.sol
+++ b/src/test/mocks/MockECDSACertificateVerifierFailure.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IECDSACertificateVerifier, IECDSACertificateVerifierTypes} from "src/contracts/interfaces/IECDSACertificateVerifier.sol";
+import {IECDSACertificateVerifier} from "src/contracts/interfaces/IECDSACertificateVerifier.sol";
 import {OperatorSet} from "src/contracts/libraries/OperatorSetLib.sol";
 
 contract MockECDSACertificateVerifierFailure is IECDSACertificateVerifier {

--- a/src/test/unit/DeployFromScratch.t.sol
+++ b/src/test/unit/DeployFromScratch.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
-import {Test, console2} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {DeployFromScratch} from "script/deploy/local/deploy_from_scratch.slashing.s.sol";
 
 // NOTE: Run the following command to deploy from scratch in an anvil instance:

--- a/src/test/unit/TaskMailboxUnit.t.sol
+++ b/src/test/unit/TaskMailboxUnit.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {Test, console, Vm} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
@@ -13,7 +13,7 @@ import {OperatorSet, OperatorSetLib} from "src/contracts/libraries/OperatorSetLi
 import {BN254} from "src/contracts/libraries/BN254.sol";
 import {IKeyRegistrarTypes} from "src/contracts/interfaces/IKeyRegistrar.sol";
 import {TaskMailbox} from "src/contracts/avs/task/TaskMailbox.sol";
-import {ITaskMailbox, ITaskMailboxTypes, ITaskMailboxErrors, ITaskMailboxEvents} from "src/contracts/interfaces/ITaskMailbox.sol";
+import {ITaskMailboxTypes, ITaskMailboxErrors, ITaskMailboxEvents} from "src/contracts/interfaces/ITaskMailbox.sol";
 import {IAVSTaskHook} from "src/contracts/interfaces/IAVSTaskHook.sol";
 
 import {MockAVSTaskHook} from "src/test/mocks/MockAVSTaskHook.sol";


### PR DESCRIPTION
**Motivation:**

Want to remove unused imports to improve compile times, and readability.

**Modifications:**

- Removed unused imports found with: `forge lint --only-lint unused-import`.

**Result:**

No more unused imports.
