### PR TITLE
fix(docs): correct hash value in natspec

### DIFF
--- a/src/contracts/mixins/LeafCalculatorMixin.sol
+++ b/src/contracts/mixins/LeafCalculatorMixin.sol
@@ -17,7 +17,7 @@ abstract contract LeafCalculatorMixin {
     /// validate a proof. The salt ensures that leaves cannot be concatenated together to
     /// form a valid proof, as well as reducing the likelihood of an internal node matching
     /// the salt prefix.
-    /// @dev Value derived from keccak256("OPERATOR_INFO_LEAF_SALT") = 0x38...
+    /// @dev Value derived from keccak256("OPERATOR_INFO_LEAF_SALT") = 0x75...
     /// This ensures collision resistance and semantic meaning.
     uint8 public constant OPERATOR_INFO_LEAF_SALT = 0x75;
 
@@ -27,7 +27,7 @@ abstract contract LeafCalculatorMixin {
     /// validate a proof. The salt ensures that leaves cannot be concatenated together to
     /// form a valid proof, as well as reducing the likelihood of an internal node matching
     /// the salt prefix.
-    /// @dev Value derived from keccak256("OPERATOR_TABLE_LEAF_SALT") = 0x7d...
+    /// @dev Value derived from keccak256("OPERATOR_TABLE_LEAF_SALT") = 0x8e...
     /// This ensures collision resistance and semantic meaning.
     uint8 public constant OPERATOR_TABLE_LEAF_SALT = 0x8e;
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**

Small typo in natspec regarding hash value. The value in the code is correct, but the docs are not.

**Modifications:**

* Fixed value in documentation for how salts were derived

**Result:**

More accurate docs
