### PR TITLE
stake function with compounding

### DIFF
--- a/src/contracts/interfaces/IEigenPod.sol
+++ b/src/contracts/interfaces/IEigenPod.sol
@@ -74,8 +74,8 @@ interface IEigenPodErrors {
     error InvalidEIP4788Response();
     /// @dev Thrown when attempting to send an invalid amount to the beacon deposit contract.
     error MsgValueNot32ETH();
-    /// @dev Thrown when attempting to send an zero amount to the beacon deposit contract for compounding.
-    error MsgValueZero();
+    /// @dev Thrown when attempting to send an amount less than one to the beacon deposit contract for compounding.
+    error MsgValueNotMoreThanOne();
     /// @dev Thrown when provided `beaconTimestamp` is too far in the past.
     error BeaconTimestampTooFarInPast();
     /// @dev Thrown when provided `beaconTimestamp` is before the last checkpoint

--- a/src/contracts/interfaces/IEigenPodManager.sol
+++ b/src/contracts/interfaces/IEigenPodManager.sol
@@ -105,6 +105,16 @@ interface IEigenPodManager is
     function createPod() external returns (address);
 
     /**
+     * @notice Stakes for a new beacon chain validator with compounding on the sender's EigenPod.
+     * Also creates an EigenPod for the sender if they don't have one already.
+     * @param pubkey The 48 bytes public key of the beacon chain validator.
+     * @param signature The validator's signature of the deposit data.
+     * @param depositDataRoot The root/hash of the deposit data for the validator's deposit.
+     */
+    function stakeCompounding(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable;
+
+
+    /**
      * @notice Stakes for a new beacon chain validator on the sender's EigenPod.
      * Also creates an EigenPod for the sender if they don't have one already.
      * @param pubkey The 48 bytes public key of the beacon chain validator.

--- a/src/contracts/pods/EigenPod.sol
+++ b/src/contracts/pods/EigenPod.sol
@@ -498,7 +498,7 @@ contract EigenPod is
         if (validatorStatus(validatorPubkeyHash) == VALIDATOR_STATUS.INACTIVE) {
             require(msg.value == 32 ether, MsgValueNot32ETH());
         } else {
-            require(msg.value > 0, MsgValueZero());
+            require(msg.value >= 1 ether, MsgValueNotMoreThanOne());
         }
 
         // stake on ethpos

--- a/src/test/mocks/EigenPodMock.sol
+++ b/src/test/mocks/EigenPodMock.sol
@@ -17,6 +17,9 @@ contract EigenPodMock is IEigenPod, SemVerMixin, Test {
     /// @notice Called by EigenPodManager when the owner wants to create another ETH validator.
     function stake(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable {}
 
+    /// @notice Called by EigenPodManager when the owner wants to create another ETH validator with compounding.
+    function stakeCompounding(bytes calldata pubkey, bytes calldata signature, bytes32 depositDataRoot) external payable {}
+
     /**
      * @notice Transfers `amountWei` in ether from this contract to the specified `recipient` address
      * @notice Called by EigenPodManager to withdrawBeaconChainETH that has been added to the EigenPod's balance due to a withdrawal from the beacon chain.


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->
<type> feat!

**Motivation:**
Currently Eigen Layer has only stake function which verifies only the withdrawal credentials with 0x01, i.e, without compounding and pectra update.

**Modifications:**
I have added another function inside EigenPod.sol namely "stakeCompounding" with the same function signature as "stake" but inside the function I am checking the validator status. If the validator is INACTIVE then the msg.value should be 32 ethers (intial deposit" and if its not INACTIVE the msg.value can be any amount greater than zero. After this it will create the withdrawal credentails using "_podCompoundingWithdrawalCredentials" which is already available in the EigenLayer contracts and calls "deposit" function.

**Result:**
Now both 0x01 and 0x02 withdrawal credentials are supported for staking and after the initial deposit any amount greater than zero can be added to the validator.

BREAKING_CHANGE
