### PR TITLE
chore: clearer error message

### DIFF
--- a/src/contracts/interfaces/IKeyRegistrar.sol
+++ b/src/contracts/interfaces/IKeyRegistrar.sol
@@ -11,6 +11,11 @@ interface IKeyRegistrarErrors {
     /// @dev We prevent duplicate key registrations to maintain global key uniqueness and avoid conflicting operator-key mappings
     error KeyAlreadyRegistered();
 
+    /// @notice Error thrown when an operator is already registered
+    /// @dev Error code: 0x42ee68b5
+    /// @dev We prevent duplicate operator registrations to prevent re-registrations with a new key
+    error OperatorAlreadyRegistered();
+
     /// @notice Error thrown when the key format is invalid
     /// @dev Error code: 0xd1091181
     /// @dev We enforce proper key formats (20 bytes for ECDSA, valid G1/G2 points for BN254) to ensure cryptographic validity and prevent malformed key data
@@ -115,7 +120,7 @@ interface IKeyRegistrar is IKeyRegistrarErrors, IKeyRegistrarEvents, ISemVerMixi
      * @dev Reverts for:
      *      - InvalidPermissions: Caller is not the operator or authorized via the PermissionController
      *      - OperatorSetNotConfigured: The operator set is not configured
-     *      - KeyAlreadyRegistered: The operator is already registered for the operatorSet in the KeyRegistrar
+     *      - OperatorAlreadyRegistered: The operator is already registered for the operatorSet in the KeyRegistrar
      *      - InvalidKeyFormat: For ECDSA: The key is not exactly 20 bytes
      *      - ZeroAddress: For ECDSA: The key is the zero address
      *      - KeyAlreadyRegistered: For ECDSA: The key is already registered globally by hash

--- a/src/contracts/permissions/KeyRegistrar.sol
+++ b/src/contracts/permissions/KeyRegistrar.sol
@@ -73,7 +73,7 @@ contract KeyRegistrar is KeyRegistrarStorage, PermissionControllerMixin, Signatu
         require(curveType != CurveType.NONE, OperatorSetNotConfigured());
 
         // Check if the operator is already registered to the operatorSet
-        require(!_operatorKeyInfo[operatorSet.key()][operator].isRegistered, KeyAlreadyRegistered());
+        require(!_operatorKeyInfo[operatorSet.key()][operator].isRegistered, OperatorAlreadyRegistered());
 
         // Register key based on curve type - both now require signature verification
         if (curveType == CurveType.ECDSA) {

--- a/src/test/unit/KeyRegistrarUnit.t.sol
+++ b/src/test/unit/KeyRegistrarUnit.t.sol
@@ -287,7 +287,7 @@ contract KeyRegistrarUnitTests_registerKey_ECDSA is KeyRegistrarUnitTests {
         keyRegistrar.registerKey(operator1, operatorSet, ecdsaKey1, signature);
 
         vm.prank(operator1);
-        vm.expectRevert(KeyAlreadyRegistered.selector);
+        vm.expectRevert(OperatorAlreadyRegistered.selector);
         keyRegistrar.registerKey(operator1, operatorSet, ecdsaKey1, signature);
     }
 
@@ -475,9 +475,9 @@ contract KeyRegistrarUnitTests_registerKey_BN254 is KeyRegistrarUnitTests {
         vm.prank(operator1);
         keyRegistrar.registerKey(operator1, operatorSet, bn254Key1, signature);
 
-        // Try to register the same key again
+        // Try to register the same operator again
         vm.prank(operator1);
-        vm.expectRevert(KeyAlreadyRegistered.selector);
+        vm.expectRevert(OperatorAlreadyRegistered.selector);
         keyRegistrar.registerKey(operator1, operatorSet, bn254Key1, signature);
     }
 


### PR DESCRIPTION
**Motivation:**

We used the `KeyAlreadyRegistered` error when an operator is already registered as well as when a key already registered. This is not a descriptive error message. 

**Modifications:**

Add `OperatorAlreadyRegistered` message

**Result:**

More descriptive code