### PR TITLE
feat: explore ghost fns

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -55,7 +55,8 @@
     ]
     # An array of file paths from which warnings should be ignored during compilation.
     ignored_warnings_from = [
-        "src/test"
+        "src/test",
+        "src/contracts/core/AllocationManager.sol" # TODO: Remove
     ]
 
     # Test Configuration

--- a/script/utils/ExistingDeploymentParser.sol
+++ b/script/utils/ExistingDeploymentParser.sol
@@ -10,6 +10,7 @@ import "../../src/contracts/core/DelegationManager.sol";
 import "../../src/contracts/core/AVSDirectory.sol";
 import "../../src/contracts/core/RewardsCoordinator.sol";
 import "../../src/contracts/core/AllocationManager.sol";
+import "../../src/contracts/core/AllocationManagerView.sol";
 import "../../src/contracts/permissions/PermissionController.sol";
 
 import "../../src/contracts/strategies/StrategyFactory.sol";
@@ -237,9 +238,12 @@ contract ExistingDeploymentParser is Script, Logger {
         allocationManagerImplementation =
             IAllocationManager(json.readAddress(".addresses.allocationManagerImplementation"));
 
-        allocationManagerView = IAllocationManagerView(json.readAddress(".addresses.allocationManagerView"));
-        allocationManagerViewImplementation =
-            IAllocationManagerView(json.readAddress(".addresses.allocationManagerViewImplementation"));
+        // allocationManagerView = IAllocationManagerView(json.readAddress(".addresses.allocationManagerView"));
+
+        // FIXME: hotfix - remove later...
+        allocationManagerView = new AllocationManagerView(
+            delegationManager, eigenStrategy, DEALLOCATION_DELAY, ALLOCATION_CONFIGURATION_DELAY
+        );
 
         // AVSDirectory
         avsDirectory = AVSDirectory(json.readAddress(".addresses.avsDirectory"));

--- a/src/contracts/core/AllocationManager.sol
+++ b/src/contracts/core/AllocationManager.sol
@@ -21,7 +21,7 @@ contract AllocationManager is
     SplitContractMixin,
     PermissionControllerMixin,
     SemVerMixin,
-    IAllocationManagerActions
+    IAllocationManager
 {
     using DoubleEndedQueue for DoubleEndedQueue.Bytes32Deque;
     using Snapshots for Snapshots.DefaultWadHistory;
@@ -642,50 +642,203 @@ contract AllocationManager is
     // TODO: Inherit doc
     // TODO: Make commonly used getters internal methods that can be easily shared between Actions and View contracts.
 
-    function getAllocationDelay(
-        address operator
-    ) public view returns (bool, uint32) {
-        AllocationDelayInfo memory info = _allocationDelayInfo[operator];
+    /**
+     *
+     *                         VIEW FUNCTIONS
+     *
+     */
 
-        uint32 delay = info.delay;
-        bool isSet = info.isSet;
-
-        // If there is a pending delay that can be applied, apply it
-        if (info.effectBlock != 0 && block.number >= info.effectBlock) {
-            delay = info.pendingDelay;
-            isSet = true;
-        }
-
-        return (isSet, delay);
+    /// @inheritdoc IAllocationManagerView
+    function getOperatorSetCount(
+        address avs
+    ) external view returns (uint256) {
+        _delegateView(secondHalf);
     }
 
+    /// @inheritdoc IAllocationManagerView
+    function getAllocatedSets(
+        address operator
+    ) external view returns (OperatorSet[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocatedStrategies(
+        address operator,
+        OperatorSet memory operatorSet
+    ) external view returns (IStrategy[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocation(
+        address operator,
+        OperatorSet memory operatorSet,
+        IStrategy strategy
+    ) external view returns (Allocation memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocations(
+        address[] memory operators,
+        OperatorSet memory operatorSet,
+        IStrategy strategy
+    ) external view returns (Allocation[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getStrategyAllocations(
+        address operator,
+        IStrategy strategy
+    ) external view returns (OperatorSet[] memory, Allocation[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getEncumberedMagnitude(address operator, IStrategy strategy) external view returns (uint64) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocatableMagnitude(address operator, IStrategy strategy) external view returns (uint64) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMaxMagnitude(address operator, IStrategy strategy) external view returns (uint64) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMaxMagnitudes(
+        address operator,
+        IStrategy[] calldata strategies
+    ) external view returns (uint64[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMaxMagnitudes(
+        address[] calldata operators,
+        IStrategy strategy
+    ) external view returns (uint64[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMaxMagnitudesAtBlock(
+        address operator,
+        IStrategy[] calldata strategies,
+        uint32 blockNumber
+    ) external view returns (uint64[] memory) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocationDelay(
+        address operator
+    ) public view returns (bool isSet, uint32 delay) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getRegisteredSets(
+        address operator
+    ) external view returns (OperatorSet[] memory operatorSets) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function isMemberOfOperatorSet(address operator, OperatorSet memory operatorSet) external view returns (bool) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function isOperatorSet(
+        OperatorSet memory operatorSet
+    ) external view returns (bool) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMembers(
+        OperatorSet memory operatorSet
+    ) external view returns (address[] memory operators) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMemberCount(
+        OperatorSet memory operatorSet
+    ) external view returns (uint256) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
     function getAVSRegistrar(
         address avs
     ) public view returns (IAVSRegistrar) {
-        IAVSRegistrar registrar = _avsRegistrar[avs];
-
-        return address(registrar) == address(0) ? IAVSRegistrar(avs) : registrar;
+        _delegateView(secondHalf);
     }
 
+    /// @inheritdoc IAllocationManagerView
+    function getStrategiesInOperatorSet(
+        OperatorSet memory operatorSet
+    ) external view returns (IStrategy[] memory strategies) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getMinimumSlashableStake(
+        OperatorSet memory operatorSet,
+        address[] memory operators,
+        IStrategy[] memory strategies,
+        uint32 futureBlock
+    ) external view returns (uint256[][] memory slashableStake) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getAllocatedStake(
+        OperatorSet memory operatorSet,
+        address[] memory operators,
+        IStrategy[] memory strategies
+    ) external view returns (uint256[][] memory slashableStake) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
     function isOperatorSlashable(address operator, OperatorSet memory operatorSet) public view returns (bool) {
-        RegistrationStatus memory status = registrationStatus[operator][operatorSet.key()];
-
-        // slashableUntil returns the last block the operator is slashable in so we check for
-        // less than or equal to
-        return status.registered || block.number <= status.slashableUntil;
+        _delegateView(secondHalf);
     }
 
+    /// @inheritdoc IAllocationManagerView
     function getRedistributionRecipient(
         OperatorSet memory operatorSet
-    ) public view returns (address) {
-        // Load the redistribution recipient and return it if set, otherwise return the default burn address.
-        address redistributionRecipient = _redistributionRecipients[operatorSet.key()];
-        return redistributionRecipient == address(0) ? DEFAULT_BURN_ADDRESS : redistributionRecipient;
+    ) external view returns (address) {
+        _delegateView(secondHalf);
     }
 
+    /// @inheritdoc IAllocationManagerView
     function isRedistributingOperatorSet(
         OperatorSet memory operatorSet
     ) public view returns (bool) {
-        return getRedistributionRecipient(operatorSet) != DEFAULT_BURN_ADDRESS;
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function getSlashCount(
+        OperatorSet memory operatorSet
+    ) external view returns (uint256) {
+        _delegateView(secondHalf);
+    }
+
+    /// @inheritdoc IAllocationManagerView
+    function isOperatorRedistributable(
+        address operator
+    ) external view returns (bool) {
+        _delegateView(secondHalf);
     }
 }

--- a/src/contracts/mixins/SplitContractMixin.sol
+++ b/src/contracts/mixins/SplitContractMixin.sol
@@ -41,12 +41,14 @@ abstract contract SplitContractMixin {
         }
     }
 
-    /**
-     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if no other
-     * function in the contract matches the call data.
-     * TODO: Explore if we want to static-delegatecall to ensure no state mutations are possible.
-     */
-    fallback() external virtual {
-        _delegate(secondHalf);
+    function _delegateView(
+        address implementation
+    ) internal view virtual {
+        function(address) fn = _delegate;
+        function(address) view fnView;
+        assembly {
+            fnView := fn
+        }
+        fnView(implementation);
     }
 }


### PR DESCRIPTION
**Motivation:**

Due to our proxy pattern with split contracts (separate view/storage/main contracts), Etherscan only displays the functions directly in the main contract when users visit its address. This means view functions defined in separate view contracts are not visible or easily accessible on Etherscan, making it difficult for users to query protocol state.

**Modifications:**

- Added "ghost funcitons" in `AllocationManager`

**Result:**

`AllocationManager` once agian supports Etherscan for view functions.