### PR TITLE
fix(L-02): use default zero hash in place valid 0 leaves

### DIFF
--- a/docs/core/libraries/Merkle.md
+++ b/docs/core/libraries/Merkle.md
@@ -1,0 +1,313 @@
+## Merkle
+
+| File | Notes |
+| -------- | -------- |
+| [`Merkle.sol`](../../../src/contracts/libraries/Merkle.sol) | Core Merkle tree library |
+
+## Overview
+
+The `Merkle` library provides cryptographically secure Merkle tree functionality for the EigenLayer protocol. It supports both Keccak256 and SHA-256 hash functions for different use cases across the system. The library enables efficient verification of data inclusion in large datasets without requiring the full dataset, which is essential for scalable proof systems in EigenLayer.
+
+Key capabilities include:
+- **Proof verification**: Verify that a leaf exists in a Merkle tree given a root and proof
+- **Tree construction**: Build Merkle trees from arrays of leaves
+- **Proof generation**: Generate inclusion proofs for specific leaves
+- **Dual hash function support**: Both Keccak256 (for EVM compatibility) and SHA-256 (for beacon chain compatibility)
+
+## Prior Reading
+
+* Understanding of [Merkle trees](https://en.wikipedia.org/wiki/Merkle_tree) and cryptographic hash functions
+* [EIP-197](https://eips.ethereum.org/EIPS/eip-197) for understanding precompiled contracts
+
+## Usage in EigenLayer
+
+The Merkle library is used extensively throughout EigenLayer for various proof systems:
+
+- **[`BN254CertificateVerifier`](../../../src/contracts/multichain/BN254CertificateVerifier.sol)**: Verifies operator information inclusion in certificate Merkle trees (see [CertificateVerifier.md](../../multichain/destination/CertificateVerifier.md))
+- **[`OperatorTableUpdater`](../../../src/contracts/multichain/OperatorTableUpdater.sol)**: Manages operator set proofs for multichain operations (see [OperatorTableUpdater.md](../../multichain/destination/OperatorTableUpdater.md))
+- **[`RewardsCoordinator`](../../../src/contracts/core/RewardsCoordinator.sol)**: Verifies reward distribution claims (see [RewardsCoordinator.md](../RewardsCoordinator.md))
+- **[`BeaconChainProofs`](../../../src/contracts/libraries/BeaconChainProofs.sol)**: Processes beacon chain state proofs (see [EigenPod.md](../EigenPod.md) for beacon chain proof usage)
+
+## Security Considerations
+
+### **Critical Security Warning**
+
+**You should avoid using leaf values that are 64 bytes long prior to hashing, salt the leaves, or hash the leaves with a hash function other than what is used for the Merkle tree's internal nodes.** This prevents potential collision attacks where the concatenation of a sorted pair of internal nodes could be reinterpreted as a leaf value.
+
+### **Zero Hash Padding**
+
+When trees are not perfect powers of 2, the library pads with `bytes32(0)` values. For security-critical applications, consider using unique filler values to prevent potential collision attacks with legitimate zero-valued leaves.
+
+---
+
+## Proof Verification
+
+### **Keccak256 Proof Verification**
+
+#### `verifyInclusionKeccak`
+
+```solidity
+function verifyInclusionKeccak(
+    bytes memory proof,
+    bytes32 root,
+    bytes32 leaf,
+    uint256 index
+) internal pure returns (bool)
+```
+
+Verifies that a given leaf is included in a Merkle tree using Keccak256.
+
+*Effects:*
+* Computes the root hash by traversing the Merkle proof path
+* Compares computed root with expected root for verification
+
+*Used in:*
+* [`BN254CertificateVerifier.verifyOperatorInfoProof`](../../../src/contracts/multichain/BN254CertificateVerifier.sol)
+* [`OperatorTableUpdater.checkGlobalTableHash`](../../../src/contracts/multichain/OperatorTableUpdater.sol)
+* [`RewardsCoordinator`](../../../src/contracts/core/RewardsCoordinator.sol) for reward claim verification
+
+#### `processInclusionProofKeccak`
+
+```solidity
+function processInclusionProofKeccak(
+    bytes memory proof,
+    bytes32 leaf,
+    uint256 index
+) internal pure returns (bytes32)
+```
+
+Returns the computed root hash by traversing up the tree from the leaf.
+
+*Effects:*
+* Traverses the Merkle tree from leaf to root using provided proof
+* Computes hash at each level by combining current hash with proof siblings
+* Returns the final computed root hash
+
+*Requirements:*
+* Proof length MUST be a multiple of 32 bytes (reverts with `InvalidProofLength` otherwise)
+* Index MUST reach 0 after processing all proof elements (reverts with `InvalidIndex` if proof length mismatch)
+
+### **SHA-256 Proof Verification**
+
+#### `verifyInclusionSha256`
+
+```solidity
+function verifyInclusionSha256(
+    bytes memory proof,
+    bytes32 root,
+    bytes32 leaf,
+    uint256 index
+) internal pure returns (bool)
+```
+
+Verifies inclusion using SHA-256 hash function via precompiled contract.
+
+*Effects:*
+* Computes the root hash using SHA-256 via precompiled contract
+* Compares computed root with expected root for verification
+
+*Used in:*
+* [`BeaconChainProofs`](../../../src/contracts/libraries/BeaconChainProofs.sol) for beacon chain state verification
+
+#### `processInclusionProofSha256`
+
+```solidity
+function processInclusionProofSha256(
+    bytes memory proof,
+    bytes32 leaf,
+    uint256 index
+) internal view returns (bytes32)
+```
+
+Returns the computed root hash by traversing up the tree from the leaf using SHA-256.
+
+*Effects:*
+* Traverses the Merkle tree from leaf to root using provided proof
+* Computes hash at each level combining current hash with proof siblings
+* Returns the final computed root hash
+
+*Requirements:*
+* Proof length MUST be non-zero and a multiple of 32 bytes (reverts with `InvalidProofLength` otherwise)
+* Index MUST reach 0 after processing all proof elements (reverts with `InvalidIndex` if proof length mismatch)
+
+---
+
+## Tree Construction
+
+### **Keccak256 Tree Construction**
+
+#### `merkleizeKeccak`
+
+```solidity
+function merkleizeKeccak(bytes32[] memory leaves) internal pure returns (bytes32)
+```
+
+Constructs a Merkle tree root from an array of leaves using Keccak256. Accepts any non-empty array of leaves, including single-leaf trees, and automatically pads to the next power of 2 using `bytes32(0)` values.
+
+*Effects:*
+* Pads input array to next power of 2 (if needed) using `bytes32(0)` values
+* Constructs binary Merkle tree bottom-up by hashing pairs using in-place array modification
+* For single-leaf arrays, returns the leaf itself as the root
+* Returns the single root hash representing the entire tree
+
+*Algorithm:*
+1. Pad leaves array to next power of 2
+2. Iteratively hash pairs level by level until single root remains
+3. Uses in-place array modification for gas efficiency
+
+*Used in:*
+* [`BN254CertificateVerifier`](../../../src/contracts/multichain/BN254CertificateVerifier.sol) for operator info trees
+* [`OperatorTableUpdater`](../../../src/contracts/multichain/OperatorTableUpdater.sol) for operator set hashing
+
+### **SHA-256 Tree Construction**
+
+#### `merkleizeSha256`
+
+```solidity
+function merkleizeSha256(bytes32[] memory leaves) internal pure returns (bytes32)
+```
+
+Constructs a Merkle tree root using SHA-256 hash function.
+
+*Effects:*
+* Validates input meets strict requirements (power of 2, minimum 2 leaves)
+* Constructs binary Merkle tree bottom-up using SHA-256 hashing
+* Returns the single root hash representing the entire tree
+
+*Requirements*:
+* Input array MUST contain at least 2 leaves (rejects single-leaf trees with `NotEnoughLeaves` error)
+* Input array length MUST be an exact power of 2 (validates with `LeavesNotPowerOfTwo` error)
+* No auto-padding available - stricter requirements for beacon chain compatibility
+
+*Used in:*
+* [`BeaconChainProofs`](../../../src/contracts/libraries/BeaconChainProofs.sol) for beacon chain compatibility
+
+---
+
+## Proof Generation
+
+### **Keccak256 Proof Generation**
+
+#### `getProofKeccak`
+
+```solidity
+function getProofKeccak(bytes32[] memory leaves, uint256 index) internal pure returns (bytes memory proof)
+```
+
+Generates an inclusion proof for a specific leaf in a Keccak256 tree. Supports single-leaf trees (returns empty proof) and automatically handles non-power-of-2 leaf arrays through padding.
+
+*Effects:*
+* Constructs a Merkle tree from the provided leaves with automatic padding
+* Traverses from specified leaf to root, collecting sibling hashes at each level
+* For single-leaf trees, returns empty proof since root equals leaf
+* Returns concatenated proof bytes for verification
+
+*Algorithm:*
+1. Pad leaves to next power of 2
+2. For each tree level, find sibling of current index
+3. Append sibling to proof bytes
+4. Move up tree by dividing index by 2
+5. Continue until reaching root
+
+*Used in:*
+* Test frameworks for generating proofs
+* Off-chain proof generation systems
+
+### **SHA-256 Proof Generation**
+
+#### `getProofSha256`
+
+```solidity
+function getProofSha256(bytes32[] memory leaves, uint256 index) internal pure returns (bytes memory proof)
+```
+
+Generates SHA-256 inclusion proof with same algorithm as Keccak version but using SHA-256 hashing.
+
+*Effects:*
+* Validates input meets SHA-256 requirements (minimum 2 leaves)
+* Constructs a Merkle tree using SHA-256 hashing
+* Traverses from specified leaf to root, collecting sibling hashes
+* Returns concatenated proof bytes for verification
+
+*Requirements*:
+* Input array MUST contain at least 2 leaves (rejects single-leaf trees with `NotEnoughLeaves` error)
+* Cannot generate proofs for single-element arrays
+* Follows stricter validation for beacon chain compatibility
+
+---
+
+## Utility Functions
+
+### **Power of Two Check**
+
+#### `isPowerOfTwo`
+
+```solidity
+function isPowerOfTwo(uint256 value) internal pure returns (bool)
+```
+
+Efficiently determines if a value is a power of 2 using bit manipulation.
+
+*Effects:*
+* Performs bitwise operations to check power-of-2 property
+
+*Used internally* for validation in `merkleizeSha256` and optimization paths.
+
+---
+
+## Error Reference
+
+| Error | Code | Description |
+|-------|------|-------------|
+| `InvalidProofLength` | `0x4dc5f6a4` | Proof length not multiple of 32 bytes |
+| `InvalidIndex` | `0x63df8171` | Index outside valid range for tree |
+| `LeavesNotPowerOfTwo` | `0xf6558f51` | Leaves array not power of 2 (SHA-256 only) |
+| `NoLeaves` | `0xbaec3d9a` | Empty leaves array provided |
+| `NotEnoughLeaves` | `0xf8ef0367` | Less than 2 leaves for SHA-256 operations |
+
+---
+
+## Implementation Optimizations
+
+### **Assembly Usage**
+- Proof verification uses inline assembly for gas efficiency
+- Manual memory management avoids Solidity's safety overhead
+- Direct opcode usage (Keccak256) vs precompile calls (SHA-256)
+
+### **Memory Efficiency**
+- Tree construction reuses input array space
+- In-place modifications reduce memory allocation costs
+- Sibling calculation uses XOR instead of arithmetic operations
+
+### **Precompile Handling**
+- SHA-256 functions reserve gas before precompile calls
+- Static call pattern optimized for success case
+- Explicit revert handling for precompile failures
+
+---
+
+## Implementation Notes
+
+### **Keccak256 vs SHA-256 Differences**
+
+The library provides two distinct implementations with different design philosophies:
+
+| Feature | Keccak256 Functions | SHA-256 Functions |
+|---------|-------------------|-------------------|
+| **Single-leaf trees** | ✅ Supported | ❌ Rejected (`NotEnoughLeaves`) |
+| **Input validation** | Flexible (any non-empty array) | Strict (≥2 leaves, power of 2) |
+| **Auto-padding** | ✅ Pads to next power of 2 | ❌ Requires exact power of 2 |
+| **Use case** | General EVM Merkle trees | Beacon chain compatibility |
+| **Error handling** | Permissive | Strict validation |
+
+### **Tree Padding Strategy**
+The library uses different padding strategies for different hash functions:
+
+- **Keccak256**: Pads with `bytes32(0)` to next power of 2
+- **SHA-256**: Requires exact power of 2, no padding
+
+### **Index Validation**
+Index validation occurs during proof processing rather than upfront, allowing the tree traversal algorithm to naturally detect out-of-bounds conditions.
+
+### **Memory Layout**
+Proof bytes are laid out as concatenated 32-byte chunks: `[sibling₀, sibling₁, ..., siblingₙ]` where siblings are sequenced by tree depth, with `sibling₀` being the sibling at the leaf level, `sibling₁` at the next level up, and so on until reaching the root.

--- a/src/contracts/libraries/Merkle.sol
+++ b/src/contracts/libraries/Merkle.sol
@@ -6,27 +6,45 @@ pragma solidity ^0.8.0;
 /**
  * @dev These functions deal with verification of Merkle Tree proofs.
  *
- * The tree and the proofs can be generated using our
- * https://github.com/OpenZeppelin/merkle-tree[JavaScript library].
- * You will find a quickstart guide in the readme.
- *
  * WARNING: You should avoid using leaf values that are 64 bytes long prior to
- * hashing, or use a hash function other than keccak256 for hashing leaves.
- * This is because the concatenation of a sorted pair of internal nodes in
- * the merkle tree could be reinterpreted as a leaf value.
- * OpenZeppelin's JavaScript library generates merkle trees that are safe
- * against this attack out of the box.
+ * hashing, salt the leaves, or hash the leaves with a hash function other than
+ * what is used for the Merkle tree's internal nodes. This is because the
+ * concatenation of a sorted pair of internal nodes in the Merkle tree could
+ * be reinterpreted as a leaf value.
  */
 library Merkle {
+    // @notice Thrown when the provided proof was not a multiple of 32, or was empty for SHA256.
+    // @dev Error code: 0x4dc5f6a4
     error InvalidProofLength();
 
+    // @notice Thrown when the provided index was outside the max index for the tree.
+    // @dev Error code: 0x63df8171
+    error InvalidIndex();
+
+    // @notice Thrown when the provided leaves' length was not a power of two.
+    // @dev Error code: 0xf6558f51
+    error LeavesNotPowerOfTwo();
+
+    // @notice Thrown when the provided leaves' length was 0.
+    // @dev Error code: 0xbaec3d9a
+    error NoLeaves();
+
+    // @notice Thrown when the provided leaves' length was insufficient.
+    // @dev Error code: 0xf8ef0367
+    // @dev This is used for the SHA256 Merkle tree, where the tree must have more than 1 leaf.
+    error NotEnoughLeaves();
+
     /**
-     * @dev Returns the rebuilt hash obtained by traversing a Merkle tree up
-     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
-     * hash matches the root of the tree. The tree is built assuming `leaf` is
-     * the 0 indexed `index`'th leaf from the bottom left of the tree.
-     *
-     * Note this is for a Merkle tree using the keccak/sha3 hash function
+     * @notice Verifies that a given leaf is included in a Merkle tree
+     * @param proof The proof of inclusion for the leaf
+     * @param root The root of the Merkle tree
+     * @param leaf The leaf to verify
+     * @param index The index of the leaf in the Merkle tree
+     * @return True if the leaf is included in the Merkle tree, false otherwise
+     * @dev A `proof` is valid if and only if the rebuilt hash matches the root of the tree.
+     * @dev Reverts for:
+     *      - InvalidProofLength: proof.length is not a multiple of 32.
+     *      - InvalidIndex: index is not 0 at conclusion of computation (implying outside the max index for the tree).
      */
     function verifyInclusionKeccak(
         bytes memory proof,
@@ -38,26 +56,32 @@ library Merkle {
     }
 
     /**
-     * @dev Returns the rebuilt hash obtained by traversing a Merkle tree up
-     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
-     * hash matches the root of the tree. The tree is built assuming `leaf` is
-     * the 0 indexed `index`'th leaf from the bottom left of the tree.
-     * @dev If the proof length is 0 then the leaf hash is returned.
-     *
-     * _Available since v4.4._
-     *
-     * Note this is for a Merkle tree using the keccak/sha3 hash function
+     * @notice Returns the rebuilt hash obtained by traversing a Merkle tree up
+     * from `leaf` using `proof`.
+     * @param proof The proof of inclusion for the leaf
+     * @param leaf The leaf to verify
+     * @param index The index of the leaf in the Merkle tree
+     * @return The rebuilt hash
+     * @dev Reverts for:
+     *      - InvalidProofLength: proof.length is not a multiple of 32.
+     *      - InvalidIndex: index is not 0 at conclusion of computation (implying outside the max index for the tree).
+     * @dev The tree is built assuming `leaf` is the 0 indexed `index`'th leaf from the bottom left of the tree.
      */
     function processInclusionProofKeccak(
         bytes memory proof,
         bytes32 leaf,
         uint256 index
     ) internal pure returns (bytes32) {
+        if (proof.length == 0) {
+            return leaf;
+        }
+
         require(proof.length % 32 == 0, InvalidProofLength());
+
         bytes32 computedHash = leaf;
         for (uint256 i = 32; i <= proof.length; i += 32) {
             if (index % 2 == 0) {
-                // if ith bit of index is 0, then computedHash is a left sibling
+                // if index is even, then computedHash is a left sibling
                 assembly {
                     mstore(0x00, computedHash)
                     mstore(0x20, mload(add(proof, i)))
@@ -65,7 +89,7 @@ library Merkle {
                     index := div(index, 2)
                 }
             } else {
-                // if ith bit of index is 1, then computedHash is a right sibling
+                // if index is odd, then computedHash is a right sibling
                 assembly {
                     mstore(0x00, mload(add(proof, i)))
                     mstore(0x20, computedHash)
@@ -74,16 +98,24 @@ library Merkle {
                 }
             }
         }
+
+        // Confirm proof was fully consumed by end of computation
+        require(index == 0, InvalidIndex());
+
         return computedHash;
     }
 
     /**
-     * @dev Returns the rebuilt hash obtained by traversing a Merkle tree up
-     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
-     * hash matches the root of the tree. The tree is built assuming `leaf` is
-     * the 0 indexed `index`'th leaf from the bottom left of the tree.
-     *
-     * Note this is for a Merkle tree using the sha256 hash function
+     * @notice Verifies that a given leaf is included in a Merkle tree
+     * @param proof The proof of inclusion for the leaf
+     * @param root The root of the Merkle tree
+     * @param leaf The leaf to verify
+     * @param index The index of the leaf in the Merkle tree
+     * @return True if the leaf is included in the Merkle tree, false otherwise
+     * @dev A `proof` is valid if and only if the rebuilt hash matches the root of the tree.
+     * @dev Reverts for:
+     *      - InvalidProofLength: proof.length is 0 or not a multiple of 32.
+     *      - InvalidIndex: index is not 0 at conclusion of computation (implying outside the max index for the tree).
      */
     function verifyInclusionSha256(
         bytes memory proof,
@@ -95,14 +127,16 @@ library Merkle {
     }
 
     /**
-     * @dev Returns the rebuilt hash obtained by traversing a Merkle tree up
-     * from `leaf` using `proof`. A `proof` is valid if and only if the rebuilt
-     * hash matches the root of the tree. The tree is built assuming `leaf` is
-     * the 0 indexed `index`'th leaf from the bottom left of the tree.
-     *
-     * _Available since v4.4._
-     *
-     * Note this is for a Merkle tree using the sha256 hash function
+     * @notice Returns the rebuilt hash obtained by traversing a Merkle tree up
+     * from `leaf` using `proof`.
+     * @param proof The proof of inclusion for the leaf
+     * @param leaf The leaf to verify
+     * @param index The index of the leaf in the Merkle tree
+     * @return The rebuilt hash
+     * @dev Reverts for:
+     *      - InvalidProofLength: proof.length is 0 or not a multiple of 32.
+     *      - InvalidIndex: index is not 0 at conclusion of computation (implying outside the max index for the tree).
+     * @dev The tree is built assuming `leaf` is the 0 indexed `index`'th leaf from the bottom left of the tree.
      */
     function processInclusionProofSha256(
         bytes memory proof,
@@ -113,7 +147,7 @@ library Merkle {
         bytes32[1] memory computedHash = [leaf];
         for (uint256 i = 32; i <= proof.length; i += 32) {
             if (index % 2 == 0) {
-                // if ith bit of index is 0, then computedHash is a left sibling
+                // if index is even, then computedHash is a left sibling
                 assembly {
                     mstore(0x00, mload(computedHash))
                     mstore(0x20, mload(add(proof, i)))
@@ -121,7 +155,7 @@ library Merkle {
                     index := div(index, 2)
                 }
             } else {
-                // if ith bit of index is 1, then computedHash is a right sibling
+                // if index is odd, then computedHash is a right sibling
                 assembly {
                     mstore(0x00, mload(add(proof, i)))
                     mstore(0x20, mload(computedHash))
@@ -130,75 +164,102 @@ library Merkle {
                 }
             }
         }
+
+        // Confirm proof was fully consumed by end of computation
+        require(index == 0, InvalidIndex());
+
         return computedHash[0];
     }
 
     /**
-     * @notice this function returns the merkle root of a tree created from a set of leaves using sha256 as its hash function
-     *  @param leaves the leaves of the merkle tree
-     *  @return The computed Merkle root of the tree.
-     *  @dev A pre-condition to this function is that leaves.length is a power of two.  If not, the function will merkleize the inputs incorrectly.
+     * @notice Returns the Merkle root of a tree created from a set of leaves using SHA-256 as its hash function
+     * @param leaves the leaves of the Merkle tree
+     * @return The computed Merkle root of the tree.
+     * @dev Reverts for:
+     *      - NotEnoughLeaves: leaves.length is less than 2.
+     *      - LeavesNotPowerOfTwo: leaves.length is not a power of two.
+     * @dev Unlike the Keccak version, this function does not allow a single-leaf tree.
      */
     function merkleizeSha256(
         bytes32[] memory leaves
     ) internal pure returns (bytes32) {
-        //there are half as many nodes in the layer above the leaves
+        require(leaves.length > 1, NotEnoughLeaves());
+        require(isPowerOfTwo(leaves.length), LeavesNotPowerOfTwo());
+
+        // There are half as many nodes in the layer above the leaves
         uint256 numNodesInLayer = leaves.length / 2;
-        //create a layer to store the internal nodes
+        // Create a layer to store the internal nodes
         bytes32[] memory layer = new bytes32[](numNodesInLayer);
-        //fill the layer with the pairwise hashes of the leaves
+        // Fill the layer with the pairwise hashes of the leaves
         for (uint256 i = 0; i < numNodesInLayer; i++) {
             layer[i] = sha256(abi.encodePacked(leaves[2 * i], leaves[2 * i + 1]));
         }
-        //the next layer above has half as many nodes
-        numNodesInLayer /= 2;
-        //while we haven't computed the root
-        while (numNodesInLayer != 0) {
-            //overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
+
+        // While we haven't computed the root
+        while (numNodesInLayer != 1) {
+            // The next layer above has half as many nodes
+            numNodesInLayer /= 2;
+            // Overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
             for (uint256 i = 0; i < numNodesInLayer; i++) {
                 layer[i] = sha256(abi.encodePacked(layer[2 * i], layer[2 * i + 1]));
             }
-            //the next layer above has half as many nodes
-            numNodesInLayer /= 2;
         }
-        //the first node in the layer is the root
+        // The first node in the layer is the root
         return layer[0];
     }
 
     /**
-     * @notice this function returns the merkle root of a tree created from a set of leaves using keccak as its hash function
-     * @param leaves the leaves of the merkle tree
+     * @notice Returns the Merkle root of a tree created from a set of leaves using Keccak as its hash function
+     * @param leaves the leaves of the Merkle tree
      * @return The computed Merkle root of the tree.
+     * @dev Reverts for:
+     *      - NoLeaves: leaves.length is 0.
      */
     function merkleizeKeccak(
         bytes32[] memory leaves
     ) internal pure returns (bytes32) {
-        // TODO: very inefficient, use ZERO_HASHES
-        // pad to the next power of 2
-        uint256 numNodesInLayer = 1;
-        while (numNodesInLayer < leaves.length) {
-            numNodesInLayer *= 2;
+        require(leaves.length > 0, NoLeaves());
+
+        uint256 numNodesInLayer;
+        if (!isPowerOfTwo(leaves.length)) {
+            // Pad to the next power of 2
+            numNodesInLayer = 1;
+            while (numNodesInLayer < leaves.length) {
+                numNodesInLayer *= 2;
+            }
+        } else {
+            numNodesInLayer = leaves.length;
         }
+
+        // Create a layer to store the internal nodes
         bytes32[] memory layer = new bytes32[](numNodesInLayer);
         for (uint256 i = 0; i < leaves.length; i++) {
             layer[i] = leaves[i];
         }
 
-        //while we haven't computed the root
+        // While we haven't computed the root
         while (numNodesInLayer != 1) {
-            uint256 numNodesInNextLayer = numNodesInLayer / 2;
-            //overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
-            for (uint256 i = 0; i < numNodesInNextLayer; i++) {
+            // The next layer above has half as many nodes
+            numNodesInLayer /= 2;
+            // Overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
+            for (uint256 i = 0; i < numNodesInLayer; i++) {
                 layer[i] = keccak256(abi.encodePacked(layer[2 * i], layer[2 * i + 1]));
             }
-            //the next layer above has half as many nodes
-            numNodesInLayer = numNodesInNextLayer;
         }
-        //the first node in the layer is the root
+        // The first node in the layer is the root
         return layer[0];
     }
 
+    /**
+     * @notice Returns the Merkle proof for a given index in a tree created from a set of leaves using Keccak as its hash function
+     * @param leaves the leaves of the Merkle tree
+     * @param index the index of the leaf to get the proof for
+     * @return proof The computed Merkle proof for the leaf at index.
+     * @dev Reverts for:
+     *      - InvalidIndex: index is outside the max index for the tree.
+     */
     function getProofKeccak(bytes32[] memory leaves, uint256 index) internal pure returns (bytes memory proof) {
+        require(leaves.length > 0, NoLeaves());
         // TODO: very inefficient, use ZERO_HASHES
         // pad to the next power of 2
         uint256 numNodesInLayer = 1;
@@ -210,24 +271,74 @@ library Merkle {
             layer[i] = leaves[i];
         }
 
-        //while we haven't computed the root
-        while (numNodesInLayer != 1) {
-            //overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
-            for (uint256 i = 0; i < layer.length; i++) {
-                if (i == index) {
-                    uint256 siblingIndex = i + 1 - 2 * (i % 2);
-                    proof = abi.encodePacked(proof, layer[siblingIndex]);
-                    index /= 2;
-                }
-            }
+        if (index >= layer.length) revert InvalidIndex();
 
-            uint256 numNodesInNextLayer = numNodesInLayer / 2;
-            //overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
-            for (uint256 i = 0; i < numNodesInNextLayer; i++) {
+        // While we haven't computed the root
+        while (numNodesInLayer != 1) {
+            // Flip the least significant bit of index to get the sibling index
+            uint256 siblingIndex = index ^ 1;
+            // Add the sibling to the proof
+            proof = abi.encodePacked(proof, layer[siblingIndex]);
+            index /= 2;
+
+            // The next layer above has half as many nodes
+            numNodesInLayer /= 2;
+            // Overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
+            for (uint256 i = 0; i < numNodesInLayer; i++) {
                 layer[i] = keccak256(abi.encodePacked(layer[2 * i], layer[2 * i + 1]));
             }
-            //the next layer above has half as many nodes
-            numNodesInLayer = numNodesInNextLayer;
         }
+    }
+
+    /**
+     * @notice Returns the Merkle proof for a given index in a tree created from a set of leaves using SHA-256 as its hash function
+     * @param leaves the leaves of the Merkle tree
+     * @param index the index of the leaf to get the proof for
+     * @return proof The computed Merkle proof for the leaf at index.
+     * @dev Reverts for:
+     *      - NotEnoughLeaves: leaves.length is less than 2.
+     * @dev Unlike the Keccak version, this function does not allow a single-leaf proof.
+     */
+    function getProofSha256(bytes32[] memory leaves, uint256 index) internal pure returns (bytes memory proof) {
+        require(leaves.length > 1, NotEnoughLeaves());
+        // TODO: very inefficient, use ZERO_HASHES
+        // pad to the next power of 2
+        uint256 numNodesInLayer = 1;
+        while (numNodesInLayer < leaves.length) {
+            numNodesInLayer *= 2;
+        }
+        bytes32[] memory layer = new bytes32[](numNodesInLayer);
+        for (uint256 i = 0; i < leaves.length; i++) {
+            layer[i] = leaves[i];
+        }
+
+        if (index >= layer.length) revert InvalidIndex();
+
+        // While we haven't computed the root
+        while (numNodesInLayer != 1) {
+            // Flip the least significant bit of index to get the sibling index
+            uint256 siblingIndex = index ^ 1;
+            // Add the sibling to the proof
+            proof = abi.encodePacked(proof, layer[siblingIndex]);
+            index /= 2;
+
+            // The next layer above has half as many nodes
+            numNodesInLayer /= 2;
+            // Overwrite the first numNodesInLayer nodes in layer with the pairwise hashes of their children
+            for (uint256 i = 0; i < numNodesInLayer; i++) {
+                layer[i] = sha256(abi.encodePacked(layer[2 * i], layer[2 * i + 1]));
+            }
+        }
+    }
+
+    /**
+     * @notice Returns whether the input is a power of two
+     * @param value the value to check
+     * @return True if the input is a power of two, false otherwise
+     */
+    function isPowerOfTwo(
+        uint256 value
+    ) internal pure returns (bool) {
+        return value != 0 && (value & (value - 1)) == 0;
     }
 }

--- a/src/contracts/libraries/Merkle.sol
+++ b/src/contracts/libraries/Merkle.sol
@@ -13,26 +13,31 @@ pragma solidity ^0.8.0;
  * be reinterpreted as a leaf value.
  */
 library Merkle {
-    // @notice Thrown when the provided proof was not a multiple of 32, or was empty for SHA256.
-    // @dev Error code: 0x4dc5f6a4
+    /// @notice Thrown when the provided proof was not a multiple of 32, or was empty for SHA256.
+    /// @dev Error code: 0x4dc5f6a4
     error InvalidProofLength();
 
-    // @notice Thrown when the provided index was outside the max index for the tree.
-    // @dev Error code: 0x63df8171
+    /// @notice Thrown when the provided index was outside the max index for the tree.
+    /// @dev Error code: 0x63df8171
     error InvalidIndex();
 
-    // @notice Thrown when the provided leaves' length was not a power of two.
-    // @dev Error code: 0xf6558f51
+    /// @notice Thrown when the provided leaves' length was not a power of two.
+    /// @dev Error code: 0xf6558f51
     error LeavesNotPowerOfTwo();
 
-    // @notice Thrown when the provided leaves' length was 0.
-    // @dev Error code: 0xbaec3d9a
+    /// @notice Thrown when the provided leaves' length was 0.
+    /// @dev Error code: 0xbaec3d9a
     error NoLeaves();
 
-    // @notice Thrown when the provided leaves' length was insufficient.
-    // @dev Error code: 0xf8ef0367
-    // @dev This is used for the SHA256 Merkle tree, where the tree must have more than 1 leaf.
+    /// @notice Thrown when the provided leaves' length was insufficient.
+    /// @dev Error code: 0xf8ef0367
+    /// @dev This is used for the SHA256 Merkle tree, where the tree must have more than 1 leaf.
     error NotEnoughLeaves();
+
+    /// @notice Thrown when the root is empty.
+    /// @dev Error code: 0x53ce4ece
+    /// @dev Empty roots should never be valid. We prevent them to avoid issues like the Nomad bridge attack: <https://medium.com/nomad-xyz-blog/nomad-bridge-hack-root-cause-analysis-875ad2e5aacd>
+    error EmptyRoot();
 
     /**
      * @notice Verifies that a given leaf is included in a Merkle tree
@@ -52,6 +57,7 @@ library Merkle {
         bytes32 leaf,
         uint256 index
     ) internal pure returns (bool) {
+        require(root != bytes32(0), EmptyRoot());
         return processInclusionProofKeccak(proof, leaf, index) == root;
     }
 
@@ -123,6 +129,7 @@ library Merkle {
         bytes32 leaf,
         uint256 index
     ) internal view returns (bool) {
+        require(root != bytes32(0), EmptyRoot());
         return processInclusionProofSha256(proof, leaf, index) == root;
     }
 

--- a/src/test/unit/BN254CertificateVerifierUnit.t.sol
+++ b/src/test/unit/BN254CertificateVerifierUnit.t.sol
@@ -517,7 +517,7 @@ contract BN254CertificateVerifierUnitTests_verifyCertificate is BN254Certificate
             nonSignerWitnesses: witnesses
         });
 
-        vm.expectRevert(VerificationFailed.selector);
+        vm.expectRevert(Merkle.InvalidIndex.selector);
         verifier.verifyCertificate(defaultOperatorSet, cert);
     }
 


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**

0 leaves are currently considered valid within the Merkle library. In the event of an uninitialized struct, this can lead to proofs unintentionally being valid. As such, a default non-zero hash is used to represent these placeholder leaves for padding.

**Modifications:**

* Added a new "MERKLE_ZERO_HASH" constant derived from `keccak256("MERKLE_ZERO_HASH")`
* Created a new internal helper function to consolidate logic

**Result:**

* 0 leaves no longer being valid for constructing proofs.

_Note: this change may impact offchain services that generate roots + proofs. This change should only be merged if offchain services are ready to integrate with this change to root & proof calculations. Closing this PR is a possible outcome as this is a non-essential fix._