### PR TITLE
Fix Eigen.totalSupply to return EIGEN supply (not bEIGEN) for ERC20/Votes consistency

### DIFF
--- a/src/contracts/token/Eigen.sol
+++ b/src/contracts/token/Eigen.sol
@@ -177,12 +177,11 @@ contract Eigen is OwnableUpgradeable, ERC20VotesUpgradeable, SemVerMixin {
     }
 
     /**
-     * @notice Overridden to return the total bEIGEN supply instead.
-     * @dev The issued supply of EIGEN should match the bEIGEN balance of this contract,
-     * less any bEIGEN tokens that were sent directly to the contract (rather than being wrapped)
+     * @notice Use the ERC20 supply for EIGEN itself.
+     * @dev Returning bEIGEN total supply breaks ERC20/Votes invariants; this must report EIGEN's own supply.
      */
     function totalSupply() public view override returns (uint256) {
-        return bEIGEN.totalSupply();
+        return super.totalSupply();
     }
 
     /**


### PR DESCRIPTION


### PR Description
- **Summary**: Align `Eigen.totalSupply()` with ERC20/Votes expectations by returning the EIGEN token’s own supply via `super.totalSupply()` instead of `bEIGEN.totalSupply()`.

- **Changes**
  - `src/contracts/token/Eigen.sol`: Replace `totalSupply()` implementation to call `super.totalSupply()` and update the comment.

- **Rationale**
  - Returning `bEIGEN.totalSupply()` breaks ERC20 invariants and may corrupt `ERC20VotesUpgradeable` accounting and external indexers relying on `totalSupply()`.

