### PR TITLE
fix: lint src contracts in npm hint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "forge test -v",
     "fmt:check": "forge fmt --check",
     "fmt:fix": "forge fmt",
-    "hint": "solhint -c .github/configs/solhint.json 'contracts/**/*.sol' 'script/**/*.sol'"
+    "hint": "solhint -c .github/configs/solhint.json 'src/contracts/**/*.sol' 'script/**/*.sol'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- 
    🚨 ATTENTION! 🚨 
    
    This PR template is REQUIRED. PRs not following this format will be closed without review.
    
    Requirements:
    - PR title must follow commit conventions: https://www.conventionalcommits.org/en/v1.0.0/
    - Label your PR with the correct type (e.g., 🐛 Bug, ✨ Enhancement, 🧪 Test, etc.)
    - Provide clear and specific details in each section
-->

**Motivation:**


`npm run hint` currently targets `contracts/**/*.sol`, but Solidity contracts live under `src/contracts`. This causes the local lint script to skip the main contracts directory.


**Modifications:**

- Updated the solhint glob from `contracts/**/*.sol` to `src/contracts/**/*.sol`.


**Result:**

`npm run hint` now checks the contract sources documented in CONTRIBUTING.md.
