### PR TITLE
feat: slashing commitments

### DIFF
--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -317,6 +317,44 @@ contract AllocationManager is
         }
     }
 
+    /// @inheritdoc IAllocationManager
+    function updateSlasher(OperatorSet memory operatorSet, address slasher) external checkCanCall(operatorSet.avs) {
+        require(_operatorSets[operatorSet.avs].contains(operatorSet.id), InvalidOperatorSet());
+        uint32 effectBlock = uint32(block.number) + DEALLOCATION_DELAY + 1;
+        _updateSlasher(operatorSet, slasher, effectBlock);
+    }
+
+    /// @inheritdoc IAllocationManager
+    function migrateSlasher(
+        OperatorSet[] memory operatorSets
+    ) external {
+        for (uint256 i = 0; i < operatorSets.length; i++) {
+            // Check that the operatorSet exists
+            require(_operatorSets[operatorSets[i].avs].contains(operatorSets[i].id), InvalidOperatorSet());
+
+            // Check that the operatorSet is not already migrated
+            require(!_slashers[operatorSets[i].key()].isMigrated, OperatorSetAlreadyMigrated());
+
+            // Get the slasher from the permission controller.
+            address[] memory slashers =
+                permissionController.getAppointees(operatorSets[i].avs, address(this), this.slashOperator.selector);
+
+            address slasher;
+            // If there are no slashers, set the slasher to the AVS
+            if (slashers.length == 0) {
+                slasher = operatorSets[i].avs;
+            } else {
+            // Else, set the slasher to the first slasher
+                slasher = slashers[0];
+            }
+
+            _updateSlasher(operatorSets[i], slasher, uint32(block.number));
+
+            // Mark the operatorSet as being migrated
+            _slashers[operatorSets[i].key()].isMigrated = true;
+        }
+    }
+
     /**
      *
      *                         INTERNAL FUNCTIONS
@@ -696,6 +734,22 @@ contract AllocationManager is
     }
 
     /**
+     * @dev Helper function to update the slasher for an operator set
+     * @param operatorSet the operator set to update the slasher for
+     * @param slasher the new slasher
+     * @param effectBlock the block at which the new slasher will take effect. If this is called by the migrate function, this is instant.
+     */
+    function _updateSlasher(OperatorSet memory operatorSet, address slasher, uint32 effectBlock) internal {
+        SlasherParams memory params = _slashers[operatorSet.key()];
+
+        params.pendingSlasher = slasher;
+        params.effectBlock = effectBlock;
+
+        _slashers[operatorSet.key()] = params;
+        emit SlasherUpdated(operatorSet, slasher, effectBlock);
+    }
+
+    /**
      *
      *                         VIEW FUNCTIONS
      *
@@ -997,8 +1051,19 @@ contract AllocationManager is
     }
 
     /// @inheritdoc IAllocationManager
-    function getSlasher(OperatorSet memory operatorSet) public view returns (address) {
-        return _slashers[operatorSet.key()];
+    function getSlasher(
+        OperatorSet memory operatorSet
+    ) public view returns (address) {
+        SlasherParams memory params = _slashers[operatorSet.key()];
+
+        address slasher = params.slasher;
+
+        // If there is a pending slasher that can be applied, apply it
+        if (params.effectBlock != 0 && block.number >= params.effectBlock) {
+            slasher = params.pendingSlasher;
+        }
+
+        return slasher;
     }
 
     /// @inheritdoc IAllocationManager

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -64,7 +64,10 @@ contract AllocationManager is
     function slashOperator(
         address avs,
         SlashingParams calldata params
-    ) external onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING) checkCanCall(avs) returns (uint256, uint256[] memory) {
+    ) external onlyWhenNotPaused(PAUSED_OPERATOR_SLASHING) returns (uint256, uint256[] memory) {
+        // Caller must be the slasher for the operator set
+        require(msg.sender == getSlasher(OperatorSet(avs, params.operatorSetId)), InvalidCaller());
+
         // Check that the operator set exists and the operator is registered to it
         OperatorSet memory operatorSet = OperatorSet(avs, params.operatorSetId);
         require(params.strategies.length == params.wadsToSlash.length, InputArrayLengthMismatch());
@@ -991,6 +994,11 @@ contract AllocationManager is
         // slashableUntil returns the last block the operator is slashable in so we check for
         // less than or equal to
         return status.registered || block.number <= status.slashableUntil;
+    }
+
+    /// @inheritdoc IAllocationManager
+    function getSlasher(OperatorSet memory operatorSet) public view returns (address) {
+        return _slashers[operatorSet.key()];
     }
 
     /// @inheritdoc IAllocationManager

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -114,7 +114,7 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     mapping(bytes32 operatorSetKey => address redistributionAddr) internal _redistributionRecipients;
 
     /// @notice Returns the address that can slash a given operator set.
-    mapping(bytes32 operatorSetKey => address slasher) internal _slashers;
+    mapping(bytes32 operatorSetKey => SlasherParams params) internal _slashers;
 
     // Construction
 
@@ -135,5 +135,5 @@ abstract contract AllocationManagerStorage is IAllocationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[33] private __gap;
+    uint256[32] private __gap;
 }

--- a/src/contracts/core/AllocationManagerStorage.sol
+++ b/src/contracts/core/AllocationManagerStorage.sol
@@ -113,6 +113,9 @@ abstract contract AllocationManagerStorage is IAllocationManager {
     ///      returns `DEFAULT_BURN_ADDRESS`
     mapping(bytes32 operatorSetKey => address redistributionAddr) internal _redistributionRecipients;
 
+    /// @notice Returns the address that can slash a given operator set.
+    mapping(bytes32 operatorSetKey => address slasher) internal _slashers;
+
     // Construction
 
     constructor(
@@ -132,5 +135,5 @@ abstract contract AllocationManagerStorage is IAllocationManager {
      * variables without shifting down storage in the inheritance chain.
      * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
      */
-    uint256[34] private __gap;
+    uint256[33] private __gap;
 }

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -640,6 +640,13 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
     function isOperatorSlashable(address operator, OperatorSet memory operatorSet) external view returns (bool);
 
     /**
+     * @notice Returns the address that can slash a given operator set.
+     * @param operatorSet The operator set to query.
+     * @return The address that can slash the operator set.
+     */
+    function getSlasher(OperatorSet memory operatorSet) external view returns (address);
+
+    /**
      * @notice Returns the address where slashed funds will be sent for a given operator set.
      * @param operatorSet The Operator Set to query.
      * @return For redistributing Operator Sets, returns the configured redistribution address set during Operator Set creation.

--- a/src/contracts/interfaces/IAllocationManager.sol
+++ b/src/contracts/interfaces/IAllocationManager.sol
@@ -21,6 +21,8 @@ interface IAllocationManagerErrors {
     error InvalidStrategy();
     /// @dev Thrown when an invalid redistribution recipient is provided.
     error InvalidRedistributionRecipient();
+    /// @dev Thrown when an operatorSet is already migrated
+    error OperatorSetAlreadyMigrated();
 
     /// Caller
 
@@ -74,6 +76,20 @@ interface IAllocationManagerTypes {
         uint64 currentMagnitude;
         int128 pendingDiff;
         uint32 effectBlock;
+    }
+
+    /**
+     * @notice Parameters for addresses that can slash operatorSets
+     * @param slasher the address that can slash the operator set
+     * @param pendingSlasher the address that will become the slasher for the operator set after a delay
+     * @param effectBlock the block at which the pending slasher will take effect
+     * @param isMigrated whether the slasher of the operatorSet has been migrated from the permission controller
+     */
+    struct SlasherParams {
+        address slasher;
+        address pendingSlasher;
+        uint32 effectBlock;
+        bool isMigrated;
     }
 
     /**
@@ -179,6 +195,9 @@ interface IAllocationManagerTypes {
 interface IAllocationManagerEvents is IAllocationManagerTypes {
     /// @notice Emitted when operator updates their allocation delay.
     event AllocationDelaySet(address operator, uint32 delay, uint32 effectBlock);
+
+    /// @notice Emitted when an operator set's slasher is updated.
+    event SlasherUpdated(OperatorSet operatorSet, address slasher, uint32 effectBlock);
 
     /// @notice Emitted when an operator's magnitude is updated for a given operatorSet and strategy
     event AllocationUpdated(
@@ -376,6 +395,29 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
         uint32 operatorSetId,
         IStrategy[] calldata strategies
     ) external;
+
+    /**
+     * @notice Allows an AVS to update the slasher for an operator set
+     * @param operatorSet the operator set to update the slasher for
+     * @param slasher the new slasher
+     * @dev The new slasher will take effect in DEALLOCATION_DELAY blocks
+     * @dev Reverts for: 
+     *      - InvalidOperatorSet: The operator set does not exist
+     *      - InvalidCaller: The caller cannot update the slasher for the operator set
+     */
+    function updateSlasher(OperatorSet memory operatorSet, address slasher) external;
+
+    /**
+     * @notice Allows any address to migrate the slasher from the permission controller to the ALM
+     * @param operatorSets the list of operator sets to migrate the slasher for
+     * @dev If there is no slasher set, the AVS address will be set as the slasher
+     * @dev If there is a slasher set, the first slasher will be set as the slasher
+     * @dev This function can only be called once for a given operatorSet
+     * @dev Reverts for: 
+     *      - InvalidOperatorSet: The operator set does not exist
+     *      - OperatorSetAlreadyMigrated: The operator set has already been migrated
+     */
+    function migrateSlasher(OperatorSet[] memory operatorSets) external;
 
     /**
      *
@@ -643,8 +685,11 @@ interface IAllocationManager is IAllocationManagerErrors, IAllocationManagerEven
      * @notice Returns the address that can slash a given operator set.
      * @param operatorSet The operator set to query.
      * @return The address that can slash the operator set.
+     * @dev If there is a pending slasher that can be applied after the `effectBlock`, the pending slasher will be returned.
      */
-    function getSlasher(OperatorSet memory operatorSet) external view returns (address);
+    function getSlasher(
+        OperatorSet memory operatorSet
+    ) external view returns (address);
 
     /**
      * @notice Returns the address where slashed funds will be sent for a given operator set.


### PR DESCRIPTION
**Motivation:**

We want to solve the following use cases:
- As an AVS I want to make a commitment on the address that can slash a given operatorSet
- As an AVS I want to allow *one* address to slash an 
- As an AVS I DO NOT want to allow the admin to slash the operatorSet via `PermissionController` actions

**Modifications:**

- `updateSlasher`: can set a new slasher on a `DEALLOCATION_DELAY`
- `migrateSlasher`: migrates the slasher address from the `PermissionController` to the `AllocationManager`. Can be migrated only once for a given operatorSet
- `createOperatorSet`: modified to take in a slasher address, which can immediately slash an operatorSet

We are currently 1.3kB over. 

**Result:**

Stronger commitments. 
