### PR TITLE
Enforce index==0 for empty Keccak Merkle proofs

### DIFF
--- a/src/contracts/libraries/Merkle.sol
+++ b/src/contracts/libraries/Merkle.sol
@@ -79,6 +79,7 @@ library Merkle {
         uint256 index
     ) internal pure returns (bytes32) {
         if (proof.length == 0) {
+            require(index == 0, InvalidIndex());
             return leaf;
         }
 


### PR DESCRIPTION


**Motivation:**e problem you're trying to solve.*

In the Keccak implementation, it is worth adding a check require(index == 0, InvalidIndex()) when proof.length == 0, so that the behavior matches the documentation and excludes the case described in OperatorTableUpdater.

**Modifications:**

Align processInclusionProofKeccak with documentation and SHA-256 behavior by requiring index==0 when proof.length==0.

**Result:**
This prevents acceptance of arbitrary non-zero indices in single-leaf trees and eliminates a potential bypass in callers that don’t pre-validate indices.

