### PR TITLE
bEIGEN: Allow burns while transfer restrictions are enabled

### DIFF
--- a/src/contracts/token/BackingEigen.sol
+++ b/src/contracts/token/BackingEigen.sol
@@ -162,8 +162,9 @@ contract BackingEigen is OwnableUpgradeable, ERC20VotesUpgradeable {
         // if transfer restrictions are enabled
         if (block.timestamp <= transferRestrictionsDisabledAfter) {
             // if both from and to are not whitelisted
+            // Allow burns when restrictions are enabled (permit to == address(0))
             require(
-                allowedFrom[from] || allowedTo[to] || from == address(0),
+                allowedFrom[from] || allowedTo[to] || from == address(0) || to == address(0),
                 "BackingEigen._beforeTokenTransfer: from or to must be whitelisted"
             );
         }


### PR DESCRIPTION


Description
- Summary: Enable ERC20 burns under active transfer restrictions by permitting transfers to the zero address.
- Motivation: Public burn() was effectively blocked for non-whitelisted holders; this aligns mint/burn symmetry and expected ERC20 behavior.
- Change: In BackingEigen._beforeTokenTransfer add to == address(0) allowance and a clarifying comment.
